### PR TITLE
[TLX][AMD] Implement optimized gfx950 Flash Attention forward

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -55,6 +55,12 @@ LinearLayout toLinearLayout(TensorOrMemDesc type);
 // with the allocShape as the shape, otherwise the layout will be incorrect!
 LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout);
 
+// Returns true if the layouts differ only in the order of their register
+// basis vectors. Reordering those vectors changes the order of values within a
+// thread, but not the set of tensor elements owned by each lane/warp/block.
+bool isLayoutEquivalentIgnoringRegisterOrder(const LinearLayout &lhs,
+                                             const LinearLayout &rhs);
+
 // Returns the linear component of a padded shared encoding. The encoding must
 // satisfy isPaddedEncoding (asserts otherwise).
 //

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -830,6 +830,49 @@ def TTG_WarpReturnOp
   let assemblyFormat = "attr-dict";
 }
 
+def TTG_WarpPredicateOp : TTG_Op<"warp_predicate", [
+  RecursiveMemoryEffects, RecursivelySpeculatable
+]> {
+  let summary = "run a region under a per-lane predicate";
+  let description = [{
+    Executes `$region` with the per-thread execution mask restricted to lanes
+    where `$predicate` is true. A scalar predicate supplies the execution bit
+    for the current physical lane. For a tensor predicate, all elements owned
+    by one lane are OR-reduced to its execution bit. If no lane in a wavefront
+    has the predicate set, the region is skipped for that wavefront without
+    cross-warp synchronization. Lanes where that bit is false keep the
+    corresponding `$inits` value. The region implicitly captures values from
+    above and is terminated by `ttg.predicate_yield`.
+
+    The region must contain exactly one block and may not contain nested
+    dynamic control flow. Cross-lane operations require `wave_uniform`, which
+    declares that every lane in each wavefront observes the same predicate.
+    Reductions spanning multiple warps remain unsupported. Other operations
+    with nested regions are rejected. Each init, result, and yielded value at
+    a given position must have the same type. A tensor predicate must have the
+    same leading logical shape and lane ownership as every tensor carried
+    through the region.
+  }];
+
+  let arguments = (ins TT_BoolLike:$predicate, Variadic<AnyType>:$inits,
+                       OptionalAttr<UnitAttr>:$wave_uniform);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region SizedRegion<1>:$region);
+
+  let assemblyFormat = [{
+    $predicate `(` $inits `)` $region attr-dict `:` functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
+def TTG_PredicateYieldOp : TTG_Op<"predicate_yield", [
+  Pure, Terminator, ReturnLike, HasParent<"WarpPredicateOp">
+]> {
+  let summary = "yield values from a ttg.warp_predicate region";
+  let arguments = (ins Variadic<AnyType>:$values);
+  let assemblyFormat = "($values^)? attr-dict (`:` type($values)^)?";
+}
+
 def TTG_Clock64Op
     : TTG_Op<"clock64", [MemoryEffects<[MemRead<DefaultResource>,
                                         MemWrite<DefaultResource>]>]> {

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -108,6 +108,12 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
     return false;
   });
 
+  addDynamicallyLegalOp<WarpPredicateOp>([&](WarpPredicateOp op) -> bool {
+    return typeConverter.isLegal(&op.getRegion()) && typeConverter.isLegal(op);
+  });
+  addDynamicallyLegalOp<PredicateYieldOp>(
+      [&](PredicateYieldOp op) -> bool { return typeConverter.isLegal(op); });
+
   addDynamicallyLegalOp<
       triton::gpu::AsyncCopyGlobalToLocalOp, triton::gpu::LocalLoadOp,
       triton::gpu::LocalStoreOp, triton::gpu::RemoteShmemStoreOp,

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -565,6 +565,32 @@ public:
   }
 };
 
+class TritonWarpPredicatePattern : public OpConversionPattern<WarpPredicateOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(WarpPredicateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(
+            getTypeConverter()->convertTypes(op.getResultTypes(), resultTypes)))
+      return rewriter.notifyMatchFailure(op, "could not convert result types");
+
+    auto newOp = WarpPredicateOp::create(
+        rewriter, op.getLoc(), resultTypes, adaptor.getPredicate(),
+        adaptor.getInits(), op.getWaveUniformAttr());
+    rewriter.inlineRegionBefore(op.getRegion(), newOp.getRegion(),
+                                newOp.getRegion().end());
+    if (failed(rewriter.convertRegionTypes(&newOp.getRegion(),
+                                           *getTypeConverter())))
+      return rewriter.notifyMatchFailure(op, "could not convert body types");
+
+    rewriter.replaceOp(op, newOp.getResults());
+    return success();
+  }
+};
+
 struct TTNGPrefetchPattern
     : public OpConversionPattern<triton::nvidia_gpu::PrefetchOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -611,6 +637,8 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       TritonDotPattern,
       TritonMapElementwisePattern,
       TritonWarpSpecializePattern,
+      TritonWarpPredicatePattern,
+      GenericOpPattern<PredicateYieldOp>,
       GatherScatterOpPattern<DescriptorGatherOp>,
       GatherScatterOpPattern<DescriptorScatterOp>,
       GenericOpPattern<triton::LoadOp>,

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <vector>
 
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -1453,6 +1454,31 @@ LinearLayout toLinearLayout(ArrayRef<int64_t> shape, Attribute layout) {
   auto *ctx = layout.getContext();
   return ctx->getLoadedDialect<TritonGPUDialect>()->toLinearLayout(shape,
                                                                    layout);
+}
+
+bool isLayoutEquivalentIgnoringRegisterOrder(const LinearLayout &lhs,
+                                             const LinearLayout &rhs) {
+  if (lhs.getOutDims() != rhs.getOutDims() ||
+      lhs.getBases().size() != rhs.getBases().size())
+    return false;
+
+  for (auto [lhsDim, rhsDim] : llvm::zip(lhs.getBases(), rhs.getBases())) {
+    if (lhsDim.first != rhsDim.first)
+      return false;
+    if (lhsDim.first.getValue() != "register") {
+      if (lhsDim.second != rhsDim.second)
+        return false;
+      continue;
+    }
+
+    auto lhsRegisterBases = lhsDim.second;
+    auto rhsRegisterBases = rhsDim.second;
+    std::sort(lhsRegisterBases.begin(), lhsRegisterBases.end());
+    std::sort(rhsRegisterBases.begin(), rhsRegisterBases.end());
+    if (lhsRegisterBases != rhsRegisterBases)
+      return false;
+  }
+  return true;
 }
 
 LinearLayout paddedLinearLayout(ArrayRef<int64_t> shape, Attribute encoding) {

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1665,6 +1665,211 @@ LogicalResult WarpYieldOp::verify() {
   return success();
 }
 
+LogicalResult WarpPredicateOp::verify() {
+  if (!getRegion().hasOneBlock())
+    return emitOpError("region must contain exactly one block");
+  if (getRegion().front().getNumArguments() != 0)
+    return emitOpError("region block must not have arguments");
+
+  auto yield = dyn_cast<PredicateYieldOp>(getRegion().front().getTerminator());
+  if (!yield)
+    return emitOpError("region must terminate with ttg.predicate_yield");
+
+  if (getInits().size() != getNumResults() ||
+      yield.getNumOperands() != getNumResults()) {
+    return emitOpError("expected equal numbers of inits, results, and yields, "
+                       "but got ")
+           << getInits().size() << ", " << getNumResults() << ", and "
+           << yield.getNumOperands();
+  }
+
+  for (auto [index, init, result, yielded] :
+       llvm::enumerate(getInits(), getResults(), yield.getValues())) {
+    Type expected = init.getType();
+    if (result.getType() != expected || yielded.getType() != expected) {
+      return emitOpError("init, result, and yield #")
+             << index << " must have the same type, but got " << expected
+             << ", " << result.getType() << ", and " << yielded.getType();
+    }
+  }
+
+  auto predicateType = dyn_cast<RankedTensorType>(getPredicate().getType());
+  if (predicateType) {
+    if (predicateType.getRank() == 0)
+      return emitOpError(
+          "tensor predicate must have positive rank; use a scalar i1 instead");
+    // TLX initially assigns provisional concrete layouts during TTIR-to-TTGIR
+    // conversion, then reconciles them during layout propagation. Shape is
+    // already stable and can be checked here, but exact lane ownership must be
+    // deferred until those layouts are resolved. AMD lowering repeats the
+    // ownership check before expanding this op to lane-wise LLVM values.
+    ModuleOp module = getOperation()->getParentOfType<ModuleOp>();
+    bool hasProvisionalTlxLayouts =
+        module && module->hasAttr("tlx.has_tlx_ops");
+    for (Value init : getInits()) {
+      auto initType = dyn_cast<RankedTensorType>(init.getType());
+      if (!initType)
+        continue;
+      if (initType.getRank() < predicateType.getRank() ||
+          !llvm::equal(predicateType.getShape(),
+                       initType.getShape().take_front(predicateType.getRank())))
+        return emitOpError(
+            "predicate shape must be a leading shape of every carried tensor");
+
+      // Layout-free TTIR, TLX modules undergoing layout propagation, and TLX
+      // no-verify placeholders do not yet have final distributed encodings.
+      Attribute predicateEncoding = predicateType.getEncoding();
+      Attribute initEncoding = initType.getEncoding();
+      if (!predicateEncoding || !initEncoding)
+        continue;
+      if (!isa<DistributedEncodingTrait>(predicateEncoding) ||
+          !isa<DistributedEncodingTrait>(initEncoding))
+        return emitOpError(
+            "expected distributed encodings on tensor predicate and carried "
+            "tensor");
+      if (hasProvisionalTlxLayouts)
+        continue;
+      if (triton::encodingContainsTlxNoVerifyLayout(predicateEncoding) ||
+          triton::encodingContainsTlxNoVerifyLayout(initEncoding))
+        continue;
+
+      Attribute projectedEncoding = initEncoding;
+      for (int rank = initType.getRank(); rank > predicateType.getRank();
+           --rank)
+        projectedEncoding = SliceEncodingAttr::get(
+            getContext(), rank - 1,
+            cast<DistributedEncodingTrait>(projectedEncoding));
+      auto projectedType = RankedTensorType::get(predicateType.getShape(),
+                                                 predicateType.getElementType(),
+                                                 projectedEncoding);
+      if (!isLayoutEquivalentIgnoringRegisterOrder(
+              toLinearLayout(projectedType), toLinearLayout(predicateType)))
+        return emitOpError(
+            "predicate and carried tensors must have matching lane ownership");
+    }
+  } else if (!getPredicate().getType().isInteger(1)) {
+    return emitOpError("expected an i1 or distributed tensor predicate");
+  }
+
+  WalkResult nestedControlFlow = getRegion().walk([&](Operation *nested) {
+    // A nested warp predicate is lowered independently after its enclosing
+    // predicate has been converted to CFG. Its own verifier checks the nested
+    // body; do not mistake its region for dynamic control flow in this one.
+    if (nested != getOperation() && isa<WarpPredicateOp>(nested))
+      return WalkResult::skip();
+    if (nested == getOperation() || !isa<RegionBranchOpInterface>(nested))
+      return WalkResult::advance();
+    return WalkResult::interrupt();
+  });
+  if (nestedControlFlow.wasInterrupted())
+    return emitOpError("region may not contain nested dynamic control flow");
+
+  bool waveUniform = getWaveUniform().value_or(false);
+  Operation *unsupportedRegion = nullptr;
+  Operation *crossLaneOp = nullptr;
+  triton::ReduceOp crossWarpReduce;
+  WalkResult nestedRegion = getRegion().walk([&](Operation *nested) {
+    // Nested predicates are a supported composition. Validate their own
+    // regions separately instead of applying the enclosing predicate's
+    // reduction/region restrictions to the inner body.
+    if (nested != getOperation() && isa<WarpPredicateOp>(nested))
+      return WalkResult::skip();
+    if (nested->getNumRegions() == 0)
+      return WalkResult::advance();
+    auto reduce = dyn_cast<triton::ReduceOp>(nested);
+    if (!reduce) {
+      unsupportedRegion = nested;
+      return WalkResult::interrupt();
+    }
+
+    unsigned axis = reduce.getAxis();
+    // Leave malformed reductions to ReduceOp's verifier. In particular, do
+    // not index the distributed layout with an out-of-range axis while the
+    // enclosing WarpPredicateOp is being verified first.
+    bool hasInvalidSource = false;
+    for (Value src : reduce.getSrcs()) {
+      auto srcType = dyn_cast<RankedTensorType>(src.getType());
+      if (!srcType || axis >= srcType.getRank()) {
+        hasInvalidSource = true;
+        break;
+      }
+    }
+    if (hasInvalidSource)
+      return WalkResult::advance();
+    for (Value src : reduce.getSrcs()) {
+      auto srcType = cast<RankedTensorType>(src.getType());
+      // WarpPredicateOp is present in layout-free TTIR before conversion to
+      // TTGIR. Defer the ownership check until the converter assigns the
+      // distributed encoding; verification runs again on the converted op.
+      if (!srcType.getEncoding())
+        continue;
+      if (getWarpsPerCTA(srcType)[axis] != 1) {
+        crossWarpReduce = reduce;
+        return WalkResult::interrupt();
+      }
+    }
+    if (!waveUniform) {
+      crossLaneOp = reduce;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  if (nestedRegion.wasInterrupted()) {
+    if (crossWarpReduce)
+      return emitOpError("region reduction axis must be warp-local");
+    if (crossLaneOp)
+      return emitOpError("cross-lane operation ")
+             << crossLaneOp->getName() << " requires a wave-uniform predicate";
+    return emitOpError("region may not contain nested operation ")
+           << unsupportedRegion->getName();
+  }
+
+  if (!waveUniform) {
+    getRegion().walk([&](Operation *nested) {
+      if (crossLaneOp)
+        return WalkResult::interrupt();
+      if (nested != getOperation() && isa<WarpPredicateOp>(nested))
+        return WalkResult::skip();
+      if (isa<triton::DotOp>(nested)) {
+        crossLaneOp = nested;
+        return WalkResult::interrupt();
+      }
+      if (auto convert = dyn_cast<ConvertLayoutOp>(nested);
+          convert && !isConvertTrivial(convert)) {
+        Region *sourceRegion = convert.getSrc().getParentRegion();
+        bool captured = sourceRegion != &getRegion() &&
+                        !getRegion().isAncestor(sourceRegion);
+        bool boundary = convert->hasOneUse() &&
+                        llvm::any_of(yield.getValues(), [&](Value value) {
+                          return value == convert;
+                        });
+        // Layout propagation moves captured conversions before EXEC is
+        // restricted and yielded conversions after reconvergence. Only an
+        // internal shuffle truly executes under the predicate.
+        if (!captured && !boundary) {
+          crossLaneOp = nested;
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (crossLaneOp)
+      return emitOpError("cross-lane operation ")
+             << crossLaneOp->getName() << " requires a wave-uniform predicate";
+  }
+
+  WalkResult barrier = getRegion().walk([&](Operation *nested) {
+    if (nested != getOperation() && isa<WarpPredicateOp>(nested))
+      return WalkResult::skip();
+    return isa<BarrierOp>(nested) ? WalkResult::interrupt()
+                                  : WalkResult::advance();
+  });
+  if (barrier.wasInterrupted())
+    return emitOpError("region may not contain CTA barriers");
+
+  return success();
+}
+
 // Get the size of a scalar type when stored in shared memory.
 // TODO: Generalize this as needed.
 size_t getSharedMemorySize(Type type) {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -127,7 +127,9 @@ public:
   void rewriteForOp(scf::ForOp forOp);
   void rewriteWhileOp(scf::WhileOp whileOp);
   void rewriteIfOp(scf::IfOp ifOp);
+  void rewriteWarpPredicateOp(WarpPredicateOp predicateOp);
   void rewriteYieldOp(scf::YieldOp yieldOp);
+  void rewritePredicateYieldOp(PredicateYieldOp yieldOp);
   void rewriteConditionOp(scf::ConditionOp conditionOp);
   void rewriteReduceToScalar(Operation *reduceOp);
   void rewriteAssertOp(AssertOp assertOp);
@@ -313,6 +315,31 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
       // through the same local-store path as local_store.
       if ((isMMAV3 || isAMDMMA) && isa<LocalAllocOp, LocalStoreOp>(op))
         return true;
+
+      // A warp_predicate result is the lane-wise merge of its corresponding
+      // init and yielded value. Follow those per-result carrier edges when
+      // looking for a later conversion back to the MFMA accumulator layout.
+      if (auto predicateOp = dyn_cast<WarpPredicateOp>(op)) {
+        for (auto [init, result] :
+             llvm::zip(predicateOp.getInits(), predicateOp.getResults())) {
+          Operation *def = init.getDefiningOp();
+          if ((init == currentValue || (def && forwardSlice.count(def))) &&
+              seen.insert(result).second)
+            queue.push_back(result);
+        }
+      }
+      if (auto predicateYield = dyn_cast<PredicateYieldOp>(op)) {
+        auto predicateOp = cast<WarpPredicateOp>(predicateYield->getParentOp());
+        for (OpOperand &operand : predicateYield->getOpOperands()) {
+          Operation *def = operand.get().getDefiningOp();
+          Value result = predicateOp.getResult(operand.getOperandNumber());
+          if ((operand.get() == currentValue ||
+               (def && forwardSlice.count(def))) &&
+              seen.insert(result).second)
+            queue.push_back(result);
+        }
+      }
+
       auto yield = dyn_cast<scf::YieldOp>(op);
       if (!yield)
         continue;
@@ -340,6 +367,27 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 }
 // Facebook end
 
+// A frontend may defer verification by wrapping a user pin in another layout
+// attribute (for example #tlx.no_verify_layout<#tlx.user_layout<...>>).  The
+// PinnedEncodingTrait is therefore not necessarily implemented by the
+// top-level encoding.  Detect it anywhere in the attribute tree so a deferred
+// hard constraint remains a hard constraint in this pass.
+static bool containsPinnedEncoding(Attribute encoding) {
+  if (!encoding)
+    return false;
+  if (isa<PinnedEncodingTrait>(encoding))
+    return true;
+
+  bool pinned = false;
+  encoding.walkImmediateSubElements(
+      [&](Attribute nested) {
+        if (!pinned)
+          pinned = containsPinnedEncoding(nested);
+      },
+      [](Type) {});
+  return pinned;
+}
+
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
 bool isLayoutAnchor(Operation *op) {
@@ -354,7 +402,7 @@ bool isLayoutAnchor(Operation *op) {
   // explicitly chose that layout, so layout optimization must not rewrite it.
   for (Value result : op->getResults())
     if (auto rankedTy = dyn_cast<RankedTensorType>(result.getType()))
-      if (isa_and_nonnull<PinnedEncodingTrait>(rankedTy.getEncoding()))
+      if (containsPinnedEncoding(rankedTy.getEncoding()))
         return true;
 
   if (isa<DescriptorOpInterface>(op))
@@ -444,6 +492,15 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
 SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
                                                        LayoutInfo &info) {
   SmallVector<Value> changed;
+  auto propagateSameEncoding = [&](Value target) {
+    if (!isa<RankedTensorType>(target.getType()))
+      return;
+    bool hasChanged = false;
+    for (Attribute encoding : info.encodings)
+      hasChanged |= layouts[target].encodings.insert(encoding);
+    if (hasChanged)
+      changed.push_back(target);
+  };
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
     if (auto forOp = dyn_cast<scf::ForOp>(user)) {
@@ -490,6 +547,21 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
       Value afterArg = whileOp.getAfterArguments()[argIndex];
       Value result = whileOp->getResult(argIndex);
       setEncoding({afterArg, result}, info, changed, user);
+      continue;
+    }
+    if (auto predicateOp = dyn_cast<WarpPredicateOp>(user)) {
+      unsigned operandNumber = use.getOperandNumber();
+      // Operand zero is the predicate; every later operand is an init tied to
+      // the result at the preceding index.
+      if (operandNumber > 0 && operandNumber - 1 < predicateOp.getNumResults())
+        propagateSameEncoding(predicateOp.getResult(operandNumber - 1));
+      continue;
+    }
+    if (auto predicateYield = dyn_cast<PredicateYieldOp>(user)) {
+      auto predicateOp = cast<WarpPredicateOp>(predicateYield->getParentOp());
+      unsigned operandNumber = use.getOperandNumber();
+      if (operandNumber < predicateOp.getNumResults())
+        propagateSameEncoding(predicateOp.getResult(operandNumber));
       continue;
     }
     if (auto dotWaitOp = dyn_cast<nvidia_gpu::WarpGroupDotWaitOp>(user)) {
@@ -694,8 +766,13 @@ void LayoutPropagation::resolveConflicts() {
     LayoutInfo &info = it.second;
     if (info.encodings.size() <= 1)
       continue;
-    if (op && op->hasAttr("tlx.preserve_layout")) {
-      auto originalType = cast<RankedTensorType>(it.first.getType());
+    auto originalType = cast<RankedTensorType>(it.first.getType());
+    if ((op && op->hasAttr("tlx.preserve_layout")) ||
+        containsPinnedEncoding(originalType.getEncoding())) {
+      // A user pin is an invariant, not merely another profitable anchor.
+      // In particular, a nested no_verify<user_layout<MMA>> must beat a
+      // competing high-vectorization linear layout propagated from its
+      // producer.
       info.encodings.clear();
       info.encodings.insert(originalType.getEncoding());
       continue;
@@ -815,6 +892,8 @@ void LayoutPropagation::rewriteRegion(Region &region) {
           queue.push_back(&R);
       } else if (auto yieldOp = dyn_cast<scf::YieldOp>(&op)) {
         rewriteYieldOp(yieldOp);
+      } else if (auto yieldOp = dyn_cast<PredicateYieldOp>(&op)) {
+        rewritePredicateYieldOp(yieldOp);
       } else if (auto conditionOp = dyn_cast<scf::ConditionOp>(&op)) {
         rewriteConditionOp(conditionOp);
       } else if (reduceToScalar(&op)) {
@@ -951,6 +1030,18 @@ void LayoutPropagation::rewriteIfOp(scf::IfOp ifOp) {
   }
 }
 
+void LayoutPropagation::rewriteWarpPredicateOp(WarpPredicateOp predicateOp) {
+  for (auto [index, init, result] :
+       llvm::enumerate(predicateOp.getInits(), predicateOp.getResults())) {
+    auto it = layouts.find(result);
+    if (it == layouts.end())
+      continue;
+    Attribute encoding = *it->second.encodings.begin();
+    predicateOp->setOperand(index + 1, getValueAs(init, encoding));
+    setEncodingInPlace(result, encoding);
+  }
+}
+
 void LayoutPropagation::rewriteYieldOp(scf::YieldOp yieldOp) {
   Operation *parentOp = yieldOp->getParentOp();
   for (OpOperand &operand : yieldOp->getOpOperands()) {
@@ -965,6 +1056,18 @@ void LayoutPropagation::rewriteYieldOp(scf::YieldOp yieldOp) {
       continue;
     Value newOperand = getValueAs(operand.get(), tensorType.getEncoding());
     yieldOp->setOperand(operand.getOperandNumber(), newOperand);
+  }
+}
+
+void LayoutPropagation::rewritePredicateYieldOp(PredicateYieldOp yieldOp) {
+  auto predicateOp = cast<WarpPredicateOp>(yieldOp->getParentOp());
+  for (OpOperand &operand : yieldOp->getOpOperands()) {
+    auto resultType = dyn_cast<RankedTensorType>(
+        predicateOp.getResult(operand.getOperandNumber()).getType());
+    if (!resultType)
+      continue;
+    yieldOp->setOperand(operand.getOperandNumber(),
+                        getValueAs(operand.get(), resultType.getEncoding()));
   }
 }
 
@@ -1020,6 +1123,8 @@ void LayoutPropagation::rewriteOp(Operation *op) {
     rewriteWhileOp(whileOp);
   else if (auto ifOp = dyn_cast<scf::IfOp>(op))
     rewriteIfOp(ifOp);
+  else if (auto predicateOp = dyn_cast<WarpPredicateOp>(op))
+    rewriteWarpPredicateOp(predicateOp);
   else {
     Attribute encoding = *layouts[op->getResult(0)].encodings.begin();
     if (canUseResultEncoding(op, encoding)) {
@@ -1039,6 +1144,13 @@ void LayoutPropagation::rewriteOp(Operation *op) {
 bool canBeRemat(Operation *op) {
   if (op->hasAttr("tlx.preserve_layout"))
     return false;
+  // A pinned result is a semantic boundary.  Cloning its producer in a
+  // different encoding would bypass the user-requested layout even if the
+  // original pinned value is left behind and later deleted as dead code.
+  for (Value result : op->getResults())
+    if (auto rankedTy = dyn_cast<RankedTensorType>(result.getType()))
+      if (containsPinnedEncoding(rankedTy.getEncoding()))
+        return false;
   if (isa<LoadOp, StoreOp>(op))
     return !isExpensiveLoadOrStore(op);
   if (isa<triton::gpu::LocalLoadOp>(op))

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -27,10 +27,18 @@ from triton.compiler.errors import CompilationError
 from triton.backends.amd import compiler as amd_compiler
 from triton.backends.compiler import GPUTarget
 from triton.runtime.jit import MockTensor
+from triton.language.extra.tlx.tutorials import amd_fa_cluster as _amd_fa_cluster_module
 from triton.language.extra.tlx.tutorials.amd_tdm_gemm_pipelined import (
     matmul_tdm_pipelined_kernel as _amd_tdm_gemm_kernel, )
 from triton.language.extra.tlx.tutorials.amd_mxfp_gemm_tdm_pipelined import (
     mxgemm_tdm_pipelined_kernel as _amd_mxfp_gemm_kernel, )
+from triton.language.extra.tlx.tutorials.amd_fa_cluster import (
+    _cluster_causal_query_tile as _amd_fa_cluster_causal_query_tile,
+    _cluster_direct_workgroup_window as _amd_fa_cluster_direct_workgroup_window,
+    _validate_cluster_inputs as _validate_amd_fa_cluster_inputs,
+    _validate_cluster_tiles as _validate_amd_fa_cluster_tiles,
+    persistent_attention as _amd_fa_cluster_persistent_attention,
+)
 from triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.bench import (
     compile_shape as _compile_a4w4_shape,
     generate_mxfp4_inputs as _generate_a4w4_inputs,
@@ -399,6 +407,621 @@ def test_d64_dispatch_contract_is_ci_discovered(q_shape, k_shape, causal, family
     amd_fa_bwd._validate_d64_dispatch(q_shape, k_shape, causal, dispatch)
 
 
+def test_amd_fa_cluster_rejects_unsupported_inputs():
+    q = torch.empty((1, 1, 8, 64), dtype=torch.float16)
+    with pytest.raises(ValueError, match="same shape"):
+        _validate_amd_fa_cluster_inputs(q, torch.empty((1, 1, 7, 64), dtype=q.dtype), q)
+    with pytest.raises(ValueError, match="only FP16/BF16"):
+        _validate_amd_fa_cluster_inputs(q.float(), q.float(), q.float())
+    with pytest.raises(ValueError, match="BLOCK_M"):
+        _validate_amd_fa_cluster_tiles(64, 64)
+    with pytest.raises(ValueError, match="BLOCK_N"):
+        _validate_amd_fa_cluster_tiles(256, 128)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "n_ctx", "head_dim", "causal", "config", "expected"),
+    [
+        pytest.param(torch.float16, 2048, 128, False, {}, -1, id="short-row"),
+        pytest.param(torch.float16, 4096, 128, False, {}, 263, id="n4096"),
+        pytest.param(torch.float16, 8192, 128, False, {}, 263, id="n8192"),
+        pytest.param(torch.bfloat16, 4096, 128, False, {}, -1, id="bf16"),
+        pytest.param(torch.float16, 4096, 128, True, {}, -1, id="causal"),
+        pytest.param(torch.float16, 4096, 64, False, {}, -1, id="d64"),
+        pytest.param(torch.float16, 4096, 128, False, {"use_autotune": False}, -1, id="explicit-config"),
+        pytest.param(torch.float16, 4096, 128, False, {"block_m": 128}, -1, id="bm128"),
+        pytest.param(torch.float16, 4096, 128, False, {"block_n": 32}, -1, id="bn32"),
+        pytest.param(torch.float16, 4096, 128, False, {"waves_per_eu": 0}, -1, id="wpe0"),
+    ],
+)
+def test_amd_fa_cluster_selects_static_k_row_stride(dtype, n_ctx, head_dim, causal, config, expected):
+    """The regular kernel specializes only the measured long noncausal K rows."""
+    q_strides = (64 * n_ctx * 257, n_ctx * 257, 257, 1)
+    k_strides = (64 * n_ctx * 263, n_ctx * 263, 263, 1)
+    q = SimpleNamespace(shape=(1, 64, n_ctx, head_dim), dtype=dtype, stride=lambda dim: q_strides[dim])
+    k = SimpleNamespace(shape=(1, 64, n_ctx, head_dim), dtype=dtype, stride=lambda dim: k_strides[dim])
+    launch = {
+        "use_autotune": True,
+        "block_m": 256,
+        "block_n": 64,
+        "num_warps": 8,
+        "waves_per_eu": 2,
+        **config,
+    }
+
+    assert _amd_fa_cluster_module._cluster_static_k_row_stride(q, k, causal, **launch) == expected
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        pytest.param(torch.float16, 263, id="selected-fp16"),
+        pytest.param(torch.bfloat16, -1, id="dynamic-bf16"),
+    ],
+)
+def test_amd_fa_cluster_launch_forwards_static_k_row_stride(monkeypatch, dtype, expected):
+    """The public wrapper forwards the selected stride to the compiled kernel."""
+    n_ctx = _amd_fa_cluster_module._CLUSTER_STATIC_K_ROW_MIN_N
+    strides = (64 * n_ctx * 263, n_ctx * 263, 263, 1)
+    tensor = SimpleNamespace(shape=(1, 64, n_ctx, 128), dtype=dtype, stride=lambda dim: strides[dim])
+    captured = {}
+
+    class CaptureKernel:
+
+        def __getitem__(self, grid):
+            captured["grid"] = grid
+
+            def launch(*args, **kwargs):
+                captured["kwargs"] = kwargs
+
+            return launch
+
+    kernel = CaptureKernel()
+    monkeypatch.setattr(_amd_fa_cluster_module, "_validate_cluster_inputs", lambda q, k, v: None)
+    monkeypatch.setattr(_amd_fa_cluster_module.torch, "empty_like", lambda q: q)
+    monkeypatch.setattr(_amd_fa_cluster_module, "_attn_fwd_cluster_pipeline_autotuned", kernel)
+
+    out = _amd_fa_cluster_module.flash_attn_cluster_pipeline(tensor, tensor, tensor, 1.3, False)
+
+    assert out is tensor
+    assert captured["grid"] == (n_ctx // 256, 64, 1)
+    assert captured["kwargs"]["STATIC_STRIDE_KN"] == expected
+    assert captured["kwargs"]["enable_sched_group_barrier_scheduler"] is False
+
+
+def test_amd_fa_result_war_barriers_depend_on_all_mfma_groups_gfx950():
+    """Each lightweight slot handoff remains data-dependent on its last consumers."""
+    qk_barrier = _amd_fa_cluster_module._attn_qk_war_barrier_relaxed
+    pv_barrier = _amd_fa_cluster_module._attn_pv_war_barrier_relaxed
+
+    @triton.jit
+    def result_war_barriers(qk_ptr, acc_ptr):
+        rows = tl.arange(0, 128)
+        qk_cols = tl.arange(0, 64)
+        acc_cols = tl.arange(0, 128)
+        qk_offsets = rows[:, None] * 64 + qk_cols[None, :]
+        acc_offsets = rows[:, None] * 128 + acc_cols[None, :]
+        qk = tl.load(qk_ptr + qk_offsets)
+        acc = tl.load(acc_ptr + acc_offsets)
+        qk_barrier(qk)
+        pv_barrier(acc)
+        tl.store(qk_ptr + qk_offsets, qk)
+        tl.store(acc_ptr + acc_offsets, acc)
+
+    compiled = compile_for_gfx950(
+        result_war_barriers,
+        signature={"qk_ptr": "*fp32", "acc_ptr": "*fp32"},
+        constexprs={},
+    )
+    barriers = re.findall(r'tt\.elementwise_inline_asm "[^"\n]*s_barrier"[^\n]+', compiled.asm["ttir"])
+    assert len(barriers) == 2
+    qk_constraints = 'constraints = "=s,=s,=s,=s,v,v,v,v,v,v,v,v"'
+    pv_constraints = 'constraints = "=s,=s,=s,=s,' + ','.join(["v"] * 16) + '"'
+    assert sum(qk_constraints in barrier for barrier in barriers) == 1
+    assert sum(pv_constraints in barrier for barrier in barriers) == 1
+    assert all("s_waitcnt lgkmcnt(0)" not in barrier for barrier in barriers)
+    assert all("packed_element = 4 : i32" in barrier for barrier in barriers)
+
+
+def test_amd_fa_cluster_one_tile_prefix_handoff_codegen_gfx950():
+    """The heavy N512 class hands prefetched diagonal slots to the short tail."""
+    batch, heads, n_ctx, head_dim = 1, 64, 512, 128
+    tensor = MockTensor(torch.float16, (batch, heads, n_ctx, head_dim))
+    strides = (heads * n_ctx * head_dim, n_ctx * head_dim, head_dim, 1)
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        compiled = _amd_fa_cluster_module._attn_fwd_cluster_short_causal_pipeline.warmup(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            *strides,
+            *strides,
+            *strides,
+            *strides,
+            batch,
+            H=heads,
+            N_CTX=n_ctx,
+            sm_scale=1.0 / head_dim**0.5,
+            BLOCK_M=128,
+            BLOCK_N=64,
+            BUF_DEPTH=2,
+            HEAD_DIM=head_dim,
+            USE_DIRECT_LOAD=False,
+            IS_CAUSAL=True,
+            SPECIALIZE_QUERY_CLASSES=True,
+            grid=(heads, n_ctx // 128, batch),
+            num_warps=4,
+            num_stages=3,
+            waves_per_eu=0,
+            enable_sched_group_barrier_scheduler=False,
+            llvm_fn_attrs=_amd_fa_cluster_module._CLUSTER_SHORT_N512_LLVM_FN_ATTRS,
+        )
+
+    ttir = compiled.asm["ttir"]
+    # The dedicated dense short-class route specializes physical strides, so
+    # no stride remains a runtime scalar anywhere in the generated module.
+    assert not any(
+        f"%stride_{suffix}" in ttir
+        for suffix in ("qz", "qh", "qm", "qk", "kz", "kh", "kn", "kk", "vz", "vh", "vn", "vk", "oz", "oh", "om", "ok"))
+    # The four class-specialized bodies retain five full CTA rendezvous.  The
+    # two pipelined prefixes use result-dependent inline-asm barriers instead;
+    # an extra full barrier means the diagonal handoff was broken.
+    assert ttir.count("ttg.barrier all") == 5
+    amdgcn = compiled.asm["amdgcn"]
+    assert ".private_segment_fixed_size: 0" in amdgcn
+    assert ".vgpr_spill_count: 0" in amdgcn
+
+
+def test_amd_fa_cluster_n1024_fp16_qk_handoff_uses_result_barrier_gfx950():
+    """The long BM128 prefix anchors both QK groups before reusing K0."""
+    batch, heads, n_ctx, head_dim = 1, 64, 1024, 128
+    tensor = MockTensor(torch.float16, (batch, heads, n_ctx, head_dim))
+    strides = (heads * n_ctx * head_dim, n_ctx * head_dim, head_dim, 1)
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        compiled = _amd_fa_cluster_module._attn_fwd_cluster_short_causal_pipeline.warmup(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            *strides,
+            *strides,
+            *strides,
+            *strides,
+            batch,
+            H=heads,
+            N_CTX=n_ctx,
+            sm_scale=1.0 / head_dim**0.5,
+            BLOCK_M=128,
+            BLOCK_N=64,
+            BUF_DEPTH=2,
+            HEAD_DIM=head_dim,
+            USE_DIRECT_LOAD=False,
+            IS_CAUSAL=True,
+            SPECIALIZE_QUERY_CLASSES=False,
+            grid=(heads, n_ctx // 128, batch),
+            num_warps=4,
+            num_stages=3,
+            waves_per_eu=0,
+            enable_sched_group_barrier_scheduler=False,
+            llvm_fn_attrs=_amd_fa_cluster_module._CLUSTER_SHORT_N1024_LLVM_FN_ATTRS,
+        )
+
+    qk_constraints = 'constraints = "=s,=s,=s,=s,v,v,v,v,v,v,v,v"'
+    assert compiled.asm["ttir"].count(qk_constraints) == 1
+
+
+def test_amd_fa_cluster_static_k_row_stride_codegen_gfx950():
+    """A selected K-row override removes the dynamic stride from pointer arithmetic."""
+    batch, heads, n_ctx, head_dim = 1, 64, 4096, 128
+    tensor = MockTensor(torch.float16, (batch, heads, n_ctx, head_dim))
+    q_strides = (heads * n_ctx * 257, n_ctx * 257, 257, 1)
+    k_strides = (heads * n_ctx * 263, n_ctx * 263, 263, 1)
+    v_strides = (heads * n_ctx * 269, n_ctx * 269, 269, 1)
+    o_strides = q_strides
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        compiled = _amd_fa_cluster_module._attn_fwd_cluster_pipeline.warmup(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            *q_strides,
+            *k_strides,
+            *v_strides,
+            *o_strides,
+            batch,
+            H=heads,
+            N_CTX=n_ctx,
+            sm_scale=1.0 / head_dim**0.5,
+            BLOCK_M=256,
+            BLOCK_N=64,
+            BUF_DEPTH=2,
+            HEAD_DIM=head_dim,
+            USE_DIRECT_LOAD=False,
+            IS_CAUSAL=False,
+            STATIC_STRIDE_KN=k_strides[2],
+            grid=(n_ctx // 256, heads, batch),
+            num_warps=8,
+            num_stages=3,
+            waves_per_eu=2,
+            enable_sched_group_barrier_scheduler=False,
+            llvm_fn_attrs=_amd_fa_cluster_module._CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS,
+        )
+
+    ttir = compiled.asm["ttir"]
+    # Runtime kernel parameters remain in the public ABI, but a specialized
+    # stride has no use beyond that declaration. The unselected Q stride still
+    # participates in its assumption and address-vector construction.
+    kernel_body = "\n".join(ttir.split("tt.func public @_attn_fwd_cluster_pipeline", 1)[1].splitlines()[1:])
+    assert "%stride_kn" not in kernel_body
+    assert "%stride_qm" in kernel_body
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+def test_amd_fa_cluster_n2048_four_slot_prefix_handoff_codegen_gfx950(dtype):
+    """The N2048 prefix supplies all four diagonal slots without reloading them."""
+    batch, heads, n_ctx, head_dim = 1, 64, 2048, 128
+    tensor = MockTensor(dtype, (batch, heads, n_ctx, head_dim))
+    strides = (heads * n_ctx * head_dim, n_ctx * head_dim, head_dim, 1)
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        compiled = _amd_fa_cluster_module._attn_fwd_cluster_pipeline.warmup(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            *strides,
+            *strides,
+            *strides,
+            *strides,
+            batch,
+            H=heads,
+            N_CTX=n_ctx,
+            sm_scale=1.0 / head_dim**0.5,
+            BLOCK_M=256,
+            BLOCK_N=64,
+            BUF_DEPTH=2,
+            HEAD_DIM=head_dim,
+            USE_DIRECT_LOAD=False,
+            IS_CAUSAL=True,
+            grid=(heads, n_ctx // 256, batch),
+            num_warps=8,
+            num_stages=3,
+            waves_per_eu=2,
+            enable_sched_group_barrier_scheduler=False,
+            llvm_fn_attrs=_amd_fa_cluster_module._CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS,
+        )
+
+    ttir = compiled.asm["ttir"]
+    # One object serves both query tiles with a prefix and the early tiles
+    # without one.  It therefore retains eight fallback diagonal copies in
+    # addition to five prologue, four paired-loop, two odd-tail, and five
+    # prefix-handoff copies.  The old three-tile drain has 20 sites instead.
+    assert ttir.count("ttg.async_copy_global_to_local") == 24
+    amdgcn = compiled.asm["amdgcn"]
+    assert ".private_segment_fixed_size: 0" in amdgcn
+    assert ".vgpr_spill_count: 0" in amdgcn
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize(
+    "config,match",
+    [
+        ({"NUM_XCDS": 0}, "NUM_XCDS must be positive"),
+        ({"NUM_XCDS": 8, "NUM_SMS": 4}, "NUM_SMS .* must be >= NUM_XCDS"),
+        ({"NUM_XCDS": 4, "NUM_SMS": 10}, "NUM_SMS .* must be divisible by NUM_XCDS"),
+    ],
+    ids=["zero-xcds", "too-few-sms", "nondivisible-sms"],
+)
+def test_amd_fa_cluster_rejects_invalid_persistent_scheduler(config, match):
+    q = torch.empty((1, 1, 8, 64), device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match=match):
+        _amd_fa_cluster_persistent_attention(q, q, q, 1.0, False, config=config)
+
+
+@triton.jit
+def _amd_fa_cluster_causal_query_order_kernel(output, N_CTX: tl.constexpr, BLOCK_M: tl.constexpr):
+    raw_pid_m = tl.program_id(0)
+    pid_m = _amd_fa_cluster_causal_query_tile(raw_pid_m, N_CTX, BLOCK_M)
+    tl.store(output + raw_pid_m, pid_m)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize("N_CTX,BLOCK_M", [(1024, 256), (1025, 256)])
+def test_amd_fa_cluster_causal_query_order_gfx950(N_CTX, BLOCK_M):
+    num_m_blocks = triton.cdiv(N_CTX, BLOCK_M)
+    actual = torch.empty(num_m_blocks, device="cuda", dtype=torch.int32)
+    _amd_fa_cluster_causal_query_order_kernel[(num_m_blocks, )](
+        actual,
+        N_CTX=N_CTX,
+        BLOCK_M=BLOCK_M,
+        num_warps=1,
+    )
+    expected = torch.arange(num_m_blocks - 1, -1, -1, device="cuda", dtype=torch.int32)
+    torch.testing.assert_close(actual, expected)
+
+
+@triton.jit
+def _amd_fa_cluster_workgroup_order_kernel(
+    output,
+    H: tl.constexpr,
+    N_CTX: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    USE_24_HEAD_WINDOW: tl.constexpr,
+    USE_FACTORED_24: tl.constexpr,
+):
+    raw_off_h = tl.program_id(0)
+    raw_pid_m = tl.program_id(1)
+    off_h, pid_m = _amd_fa_cluster_direct_workgroup_window(
+        raw_off_h,
+        raw_pid_m,
+        H,
+        N_CTX,
+        BLOCK_M,
+        IS_CAUSAL,
+        USE_24_HEAD_WINDOW,
+        USE_FACTORED_24,
+    )
+    if IS_CAUSAL:
+        pid_m = _amd_fa_cluster_causal_query_tile(pid_m, N_CTX, BLOCK_M)
+    num_m_blocks: tl.constexpr = (N_CTX + BLOCK_M - 1) // BLOCK_M
+    raw_linear = raw_off_h + raw_pid_m * H
+    mapped_linear = off_h + pid_m * H
+    tl.store(output + raw_linear, mapped_linear, mask=raw_pid_m < num_m_blocks)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize(
+    "H,N_CTX,BLOCK_M,IS_CAUSAL,USE_24_HEAD_WINDOW,USE_FACTORED_24,CHECK_INDEX,EXPECTED_MAPPED",
+    [
+        (64, 4096, 256, False, False, False, 64, 512),
+        (64, 4096, 256, True, False, False, 0, 960),
+        (64, 16384, 256, True, True, False, 3072, 4080),
+        (64, 16384, 256, True, True, True, 3072, 4080),
+        (4, 1025, 256, True, False, False, 0, 16),
+    ],
+)
+def test_amd_fa_cluster_workgroup_window_is_bijective_gfx950(
+    H,
+    N_CTX,
+    BLOCK_M,
+    IS_CAUSAL,
+    USE_24_HEAD_WINDOW,
+    USE_FACTORED_24,
+    CHECK_INDEX,
+    EXPECTED_MAPPED,
+):
+    num_m_blocks = triton.cdiv(N_CTX, BLOCK_M)
+    num_workgroups = H * num_m_blocks
+    actual = torch.empty(num_workgroups, device="cuda", dtype=torch.int32)
+    _amd_fa_cluster_workgroup_order_kernel[(H, num_m_blocks)](
+        actual,
+        H=H,
+        N_CTX=N_CTX,
+        BLOCK_M=BLOCK_M,
+        IS_CAUSAL=IS_CAUSAL,
+        USE_24_HEAD_WINDOW=USE_24_HEAD_WINDOW,
+        USE_FACTORED_24=USE_FACTORED_24,
+        num_warps=1,
+    )
+    expected = torch.arange(num_workgroups, device="cuda", dtype=torch.int32)
+    torch.testing.assert_close(actual.sort().values, expected)
+    assert actual[CHECK_INDEX].item() == EXPECTED_MAPPED
+
+
+@triton.jit
+def _warp_predicate_update(lhs, rhs, increment, side_ptr, offsets):
+    tl.store(side_ptr + offsets, lhs)
+    return lhs + increment, rhs - increment
+
+
+@triton.jit
+def _warp_predicate_kernel(x_ptr, lhs_ptr, rhs_ptr, side_ptr, size: tl.constexpr):
+    offsets = tl.arange(0, size)
+    lhs = tl.load(x_ptr + offsets)
+    rhs = lhs * 2.0
+    predicate = (offsets >= 64) & (offsets < 128) & (offsets % 5 < 2)
+    lhs, rhs = tlx.warp_predicate(
+        predicate,
+        (lhs, rhs),
+        _warp_predicate_update,
+        args=(3.0, side_ptr, offsets),
+    )
+    tl.store(lhs_ptr + offsets, lhs)
+    tl.store(rhs_ptr + offsets, rhs)
+
+
+def test_warp_predicate_lowers_to_amd_exec_mask_gfx950():
+    compiled = compile_for_gfx950(
+        _warp_predicate_kernel,
+        signature={
+            "x_ptr": "*fp32",
+            "lhs_ptr": "*fp32",
+            "rhs_ptr": "*fp32",
+            "side_ptr": "*fp32",
+        },
+        constexprs={"size": 256},
+    )
+    assert "ttg.warp_predicate" in compiled.asm["ttgir"]
+    amdgcn = compiled.asm["amdgcn"]
+    assert "s_and_saveexec_b64" in amdgcn
+    assert "s_cbranch_execz" in amdgcn
+
+
+@triton.jit
+def _nested_warp_predicate_inner(value):
+    return value + 1.0
+
+
+@triton.jit
+def _nested_warp_predicate_outer(value, predicate):
+    return tlx.warp_predicate(predicate, value, _nested_warp_predicate_inner)
+
+
+@triton.jit
+def _nested_warp_predicate_kernel(x_ptr, output_ptr):
+    offsets = tl.arange(0, 256)
+    value = tl.load(x_ptr + offsets)
+    predicate = offsets % 3 == 0
+    value = tlx.warp_predicate(
+        predicate,
+        value,
+        _nested_warp_predicate_outer,
+        args=(predicate, ),
+    )
+    tl.store(output_ptr + offsets, value)
+
+
+def test_nested_warp_predicate_lowers_to_amd_exec_mask_gfx950():
+    compiled = compile_for_gfx950(
+        _nested_warp_predicate_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32"},
+        constexprs={},
+    )
+    assert compiled.asm["ttgir"].count("ttg.warp_predicate") == 2
+    assert "amdgcn" in compiled.asm
+
+
+@triton.jit
+def _warp_predicate_cross_wave_reduce(value):
+    return value + tl.sum(value, axis=0)
+
+
+@triton.jit
+def _warp_predicate_cross_wave_reduce_kernel(x_ptr, output_ptr, size: tl.constexpr):
+    offsets = tl.arange(0, size)
+    value = tl.load(x_ptr + offsets)
+    wave = tlx.thread_id(0) // 64
+    predicate = wave >= 2
+    value = tlx.warp_predicate(predicate, value, _warp_predicate_cross_wave_reduce, wave_uniform=True)
+    tl.store(output_ptr + offsets, value)
+
+
+def test_warp_predicate_rejects_cross_wave_reduce_gfx950():
+    with pytest.raises(RuntimeError, match="region reduction axis must be warp-local"):
+        compile_for_gfx950(
+            _warp_predicate_cross_wave_reduce_kernel,
+            signature={"x_ptr": "*fp32", "output_ptr": "*fp32"},
+            constexprs={"size": 256},
+        )
+
+
+@triton.jit
+def _warp_predicate_warp_local_reduce(value):
+    row_sum = tl.sum(value, axis=1)
+    return value + row_sum[:, None]
+
+
+@triton.jit
+def _warp_predicate_warp_local_reduce_kernel(x_ptr, output_ptr):
+    offsets = tl.arange(0, 256)
+    value = tl.reshape(tl.load(x_ptr + offsets), (4, 64))
+    wave = tlx.thread_id(0) // 64
+    predicate = wave >= 2
+    value = tlx.warp_predicate(predicate, value, _warp_predicate_warp_local_reduce, wave_uniform=True)
+    tl.store(output_ptr + offsets, tl.reshape(value, (256, )))
+
+
+def test_warp_predicate_accepts_scalar_warp_local_reduce_gfx950():
+    compiled = compile_for_gfx950(
+        _warp_predicate_warp_local_reduce_kernel,
+        signature={"x_ptr": "*fp32", "output_ptr": "*fp32"},
+        constexprs={},
+    )
+    assert "ttg.warp_predicate" in compiled.asm["ttgir"]
+    assert "s_barrier" not in compiled.asm["amdgcn"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_warp_predicate_scalar_warp_local_reduce_gfx950():
+    source = torch.arange(256, device="cuda", dtype=torch.float32).reshape(4, 64)
+    output = torch.empty_like(source)
+    _warp_predicate_warp_local_reduce_kernel[(1, )](source, output, num_warps=4)
+    row_sum = source.sum(axis=1)
+    active_wave = torch.arange(4, device="cuda") >= 2
+    expected = torch.where(active_wave[:, None], source + row_sum[:, None], source)
+    torch.testing.assert_close(output, expected)
+
+
+@triton.jit
+def _warp_predicate_lane_divergent_reduce_kernel(x_ptr, output_ptr):
+    offsets = tl.arange(0, 256)
+    value = tl.reshape(tl.load(x_ptr + offsets), (4, 64))
+    predicate = tlx.thread_id(0) % 2 == 0
+    value = tlx.warp_predicate(predicate, value, _warp_predicate_warp_local_reduce)
+    tl.store(output_ptr + offsets, tl.reshape(value, (256, )))
+
+
+def test_warp_predicate_rejects_lane_divergent_reduce_gfx950():
+    with pytest.raises(RuntimeError, match="cross-lane operation tt.reduce requires a wave-uniform predicate"):
+        compile_for_gfx950(
+            _warp_predicate_lane_divergent_reduce_kernel,
+            signature={"x_ptr": "*fp32", "output_ptr": "*fp32"},
+            constexprs={},
+        )
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_warp_predicate_false_lanes_keep_inits_gfx950():
+    size = 256
+    source = torch.arange(size, device="cuda", dtype=torch.float32)
+    lhs = torch.empty_like(source)
+    rhs = torch.empty_like(source)
+    side = torch.full_like(source, -1.0)
+    _warp_predicate_kernel[(1, )](
+        source,
+        lhs,
+        rhs,
+        side,
+        size=size,
+        num_warps=4,
+    )
+
+    offsets = torch.arange(size, device="cuda")
+    predicate = (offsets >= 64) & (offsets < 128) & (offsets % 5 < 2)
+    torch.testing.assert_close(lhs, torch.where(predicate, source + 3.0, source))
+    torch.testing.assert_close(rhs, torch.where(predicate, source * 2.0 - 3.0, source * 2.0))
+    torch.testing.assert_close(side, torch.where(predicate, source, torch.full_like(source, -1.0)))
+
+
+@triton.jit
+def _async_local_slice_dot_kernel(q_ptr, k_ptr, output_ptr):
+    rows = tl.arange(0, 128)
+    cols = tl.arange(0, 32)
+    reduction = tl.arange(0, 128)
+    q = tl.load(q_ptr + rows[:, None] * 128 + reduction[None, :])
+
+    k_rows = tl.arange(0, 64)
+    k_ptrs = k_ptr + k_rows[:, None] * 128 + reduction[None, :]
+    k_buffers = tlx.local_alloc((64, 128), tl.float16, 1)
+    k_view = tlx.local_view(k_buffers, 0)
+    token = tlx.async_load(k_ptrs, k_view)
+    tlx.async_load_commit_group([token])
+    wait = tlx.async_load_wait_group(0)
+
+    k_lo = tlx.local_slice(k_view, [0, 0], [32, 128])
+    kt = tlx.local_load(tlx.local_trans(k_lo), token=wait, relaxed=True)
+    result = tl.dot(q, kt)
+    tl.store(output_ptr + rows[:, None] * 32 + cols[None, :], result)
+
+
+def test_async_local_slice_dot_compiles_gfx950():
+    compiled = compile_for_gfx950(
+        _async_local_slice_dot_kernel,
+        signature={"q_ptr": "*fp16", "k_ptr": "*fp16", "output_ptr": "*fp32"},
+        constexprs={},
+    )
+    assert "ttg.memdesc_subslice" in compiled.asm["ttgir"]
+    assert "v_mfma" in compiled.asm["amdgcn"]
+
+
 @triton.jit
 def _warp_vote_kernel(x_ptr, all_ptr, any_ptr, BLOCK: tl.constexpr):
     offsets = tl.arange(0, BLOCK)
@@ -557,6 +1180,152 @@ def test_mixed_helper_result_abi_compiles_gfx950():
         constexprs={},
     )
     assert "amdgcn" in compiled.asm
+
+
+@triton.jit
+def _concrete_layout_while_kernel(x_ptr, y_ptr, count):
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    rows = tl.arange(0, 16)
+    cols = tl.arange(0, 64)
+    offsets = rows[:, None] * 64 + cols[None, :]
+    values = tl.load(x_ptr + offsets)
+    i = 0
+    while i < count:
+        values = tlx.require_layout(values, mma, pin=False)
+        values += 1.0
+        i += 1
+    tl.store(y_ptr + offsets, values)
+
+
+def test_concrete_layout_while_compiles_gfx950():
+    """Fixup synchronizes both carried-value domains of a dynamic while."""
+    compiled = compile_for_gfx950(
+        _concrete_layout_while_kernel,
+        signature={"x_ptr": "*fp32", "y_ptr": "*fp32", "count": "i32"},
+        constexprs={},
+    )
+    assert "amdgcn" in compiled.asm
+
+
+@triton.jit
+def _slice_layout_validation_kernel(output, layout: tl.constexpr):
+    values = tlx.zeros([16], tl.float32, layout=layout)
+    tl.store(output + tl.arange(0, 16), values)
+
+
+def test_slice_layout_rejects_out_of_range_dimension_gfx950():
+    mma = tlx.amd_mfma_layout(4, [16, 16, 32], True, [1, 4])
+    rank_one = tlx.slice_layout(mma, dim=1)
+    cases = [
+        (tlx.slice_layout(mma, dim=2), r"slice dim=2 must be less than the parent rank=2"),
+        (tlx.slice_layout(rank_one, dim=0), r"parent layout must have at least rank >= 2"),
+    ]
+    for invalid, error in cases:
+        with pytest.raises(CompilationError, match=error):
+            compile_for_gfx950(
+                _slice_layout_validation_kernel,
+                signature={"output": "*fp32"},
+                constexprs={"layout": invalid},
+            )
+
+
+@triton.jit
+def _concrete_predicate_scale(value, scale):
+    return value * scale
+
+
+@triton.jit
+def _concrete_dot_control_flow_helper(a, b, condition, predicate, MMA: tl.constexpr, DOT0: tl.constexpr,
+                                      DOT1: tl.constexpr):
+    a = tlx.require_layout(a, DOT0, pin=False)
+    b = tlx.require_layout(b, DOT1, pin=False)
+    acc = tlx.require_layout(tl.zeros((16, 64), tl.float32), MMA, pin=False)
+    result = tl.dot(a, b, acc)
+    if condition:
+        result = result * 2.0
+    else:
+        result = result + 1.0
+    return tlx.warp_predicate(predicate, result, _concrete_predicate_scale, args=(0.5, ))
+
+
+@triton.jit
+def _concrete_helper_release_kernel(a_ptr, b_ptr, output_ptr, condition):
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    dot0: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    dot1: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+    rows = tl.arange(0, 16)
+    reduction = tl.arange(0, 32)
+    cols = tl.arange(0, 64)
+    a = tl.load(a_ptr + rows[:, None] * 32 + reduction[None, :])
+    b = tl.load(b_ptr + reduction[:, None] * 64 + cols[None, :])
+    predicate = (rows[:, None] < 8) & (cols[None, :] >= 0)
+    concrete = _concrete_dot_control_flow_helper(a, b, condition, predicate, mma, dot0, dot1)
+
+    offsets = rows[:, None] * 64 + cols[None, :]
+    # Fixup must specialize this pointer use when the helper result acquires
+    # its concrete MFMA layout.
+    tl.store(output_ptr + offsets, concrete)
+    # The call result is still encoding-free while the Python frontend builds
+    # this operation. The release remains as a deliberate layout-domain edge
+    # after helper-ABI specialization and lets this store choose a fresh layout.
+    generic = tlx.release_layout(concrete)
+    tl.store(output_ptr + 1024 + offsets, generic)
+
+
+def test_concrete_helper_control_flow_release_compiles_gfx950():
+    compiled = compile_for_gfx950(
+        _concrete_helper_release_kernel,
+        signature={
+            "a_ptr": "*fp16",
+            "b_ptr": "*fp16",
+            "output_ptr": "*fp32",
+            "condition": "i1",
+        },
+        constexprs={},
+    )
+    assert "tlx.release_layout" in compiled.asm["ttir"]
+    ttgir = compiled.asm["ttgir"]
+    assert "ttg.warp_predicate" in ttgir
+    assert ": (tensor<16x64xi1, #mma>, tensor<16x64xf32, #mma>)" in ttgir
+    assert "v_mfma" in compiled.asm["amdgcn"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize("condition", [False, True])
+def test_concrete_helper_release_preserves_values_gfx950(condition):
+    torch.manual_seed(0)
+    a = torch.randn((16, 32), device="cuda", dtype=torch.float16)
+    b = torch.randn((32, 64), device="cuda", dtype=torch.float16)
+    output = torch.empty(2048, device="cuda", dtype=torch.float32)
+    _concrete_helper_release_kernel[(1, )](
+        a,
+        b,
+        output,
+        condition,
+        num_warps=4,
+        matrix_instr_nonkdim=16,
+    )
+
+    concrete = output[:1024].reshape(16, 64)
+    released = output[1024:].reshape(16, 64)
+    assert torch.isfinite(concrete).all()
+    expected = a.float() @ b.float()
+    expected = expected * 2.0 if condition else expected + 1.0
+    expected[:8] *= 0.5
+    torch.testing.assert_close(concrete, expected, atol=5e-2, rtol=1e-2)
+    # release_layout changes only the register distribution, so its generic
+    # store must preserve the concrete store's logical tensor exactly.
+    torch.testing.assert_close(released, concrete, atol=0, rtol=0)
 
 
 @triton.jit

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -425,7 +425,8 @@ def test_amd_fa_cluster_rejects_unsupported_inputs():
         pytest.param(torch.float16, 2048, 128, False, {}, -1, id="short-row"),
         pytest.param(torch.float16, 4096, 128, False, {}, 263, id="n4096"),
         pytest.param(torch.float16, 8192, 128, False, {}, 263, id="n8192"),
-        pytest.param(torch.bfloat16, 4096, 128, False, {}, -1, id="bf16"),
+        pytest.param(torch.bfloat16, 4096, 128, False, {}, -1, id="bf16-n4096"),
+        pytest.param(torch.bfloat16, 16384, 128, False, {}, 263, id="bf16-n16384"),
         pytest.param(torch.float16, 4096, 128, True, {}, -1, id="causal"),
         pytest.param(torch.float16, 4096, 64, False, {}, -1, id="d64"),
         pytest.param(torch.float16, 4096, 128, False, {"use_autotune": False}, -1, id="explicit-config"),
@@ -453,15 +454,15 @@ def test_amd_fa_cluster_selects_static_k_row_stride(dtype, n_ctx, head_dim, caus
 
 
 @pytest.mark.parametrize(
-    ("dtype", "expected"),
+    ("dtype", "n_ctx", "expected"),
     [
-        pytest.param(torch.float16, 263, id="selected-fp16"),
-        pytest.param(torch.bfloat16, -1, id="dynamic-bf16"),
+        pytest.param(torch.float16, 4096, 263, id="selected-fp16"),
+        pytest.param(torch.bfloat16, 4096, -1, id="dynamic-bf16-n4096"),
+        pytest.param(torch.bfloat16, 16384, 263, id="selected-bf16-n16384"),
     ],
 )
-def test_amd_fa_cluster_launch_forwards_static_k_row_stride(monkeypatch, dtype, expected):
+def test_amd_fa_cluster_launch_forwards_static_k_row_stride(monkeypatch, dtype, n_ctx, expected):
     """The public wrapper forwards the selected stride to the compiled kernel."""
-    n_ctx = _amd_fa_cluster_module._CLUSTER_STATIC_K_ROW_MIN_N
     strides = (64 * n_ctx * 263, n_ctx * 263, 263, 1)
     tensor = SimpleNamespace(shape=(1, 64, n_ctx, 128), dtype=dtype, stride=lambda dim: strides[dim])
     captured = {}
@@ -614,10 +615,11 @@ def test_amd_fa_cluster_n1024_fp16_qk_handoff_uses_result_barrier_gfx950():
     assert compiled.asm["ttir"].count(qk_constraints) == 1
 
 
-def test_amd_fa_cluster_static_k_row_stride_codegen_gfx950():
-    """A selected K-row override removes the dynamic stride from pointer arithmetic."""
-    batch, heads, n_ctx, head_dim = 1, 64, 4096, 128
-    tensor = MockTensor(torch.float16, (batch, heads, n_ctx, head_dim))
+@pytest.fixture(scope="module")
+def amd_fa_cluster_long_bf16_codegen_gfx950():
+    """Compile the long BF16 object shared by its focused codegen checks."""
+    batch, heads, n_ctx, head_dim = 1, 64, 16384, 128
+    tensor = MockTensor(torch.bfloat16, (batch, heads, n_ctx, head_dim))
     q_strides = (heads * n_ctx * 257, n_ctx * 257, 257, 1)
     k_strides = (heads * n_ctx * 263, n_ctx * 263, 263, 1)
     v_strides = (heads * n_ctx * 269, n_ctx * 269, 269, 1)
@@ -652,6 +654,12 @@ def test_amd_fa_cluster_static_k_row_stride_codegen_gfx950():
             enable_sched_group_barrier_scheduler=False,
             llvm_fn_attrs=_amd_fa_cluster_module._CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS,
         )
+    return compiled
+
+
+def test_amd_fa_cluster_static_k_row_stride_codegen_gfx950(amd_fa_cluster_long_bf16_codegen_gfx950):
+    """A selected K-row override removes the dynamic stride from pointer arithmetic."""
+    compiled = amd_fa_cluster_long_bf16_codegen_gfx950
 
     ttir = compiled.asm["ttir"]
     # Runtime kernel parameters remain in the public ABI, but a specialized
@@ -660,6 +668,17 @@ def test_amd_fa_cluster_static_k_row_stride_codegen_gfx950():
     kernel_body = "\n".join(ttir.split("tt.func public @_attn_fwd_cluster_pipeline", 1)[1].splitlines()[1:])
     assert "%stride_kn" not in kernel_body
     assert "%stride_qm" in kernel_body
+
+
+def test_amd_fa_cluster_row_reduction_preserves_mfma_slices_gfx950(amd_fa_cluster_long_bf16_codegen_gfx950):
+    """The four row-reduction slices retain their parent MFMA layout."""
+    compiled = amd_fa_cluster_long_bf16_codegen_gfx950
+    ttgir = compiled.asm["ttgir"]
+    reduction_slices = re.findall(
+        r"amdg\.extract_slice .*tensor<256x64xf32, #mma> to tensor<256x16xf32, #mma>",
+        ttgir,
+    )
+    assert len(reduction_slices) >= 4
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -575,6 +575,49 @@ def test_amd_fa_cluster_one_tile_prefix_handoff_codegen_gfx950():
     assert ".vgpr_spill_count: 0" in amdgcn
 
 
+def test_amd_fa_cluster_persistent_reuse_waits_for_lds_consumers_gfx950():
+    """Persistent tiles rendezvous before their LDS slots are reused."""
+    batch, heads, n_ctx, head_dim = 2, 9, 1024, 128
+    tensor = MockTensor(torch.bfloat16, (batch, heads, n_ctx, head_dim))
+    strides = (heads * n_ctx * head_dim, n_ctx * head_dim, head_dim, 1)
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        compiled = _amd_fa_cluster_module._attn_fwd_cluster_persistent_pipeline.warmup(
+            tensor,
+            tensor,
+            tensor,
+            tensor,
+            *strides,
+            *strides,
+            *strides,
+            *strides,
+            batch,
+            H=heads,
+            N_CTX=n_ctx,
+            sm_scale=1.0 / head_dim**0.5,
+            BLOCK_M=256,
+            BLOCK_N=64,
+            BUF_DEPTH=2,
+            HEAD_DIM=head_dim,
+            USE_DIRECT_LOAD=False,
+            IS_CAUSAL=True,
+            NUM_M_BLOCKS=n_ctx // 256,
+            NUM_SMS=16,
+            NUM_XCDS=4,
+            grid=(16, ),
+            num_warps=8,
+            num_stages=3,
+            waves_per_eu=2,
+            enable_sched_group_barrier_scheduler=False,
+        )
+
+    ttgir = compiled.asm["ttgir"]
+    output_stores = re.findall(r"amdg\.buffer_store[^\n]*\n\s+ttg\.barrier all", ttgir)
+    # A causal persistent work unit statically contains two tile bodies.
+    assert len(output_stores) == 2
+
+
 def test_amd_fa_cluster_n1024_fp16_qk_handoff_uses_result_barrier_gfx950():
     """The long BM128 prefix anchors both QK groups before reusing K0."""
     batch, heads, n_ctx, head_dim = 1, 64, 1024, 128

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -704,6 +704,10 @@ def test_amd_fa_cluster_n2048_four_slot_prefix_handoff_codegen_gfx950(dtype):
     # addition to five prologue, four paired-loop, two odd-tail, and five
     # prefix-handoff copies.  The old three-tile drain has 20 sites instead.
     assert ttir.count("ttg.async_copy_global_to_local") == 24
+    # The diagonal decision is all-or-none within each wave.  Preserve the
+    # wave vote + uniform-if lowering instead of reintroducing EXEC masking.
+    assert ttir.count("ttg.warp_vote") == 2
+    assert ttir.count("ttg.warp_predicate") == 3
     amdgcn = compiled.asm["amdgcn"]
     assert ".private_segment_fixed_size: 0" in amdgcn
     assert ".vgpr_spill_count: 0" in amdgcn

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -16,6 +16,12 @@ def test_amd_mfma_tiles_per_warp_uses_warp_rank():
     assert tiled.tiles_per_warp == [2, 2]
 
 
+def test_slice_layout_rejects_negative_dimension():
+    mma = tlx.amd_mfma_layout(4, [32, 32, 16], True, [4, 1])
+    with pytest.raises(ValueError, match="dim must be non-negative"):
+        tlx.slice_layout(mma, dim=-1)
+
+
 # The FA4 "separable" layout for a 128x128 TMEM tile, written purely as
 # shape/stride (a CuTe thread-value layout). The two top-level modes are
 # (thread, value); strides are flat row-major offsets into the tile
@@ -1018,6 +1024,85 @@ def test_tlx_dot_preserves_explicit_accumulator_layout_on_cdna4():
     compiled = kernel.warmup(x, y, shared, dot0, dot1, mma, store, grid=(1, ), num_warps=4)
     assert "#ttg.amd_mfma" in compiled.asm["ttir"]
     assert "#tlx.no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_mfma_split_concat_preserves_logical_columns_on_cdna4():
+    """Order-preserving reshape/split/join reconstructs an MFMA score tile.
+
+    Flash attention carries N8 probability fragments across source stages and
+    later reassembles them for its row sum and P-by-V dot.  Marking these
+    reshapes reorderable changes their logical register interpretation: the
+    shapes still verify, but every reconstructed row can contain wrong values.
+    """
+
+    @triton.jit
+    def split_cols(x):
+        x0, x1 = x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1).split()
+        return x0, x1
+
+    @triton.jit
+    def concat_cols(x0, x1):
+        return tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] + x1.shape[1]])
+
+    @triton.jit
+    def sum_rows_chain4(x):
+        x_01, x_23 = split_cols(x)
+        x_0, x_1 = split_cols(x_01)
+        x_2, x_3 = split_cols(x_23)
+        return tl.sum(x_0 + x_1 + x_2 + x_3, 1)
+
+    @triton.jit
+    def kernel(X, Recon, Chain, Direct, MMA: tl.constexpr):
+        rows = tl.arange(0, 256)
+        cols = tl.arange(0, 64)
+        offsets = rows[:, None] * 64 + cols[None, :]
+        x = tlx.require_layout(tl.load(X + offsets), MMA)
+        x_lo, x_hi = split_cols(x)
+        reconstructed = concat_cols(x_lo, x_hi)
+        chain = sum_rows_chain4(x)
+        direct = tl.sum(x, 1)
+        tl.store(Recon + offsets, reconstructed)
+        tl.store(Chain + rows, chain)
+        tl.store(Direct + rows, direct)
+
+    mma = tlx.amd_mfma_layout(4, [32, 32, 16], True, [8, 1])
+    torch.manual_seed(7)
+    x = torch.rand((256, 64), device=DEVICE, dtype=torch.float32)
+    reconstructed = torch.empty_like(x)
+    chain = torch.empty((256, ), device=DEVICE, dtype=torch.float32)
+    direct = torch.empty_like(chain)
+    compiled = kernel[(1, )](x, reconstructed, chain, direct, mma, num_warps=8, enable_tree_reduction=True)
+
+    reference = x.sum(1)
+    torch.testing.assert_close(reconstructed, x, atol=0, rtol=0)
+    torch.testing.assert_close(chain, reference, atol=1e-5, rtol=1e-6)
+    torch.testing.assert_close(direct, reference, atol=1e-5, rtol=1e-6)
+    _assert_no_layout_residue(compiled.asm["ttgir"])
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_slice_layout_matches_mfma_row_reduction_on_cdna4():
+    """The public slice layout names the rank-1 result of an MFMA row sum."""
+    mma = tlx.amd_mfma_layout(4, [32, 32, 16], True, [8, 1])
+    rows = tlx.slice_layout(mma, dim=1)
+
+    @triton.jit
+    def kernel(X, Y, MMA: tl.constexpr, ROWS: tl.constexpr):
+        offs_m = tl.arange(0, 256)
+        offs_n = tl.arange(0, 64)
+        offsets = offs_m[:, None] * 64 + offs_n[None, :]
+        x = tlx.require_layout(tl.load(X + offsets), MMA)
+        reduced = tl.reduce(x, 1, _pinned_add_combine)
+        reduced = tlx.require_layout(reduced, ROWS)
+        tlx.assert_same_layout(reduced, ROWS)
+        tl.store(Y + offs_m, reduced)
+
+    x = torch.rand((256, 64), device=DEVICE, dtype=torch.float32)
+    y = torch.empty((256, ), device=DEVICE, dtype=torch.float32)
+    compiled = kernel[(1, )](x, y, mma, rows, num_warps=8, enable_tree_reduction=True)
+    torch.testing.assert_close(y, x.sum(1), atol=1e-5, rtol=1e-6)
+    _assert_no_layout_residue(compiled.asm["ttgir"])
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")

--- a/test/Conversion/amd/invalid_concat_op.mlir
+++ b/test/Conversion/amd/invalid_concat_op.mlir
@@ -23,6 +23,27 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
 
 // -----
 
+// Layout propagation may temporarily leave a captured/yielded conversion in a
+// warp-predicated body, but it must be hoisted before LLVM lowering. Otherwise
+// the shuffle would execute with a lane-divergent EXEC mask.
+#row = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+#column = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @warp_predicate_residual_layout_conversion(
+      %predicate: i1,
+      %init: tensor<64x64xf32, #row>,
+      %native: tensor<64x64xf32, #column>) -> tensor<64x64xf32, #row> {
+    // expected-error @+1 {{non-wave-uniform body still contains cross-lane layout conversion}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      %restored = ttg.convert_layout %native : tensor<64x64xf32, #column> -> tensor<64x64xf32, #row>
+      ttg.predicate_yield %restored : tensor<64x64xf32, #row>
+    } : (i1, tensor<64x64xf32, #row>) -> tensor<64x64xf32, #row>
+    tt.return %result : tensor<64x64xf32, #row>
+  }
+}
+
+// -----
+
 // Invalid shapes 1
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -48,6 +48,158 @@ llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#predicate_register_order = #ttg.linear<{register = [[1], [2]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
+#carried_register_order = #ttg.linear<{register = [[2], [1]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32, "ttg.target" = "hip:gfx950"} {
+// AMD-LABEL: llvm.func @lower_warp_predicate
+llvm.func @lower_warp_predicate(
+    %predicate_struct: !llvm.struct<(i1)>,
+    %init_struct: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %predicate = builtin.unrealized_conversion_cast %predicate_struct : !llvm.struct<(i1)> to tensor<64xi1, #blocked>
+
+  %init = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+
+  // AMD: cf.cond_br %{{.*}}, ^[[BODY:bb[0-9]+]], ^[[MERGE:bb[0-9]+]](%{{.*}} : !llvm.struct<(i32)>)
+  %result = ttg.warp_predicate %predicate (%init) {
+    %two = llvm.mlir.constant(2 : i32) : i32
+    %yield_undef = llvm.mlir.undef : !llvm.struct<(i32)>
+    %yield_struct = llvm.insertvalue %two, %yield_undef[0] : !llvm.struct<(i32)>
+    %yield = builtin.unrealized_conversion_cast %yield_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+    ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+  } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+  %result_struct = builtin.unrealized_conversion_cast %result : tensor<64xi32, #blocked> to !llvm.struct<(i32)>
+  // AMD: ^[[BODY]]:
+  // AMD: cf.br ^[[MERGE]](%{{.*}} : !llvm.struct<(i32)>)
+  // AMD: ^[[MERGE]](%{{.*}}: !llvm.struct<(i32)>):
+  // AMD-NOT: ttg.warp_predicate
+  llvm.return %result_struct : !llvm.struct<(i32)>
+}
+
+// AMD-LABEL: llvm.func @lower_scalar_warp_predicate(
+// AMD-SAME: %[[PREDICATE:.*]]: i1
+llvm.func @lower_scalar_warp_predicate(
+    %predicate: i1,
+    %init_struct: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %init = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+
+  // AMD: cf.cond_br %[[PREDICATE]], ^[[BODY:bb[0-9]+]], ^[[MERGE:bb[0-9]+]](%{{.*}} : !llvm.struct<(i32)>)
+  %result = ttg.warp_predicate %predicate (%init) {
+    %two = llvm.mlir.constant(2 : i32) : i32
+    %yield_undef = llvm.mlir.undef : !llvm.struct<(i32)>
+    %yield_struct = llvm.insertvalue %two, %yield_undef[0] : !llvm.struct<(i32)>
+    %yield = builtin.unrealized_conversion_cast %yield_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+    ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+  } : (i1, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+  %result_struct = builtin.unrealized_conversion_cast %result : tensor<64xi32, #blocked> to !llvm.struct<(i32)>
+  // AMD: ^[[BODY]]:
+  // AMD: cf.br ^[[MERGE]](%{{.*}} : !llvm.struct<(i32)>)
+  // AMD: ^[[MERGE]](%{{.*}}: !llvm.struct<(i32)>):
+  // AMD-NOT: ttg.warp_predicate
+  llvm.return %result_struct : !llvm.struct<(i32)>
+}
+
+// AMD-LABEL: llvm.func @lower_scalar_carried_warp_predicate(
+// AMD-SAME: %[[PREDICATE:.*]]: i1,
+// AMD-SAME: %[[INIT:.*]]: i32
+llvm.func @lower_scalar_carried_warp_predicate(
+    %predicate: i1,
+    %init: i32) -> i32 {
+  // AMD: cf.cond_br %[[PREDICATE]], ^[[BODY:bb[0-9]+]], ^[[MERGE:bb[0-9]+]](%[[INIT]] : i32)
+  %result = ttg.warp_predicate %predicate (%init) {
+    %one = llvm.mlir.constant(1 : i32) : i32
+    %yield = llvm.add %init, %one : i32
+    ttg.predicate_yield %yield : i32
+  } : (i1, i32) -> i32
+  %two = llvm.mlir.constant(2 : i32) : i32
+  // AMD: ^[[BODY]]:
+  // AMD: cf.br ^[[MERGE]](%{{.*}} : i32)
+  // AMD: ^[[MERGE]](%[[RESULT:.*]]: i32):
+  // AMD: %[[SUM:.*]] = llvm.add %[[RESULT]], %{{.*}} : i32
+  %sum = llvm.add %result, %two : i32
+  // AMD: llvm.return %[[SUM]] : i32
+  // AMD-NOT: ttg.warp_predicate
+  llvm.return %sum : i32
+}
+
+// AMD-LABEL: llvm.func @lower_register_reordered_warp_predicate
+// AMD: cf.cond_br %{{.*}}, ^[[BODY:bb[0-9]+]], ^[[MERGE:bb[0-9]+]](%{{.*}} : !llvm.struct<(i32, i32, i32, i32)>)
+// AMD: ^[[BODY]]:
+// AMD: cf.br ^[[MERGE]](%{{.*}} : !llvm.struct<(i32, i32, i32, i32)>)
+// AMD: ^[[MERGE]](%{{.*}}: !llvm.struct<(i32, i32, i32, i32)>):
+// AMD-NOT: ttg.warp_predicate
+llvm.func @lower_register_reordered_warp_predicate(
+    %predicate_struct: !llvm.struct<(i1, i1, i1, i1)>,
+    %init_struct: !llvm.struct<(i32, i32, i32, i32)>) -> !llvm.struct<(i32, i32, i32, i32)> {
+  %predicate = builtin.unrealized_conversion_cast %predicate_struct : !llvm.struct<(i1, i1, i1, i1)> to tensor<256xi1, #predicate_register_order>
+  %init = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32, i32, i32, i32)> to tensor<256xi32, #carried_register_order>
+  %result = ttg.warp_predicate %predicate (%init) {
+    %one = llvm.mlir.constant(1 : i32) : i32
+    %undef = llvm.mlir.undef : !llvm.struct<(i32, i32, i32, i32)>
+    %yield_struct = llvm.insertvalue %one, %undef[0] : !llvm.struct<(i32, i32, i32, i32)>
+    %yield = builtin.unrealized_conversion_cast %yield_struct : !llvm.struct<(i32, i32, i32, i32)> to tensor<256xi32, #carried_register_order>
+    ttg.predicate_yield %yield : tensor<256xi32, #carried_register_order>
+  } : (tensor<256xi1, #predicate_register_order>, tensor<256xi32, #carried_register_order>) -> tensor<256xi32, #carried_register_order>
+  %result_struct = builtin.unrealized_conversion_cast %result : tensor<256xi32, #carried_register_order> to !llvm.struct<(i32, i32, i32, i32)>
+  llvm.return %result_struct : !llvm.struct<(i32, i32, i32, i32)>
+}
+
+// AMD-LABEL: llvm.func @lower_chained_warp_predicates
+// AMD-COUNT-2: cf.cond_br
+// AMD-NOT: ttg.warp_predicate
+llvm.func @lower_chained_warp_predicates(
+    %predicate_struct: !llvm.struct<(i1)>,
+    %init_struct: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %predicate = builtin.unrealized_conversion_cast %predicate_struct : !llvm.struct<(i1)> to tensor<64xi1, #blocked>
+  %init = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+
+  %first = ttg.warp_predicate %predicate (%init) {
+    %two = llvm.mlir.constant(2 : i32) : i32
+    %undef = llvm.mlir.undef : !llvm.struct<(i32)>
+    %struct = llvm.insertvalue %two, %undef[0] : !llvm.struct<(i32)>
+    %yield = builtin.unrealized_conversion_cast %struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+    ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+  } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+
+  %second = ttg.warp_predicate %predicate (%first) {
+    %three = llvm.mlir.constant(3 : i32) : i32
+    %undef = llvm.mlir.undef : !llvm.struct<(i32)>
+    %struct = llvm.insertvalue %three, %undef[0] : !llvm.struct<(i32)>
+    %yield = builtin.unrealized_conversion_cast %struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+    ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+  } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+
+  %result = builtin.unrealized_conversion_cast %second : tensor<64xi32, #blocked> to !llvm.struct<(i32)>
+  llvm.return %result : !llvm.struct<(i32)>
+}
+
+// AMD-LABEL: llvm.func @lower_nested_warp_predicates
+// AMD-COUNT-2: cf.cond_br
+// AMD-NOT: ttg.warp_predicate
+llvm.func @lower_nested_warp_predicates(
+    %predicate_struct: !llvm.struct<(i1)>,
+    %init_struct: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %predicate = builtin.unrealized_conversion_cast %predicate_struct : !llvm.struct<(i1)> to tensor<64xi1, #blocked>
+  %init = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+
+  %outer = ttg.warp_predicate %predicate (%init) {
+    %inner = ttg.warp_predicate %predicate (%init) {
+      %two = llvm.mlir.constant(2 : i32) : i32
+      %undef = llvm.mlir.undef : !llvm.struct<(i32)>
+      %struct = llvm.insertvalue %two, %undef[0] : !llvm.struct<(i32)>
+      %yield = builtin.unrealized_conversion_cast %struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+      ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+    } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+    ttg.predicate_yield %inner : tensor<64xi32, #blocked>
+  } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+
+  %result = builtin.unrealized_conversion_cast %outer : tensor<64xi32, #blocked> to !llvm.struct<(i32)>
+  llvm.return %result : !llvm.struct<(i32)>
+}
+}
+
+// -----
+
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 11 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.target" = "hip:gfx1250"} {
 
 llvm.mlir.global external @global_smem() {addr_space = 3 : i32, alignment = 16 : i64} : !llvm.array<0 x i8>

--- a/test/TLX/pinned-helper-offset-layout.mlir
+++ b/test/TLX/pinned-helper-offset-layout.mlir
@@ -13,7 +13,8 @@
 // releasing only its operand.
 //
 // CHECK-DAG: #[[$TRANSPOSE_SRC_LINEAR:.*]] = #ttg.linear<{{.*}}register = {{\[\[0, 1\], \[8, 0\], \[0, 8\], \[0, 16\], \[0, 32\]\]}}
-// CHECK-DAG: #[[$TRANSPOSE_SRC_USER:.*]] = #tlx.user_layout<#[[$TRANSPOSE_SRC_LINEAR]]>
+// CHECK-DAG: #[[$TRANSPOSE_DST_LINEAR:.*]] = #ttg.linear<{{.*}}register = {{\[\[1, 0\], \[0, 8\], \[8, 0\], \[16, 0\], \[32, 0\]\]}}
+// CHECK-DAG: #[[$TRANSPOSE_DST_USER:.*]] = #tlx.user_layout<#[[$TRANSPOSE_DST_LINEAR]]>
 // The helper restructures only the loaded value. The pinned offset flows into
 // amdg.buffer_load, which is an ownership boundary for argument dataflow.
 //
@@ -39,9 +40,18 @@
 // CHECK: tt.return
 // CHECK-LABEL: tt.func public @transpose_result_pin
 // CHECK: %[[TRANSPOSE_VALUE:.*]] = arith.constant
-// CHECK-SAME: tensor<128x64xf32, #tlx.no_verify_layout<#[[$TRANSPOSE_SRC_USER]]>>
-// CHECK: tt.trans %[[TRANSPOSE_VALUE]]
+// CHECK-SAME: tensor<128x64xf32, #tlx.no_verify_layout<#[[$TRANSPOSE_SRC_LINEAR]]>>
+// CHECK: %[[TRANSPOSED:.*]] = tt.trans %[[TRANSPOSE_VALUE]]
+// CHECK-SAME: -> tensor<64x128xf32, #tlx.no_verify_layout<#[[$TRANSPOSE_DST_USER]]>>
 // CHECK: tt.return
+// CHECK-LABEL: tt.func public @while_layout
+// CHECK: %[[WHILE_INIT:.*]] = tlx.require_layout
+// CHECK-SAME: -> tensor<4x256xi32, #[[WHILE_LAYOUT:tlx.no_verify_layout<#linear[0-9]*>]]>
+// CHECK: %[[WHILE_RESULT:.*]] = scf.while (%[[BEFORE:.*]] = %[[WHILE_INIT]])
+// CHECK-SAME: (tensor<4x256xi32, #[[WHILE_LAYOUT]]>) -> tensor<4x256xi32, #[[WHILE_LAYOUT]]>
+// CHECK: scf.condition(%{{.*}}) %{{.*}} : tensor<4x256xi32, #[[WHILE_LAYOUT]]>
+// CHECK: ^bb0(%{{.*}}: tensor<4x256xi32, #[[WHILE_LAYOUT]]>):
+// CHECK: scf.yield {{.*}} : tensor<4x256xi32, #[[WHILE_LAYOUT]]>
 //
 // Full post-fixup snapshots follow. The current module uses generic syntax
 // because releasing only the call operand makes the call temporarily invalid.
@@ -164,6 +174,27 @@ module {
     %transposed = tt.trans %value {order = array<i32: 1, 0>}
         : tensor<128x64xf32, #transpose_wrong_src_pin>
           -> tensor<64x128xf32, #transpose_pin>
+    tt.return
+  }
+
+  tt.func public @while_layout(
+      %value: tensor<4x256xi32>, %keep_going: i1) {
+    %result = scf.while (%before = %value)
+        : (tensor<4x256xi32>) -> tensor<4x256xi32> {
+      scf.condition(%keep_going) %before : tensor<4x256xi32>
+    } do {
+    ^bb0(%after: tensor<4x256xi32>):
+      %pinned = tlx.require_layout %after
+          : tensor<4x256xi32> -> tensor<4x256xi32, #pin>
+      // Keep the input module verifiable: the placeholder-aware reshape
+      // verifier permits an encoding-free result. Fixup infers both reshape
+      // results first, then repairs the while edges on its next iteration.
+      %reshaped = tt.reshape %pinned allow_reorder
+          : tensor<4x256xi32, #pin> -> tensor<2x2x256xi32>
+      %restored = tt.reshape %reshaped allow_reorder
+          : tensor<2x2x256xi32> -> tensor<4x256xi32>
+      scf.yield %restored : tensor<4x256xi32>
+    }
     tt.return
   }
 }

--- a/test/TLX/propagate-layout-memdesc-trans-errors.mlir
+++ b/test/TLX/propagate-layout-memdesc-trans-errors.mlir
@@ -21,3 +21,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return %val : tensor<128x64xf16, #blocked_perm>
   }
 }
+
+// -----
+
+// One execution predicate cannot represent two incompatible native row
+// ownerships after conversions are hoisted out of the predicated region.
+
+#old_row = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#mma_a = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#mma_b = #ttg.amd_mfma<{version = 4, warpsPerCTA = [2, 2], instrShape = [32, 32, 16], isTransposed = true}>
+#row_a = #ttg.slice<{dim = 1, parent = #mma_a}>
+#row_b = #ttg.slice<{dim = 1, parent = #mma_b}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @reject_conflicting_predicate_layouts(
+      %predicate: tensor<128xi1, #old_row>,
+      %lhs: tensor<128xf32, #old_row>,
+      %rhs: tensor<128xf32, #old_row>)
+      -> (tensor<128xf32, #old_row>, tensor<128xf32, #old_row>) {
+    // expected-error @+1 {{carried row values require conflicting predicate layouts}}
+    %result:2 = ttg.warp_predicate %predicate (%lhs, %rhs) {
+      %lhs_native = ttg.convert_layout %lhs : tensor<128xf32, #old_row> -> tensor<128xf32, #row_a>
+      %lhs_old = ttg.convert_layout %lhs_native : tensor<128xf32, #row_a> -> tensor<128xf32, #old_row>
+      %rhs_native = ttg.convert_layout %rhs : tensor<128xf32, #old_row> -> tensor<128xf32, #row_b>
+      %rhs_old = ttg.convert_layout %rhs_native : tensor<128xf32, #row_b> -> tensor<128xf32, #old_row>
+      ttg.predicate_yield %lhs_old, %rhs_old : tensor<128xf32, #old_row>, tensor<128xf32, #old_row>
+    } : (tensor<128xi1, #old_row>, tensor<128xf32, #old_row>, tensor<128xf32, #old_row>) -> (tensor<128xf32, #old_row>, tensor<128xf32, #old_row>)
+    tt.return %result#0, %result#1 : tensor<128xf32, #old_row>, tensor<128xf32, #old_row>
+  }
+}

--- a/test/TLX/propagate-layout.mlir
+++ b/test/TLX/propagate-layout.mlir
@@ -38,6 +38,106 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 }
 
 // -----
+// Layout conversions that communicate between waves must surround rather than
+// execute inside a warp_predicate region. The carried values use the body's
+// native MFMA/row layouts, while the op's externally visible values retain
+// their original blocked layouts. Mark the module as TLX because the input
+// ownership is intentionally provisional until this pass hoists the bridges.
+
+#wp_blocked_acc = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+#wp_blocked_row = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#wp_mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#wp_mma_row = #ttg.slice<{dim = 1, parent = #wp_mma}>
+
+module attributes {tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-DAG: #[[$WP_BLOCKED_ROW:.*]] = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+  // CHECK-DAG: #[[$WP_BLOCKED_ACC:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+  // CHECK-DAG: #[[$WP_MMA:.*]] = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+  // CHECK-LABEL: tt.func public @hoist_warp_predicate_layout_conversions
+  // CHECK-SAME: (%[[PRED_ARG:.*]]: tensor<128xi1, #[[$WP_BLOCKED_ROW]]>, %[[ACC_ARG:.*]]: tensor<128x128xf32, #[[$WP_BLOCKED_ACC]]>, %[[ROW_ARG:.*]]: tensor<128xf32, #[[$WP_BLOCKED_ROW]]>)
+  tt.func public @hoist_warp_predicate_layout_conversions(
+      %predicate: tensor<128xi1, #wp_blocked_row>,
+      %acc: tensor<128x128xf32, #wp_blocked_acc>,
+      %row: tensor<128xf32, #wp_blocked_row>)
+      -> (tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>) {
+    // CHECK-DAG: %[[PREDICATE:.*]] = ttg.convert_layout %[[PRED_ARG]] : tensor<128xi1, #[[$WP_BLOCKED_ROW]]> -> tensor<128xi1, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>
+    // CHECK-DAG: %[[ACC_CAPTURE:.*]] = ttg.convert_layout %[[ACC_ARG]] : tensor<128x128xf32, #[[$WP_BLOCKED_ACC]]> -> tensor<128x128xf32, #[[$WP_MMA]]>
+    // CHECK-DAG: %[[ROW_CAPTURE:.*]] = ttg.convert_layout %[[ROW_ARG]] : tensor<128xf32, #[[$WP_BLOCKED_ROW]]> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>
+    // CHECK-DAG: %[[ACC_INIT:.*]] = ttg.convert_layout %[[ACC_ARG]] : tensor<128x128xf32, #[[$WP_BLOCKED_ACC]]> -> tensor<128x128xf32, #[[$WP_MMA]]>
+    // CHECK-DAG: %[[ROW_INIT:.*]] = ttg.convert_layout %[[ROW_ARG]] : tensor<128xf32, #[[$WP_BLOCKED_ROW]]> -> tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>
+    // CHECK: %[[RESULT:.*]]:2 = ttg.warp_predicate %[[PREDICATE]](%[[ACC_INIT]], %[[ROW_INIT]]) {
+    %result:2 = ttg.warp_predicate %predicate (%acc, %row) {
+      %acc_wave = ttg.convert_layout %acc : tensor<128x128xf32, #wp_blocked_acc> -> tensor<128x128xf32, #wp_mma>
+      %acc_next = arith.addf %acc_wave, %acc_wave : tensor<128x128xf32, #wp_mma>
+      %acc_old = ttg.convert_layout %acc_next : tensor<128x128xf32, #wp_mma> -> tensor<128x128xf32, #wp_blocked_acc>
+      %row_wave = ttg.convert_layout %row : tensor<128xf32, #wp_blocked_row> -> tensor<128xf32, #wp_mma_row>
+      %row_next = arith.addf %row_wave, %row_wave : tensor<128xf32, #wp_mma_row>
+      %row_old = ttg.convert_layout %row_next : tensor<128xf32, #wp_mma_row> -> tensor<128xf32, #wp_blocked_row>
+      // CHECK-NOT: ttg.convert_layout
+      // CHECK: %[[ACC_NEXT:.*]] = arith.addf %[[ACC_CAPTURE]], %[[ACC_CAPTURE]] : tensor<128x128xf32, #[[$WP_MMA]]>
+      // CHECK: %[[ROW_NEXT:.*]] = arith.addf %[[ROW_CAPTURE]], %[[ROW_CAPTURE]] : tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>
+      // CHECK: ttg.predicate_yield %[[ACC_NEXT]], %[[ROW_NEXT]] : tensor<128x128xf32, #[[$WP_MMA]]>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>
+      ttg.predicate_yield %acc_old, %row_old : tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>
+    } : (tensor<128xi1, #wp_blocked_row>, tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>) -> (tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>)
+    // CHECK: } : (tensor<128xi1, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>, tensor<128x128xf32, #[[$WP_MMA]]>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>) -> (tensor<128x128xf32, #[[$WP_MMA]]>, tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>>)
+    // CHECK-NOT: ttg.convert_layout %[[RESULT]]#
+    // CHECK: %[[SECOND_PREDICATE:.*]] = ttg.convert_layout %[[PRED_ARG]]
+    // CHECK: %[[SECOND:.*]]:2 = ttg.warp_predicate %[[SECOND_PREDICATE]](%[[RESULT]]#0, %[[RESULT]]#1) {
+    %second:2 = ttg.warp_predicate %predicate (%result#0, %result#1) {
+      %acc_wave = ttg.convert_layout %result#0 : tensor<128x128xf32, #wp_blocked_acc> -> tensor<128x128xf32, #wp_mma>
+      %acc_next = arith.addf %acc_wave, %acc_wave : tensor<128x128xf32, #wp_mma>
+      %acc_old = ttg.convert_layout %acc_next : tensor<128x128xf32, #wp_mma> -> tensor<128x128xf32, #wp_blocked_acc>
+      %row_wave = ttg.convert_layout %result#1 : tensor<128xf32, #wp_blocked_row> -> tensor<128xf32, #wp_mma_row>
+      %row_next = arith.addf %row_wave, %row_wave : tensor<128xf32, #wp_mma_row>
+      %row_old = ttg.convert_layout %row_next : tensor<128xf32, #wp_mma_row> -> tensor<128xf32, #wp_blocked_row>
+      // CHECK-NOT: ttg.convert_layout
+      // CHECK: %[[SECOND_ACC:.*]] = arith.addf %[[RESULT]]#0, %[[RESULT]]#0
+      // CHECK: %[[SECOND_ROW:.*]] = arith.addf %[[RESULT]]#1, %[[RESULT]]#1
+      // CHECK: ttg.predicate_yield %[[SECOND_ACC]], %[[SECOND_ROW]]
+      ttg.predicate_yield %acc_old, %row_old : tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>
+    } : (tensor<128xi1, #wp_blocked_row>, tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>) -> (tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>)
+    // CHECK: }
+    // CHECK-DAG: %[[ACC_RESULT:.*]] = ttg.convert_layout %[[SECOND]]#0 : tensor<128x128xf32, #[[$WP_MMA]]> -> tensor<128x128xf32, #[[$WP_BLOCKED_ACC]]>
+    // CHECK-DAG: %[[ROW_RESULT:.*]] = ttg.convert_layout %[[SECOND]]#1 : tensor<128xf32, #ttg.slice<{dim = 1, parent = #[[$WP_MMA]]}>> -> tensor<128xf32, #[[$WP_BLOCKED_ROW]]>
+    // CHECK: tt.return %[[ACC_RESULT]], %[[ROW_RESULT]]
+    tt.return %second#0, %second#1 : tensor<128x128xf32, #wp_blocked_acc>, tensor<128xf32, #wp_blocked_row>
+  }
+}
+
+// -----
+// A sibling that computes directly in the old layout must consume a restored
+// value instead of being optimistically retyped with the first region. Its
+// initial ownership is likewise a provisional TLX layout-propagation state.
+
+#mixed_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [2, 2], order = [1, 0]}>
+#mixed_row = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#mixed_mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [4, 1], instrShape = [32, 32, 16], isTransposed = true}>
+
+module attributes {tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tt.func public @preserve_old_layout_sibling
+  tt.func public @preserve_old_layout_sibling(
+      %predicate: tensor<128xi1, #mixed_row>,
+      %acc: tensor<128x128xf32, #mixed_blocked>)
+      -> tensor<128x128xf32, #mixed_blocked> {
+    // CHECK: %[[FIRST:.*]] = ttg.warp_predicate {{.*}}(%{{.*}}) {
+    %first = ttg.warp_predicate %predicate (%acc) {
+      %wave = ttg.convert_layout %acc : tensor<128x128xf32, #mixed_blocked> -> tensor<128x128xf32, #mixed_mma>
+      %next = arith.addf %wave, %wave : tensor<128x128xf32, #mixed_mma>
+      %old = ttg.convert_layout %next : tensor<128x128xf32, #mixed_mma> -> tensor<128x128xf32, #mixed_blocked>
+      ttg.predicate_yield %old : tensor<128x128xf32, #mixed_blocked>
+    } : (tensor<128xi1, #mixed_row>, tensor<128x128xf32, #mixed_blocked>) -> tensor<128x128xf32, #mixed_blocked>
+    // CHECK: %[[RESTORED:.*]] = ttg.convert_layout %[[FIRST]] : tensor<128x128xf32, #{{.*}}> -> tensor<128x128xf32, #{{.*}}>
+    // CHECK: %[[SECOND:.*]] = ttg.warp_predicate {{.*}}(%[[RESTORED]]) {
+    %second = ttg.warp_predicate %predicate (%first) {
+      %next = arith.addf %first, %first : tensor<128x128xf32, #mixed_blocked>
+      ttg.predicate_yield %next : tensor<128x128xf32, #mixed_blocked>
+    } : (tensor<128xi1, #mixed_row>, tensor<128x128xf32, #mixed_blocked>) -> tensor<128x128xf32, #mixed_blocked>
+    // CHECK: tt.return %[[SECOND]]
+    tt.return %second : tensor<128x128xf32, #mixed_blocked>
+  }
+}
+
+// -----
 
 // Test that a standalone packed i8 TMEM copy resolves its dummy destination
 // to the scales layout without a downstream require_layout or MMA consumer.

--- a/test/TLX/propagate-layout.mlir
+++ b/test/TLX/propagate-layout.mlir
@@ -105,6 +105,43 @@ module attributes {tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-wa
 }
 
 // -----
+// Carried rows with identical lane ownership may use different register
+// ordering. The shared predicate can select either ordering because EXEC is
+// controlled per lane, not per register.
+
+#register_order_old = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#register_order_a = #ttg.linear<{register = [[1], [2]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
+#register_order_b = #ttg.linear<{register = [[2], [1]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
+
+module attributes {tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-DAG: #[[$REGISTER_ORDER_A:.*]] = #ttg.linear<{register = {{\[\[}}1], [2{{\]\]}}
+  // CHECK-DAG: #[[$REGISTER_ORDER_B:.*]] = #ttg.linear<{register = {{\[\[}}2], [1{{\]\]}}
+  // CHECK-LABEL: tt.func public @allow_register_reordered_carried_rows
+  tt.func public @allow_register_reordered_carried_rows(
+      %predicate: tensor<256xi1, #register_order_old>,
+      %lhs: tensor<256xf32, #register_order_old>,
+      %rhs: tensor<256xf32, #register_order_old>)
+      -> (tensor<256xf32, #register_order_old>, tensor<256xf32, #register_order_old>) {
+    // CHECK-DAG: %[[PREDICATE:.*]] = ttg.convert_layout %{{.*}} : tensor<256xi1, #{{.*}}> -> tensor<256xi1, #[[$REGISTER_ORDER_A]]>
+    // CHECK: %[[RESULT:.*]]:2 = ttg.warp_predicate %[[PREDICATE]](%{{.*}}, %{{.*}}) {
+    %result:2 = ttg.warp_predicate %predicate (%lhs, %rhs) {
+      %lhs_native = ttg.convert_layout %lhs : tensor<256xf32, #register_order_old> -> tensor<256xf32, #register_order_a>
+      %lhs_next = arith.addf %lhs_native, %lhs_native : tensor<256xf32, #register_order_a>
+      %lhs_old = ttg.convert_layout %lhs_next : tensor<256xf32, #register_order_a> -> tensor<256xf32, #register_order_old>
+      %rhs_native = ttg.convert_layout %rhs : tensor<256xf32, #register_order_old> -> tensor<256xf32, #register_order_b>
+      %rhs_next = arith.addf %rhs_native, %rhs_native : tensor<256xf32, #register_order_b>
+      %rhs_old = ttg.convert_layout %rhs_next : tensor<256xf32, #register_order_b> -> tensor<256xf32, #register_order_old>
+      // CHECK: ttg.predicate_yield %{{.*}}, %{{.*}} : tensor<256xf32, #[[$REGISTER_ORDER_A]]>, tensor<256xf32, #[[$REGISTER_ORDER_B]]>
+      ttg.predicate_yield %lhs_old, %rhs_old : tensor<256xf32, #register_order_old>, tensor<256xf32, #register_order_old>
+    } : (tensor<256xi1, #register_order_old>, tensor<256xf32, #register_order_old>, tensor<256xf32, #register_order_old>) -> (tensor<256xf32, #register_order_old>, tensor<256xf32, #register_order_old>)
+    // CHECK: } : (tensor<256xi1, #[[$REGISTER_ORDER_A]]>, tensor<256xf32, #[[$REGISTER_ORDER_A]]>, tensor<256xf32, #[[$REGISTER_ORDER_B]]>) -> (tensor<256xf32, #[[$REGISTER_ORDER_A]]>, tensor<256xf32, #[[$REGISTER_ORDER_B]]>)
+    // CHECK-DAG: ttg.convert_layout %[[RESULT]]#0 : tensor<256xf32, #[[$REGISTER_ORDER_A]]> -> tensor<256xf32, #{{.*}}>
+    // CHECK-DAG: ttg.convert_layout %[[RESULT]]#1 : tensor<256xf32, #[[$REGISTER_ORDER_B]]> -> tensor<256xf32, #{{.*}}>
+    tt.return %result#0, %result#1 : tensor<256xf32, #register_order_old>, tensor<256xf32, #register_order_old>
+  }
+}
+
+// -----
 // A sibling that computes directly in the old layout must consume a restored
 // value instead of being optimistically retyped with the first region. Its
 // initial ownership is likewise a provisional TLX layout-propagation state.

--- a/test/TLX/remove-layout-budget-convert.mlir
+++ b/test/TLX/remove-layout-budget-convert.mlir
@@ -43,3 +43,75 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// A predicated accumulator update is a per-result layout carrier. Keep the
+// MFMA layout selected by the surrounding dot chain instead of inserting an
+// MFMA -> blocked -> MFMA redistribution around the EXEC-restricted region.
+// The module marker identifies the deliberately provisional predicate/carried
+// ownership before layout-conversion cleanup selects the MFMA layout.
+
+#wp_mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#wp_dot0 = #ttg.dot_op<{opIdx = 0, parent = #wp_mma, kWidth = 4}>
+#wp_dot1 = #ttg.dot_op<{opIdx = 1, parent = #wp_mma, kWidth = 4}>
+#wp_blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#wp_row = #ttg.slice<{dim = 1, parent = #wp_mma}>
+
+module attributes {tlx.has_tlx_ops = true, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-DAG: #[[$WP_MMA:.*]] = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
+  // CHECK-LABEL: tt.func @warp_predicate_keeps_mfma_accumulator
+  tt.func @warp_predicate_keeps_mfma_accumulator(
+      %lhs: tensor<32x32xf16, #wp_dot0>,
+      %rhs: tensor<32x32xf16, #wp_dot1>,
+      %acc: tensor<32x32xf32, #wp_mma>,
+      %predicate: tensor<32xi1, #wp_row>)
+      -> tensor<32x32xf32, #wp_mma> {
+    %dot0 = tt.dot %lhs, %rhs, %acc : tensor<32x32xf16, #wp_dot0> * tensor<32x32xf16, #wp_dot1> -> tensor<32x32xf32, #wp_mma>
+    %blocked = ttg.convert_layout %dot0 : tensor<32x32xf32, #wp_mma> -> tensor<32x32xf32, #wp_blocked>
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: %[[PREDICATED:.*]] = ttg.warp_predicate %{{.*}}(%[[DOT0:.*]]) {
+    %predicated = ttg.warp_predicate %predicate (%blocked) {
+      // CHECK: %[[SCALED:.*]] = arith.addf %[[DOT0]], %[[DOT0]] : tensor<32x32xf32, #[[$WP_MMA]]>
+      %scaled = arith.addf %blocked, %blocked : tensor<32x32xf32, #wp_blocked>
+      // CHECK: ttg.predicate_yield %[[SCALED]] : tensor<32x32xf32, #[[$WP_MMA]]>
+      ttg.predicate_yield %scaled : tensor<32x32xf32, #wp_blocked>
+    } : (tensor<32xi1, #wp_row>, tensor<32x32xf32, #wp_blocked>) -> tensor<32x32xf32, #wp_blocked>
+    %mma = ttg.convert_layout %predicated : tensor<32x32xf32, #wp_blocked> -> tensor<32x32xf32, #wp_mma>
+    // CHECK: %[[DOT1:.*]] = tt.dot %{{.*}}, %{{.*}}, %[[PREDICATED]]
+    %dot1 = tt.dot %lhs, %rhs, %mma : tensor<32x32xf16, #wp_dot0> * tensor<32x32xf16, #wp_dot1> -> tensor<32x32xf32, #wp_mma>
+    tt.return %dot1 : tensor<32x32xf32, #wp_mma>
+  }
+}
+
+// -----
+
+// A hard register-layout pin may be nested under a deferred-verification
+// wrapper.  It must win conflict resolution even when the producer's linear
+// layout has a higher vectorization score.  Otherwise the FP16 reduction is
+// silently retagged and changes from the MFMA-local reduction tree to a much
+// longer per-thread chain.
+
+#pin_mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [8, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#pin_user = #tlx.user_layout<#pin_mma>
+#pin = #tlx.no_verify_layout<#pin_user>
+#pin_row = #ttg.slice<{dim = 1, parent = #pin}>
+#pin_linear = #ttg.linear<{register = [[0, 32], [0, 16], [0, 8], [0, 1], [0, 2]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4]], warp = [[32, 0], [64, 0], [128, 0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: tt.func @nested_pin_keeps_mfma_reduction
+  tt.func @nested_pin_keeps_mfma_reduction(
+      %values: tensor<256x64xf16, #pin_linear>)
+      -> tensor<256xf16, #pin_row> {
+    // CHECK: %[[PINNED:.*]] = ttg.convert_layout %{{.*}} : tensor<256x64xf16, #{{.*}}> -> tensor<256x64xf16, #tlx.no_verify_layout<{{.*}}>>
+    %pinned = ttg.convert_layout %values : tensor<256x64xf16, #pin_linear> -> tensor<256x64xf16, #pin>
+    // CHECK: %[[SUM:.*]] = "tt.reduce"(%[[PINNED]])
+    // CHECK: }) : (tensor<256x64xf16, #tlx.no_verify_layout<{{.*}}>>) -> tensor<256xf16, #ttg.slice<{{.*}}>>
+    %sum = "tt.reduce"(%pinned) <{axis = 1 : i32, reduction_ordering = "unordered"}> ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %next = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %next : f16
+    }) : (tensor<256x64xf16, #pin>) -> tensor<256xf16, #pin_row>
+    tt.return %sum : tensor<256xf16, #pin_row>
+  }
+}

--- a/test/TLX/tlx-verifier.mlir
+++ b/test/TLX/tlx-verifier.mlir
@@ -84,6 +84,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // A private helper argument may acquire an encoding when TLX Fixup
+  // specializes the helper ABI from a concrete call site.
+  tt.func private @release_layout_defers_private_helper_source(
+      %arg: tensor<128xf32>) -> tensor<128xf32> {
+    %result = tlx.release_layout %arg : tensor<128xf32> -> tensor<128xf32>
+    tt.return %result : tensor<128xf32>
+  }
+}
+
+// -----
+
 #release_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #release_user_shared = #tlx.user_layout<#release_shared>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -742,3 +742,199 @@ tt.func public @padded_subview_unsupported_size(%arg0: !ttg.memdesc<2x32x32xf32,
 // expected-error @below {{alignment must be specified outside of the linear layout braces}}
 #shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [1, 0], [2, 0]], block = [], alignment = 16}>
 !alignment_in_layout = !ttg.memdesc<4x4xf32, #shared, #ttg.shared_memory>
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_yield_count(
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked> {
+    // expected-error @+1 {{expected equal numbers of inits, results, and yields, but got 1, 1, and 0}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      ttg.predicate_yield
+    } : (tensor<64xi1, #blocked>, tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return %result : tensor<64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_block_argument(
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked> {
+    // expected-error @+1 {{region block must not have arguments}}
+    %result = "ttg.warp_predicate"(%predicate, %init) ({
+    ^bb0(%arg: tensor<64xf32, #blocked>):
+      "ttg.predicate_yield"(%arg) : (tensor<64xf32, #blocked>) -> ()
+    }) : (tensor<64xi1, #blocked>, tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return %result : tensor<64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_cta_barrier(
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked> {
+    // expected-error @+1 {{region may not contain CTA barriers}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      ttg.barrier none
+      ttg.predicate_yield %init : tensor<64xf32, #blocked>
+    } : (tensor<64xi1, #blocked>, tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return %result : tensor<64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_nested_region(
+      %condition: i1,
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked> {
+    // expected-error @+1 {{region may not contain nested dynamic control flow}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      scf.if %condition {
+        scf.yield
+      }
+      ttg.predicate_yield %init : tensor<64xf32, #blocked>
+    } : (tensor<64xi1, #blocked>, tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return %result : tensor<64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_reduce_region(
+      %predicate: tensor<256xi1, #blocked>,
+      %init: tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked> {
+    // expected-error @+1 {{region reduction axis must be warp-local}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      %sum = "tt.reduce"(%init) <{axis = 0 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %next = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %next : f32
+      }) : (tensor<256xf32, #blocked>) -> f32
+      ttg.predicate_yield %init : tensor<256xf32, #blocked>
+    } : (tensor<256xi1, #blocked>, tensor<256xf32, #blocked>) -> tensor<256xf32, #blocked>
+    tt.return %result : tensor<256xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
+#row = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_requires_uniform_wave_for_local_reduce(
+      %predicate: i1,
+      %init: tensor<4x64xf32, #blocked>) -> tensor<4x64xf32, #blocked> {
+    // expected-error @+1 {{cross-lane operation tt.reduce requires a wave-uniform predicate}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      %sum = "tt.reduce"(%init) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %next = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %next : f32
+      }) : (tensor<4x64xf32, #blocked>) -> tensor<4xf32, #row>
+      ttg.predicate_yield %init : tensor<4x64xf32, #blocked>
+    } : (i1, tensor<4x64xf32, #blocked>) -> tensor<4x64xf32, #blocked>
+    tt.return %result : tensor<4x64xf32, #blocked>
+  }
+}
+
+// -----
+
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#dot0 = #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>
+#dot1 = #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx950"} {
+  tt.func @warp_predicate_requires_uniform_wave_for_dot(
+      %predicate: i1,
+      %lhs: tensor<32x32xf16, #dot0>,
+      %rhs: tensor<32x32xf16, #dot1>,
+      %acc: tensor<32x32xf32, #mma>) -> tensor<32x32xf32, #mma> {
+    // expected-error @+1 {{cross-lane operation tt.dot requires a wave-uniform predicate}}
+    %result = ttg.warp_predicate %predicate (%acc) {
+      %dot = tt.dot %lhs, %rhs, %acc : tensor<32x32xf16, #dot0> * tensor<32x32xf16, #dot1> -> tensor<32x32xf32, #mma>
+      ttg.predicate_yield %dot : tensor<32x32xf32, #mma>
+    } : (i1, tensor<32x32xf32, #mma>) -> tensor<32x32xf32, #mma>
+    tt.return %result : tensor<32x32xf32, #mma>
+  }
+}
+
+// -----
+
+#row = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 1], order = [1, 0]}>
+#column = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_requires_uniform_wave_for_layout_shuffle(
+      %predicate: i1,
+      %init: tensor<64x64xf32, #row>) -> tensor<64x64xf32, #row> {
+    // expected-error @+1 {{cross-lane operation ttg.convert_layout requires a wave-uniform predicate}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      %local = arith.addf %init, %init : tensor<64x64xf32, #row>
+      %shuffled = ttg.convert_layout %local : tensor<64x64xf32, #row> -> tensor<64x64xf32, #column>
+      ttg.predicate_yield %init : tensor<64x64xf32, #row>
+    } : (i1, tensor<64x64xf32, #row>) -> tensor<64x64xf32, #row>
+    tt.return %result : tensor<64x64xf32, #row>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_reduce_axis_out_of_bounds(
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked> {
+    %result = ttg.warp_predicate %predicate (%init) {
+      // expected-error @+1 {{axis out of bounds for operand rank 1}}
+      %sum = "tt.reduce"(%init) <{axis = 1 : i32}> ({
+      ^bb0(%lhs: f32, %rhs: f32):
+        %next = arith.addf %lhs, %rhs : f32
+        tt.reduce.return %next : f32
+      }) : (tensor<64xf32, #blocked>) -> f32
+      ttg.predicate_yield %init : tensor<64xf32, #blocked>
+    } : (tensor<64xi1, #blocked>, tensor<64xf32, #blocked>) -> tensor<64xf32, #blocked>
+    tt.return %result : tensor<64xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_shape_mismatch(
+      %predicate: tensor<64xi1, #blocked>,
+      %init: tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked> {
+    // expected-error @+1 {{predicate shape must be a leading shape of every carried tensor}}
+    %result = ttg.warp_predicate %predicate (%init) {
+      ttg.predicate_yield %init : tensor<128xf32, #blocked>
+    } : (tensor<64xi1, #blocked>, tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return %result : tensor<128xf32, #blocked>
+  }
+}
+
+// -----
+
+#predicate = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16], [32]], warp = [], block = []}>
+#carried = #ttg.linear<{register = [[1]], lane = [[2], [4], [8], [16], [32], [0]], warp = [], block = []}>
+module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_predicate_lane_ownership_mismatch(
+      %predicate_value: tensor<64xi1, #predicate>,
+      %init: tensor<64xf32, #carried>) -> tensor<64xf32, #carried> {
+    // expected-error @+1 {{predicate and carried tensors must have matching lane ownership}}
+    %result = ttg.warp_predicate %predicate_value (%init) {
+      ttg.predicate_yield %init : tensor<64xf32, #carried>
+    } : (tensor<64xi1, #predicate>, tensor<64xf32, #carried>) -> tensor<64xf32, #carried>
+    tt.return %result : tensor<64xf32, #carried>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -4,6 +4,7 @@
 #include "Utility.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
@@ -16,6 +17,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 namespace mlir::triton {
@@ -172,6 +174,209 @@ static LogicalResult lowerWarpSpecialize(LLVM::LLVMFuncOp func,
       totalNumWarpsAttr.getInt(), targetInfo, callbacks, 0);
 }
 
+// Lower a `ttg.warp_predicate` after its body has been converted to LLVM. The
+// per-thread condition becomes divergent control flow; AMD lowers it to an
+// EXEC-mask restriction and skips the body for waves with no active lane.
+static LogicalResult lowerOneWarpPredicate(WarpPredicateOp op) {
+  if (op.getRegion().empty() || op.getRegion().front().getNumArguments() != 0)
+    return op.emitError("expected a nonempty capture-only body region");
+
+  // Conversion of the body to LLVM may introduce CFG blocks (for example,
+  // wave-local reductions and predicated dot operations).  The entry block
+  // remains capture-only, while the predicate yield can be in any exit block.
+  // Locate that unique terminator before moving the whole region into the
+  // surrounding function CFG.
+  PredicateYieldOp yield;
+  for (Block &block : op.getRegion()) {
+    auto candidate = dyn_cast<PredicateYieldOp>(block.getTerminator());
+    if (!candidate)
+      continue;
+    if (yield)
+      return op.emitError("expected a unique ttg.predicate_yield terminator");
+    yield = candidate;
+  }
+  if (!yield)
+    return op.emitError("expected ttg.predicate_yield terminator");
+  if (op.getInits().size() != op.getNumResults() ||
+      yield.getNumOperands() != op.getNumResults())
+    return op.emitError("expected equal numbers of inits, results, and yields");
+
+  auto predicateType = dyn_cast<RankedTensorType>(op.getPredicate().getType());
+  if (predicateType) {
+    auto predicateEncoding =
+        dyn_cast_or_null<DistributedEncodingTrait>(predicateType.getEncoding());
+    if (!predicateEncoding)
+      return op.emitError("expected a distributed tensor predicate");
+    for (Value init : op.getInits()) {
+      auto initType = dyn_cast<RankedTensorType>(init.getType());
+      if (!initType)
+        continue;
+      auto initEncoding =
+          dyn_cast_or_null<DistributedEncodingTrait>(initType.getEncoding());
+      if (!initEncoding || initType.getRank() < predicateType.getRank() ||
+          !llvm::equal(predicateType.getShape(),
+                       initType.getShape().take_front(predicateType.getRank())))
+        return op.emitError(
+            "predicate shape must be a leading shape of every carried tensor");
+
+      Attribute projectedEncoding = initEncoding;
+      for (int rank = initType.getRank(); rank > predicateType.getRank();
+           --rank)
+        projectedEncoding = SliceEncodingAttr::get(
+            op.getContext(), rank - 1,
+            cast<DistributedEncodingTrait>(projectedEncoding));
+      auto projectedType = RankedTensorType::get(predicateType.getShape(),
+                                                 predicateType.getElementType(),
+                                                 projectedEncoding);
+      if (!isLayoutEquivalentIgnoringRegisterOrder(
+              toLinearLayout(projectedType), toLinearLayout(predicateType)))
+        return op.emitError(
+            "predicate and carried tensors must have matching lane ownership");
+    }
+  } else if (!op.getPredicate().getType().isInteger(1)) {
+    return op.emitError("expected an i1 or distributed tensor predicate");
+  }
+
+  // Reductions and layout conversions can introduce synchronization after the
+  // TTGIR verifier has run. Reject any resulting CTA-wide barrier before
+  // restricting EXEC, otherwise inactive waves could deadlock active ones.
+  WalkResult barrier = op.getRegion().walk([&](Operation *nested) {
+    if (isa<ROCDL::BarrierOp, ROCDL::SBarrierOp>(nested))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  if (barrier.wasInterrupted())
+    return op.emitError("lowered body may not contain CTA barriers");
+
+  Location loc = op.getLoc();
+  IRRewriter rewriter(op->getContext());
+  rewriter.setInsertionPoint(op);
+
+  auto asLLVM = [](Value value) -> Value {
+    if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>())
+      if (cast.getNumOperands() == 1 && cast.getNumResults() == 1)
+        return cast.getOperand(0);
+    return value;
+  };
+
+  Value lanePredicate;
+  Value predicate = asLLVM(op.getPredicate());
+  if (predicateType) {
+    SmallVector<Value> predicateElements =
+        unpackLLElements(loc, predicate, rewriter);
+    if (predicateElements.empty())
+      return op.emitError("empty predicate");
+    for (Value element : predicateElements) {
+      lanePredicate = lanePredicate ? LLVM::OrOp::create(rewriter, loc,
+                                                         lanePredicate, element)
+                                          .getResult()
+                                    : element;
+    }
+  } else {
+    if (!predicate.getType().isInteger(1))
+      return op.emitError("converted scalar predicate must have i1 type");
+    lanePredicate = predicate;
+  }
+
+  SmallVector<Value> initStructs;
+  SmallVector<Value> yieldStructs;
+  SmallVector<Type> resultTypes;
+  for (Value init : op.getInits())
+    initStructs.push_back(asLLVM(init));
+  for (Value yielded : yield.getValues()) {
+    Value value = asLLVM(yielded);
+    yieldStructs.push_back(value);
+    resultTypes.push_back(value.getType());
+  }
+  for (auto [init, yielded] : llvm::zip(initStructs, yieldStructs))
+    if (init.getType() != yielded.getType())
+      return op.emitError(
+          "converted init and yield values must have identical types");
+
+  // Validate every result bridge before changing the CFG. Conversion failure
+  // should leave a diagnosable source operation rather than partially inlined
+  // blocks or an invalid unrealized cast.
+  for (auto [index, result] : llvm::enumerate(op.getResults())) {
+    for (OpOperand &use : result.getUses()) {
+      if (auto cast = dyn_cast<UnrealizedConversionCastOp>(use.getOwner())) {
+        if (cast.getNumOperands() != 1 || cast.getNumResults() != 1 ||
+            cast.getResult(0).getType() != resultTypes[index])
+          return op.emitError("malformed LLVM result bridge");
+        continue;
+      }
+      // Non-tensor values are already legal LLVM dialect operands, so dialect
+      // conversion leaves their users connected directly to the source result
+      // instead of inserting an unrealized conversion cast.
+      if (!isa<RankedTensorType>(result.getType()) &&
+          result.getType() == resultTypes[index])
+        continue;
+      if (!isa<WarpPredicateOp, PredicateYieldOp>(use.getOwner()))
+        return op.emitError("unexpected use of result");
+    }
+  }
+
+  Block *currentBlock = rewriter.getInsertionBlock();
+  Block *mergeBlock = rewriter.splitBlock(currentBlock, Block::iterator(op));
+  SmallVector<Value> mergeArguments;
+  for (Type type : resultTypes)
+    mergeArguments.push_back(mergeBlock->addArgument(type, loc));
+
+  Block *bodyBlock = &op.getRegion().front();
+  rewriter.inlineRegionBefore(op.getRegion(), mergeBlock);
+
+  rewriter.setInsertionPoint(yield);
+  cf::BranchOp::create(rewriter, loc, mergeBlock, yieldStructs);
+  rewriter.eraseOp(yield);
+
+  for (auto [result, argument] : llvm::zip(op.getResults(), mergeArguments)) {
+    for (OpOperand &use : llvm::make_early_inc_range(result.getUses())) {
+      auto cast = dyn_cast<UnrealizedConversionCastOp>(use.getOwner());
+      if (cast) {
+        rewriter.replaceAllUsesWith(cast.getResult(0), argument);
+        rewriter.eraseOp(cast);
+        continue;
+      }
+
+      if (!isa<RankedTensorType>(result.getType()) &&
+          result.getType() == argument.getType()) {
+        use.set(argument);
+        continue;
+      }
+
+      // Layout cleanup can feed one warp_predicate result directly into a
+      // sibling warp_predicate, while a nested predicate can feed the
+      // enclosing predicate_yield. Bridge the already lowered LLVM merge
+      // value back to that temporary tensor type; lowering the consumer
+      // immediately unwraps this cast through asLLVM().
+      if (isa<WarpPredicateOp, PredicateYieldOp>(use.getOwner())) {
+        rewriter.setInsertionPoint(use.getOwner());
+        Value bridge = UnrealizedConversionCastOp::create(
+                           rewriter, loc, result.getType(), argument)
+                           .getResult(0);
+        use.set(bridge);
+        continue;
+      }
+
+      return op.emitError("unexpected use of result");
+    }
+  }
+  rewriter.eraseOp(op);
+
+  rewriter.setInsertionPointToEnd(currentBlock);
+  cf::CondBranchOp::create(rewriter, loc, lanePredicate, bodyBlock,
+                           ValueRange{}, mergeBlock, ValueRange(initStructs));
+  return success();
+}
+
+static LogicalResult lowerWarpPredicateOps(ModuleOp module) {
+  SmallVector<WarpPredicateOp> ops;
+  module.walk([&](WarpPredicateOp op) { ops.push_back(op); });
+  for (WarpPredicateOp op : ops)
+    if (failed(lowerOneWarpPredicate(op)))
+      return failure();
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
@@ -187,8 +392,16 @@ struct TritonAMDGPUConvertWarpSpecializeToLLVM
     this->gfxArch = gfxArch;
   }
 
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<cf::ControlFlowDialect, LLVM::LLVMDialect,
+                    ROCDL::ROCDLDialect>();
+  }
+
   void runOnOperation() override {
     ModuleOp mod = getOperation();
+
+    if (failed(lowerWarpPredicateOps(mod)))
+      return signalPassFailure();
 
     SmallVector<Operation *> wsOps;
     mod.walk([&](Operation *op) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -27,6 +27,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonInstrument/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -209,8 +210,49 @@ public:
     addLegalOp<triton::gpu::WarpYieldOp>();
     addLegalOp<triton::gpu::WarpSpecializePartitionsOp>();
     addLegalOp<triton::gpu::WarpReturnOp>();
+    // Predicated regions are lowered after their bodies have been converted
+    // to LLVM by TritonAMDGPUConvertWarpSpecializeToLLVM.
+    addLegalOp<triton::gpu::WarpPredicateOp>();
+    addLegalOp<triton::gpu::PredicateYieldOp>();
   }
 };
+
+// TLX layout propagation is allowed to create captured or yielded
+// convert_layout operations temporarily while it reconciles a predicate
+// body's native layout with its carried values. By LLVM lowering, every such
+// cross-lane conversion must have moved outside a non-wave-uniform region.
+// Otherwise its shuffle would execute after EXEC is restricted and could read
+// inactive lanes.
+static LogicalResult validateFinalWarpPredicateLayouts(ModuleOp mod) {
+  WalkResult result = mod.walk([&](triton::gpu::WarpPredicateOp predicateOp) {
+    if (predicateOp.getWaveUniform().value_or(false))
+      return WalkResult::advance();
+
+    triton::gpu::ConvertLayoutOp unsafeConvert;
+    predicateOp.getRegion().walk([&](Operation *nested) {
+      if (nested != predicateOp.getOperation() &&
+          isa<triton::gpu::WarpPredicateOp>(nested))
+        return WalkResult::skip();
+      auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(nested);
+      if (!convert)
+        return WalkResult::advance();
+      auto srcType = cast<RankedTensorType>(convert.getSrc().getType());
+      auto dstType = cast<RankedTensorType>(convert.getType());
+      if (triton::gpu::toLinearLayout(srcType) ==
+          triton::gpu::toLinearLayout(dstType))
+        return WalkResult::advance();
+      unsafeConvert = convert;
+      return WalkResult::interrupt();
+    });
+
+    if (!unsafeConvert)
+      return WalkResult::advance();
+    predicateOp.emitError(
+        "non-wave-uniform body still contains cross-lane layout conversion");
+    return WalkResult::interrupt();
+  });
+  return failure(result.wasInterrupted());
+}
 
 struct ConvertTritonAMDGPUToLLVM
     : public triton::impl::ConvertTritonAMDGPUToLLVMBase<
@@ -236,6 +278,9 @@ struct ConvertTritonAMDGPUToLLVM
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
+
+    if (failed(validateFinalWarpPredicateLayouts(mod)))
+      return signalPassFailure();
 
     AMD::TargetInfo targetInfo(this->gfxArch.getValue());
     if (targetInfo.getISAFamily() == triton::amdgpu::ISAFamily::Unknown) {

--- a/third_party/tlx/dialect/include/IR/TLXOps.td
+++ b/third_party/tlx/dialect/include/IR/TLXOps.td
@@ -289,8 +289,10 @@ def TLX_ReleaseLayoutOp : TLX_Op<"release_layout",
   let description = [{
     `tlx.release_layout` marks the boundary after which tensor layout
     propagation may choose an encoding independently of the source. The
-    source must have an explicit layout; the result may be unencoded in TTIR
-    or carry the layout selected during TTGIR propagation.
+    source normally has an explicit layout. An encoding-free private helper
+    argument or call result is also accepted because TLX Fixup may specialize
+    that helper ABI from a concrete call site. The result may be unencoded in
+    TTIR or carry the layout selected during TTGIR propagation.
   }];
 
   let arguments = (ins TT_Tensor:$src);

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -47,7 +47,7 @@ static Attribute unwrapTlxLayoutWrappers(Attribute layout) {
 }
 
 LogicalResult delegateInferredLayout(
-    Attribute srcLayout, Attribute &resultLayout,
+    Attribute srcLayout, Attribute &resultLayout, bool preserveUserPin,
     function_ref<LogicalResult(const triton::DialectInferLayoutInterface *,
                                Attribute, Attribute &)>
         infer) {
@@ -60,10 +60,12 @@ LogicalResult delegateInferredLayout(
   Attribute unwrappedResultLayout;
   if (failed(infer(delegate, unwrappedSrcLayout, unwrappedResultLayout)))
     return failure();
-  // Re-apply only the TLX wrappers the source actually had (user_layout inside,
-  // no_verify outside), so re-inference after resolve-placeholder-layouts --
-  // which strips no_verify from operands -- stays consistent with the op's
-  // stored result type instead of unconditionally re-adding no_verify.
+  // Re-apply only the wrappers that describe the result. Shape-changing view
+  // ops derive a new layout from the pinned source; that derived layout is not
+  // itself a second hard user constraint. Keeping user_layout on both sides of
+  // an explicit require_layout would create two competing anchors and allow a
+  // trivial view conversion to discard the requested destination layout.
+  // Same-shape operations may opt into carrying the pin itself.
   Attribute afterNoVerify = unwrapNoVerifyLayout(srcLayout);
   bool hadUserLayout = unwrapUserLayout(afterNoVerify) != afterNoVerify;
   // no_verify may be the top wrapper (TMEM pin: no_verify<user_layout<L>>) or
@@ -71,7 +73,7 @@ LogicalResult delegateInferredLayout(
   // so the deferred placeholder is not silently downgraded to a plain anchor.
   bool hadNoVerify = hasNoVerifyLayout(srcLayout) ||
                      hasNoVerifyLayout(unwrapUserLayout(srcLayout));
-  if (hadUserLayout)
+  if (preserveUserPin && hadUserLayout)
     unwrappedResultLayout = wrapUserLayout(unwrappedResultLayout);
   if (hadNoVerify)
     unwrappedResultLayout = wrapNoVerifyLayout(unwrappedResultLayout);
@@ -87,7 +89,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
                        ArrayRef<int32_t> order, Attribute &resultEncoding,
                        std::optional<Location> loc) const override {
     return delegateInferredLayout(
-        operandEncoding, resultEncoding,
+        operandEncoding, resultEncoding, /*preserveUserPin=*/false,
         [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
             Attribute &result) {
           return delegate->inferTransOpEncoding(enc, shape, order, result, loc);
@@ -121,8 +123,17 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
         getInferLayoutInterfaceFor(unwrapTlxLayoutWrappers(anchor));
     if (!delegate)
       return failure();
+    // A hard pin on a rank-reduced value is represented as
+    // user_layout<slice<parent>>.  The TritonGPU expand-dims inference expects
+    // SliceEncodingAttr itself at the top level, so pass the effective slice
+    // rather than its TLX wrapper.  For reduction inputs, retain `anchor` so a
+    // user_layout wrapper is preserved on the newly-created slice parent.
+    Attribute inferOperand = anchor;
+    Attribute effectiveAnchor = unwrapTlxLayoutWrappers(anchor);
+    if (isa<triton::gpu::SliceEncodingAttr>(effectiveAnchor))
+      inferOperand = effectiveAnchor;
     Attribute result;
-    if (failed(infer(delegate, anchor, result)))
+    if (failed(infer(delegate, inferOperand, result)))
       return failure();
     if (!deferred) {
       resultEncoding = result;
@@ -190,7 +201,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
                          bool allowReorder,
                          std::optional<Location> loc) const override {
     return delegateInferredLayout(
-        srcEnc, dstEnc,
+        srcEnc, dstEnc, /*preserveUserPin=*/false,
         [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
             Attribute &result) {
           return delegate->inferReshapeOpEncoding(srcShape, enc, dstShape,
@@ -220,7 +231,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
                              ArrayRef<int64_t> shape,
                              std::optional<Location> loc) const override {
     return delegateInferredLayout(
-        srcEnc, dstEnc,
+        srcEnc, dstEnc, /*preserveUserPin=*/false,
         [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
             Attribute &result) {
           return delegate->inferDefaultJoinOpEncoding(enc, result, shape, loc);
@@ -232,7 +243,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
                        ArrayRef<int64_t> shape,
                        std::optional<Location> loc) const override {
     return delegateInferredLayout(
-        srcEnc, dstEnc,
+        srcEnc, dstEnc, /*preserveUserPin=*/false,
         [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
             Attribute &result) {
           return delegate->inferSplitOpEncoding(enc, result, shape, loc);
@@ -286,7 +297,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
                          Attribute &outEnc, bool fwdInference,
                          std::optional<Location> loc) const override {
     return delegateInferredLayout(
-        inEnc, outEnc,
+        inEnc, outEnc, /*preserveUserPin=*/true,
         [&](const triton::DialectInferLayoutInterface *delegate, Attribute enc,
             Attribute &result) {
           return delegate->inferFp4ToFpOpEncoding(shape, axis, enc, result,

--- a/third_party/tlx/dialect/lib/IR/Ops.cpp
+++ b/third_party/tlx/dialect/lib/IR/Ops.cpp
@@ -42,7 +42,11 @@ OpFoldResult ReleaseLayoutOp::fold(FoldAdaptor) {
 LogicalResult ReleaseLayoutOp::verify() {
   auto srcType = cast<RankedTensorType>(getSrc().getType());
   Attribute srcEncoding = srcType.getEncoding();
-  if (!srcEncoding)
+  auto parentFunc = getOperation()->getParentOfType<triton::FuncOp>();
+  bool hasDeferredHelperLayout =
+      getSrc().getDefiningOp<triton::CallOp>() ||
+      (parentFunc && parentFunc.getSymVisibility() == "private");
+  if (!srcEncoding && !hasDeferredHelperLayout)
     return emitOpError("requires the source tensor to have a layout encoding");
   return success();
 }

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -121,6 +121,11 @@ static bool isPlaceholderEncoding(Attribute enc) {
   return found;
 }
 
+static bool haveSamePhysicalLayout(RankedTensorType lhs, RankedTensorType rhs) {
+  return lhs.getShape() == rhs.getShape() &&
+         ttg::toLinearLayout(lhs) == ttg::toLinearLayout(rhs);
+}
+
 static bool retypeWithEncoding(Value v, Attribute enc) {
   auto t = dyn_cast<RankedTensorType>(v.getType());
   if (!t || t.getEncoding() == enc)
@@ -373,6 +378,156 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
       }
     });
 
+    // A concrete tensor entering an encoding-uniform arith/math op fixes the
+    // encoding of every same-shape tensor operand and result.  The Python
+    // frontend may have inferred those result types before a helper argument
+    // or region edge acquired its concrete layout, so repair the op before
+    // MLIR's SameOperandsAndResultType-style verifier compares the types.
+    // Bridge operands per use rather than retyping their producers: one value
+    // may intentionally feed consumers in different layout domains.
+    bool elementwiseConflict = false;
+    SmallVector<Operation *> encodingUniformOps;
+    mod.walk([&](Operation *op) {
+      if (isEncodingUniformArithOp(op))
+        encodingUniformOps.push_back(op);
+    });
+    for (Operation *op : encodingUniformOps) {
+      Attribute targetEncoding;
+      auto inspectType = [&](Type type) {
+        auto tensorTy = dyn_cast<RankedTensorType>(type);
+        if (!tensorTy || !isConcreteDistributed(tensorTy))
+          return;
+        Attribute candidate = tensorTy.getEncoding();
+        if (targetEncoding && targetEncoding != candidate) {
+          op->emitError(
+              "conflicting concrete layouts on encoding-uniform operation");
+          elementwiseConflict = true;
+          return;
+        }
+        targetEncoding = candidate;
+      };
+      for (Type type : op->getOperandTypes())
+        inspectType(type);
+      for (Type type : op->getResultTypes())
+        inspectType(type);
+      if (elementwiseConflict || !targetEncoding)
+        continue;
+
+      for (OpResult result : op->getResults()) {
+        auto tensorTy = dyn_cast<RankedTensorType>(result.getType());
+        if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+          continue;
+        result.setType(RankedTensorType::get(
+            tensorTy.getShape(), tensorTy.getElementType(), targetEncoding));
+        changed = true;
+      }
+      for (OpOperand &operand : op->getOpOperands()) {
+        auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
+        if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+          continue;
+        OpBuilder b(op);
+        Type targetType = RankedTensorType::get(
+            tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
+        Value converted =
+            RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
+        operand.set(converted);
+        changed = true;
+      }
+    }
+    if (elementwiseConflict)
+      return failure();
+
+    // Triton operations with an explicit same-encoding trait need the same
+    // early repair.  This notably covers tt.load/tt.store, whose pointer,
+    // value, mask, and (for loads) result encodings must agree even though
+    // their element types differ.  Operand-only traits intentionally exclude
+    // results: a reduction result, for example, has an inferred slice layout.
+    bool traitConflict = false;
+    SmallVector<Operation *> sameEncodingOps;
+    mod.walk([&](Operation *op) {
+      if (hasSameOperandsEncodingTrait(op) ||
+          hasSameOperandsAndResultEncodingTrait(op))
+        sameEncodingOps.push_back(op);
+    });
+    for (Operation *op : sameEncodingOps) {
+      bool includeResults = hasSameOperandsAndResultEncodingTrait(op);
+      Attribute targetEncoding;
+      auto inspectType = [&](Type type) {
+        auto tensorTy = dyn_cast<RankedTensorType>(type);
+        if (!tensorTy || !isConcreteDistributed(tensorTy))
+          return;
+        Attribute candidate = tensorTy.getEncoding();
+        if (targetEncoding && targetEncoding != candidate) {
+          op->emitError(
+              "conflicting concrete layouts on same-encoding operation");
+          traitConflict = true;
+          return;
+        }
+        targetEncoding = candidate;
+      };
+      for (Type type : op->getOperandTypes())
+        inspectType(type);
+      if (includeResults)
+        for (Type type : op->getResultTypes())
+          inspectType(type);
+      if (traitConflict || !targetEncoding)
+        continue;
+
+      if (includeResults) {
+        for (OpResult result : op->getResults()) {
+          auto tensorTy = dyn_cast<RankedTensorType>(result.getType());
+          if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+            continue;
+          result.setType(RankedTensorType::get(
+              tensorTy.getShape(), tensorTy.getElementType(), targetEncoding));
+          changed = true;
+        }
+      }
+      for (OpOperand &operand : op->getOpOperands()) {
+        auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
+        if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+          continue;
+        OpBuilder b(op);
+        Type targetType = RankedTensorType::get(
+            tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
+        Value converted =
+            RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
+        operand.set(converted);
+        changed = true;
+      }
+    }
+    if (traitConflict)
+      return failure();
+
+    // A concrete accumulator fixes a tt.dot result's layout. The Python
+    // frontend constructs both with encoding-free types, so a helper or
+    // predicated region may specialize C before D and trip DotOp's exact type
+    // verifier. Mirror the accumulator type here; operand requirements are
+    // synthesized later by TLXInsertRequireLayout.
+    bool dotConflict = false;
+    mod.walk([&](::mlir::triton::DotOp dot) {
+      Type target = dot.getC().getType();
+      if (!isConcreteDistributed(target) || dot.getType() == target)
+        return;
+      auto targetTy = cast<RankedTensorType>(target);
+      auto resultTy = dyn_cast<RankedTensorType>(dot.getType());
+      if (!resultTy || resultTy.getShape() != targetTy.getShape() ||
+          resultTy.getElementType() != targetTy.getElementType()) {
+        dot.emitError("dot result has inconsistent accumulator payload type");
+        dotConflict = true;
+        return;
+      }
+      if (isConcreteDistributed(resultTy) && resultTy != targetTy) {
+        dot.emitError("dot result conflicts with concrete accumulator layout");
+        dotConflict = true;
+        return;
+      }
+      dot.getResult().setType(targetTy);
+      changed = true;
+    });
+    if (dotConflict)
+      return failure();
+
     // A helper argument can acquire its concrete layout above after the
     // Python frontend has already built a loop with encoding-free region
     // iter-arguments/results. Likewise, specializing a helper return can
@@ -383,7 +538,14 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
     SmallVector<scf::ForOp> loops;
     mod.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
     for (scf::ForOp forOp : loops) {
-      auto yield = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      Block *body = forOp.getBody();
+      auto yield =
+          body ? dyn_cast<scf::YieldOp>(body->getTerminator()) : scf::YieldOp();
+      unsigned numCarried = forOp.getNumRegionIterArgs();
+      if (!yield || forOp.getInitArgs().size() != numCarried ||
+          forOp.getNumResults() != numCarried ||
+          yield.getNumOperands() != numCarried)
+        continue;
       for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
         SmallVector<Value> linked{
             forOp.getInitArgs()[i],
@@ -449,6 +611,274 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
     }
     if (loopConflict)
       return failure();
+
+    // scf.while has two independently typed loop-carried domains. The op
+    // inits, before-region arguments, and after-region yield operands share
+    // one type; the condition arguments, after-region arguments, and op
+    // results share another. Keep each domain internally consistent without
+    // assuming that the before and after types are equal.
+    bool whileConflict = false;
+    SmallVector<scf::WhileOp> whileOps;
+    mod.walk([&](scf::WhileOp whileOp) { whileOps.push_back(whileOp); });
+    for (scf::WhileOp whileOp : whileOps) {
+      if (!whileOp.getBefore().hasOneBlock() ||
+          !whileOp.getAfter().hasOneBlock())
+        continue;
+      auto condition = dyn_cast<scf::ConditionOp>(
+          whileOp.getBefore().front().getTerminator());
+      auto yield =
+          dyn_cast<scf::YieldOp>(whileOp.getAfter().front().getTerminator());
+      unsigned numBefore = whileOp.getInits().size();
+      unsigned numAfter = whileOp.getNumResults();
+      if (!condition || !yield ||
+          whileOp.getBeforeArguments().size() != numBefore ||
+          yield.getNumOperands() != numBefore ||
+          condition.getArgs().size() != numAfter ||
+          whileOp.getAfterArguments().size() != numAfter)
+        continue;
+
+      auto findConcreteTarget = [&](ArrayRef<Value> linked, StringRef domain,
+                                    unsigned index) -> Type {
+        Type target;
+        for (Value value : linked) {
+          Type candidate = value.getType();
+          if (!isConcreteDistributed(candidate))
+            continue;
+          if (target && target != candidate) {
+            whileOp.emitError() << "conflicting concrete layouts for " << domain
+                                << " value " << index;
+            whileConflict = true;
+            return {};
+          }
+          target = candidate;
+        }
+        if (!target)
+          return {};
+
+        auto targetTy = cast<RankedTensorType>(target);
+        for (Value value : linked) {
+          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
+          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
+              valueTy.getElementType() != targetTy.getElementType()) {
+            whileOp.emitError() << domain << " value " << index
+                                << " has inconsistent tensor payload type";
+            whileConflict = true;
+            return {};
+          }
+        }
+        return target;
+      };
+
+      for (unsigned i = 0; i < numBefore && !whileConflict; ++i) {
+        Value init = whileOp.getInits()[i];
+        BlockArgument beforeArg = whileOp.getBeforeArguments()[i];
+        Value yielded = yield.getOperand(i);
+        Type target = findConcreteTarget({init, beforeArg, yielded},
+                                         "while-before-carried", i);
+        if (!target)
+          continue;
+        if (init.getType() != target) {
+          OpBuilder b(whileOp);
+          Value converted =
+              RequireLayoutOp::create(b, whileOp.getLoc(), target, init);
+          whileOp->setOperand(i, converted);
+          changed = true;
+        }
+        if (beforeArg.getType() != target) {
+          beforeArg.setType(target);
+          changed = true;
+        }
+        if (yielded.getType() != target) {
+          OpBuilder b(yield);
+          Value converted =
+              RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
+          yield->setOperand(i, converted);
+          changed = true;
+        }
+      }
+
+      for (unsigned i = 0; i < numAfter && !whileConflict; ++i) {
+        Value forwarded = condition.getArgs()[i];
+        BlockArgument afterArg = whileOp.getAfterArguments()[i];
+        Value result = whileOp.getResult(i);
+        Type target = findConcreteTarget({forwarded, afterArg, result},
+                                         "while-after-carried", i);
+        if (!target)
+          continue;
+        if (forwarded.getType() != target) {
+          OpBuilder b(condition);
+          Value converted =
+              RequireLayoutOp::create(b, condition.getLoc(), target, forwarded);
+          condition->setOperand(i + 1, converted);
+          changed = true;
+        }
+        if (afterArg.getType() != target) {
+          afterArg.setType(target);
+          changed = true;
+        }
+        if (result.getType() != target) {
+          result.setType(target);
+          changed = true;
+        }
+      }
+    }
+    if (whileConflict)
+      return failure();
+
+    // Keep scf.if result and yield edges in the same concrete layout domain.
+    // This is the branch analogue of the loop-carried repair above and is
+    // needed when a specialized helper result escapes only one branch.
+    bool ifConflict = false;
+    SmallVector<scf::IfOp> ifOps;
+    mod.walk([&](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
+    for (scf::IfOp ifOp : ifOps) {
+      if (ifOp.getNumResults() == 0)
+        continue;
+      if (!ifOp.getThenRegion().hasOneBlock() ||
+          !ifOp.getElseRegion().hasOneBlock())
+        continue;
+      auto thenYield =
+          dyn_cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
+      auto elseYield =
+          dyn_cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
+      if (!thenYield || !elseYield ||
+          thenYield.getNumOperands() != ifOp.getNumResults() ||
+          elseYield.getNumOperands() != ifOp.getNumResults())
+        continue;
+      for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
+        SmallVector<Value> linked{ifOp.getResult(i), thenYield.getOperand(i)};
+        if (elseYield)
+          linked.push_back(elseYield.getOperand(i));
+        Type target;
+        for (Value value : linked) {
+          Type candidate = value.getType();
+          if (!isConcreteDistributed(candidate))
+            continue;
+          if (target && target != candidate) {
+            ifOp.emitError()
+                << "conflicting concrete layouts for branch result " << i;
+            ifConflict = true;
+            break;
+          }
+          target = candidate;
+        }
+        if (ifConflict || !target)
+          continue;
+
+        auto targetTy = cast<RankedTensorType>(target);
+        for (Value value : linked) {
+          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
+          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
+              valueTy.getElementType() != targetTy.getElementType()) {
+            ifOp.emitError() << "branch result " << i
+                             << " has inconsistent tensor payload type";
+            ifConflict = true;
+            break;
+          }
+        }
+        if (ifConflict)
+          continue;
+
+        if (ifOp.getResult(i).getType() != target) {
+          ifOp.getResult(i).setType(target);
+          changed = true;
+        }
+        auto repairYield = [&](scf::YieldOp yield) {
+          if (!yield || yield.getOperand(i).getType() == target)
+            return;
+          OpBuilder b(yield);
+          Value converted = RequireLayoutOp::create(b, yield.getLoc(), target,
+                                                    yield.getOperand(i));
+          yield->setOperand(i, converted);
+          changed = true;
+        };
+        repairYield(thenYield);
+        repairYield(elseYield);
+      }
+    }
+    if (ifConflict)
+      return failure();
+
+    // A warp-predicate result is a lane-wise merge of its init and yielded
+    // value. If either edge acquires a concrete distributed layout through a
+    // helper ABI or an explicit require_layout, repair all three types before
+    // the TTIR verifier runs. The region captures its values rather than using
+    // block arguments, so only the init/result/yield triple is linked here.
+    bool predicateConflict = false;
+    SmallVector<ttg::WarpPredicateOp> predicates;
+    mod.walk([&](ttg::WarpPredicateOp op) { predicates.push_back(op); });
+    for (ttg::WarpPredicateOp predicateOp : predicates) {
+      // Fixup runs before the module verifier. Leave malformed regions for the
+      // op verifier instead of dereferencing an absent or multi-block body.
+      if (!predicateOp.getRegion().hasOneBlock())
+        continue;
+      auto yield = dyn_cast<ttg::PredicateYieldOp>(
+          predicateOp.getRegion().front().getTerminator());
+      if (!yield)
+        continue;
+      if (predicateOp.getInits().size() != predicateOp.getNumResults() ||
+          yield.getNumOperands() != predicateOp.getNumResults())
+        continue;
+      for (unsigned i = 0; i < predicateOp.getNumResults(); ++i) {
+        SmallVector<Value> linked{
+            predicateOp.getInits()[i],
+            predicateOp.getResult(i),
+            yield.getValues()[i],
+        };
+        Type target;
+        for (Value value : linked) {
+          Type candidate = value.getType();
+          if (!isConcreteDistributed(candidate))
+            continue;
+          if (target && target != candidate) {
+            predicateOp.emitError()
+                << "conflicting concrete layouts for predicated value " << i;
+            predicateConflict = true;
+            break;
+          }
+          target = candidate;
+        }
+        if (predicateConflict || !target)
+          continue;
+
+        auto targetTy = cast<RankedTensorType>(target);
+        for (Value value : linked) {
+          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
+          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
+              valueTy.getElementType() != targetTy.getElementType()) {
+            predicateOp.emitError() << "predicated value " << i
+                                    << " has inconsistent tensor payload type";
+            predicateConflict = true;
+            break;
+          }
+        }
+        if (predicateConflict)
+          continue;
+
+        Value init = predicateOp.getInits()[i];
+        if (init.getType() != target) {
+          OpBuilder b(predicateOp);
+          Value converted =
+              RequireLayoutOp::create(b, predicateOp.getLoc(), target, init);
+          predicateOp->setOperand(i + 1, converted);
+          changed = true;
+        }
+        if (predicateOp.getResult(i).getType() != target) {
+          predicateOp.getResult(i).setType(target);
+          changed = true;
+        }
+        Value yielded = yield.getValues()[i];
+        if (yielded.getType() != target) {
+          OpBuilder b(yield);
+          Value converted =
+              RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
+          yield->setOperand(i, converted);
+          changed = true;
+        }
+      }
+    }
+    if (predicateConflict)
+      return failure();
   }
   return success();
 }
@@ -467,6 +897,22 @@ static void appendForwardedValues(OpOperand &use,
         worklist.push_back(forOp.getRegionIterArg(index));
         worklist.push_back(forOp.getResult(index));
       }
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+      if (index < whileOp.getBeforeArguments().size())
+        worklist.push_back(whileOp.getBeforeArguments()[index]);
+    }
+    return;
+  }
+  if (auto condition = dyn_cast<scf::ConditionOp>(user)) {
+    unsigned index = use.getOperandNumber();
+    auto whileOp = condition->getParentOfType<scf::WhileOp>();
+    if (whileOp && index > 0) {
+      --index;
+      if (index < whileOp.getAfterArguments().size() &&
+          index < whileOp.getNumResults()) {
+        worklist.push_back(whileOp.getAfterArguments()[index]);
+        worklist.push_back(whileOp.getResult(index));
+      }
     }
     return;
   }
@@ -479,6 +925,12 @@ static void appendForwardedValues(OpOperand &use,
         worklist.push_back(forOp.getResult(index));
       }
     }
+    return;
+  }
+  if (auto whileOp = dyn_cast<scf::WhileOp>(user)) {
+    unsigned index = use.getOperandNumber();
+    if (index < whileOp.getBeforeArguments().size())
+      worklist.push_back(whileOp.getBeforeArguments()[index]);
     return;
   }
   // An scf.if operand is its condition, not a value forwarded to its results.
@@ -551,18 +1003,23 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
   // pins meeting on one op) -- report it instead of silently retagging one.
   auto findPlaceholder = [&](ArrayRef<Value> vs, Operation *op) -> Attribute {
     Attribute enc;
+    RankedTensorType selectedType;
     for (Value v : vs)
       if (auto t = dyn_cast<RankedTensorType>(v.getType()))
         if (isPlaceholderEncoding(t.getEncoding())) {
-          if (enc && enc != t.getEncoding()) {
-            op->emitError("conflicting user-pinned layouts meet on this "
-                          "operation; insert tlx.release_layout to reconcile "
-                          "them before combining");
+          if (enc && enc != t.getEncoding() &&
+              !haveSamePhysicalLayout(selectedType, t)) {
+            op->emitError(
+                "conflicting user-pinned layouts meet on this operation; "
+                "insert tlx.release_layout to reconcile them before "
+                "combining");
             conflict = true;
             return enc;
           }
-          if (!enc)
+          if (!enc) {
             enc = t.getEncoding();
+            selectedType = t;
+          }
         }
     return enc;
   };
@@ -606,7 +1063,12 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
       return;
     bool isConst = v.getDefiningOp<arith::ConstantOp>() != nullptr;
     bool isCall = v.getDefiningOp<::mlir::triton::CallOp>() != nullptr;
-    if (forceBridge || isConst || isCall) {
+    // A function block argument belongs to the helper ABI. Retyping it from a
+    // single internal use leaves the function signature (and every other call
+    // site) inconsistent. Keep the ABI neutral and bridge only this use, just
+    // as for call results and constants.
+    bool isBlockArgument = isa<BlockArgument>(v);
+    if (forceBridge || isConst || isCall || isBlockArgument) {
       OpBuilder b(user);
       auto convTy =
           RankedTensorType::get(t.getShape(), t.getElementType(), enc);
@@ -817,6 +1279,51 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
         }
         return;
       }
+      // scf.while has separate before and after carried-value domains. The
+      // initial operands / before arguments / after yields share one encoding;
+      // condition arguments / after arguments / results share another.
+      if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
+        if (!whileOp.getBefore().hasOneBlock() ||
+            !whileOp.getAfter().hasOneBlock())
+          return;
+        auto condition = dyn_cast<scf::ConditionOp>(
+            whileOp.getBefore().front().getTerminator());
+        auto yield =
+            dyn_cast<scf::YieldOp>(whileOp.getAfter().front().getTerminator());
+        unsigned numBefore = whileOp.getInits().size();
+        unsigned numAfter = whileOp.getNumResults();
+        if (!condition || !yield ||
+            whileOp.getBeforeArguments().size() != numBefore ||
+            yield.getNumOperands() != numBefore ||
+            condition.getArgs().size() != numAfter ||
+            whileOp.getAfterArguments().size() != numAfter)
+          return;
+
+        for (unsigned i = 0; i < numBefore; ++i) {
+          Value init = whileOp.getInits()[i];
+          Value beforeArg = whileOp.getBeforeArguments()[i];
+          Value yielded = yield.getOperand(i);
+          Attribute enc = findPlaceholder({init, beforeArg, yielded}, whileOp);
+          if (!enc)
+            continue;
+          bridgeOrRetype(init, enc, whileOp, i);
+          changed |= retypeWithEncoding(beforeArg, enc);
+          bridgeOrRetype(yielded, enc, yield, i);
+        }
+        for (unsigned i = 0; i < numAfter; ++i) {
+          Value forwarded = condition.getArgs()[i];
+          Value afterArg = whileOp.getAfterArguments()[i];
+          Value result = whileOp.getResult(i);
+          Attribute enc =
+              findPlaceholder({forwarded, afterArg, result}, whileOp);
+          if (!enc)
+            continue;
+          bridgeOrRetype(forwarded, enc, condition, i + 1);
+          changed |= retypeWithEncoding(afterArg, enc);
+          changed |= retypeWithEncoding(result, enc);
+        }
+        return;
+      }
       // scf.if: result / then-yield / else-yield of each value must share it.
       if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
         auto thenY = cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
@@ -870,18 +1377,59 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
           return;
         }
       }
-
-      // Re-infer any op whose operands acquired a placeholder after frontend
-      // construction. This covers split/reduce/expand-dims and future ops
-      // implementing InferTypeOpInterface.
+      // ttg.warp_predicate has the same carried-value contract as scf.if:
+      // every init/result/yield triple is one lane-wise value. Placeholder
+      // layouts can first appear inside its region after helper
+      // specialization, so keep this repair in the placeholder fixpoint (the
+      // earlier concrete-ABI synchronization cannot see them yet).
+      if (auto predicateOp = dyn_cast<ttg::WarpPredicateOp>(op)) {
+        if (!predicateOp.getRegion().hasOneBlock())
+          return;
+        auto yield = dyn_cast<ttg::PredicateYieldOp>(
+            predicateOp.getRegion().front().getTerminator());
+        if (!yield ||
+            predicateOp.getInits().size() != predicateOp.getNumResults() ||
+            yield.getNumOperands() != predicateOp.getNumResults())
+          return;
+        for (unsigned i = 0; i < predicateOp.getNumResults(); ++i) {
+          Value init = predicateOp.getInits()[i];
+          Value result = predicateOp.getResult(i);
+          Value yielded = yield.getValues()[i];
+          Attribute enc = findPlaceholder({init, result, yielded}, predicateOp);
+          if (!enc)
+            continue;
+          bridgeOrRetype(init, enc, predicateOp, i + 1);
+          changed |= retypeWithEncoding(result, enc);
+          bridgeOrRetype(yielded, enc, yield, i);
+        }
+        return;
+      }
+      // Re-infer any op whose operands acquired a layout after frontend
+      // construction. Besides deferred placeholders, this covers a concrete
+      // encoding propagated through control flow into a previously unencoded
+      // view chain (for example MFMA loop results feeding join/trans/reshape).
+      // Restrict concrete-layout repair to encoding-free results so an
+      // explicit destination layout remains authoritative.
       Attribute operandEnc;
+      Attribute placeholderOperandEnc;
       for (Value operand : op->getOperands())
-        if (auto type = dyn_cast<RankedTensorType>(operand.getType()))
-          if (isPlaceholderEncoding(type.getEncoding())) {
+        if (auto type = dyn_cast<RankedTensorType>(operand.getType())) {
+          if (!operandEnc && type.getEncoding())
             operandEnc = type.getEncoding();
+          if (isPlaceholderEncoding(type.getEncoding())) {
+            placeholderOperandEnc = type.getEncoding();
             break;
           }
-      if (operandEnc && !isa<::mlir::triton::CallOp>(op)) {
+        }
+      bool hasEncodingFreeResult = llvm::any_of(op->getResults(), [](Value v) {
+        auto type = dyn_cast<RankedTensorType>(v.getType());
+        return type && !type.getEncoding();
+      });
+      Attribute inferenceEnc =
+          placeholderOperandEnc
+              ? placeholderOperandEnc
+              : (hasEncodingFreeResult ? operandEnc : Attribute());
+      if (inferenceEnc && !isa<::mlir::triton::CallOp>(op)) {
         if (auto iface = dyn_cast<InferTypeOpInterface>(op)) {
           SmallVector<Type> inferred;
           if (succeeded(iface.inferReturnTypes(
@@ -902,20 +1450,30 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
           auto dstTy = reshape.getType();
           Attribute dstEnc = dstTy.getEncoding();
           auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
-              &operandEnc.getDialect());
+              &inferenceEnc.getDialect());
           if (succeeded(layout->inferReshapeOpEncoding(
-                  srcTy.getShape(), operandEnc, dstTy.getShape(), dstEnc,
+                  srcTy.getShape(), inferenceEnc, dstTy.getShape(), dstEnc,
                   reshape.getAllowReorder(), reshape.getLoc())))
             changed |= retypeWithEncoding(reshape.getResult(), dstEnc);
           return;
         }
         if (auto join = dyn_cast<::mlir::triton::JoinOp>(op)) {
-          SmallVector<Value> linked{join.getLhs(), join.getRhs()};
-          Attribute srcEnc = findPlaceholder(linked, op);
-          if (!srcEnc)
-            return;
-          bridgeOrRetype(join.getLhs(), srcEnc, op, 0);
-          bridgeOrRetype(join.getRhs(), srcEnc, op, 1);
+          Attribute srcEnc = inferenceEnc;
+          if (placeholderOperandEnc) {
+            SmallVector<Value> linked{join.getLhs(), join.getRhs()};
+            srcEnc = findPlaceholder(linked, op);
+            if (!srcEnc)
+              return;
+            bridgeOrRetype(join.getLhs(), srcEnc, op, 0);
+            bridgeOrRetype(join.getRhs(), srcEnc, op, 1);
+          } else {
+            auto lhsTy = join.getLhs().getType();
+            auto rhsTy = join.getRhs().getType();
+            if (!lhsTy.getEncoding() ||
+                lhsTy.getEncoding() != rhsTy.getEncoding())
+              return;
+            srcEnc = lhsTy.getEncoding();
+          }
           auto srcTy = join.getLhs().getType();
           Attribute dstEnc;
           auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
@@ -1073,8 +1631,6 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
       privatizeHelperForCall(callOp, callee, "_tlxpin");
       changed = true;
     }
-    if (conflict)
-      return failure();
   }
   return success();
 }

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -126,6 +126,46 @@ static bool haveSamePhysicalLayout(RankedTensorType lhs, RankedTensorType rhs) {
          ttg::toLinearLayout(lhs) == ttg::toLinearLayout(rhs);
 }
 
+static bool isConcreteDistributed(Type ty) {
+  auto tensorTy = dyn_cast<RankedTensorType>(ty);
+  Attribute enc = tensorTy ? tensorTy.getEncoding() : Attribute();
+  return enc && !hasNoVerifyLayout(enc) &&
+         isa<ttg::DistributedEncodingTrait>(enc);
+}
+
+// Select the concrete type shared by one logical carried value and validate
+// that every linked edge has the same tensor payload. The operation-specific
+// reconcilers below still own edge mutation because SCF operations expose
+// different carrier topologies and ttg.warp_predicate is not a
+// RegionBranchOpInterface.
+static LogicalResult findConcreteCarriedType(ArrayRef<Value> linked,
+                                             Operation *owner,
+                                             StringRef valueName,
+                                             Type &target) {
+  target = {};
+  for (Value value : linked) {
+    Type candidate = value.getType();
+    if (!isConcreteDistributed(candidate))
+      continue;
+    if (target && target != candidate)
+      return owner->emitError()
+             << "conflicting concrete layouts for " << valueName;
+    target = candidate;
+  }
+  if (!target)
+    return success();
+
+  auto targetTy = cast<RankedTensorType>(target);
+  for (Value value : linked) {
+    auto valueTy = dyn_cast<RankedTensorType>(value.getType());
+    if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
+        valueTy.getElementType() != targetTy.getElementType())
+      return owner->emitError()
+             << valueName << " has inconsistent tensor payload type";
+  }
+  return success();
+}
+
 static bool retypeWithEncoding(Value v, Attribute enc) {
   auto t = dyn_cast<RankedTensorType>(v.getType());
   if (!t || t.getEncoding() == enc)
@@ -168,251 +208,294 @@ static void privatizeHelperForCall(::mlir::triton::CallOp call,
 // boundary (for example dot operands loaded from LDS or AMD MFMA
 // accumulators). Repair that temporary ABI before the module verifier runs:
 // infer helper inputs from concrete call operands, infer results from concrete
-// return operands, update unreachable poison returns, mirror the repaired
-// types on calls, and keep any scf.for ABI crossed by those values concrete.
-static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
-  auto isConcreteDistributed = [](Type ty) {
-    auto tensorTy = dyn_cast<RankedTensorType>(ty);
-    Attribute enc = tensorTy ? tensorTy.getEncoding() : Attribute();
-    return enc && !hasNoVerifyLayout(enc) &&
-           isa<ttg::DistributedEncodingTrait>(enc);
-  };
+// return operands, update unreachable poison returns, and mirror the repaired
+// types on calls.
+static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod, bool &changed) {
+  // A frontend-monomorphized helper can be shared by call sites carrying
+  // different concrete layouts. Privatize every concrete call while the
+  // original ABI is still encoding-free; otherwise the first call would
+  // specialize the shared function and make a later, equally valid layout
+  // look like a conflict. Encoding-free callers retain the original.
+  SmallVector<std::pair<::mlir::triton::CallOp, ::mlir::triton::FuncOp>>
+      concreteClones;
+  mod.walk([&](::mlir::triton::CallOp call) {
+    if (!llvm::any_of(call.getOperandTypes(), isConcreteDistributed))
+      return;
+    auto callee = SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+        call, call.getCalleeAttr());
+    if (!callee || callee.getBody().empty())
+      return;
+    auto uses = SymbolTable::getSymbolUses(callee, mod);
+    if (!uses)
+      return;
+    unsigned useCount = 0;
+    for (const auto &use : *uses) {
+      (void)use;
+      ++useCount;
+    }
+    if (useCount > 1)
+      concreteClones.emplace_back(call, callee);
+  });
+  for (auto [call, callee] : concreteClones) {
+    privatizeHelperForCall(call, callee, "_tlxabi");
+    changed = true;
+  }
 
-  bool changed = true;
-  unsigned iteration = 0;
-  constexpr unsigned kMaxIterations = 64;
-  while (changed) {
-    changed = false;
-    if (++iteration > kMaxIterations)
-      return mod.emitError(
-          "TLX concrete helper-ABI synchronization did not converge");
+  bool inputConflict = false;
+  mod.walk([&](::mlir::triton::CallOp call) {
+    auto callee = SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+        call, call.getCalleeAttr());
+    if (!callee || callee.getBody().empty())
+      return;
 
-    // A frontend-monomorphized helper can be shared by call sites carrying
-    // different concrete layouts.  Privatize every concrete call while the
-    // original ABI is still encoding-free; otherwise the first call would
-    // specialize the shared function and make a later, equally valid layout
-    // look like a conflict.  Encoding-free callers retain the original.
-    SmallVector<std::pair<::mlir::triton::CallOp, ::mlir::triton::FuncOp>>
-        concreteClones;
-    mod.walk([&](::mlir::triton::CallOp call) {
-      if (!llvm::any_of(call.getOperandTypes(), isConcreteDistributed))
+    SmallVector<Type> inputTypes(callee.getFunctionType().getInputs().begin(),
+                                 callee.getFunctionType().getInputs().end());
+    Block &entry = callee.getBody().front();
+    bool signatureChanged = false;
+    for (unsigned i = 0; i < call.getNumOperands() && i < inputTypes.size() &&
+                         i < entry.getNumArguments();
+         ++i) {
+      Type actual = call.getOperand(i).getType();
+      Type expected = inputTypes[i];
+      Type target = isConcreteDistributed(actual)
+                        ? actual
+                        : (isConcreteDistributed(expected) ? expected : Type());
+      if (!target)
+        continue;
+
+      auto targetTy = cast<RankedTensorType>(target);
+      auto actualTy = dyn_cast<RankedTensorType>(actual);
+      auto expectedTy = dyn_cast<RankedTensorType>(expected);
+      if (!actualTy || !expectedTy ||
+          actualTy.getShape() != targetTy.getShape() ||
+          actualTy.getElementType() != targetTy.getElementType() ||
+          expectedTy.getShape() != targetTy.getShape() ||
+          expectedTy.getElementType() != targetTy.getElementType()) {
+        call.emitError() << "helper argument " << i
+                         << " has inconsistent tensor payload type";
+        inputConflict = true;
         return;
-      auto callee =
-          SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
-              call, call.getCalleeAttr());
-      if (!callee || callee.getBody().empty())
-        return;
-      auto uses = SymbolTable::getSymbolUses(callee, mod);
-      if (!uses)
-        return;
-      unsigned useCount = 0;
-      for (const auto &use : *uses) {
-        (void)use;
-        ++useCount;
       }
-      if (useCount > 1)
-        concreteClones.emplace_back(call, callee);
-    });
-    for (auto [call, callee] : concreteClones) {
-      privatizeHelperForCall(call, callee, "_tlxabi");
+      if ((isConcreteDistributed(actual) && actual != target) ||
+          (isConcreteDistributed(expected) && expected != target)) {
+        call.emitError() << "conflicting concrete layouts for helper argument "
+                         << i;
+        inputConflict = true;
+        return;
+      }
+
+      // A second call may still carry an encoding-free value after another
+      // call specialized the shared callee. Bridge only this use instead of
+      // changing the producer's type out from under its other users.
+      if (actual != target) {
+        OpBuilder b(call);
+        Value converted = RequireLayoutOp::create(b, call.getLoc(), target,
+                                                  call.getOperand(i));
+        call.setOperand(i, converted);
+        changed = true;
+      }
+      if (entry.getArgument(i).getType() != target) {
+        entry.getArgument(i).setType(target);
+        changed = true;
+      }
+      if (inputTypes[i] != target) {
+        inputTypes[i] = target;
+        signatureChanged = true;
+      }
+    }
+    if (signatureChanged) {
+      callee.setType(FunctionType::get(callee.getContext(), inputTypes,
+                                       callee.getFunctionType().getResults()));
       changed = true;
     }
+  });
+  if (inputConflict)
+    return failure();
 
-    bool inputConflict = false;
-    mod.walk([&](::mlir::triton::CallOp call) {
-      auto callee =
-          SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
-              call, call.getCalleeAttr());
-      if (!callee || callee.getBody().empty())
-        return;
+  SmallVector<::mlir::triton::FuncOp> funcs;
+  mod.walk([&](::mlir::triton::FuncOp func) { funcs.push_back(func); });
+  for (auto func : funcs) {
+    SmallVector<::mlir::triton::ReturnOp> returns;
+    func.walk([&](::mlir::triton::ReturnOp ret) { returns.push_back(ret); });
+    if (returns.empty() || func.getFunctionType().getNumResults() == 0)
+      continue;
 
-      SmallVector<Type> inputTypes(callee.getFunctionType().getInputs().begin(),
-                                   callee.getFunctionType().getInputs().end());
-      Block &entry = callee.getBody().front();
-      bool signatureChanged = false;
-      for (unsigned i = 0; i < call.getNumOperands() && i < inputTypes.size() &&
-                           i < entry.getNumArguments();
-           ++i) {
-        Type actual = call.getOperand(i).getType();
-        Type expected = inputTypes[i];
-        Type target =
-            isConcreteDistributed(actual)
-                ? actual
-                : (isConcreteDistributed(expected) ? expected : Type());
-        if (!target)
+    SmallVector<Type> resultTypes(func.getFunctionType().getResults().begin(),
+                                  func.getFunctionType().getResults().end());
+    for (unsigned i = 0; i < resultTypes.size(); ++i) {
+      Type target =
+          isConcreteDistributed(resultTypes[i]) ? resultTypes[i] : Type();
+      for (auto ret : returns) {
+        if (i >= ret.getNumOperands())
           continue;
-
-        auto targetTy = cast<RankedTensorType>(target);
-        auto actualTy = dyn_cast<RankedTensorType>(actual);
-        auto expectedTy = dyn_cast<RankedTensorType>(expected);
-        if (!actualTy || !expectedTy ||
-            actualTy.getShape() != targetTy.getShape() ||
-            actualTy.getElementType() != targetTy.getElementType() ||
-            expectedTy.getShape() != targetTy.getShape() ||
-            expectedTy.getElementType() != targetTy.getElementType()) {
-          call.emitError() << "helper argument " << i
-                           << " has inconsistent tensor payload type";
-          inputConflict = true;
-          return;
-        }
-        if ((isConcreteDistributed(actual) && actual != target) ||
-            (isConcreteDistributed(expected) && expected != target)) {
-          call.emitError() << "conflicting concrete layouts for helper "
-                              "argument "
-                           << i;
-          inputConflict = true;
-          return;
-        }
-
-        // A second call may still carry an encoding-free value after another
-        // call specialized the shared callee. Bridge only this use instead of
-        // changing the producer's type out from under its other users.
-        if (actual != target) {
-          OpBuilder b(call);
-          Value converted = RequireLayoutOp::create(b, call.getLoc(), target,
-                                                    call.getOperand(i));
-          call.setOperand(i, converted);
-          changed = true;
-        }
-        if (entry.getArgument(i).getType() != target) {
-          entry.getArgument(i).setType(target);
-          changed = true;
-        }
-        if (inputTypes[i] != target) {
-          inputTypes[i] = target;
-          signatureChanged = true;
-        }
+        Type candidate = ret.getOperand(i).getType();
+        if (!isConcreteDistributed(candidate))
+          continue;
+        if (target && target != candidate)
+          return ret.emitError()
+                 << "conflicting concrete layouts for helper result " << i;
+        target = candidate;
       }
-      if (signatureChanged) {
-        callee.setType(
-            FunctionType::get(callee.getContext(), inputTypes,
-                              callee.getFunctionType().getResults()));
-        changed = true;
-      }
-    });
-    if (inputConflict)
-      return failure();
-
-    SmallVector<::mlir::triton::FuncOp> funcs;
-    mod.walk([&](::mlir::triton::FuncOp func) { funcs.push_back(func); });
-    for (auto func : funcs) {
-      SmallVector<::mlir::triton::ReturnOp> returns;
-      func.walk([&](::mlir::triton::ReturnOp ret) { returns.push_back(ret); });
-      if (returns.empty() || func.getFunctionType().getNumResults() == 0)
+      if (!target)
         continue;
 
-      SmallVector<Type> resultTypes(func.getFunctionType().getResults().begin(),
-                                    func.getFunctionType().getResults().end());
-      for (unsigned i = 0; i < resultTypes.size(); ++i) {
-        Type target =
-            isConcreteDistributed(resultTypes[i]) ? resultTypes[i] : Type();
-        for (auto ret : returns) {
-          if (i >= ret.getNumOperands())
-            continue;
-          Type candidate = ret.getOperand(i).getType();
-          if (!isConcreteDistributed(candidate))
-            continue;
-          if (target && target != candidate)
-            return ret.emitError()
-                   << "conflicting concrete layouts for helper result " << i;
-          target = candidate;
-        }
-        if (!target)
+      if (resultTypes[i] != target) {
+        resultTypes[i] = target;
+        changed = true;
+      }
+      auto targetTy = cast<RankedTensorType>(target);
+      for (auto ret : returns) {
+        if (i >= ret.getNumOperands())
           continue;
-
-        if (resultTypes[i] != target) {
-          resultTypes[i] = target;
+        Value operand = ret.getOperand(i);
+        auto operandTy = dyn_cast<RankedTensorType>(operand.getType());
+        if (!operandTy)
+          continue;
+        if (operandTy.getShape() != targetTy.getShape() ||
+            operandTy.getElementType() != targetTy.getElementType())
+          return ret.emitError() << "helper result " << i
+                                 << " has inconsistent shape or element type";
+        if (isConcreteDistributed(operandTy) && operandTy != targetTy)
+          return ret.emitError()
+                 << "conflicting concrete layouts for helper result " << i;
+        if (operandTy != targetTy) {
+          // Specialize this return edge without retyping its producer. A value
+          // may also feed another result that intentionally remains
+          // encoding-free (or deferred), so mutating the SSA value here can
+          // silently change an unrelated result's ABI.
+          OpBuilder b(ret);
+          Value converted =
+              RequireLayoutOp::create(b, ret.getLoc(), targetTy, operand);
+          ret.setOperand(i, converted);
           changed = true;
         }
-        auto targetTy = cast<RankedTensorType>(target);
-        for (auto ret : returns) {
-          if (i >= ret.getNumOperands())
-            continue;
-          Value operand = ret.getOperand(i);
-          auto operandTy = dyn_cast<RankedTensorType>(operand.getType());
-          if (!operandTy)
-            continue;
-          if (operandTy.getShape() != targetTy.getShape() ||
-              operandTy.getElementType() != targetTy.getElementType())
-            return ret.emitError() << "helper result " << i
-                                   << " has inconsistent shape or element type";
-          if (isConcreteDistributed(operandTy) && operandTy != targetTy)
-            return ret.emitError()
-                   << "conflicting concrete layouts for helper result " << i;
-          if (operandTy != targetTy) {
-            // Specialize this return edge without retyping its producer.  A
-            // value may also feed another result that intentionally remains
-            // encoding-free (or deferred), so mutating the SSA value here can
-            // silently change an unrelated result's ABI.
-            OpBuilder b(ret);
-            Value converted =
-                RequireLayoutOp::create(b, ret.getLoc(), targetTy, operand);
-            ret.setOperand(i, converted);
-            changed = true;
-          }
-        }
-      }
-
-      if (func.getFunctionType().getResults() != ArrayRef<Type>(resultTypes)) {
-        func.setType(FunctionType::get(func.getContext(),
-                                       func.getFunctionType().getInputs(),
-                                       resultTypes));
-        changed = true;
       }
     }
 
-    mod.walk([&](::mlir::triton::CallOp call) {
-      auto callee =
-          SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
-              call, call.getCalleeAttr());
-      if (!callee)
-        return;
-      auto calleeResults = callee.getFunctionType().getResults();
-      if (calleeResults.size() != call.getNumResults())
-        return;
-      for (unsigned i = 0; i < calleeResults.size(); ++i) {
-        if (call.getResult(i).getType() != calleeResults[i]) {
-          call.getResult(i).setType(calleeResults[i]);
-          changed = true;
-        }
-      }
-    });
+    if (func.getFunctionType().getResults() != ArrayRef<Type>(resultTypes)) {
+      func.setType(FunctionType::get(
+          func.getContext(), func.getFunctionType().getInputs(), resultTypes));
+      changed = true;
+    }
+  }
 
-    // A concrete tensor entering an encoding-uniform arith/math op fixes the
-    // encoding of every same-shape tensor operand and result.  The Python
-    // frontend may have inferred those result types before a helper argument
-    // or region edge acquired its concrete layout, so repair the op before
-    // MLIR's SameOperandsAndResultType-style verifier compares the types.
-    // Bridge operands per use rather than retyping their producers: one value
-    // may intentionally feed consumers in different layout domains.
-    bool elementwiseConflict = false;
-    SmallVector<Operation *> encodingUniformOps;
-    mod.walk([&](Operation *op) {
-      if (isEncodingUniformArithOp(op))
-        encodingUniformOps.push_back(op);
-    });
-    for (Operation *op : encodingUniformOps) {
-      Attribute targetEncoding;
-      auto inspectType = [&](Type type) {
-        auto tensorTy = dyn_cast<RankedTensorType>(type);
-        if (!tensorTy || !isConcreteDistributed(tensorTy))
-          return;
-        Attribute candidate = tensorTy.getEncoding();
-        if (targetEncoding && targetEncoding != candidate) {
-          op->emitError(
-              "conflicting concrete layouts on encoding-uniform operation");
-          elementwiseConflict = true;
-          return;
-        }
-        targetEncoding = candidate;
-      };
-      for (Type type : op->getOperandTypes())
-        inspectType(type);
+  mod.walk([&](::mlir::triton::CallOp call) {
+    auto callee = SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+        call, call.getCalleeAttr());
+    if (!callee)
+      return;
+    auto calleeResults = callee.getFunctionType().getResults();
+    if (calleeResults.size() != call.getNumResults())
+      return;
+    for (unsigned i = 0; i < calleeResults.size(); ++i) {
+      if (call.getResult(i).getType() != calleeResults[i]) {
+        call.getResult(i).setType(calleeResults[i]);
+        changed = true;
+      }
+    }
+  });
+  return success();
+}
+
+// Reconcile concrete layouts across verifier-uniform arith/math operations and
+// Triton operations carrying explicit same-encoding traits.
+static LogicalResult reconcileEncodingUniformOps(ModuleOp mod, bool &changed) {
+  // A concrete tensor entering an encoding-uniform arith/math op fixes the
+  // encoding of every same-shape tensor operand and result. The Python
+  // frontend may have inferred those result types before a helper argument or
+  // region edge acquired its concrete layout, so repair the op before MLIR's
+  // SameOperandsAndResultType-style verifier compares the types. Bridge
+  // operands per use rather than retyping their producers: one value may
+  // intentionally feed consumers in different layout domains.
+  bool elementwiseConflict = false;
+  SmallVector<Operation *> encodingUniformOps;
+  mod.walk([&](Operation *op) {
+    if (isEncodingUniformArithOp(op))
+      encodingUniformOps.push_back(op);
+  });
+  for (Operation *op : encodingUniformOps) {
+    Attribute targetEncoding;
+    auto inspectType = [&](Type type) {
+      auto tensorTy = dyn_cast<RankedTensorType>(type);
+      if (!tensorTy || !isConcreteDistributed(tensorTy))
+        return;
+      Attribute candidate = tensorTy.getEncoding();
+      if (targetEncoding && targetEncoding != candidate) {
+        op->emitError(
+            "conflicting concrete layouts on encoding-uniform operation");
+        elementwiseConflict = true;
+        return;
+      }
+      targetEncoding = candidate;
+    };
+    for (Type type : op->getOperandTypes())
+      inspectType(type);
+    for (Type type : op->getResultTypes())
+      inspectType(type);
+    if (elementwiseConflict || !targetEncoding)
+      continue;
+
+    for (OpResult result : op->getResults()) {
+      auto tensorTy = dyn_cast<RankedTensorType>(result.getType());
+      if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+        continue;
+      result.setType(RankedTensorType::get(
+          tensorTy.getShape(), tensorTy.getElementType(), targetEncoding));
+      changed = true;
+    }
+    for (OpOperand &operand : op->getOpOperands()) {
+      auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
+      if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
+        continue;
+      OpBuilder b(op);
+      Type targetType = RankedTensorType::get(
+          tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
+      Value converted =
+          RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
+      operand.set(converted);
+      changed = true;
+    }
+  }
+  if (elementwiseConflict)
+    return failure();
+
+  // Triton operations with an explicit same-encoding trait need the same
+  // early repair. This notably covers tt.load/tt.store, whose pointer, value,
+  // mask, and (for loads) result encodings must agree even though their
+  // element types differ. Operand-only traits intentionally exclude results:
+  // a reduction result, for example, has an inferred slice layout.
+  bool traitConflict = false;
+  SmallVector<Operation *> sameEncodingOps;
+  mod.walk([&](Operation *op) {
+    if (hasSameOperandsEncodingTrait(op) ||
+        hasSameOperandsAndResultEncodingTrait(op))
+      sameEncodingOps.push_back(op);
+  });
+  for (Operation *op : sameEncodingOps) {
+    bool includeResults = hasSameOperandsAndResultEncodingTrait(op);
+    Attribute targetEncoding;
+    auto inspectType = [&](Type type) {
+      auto tensorTy = dyn_cast<RankedTensorType>(type);
+      if (!tensorTy || !isConcreteDistributed(tensorTy))
+        return;
+      Attribute candidate = tensorTy.getEncoding();
+      if (targetEncoding && targetEncoding != candidate) {
+        op->emitError(
+            "conflicting concrete layouts on same-encoding operation");
+        traitConflict = true;
+        return;
+      }
+      targetEncoding = candidate;
+    };
+    for (Type type : op->getOperandTypes())
+      inspectType(type);
+    if (includeResults)
       for (Type type : op->getResultTypes())
         inspectType(type);
-      if (elementwiseConflict || !targetEncoding)
-        continue;
+    if (traitConflict || !targetEncoding)
+      continue;
 
+    if (includeResults) {
       for (OpResult result : op->getResults()) {
         auto tensorTy = dyn_cast<RankedTensorType>(result.getType());
         if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
@@ -421,463 +504,317 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod) {
             tensorTy.getShape(), tensorTy.getElementType(), targetEncoding));
         changed = true;
       }
-      for (OpOperand &operand : op->getOpOperands()) {
-        auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
-        if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
-          continue;
-        OpBuilder b(op);
-        Type targetType = RankedTensorType::get(
-            tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
-        Value converted =
-            RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
-        operand.set(converted);
-        changed = true;
-      }
     }
-    if (elementwiseConflict)
-      return failure();
-
-    // Triton operations with an explicit same-encoding trait need the same
-    // early repair.  This notably covers tt.load/tt.store, whose pointer,
-    // value, mask, and (for loads) result encodings must agree even though
-    // their element types differ.  Operand-only traits intentionally exclude
-    // results: a reduction result, for example, has an inferred slice layout.
-    bool traitConflict = false;
-    SmallVector<Operation *> sameEncodingOps;
-    mod.walk([&](Operation *op) {
-      if (hasSameOperandsEncodingTrait(op) ||
-          hasSameOperandsAndResultEncodingTrait(op))
-        sameEncodingOps.push_back(op);
-    });
-    for (Operation *op : sameEncodingOps) {
-      bool includeResults = hasSameOperandsAndResultEncodingTrait(op);
-      Attribute targetEncoding;
-      auto inspectType = [&](Type type) {
-        auto tensorTy = dyn_cast<RankedTensorType>(type);
-        if (!tensorTy || !isConcreteDistributed(tensorTy))
-          return;
-        Attribute candidate = tensorTy.getEncoding();
-        if (targetEncoding && targetEncoding != candidate) {
-          op->emitError(
-              "conflicting concrete layouts on same-encoding operation");
-          traitConflict = true;
-          return;
-        }
-        targetEncoding = candidate;
-      };
-      for (Type type : op->getOperandTypes())
-        inspectType(type);
-      if (includeResults)
-        for (Type type : op->getResultTypes())
-          inspectType(type);
-      if (traitConflict || !targetEncoding)
+    for (OpOperand &operand : op->getOpOperands()) {
+      auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
+      if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
         continue;
-
-      if (includeResults) {
-        for (OpResult result : op->getResults()) {
-          auto tensorTy = dyn_cast<RankedTensorType>(result.getType());
-          if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
-            continue;
-          result.setType(RankedTensorType::get(
-              tensorTy.getShape(), tensorTy.getElementType(), targetEncoding));
-          changed = true;
-        }
-      }
-      for (OpOperand &operand : op->getOpOperands()) {
-        auto tensorTy = dyn_cast<RankedTensorType>(operand.get().getType());
-        if (!tensorTy || tensorTy.getEncoding() == targetEncoding)
-          continue;
-        OpBuilder b(op);
-        Type targetType = RankedTensorType::get(
-            tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
-        Value converted =
-            RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
-        operand.set(converted);
-        changed = true;
-      }
-    }
-    if (traitConflict)
-      return failure();
-
-    // A concrete accumulator fixes a tt.dot result's layout. The Python
-    // frontend constructs both with encoding-free types, so a helper or
-    // predicated region may specialize C before D and trip DotOp's exact type
-    // verifier. Mirror the accumulator type here; operand requirements are
-    // synthesized later by TLXInsertRequireLayout.
-    bool dotConflict = false;
-    mod.walk([&](::mlir::triton::DotOp dot) {
-      Type target = dot.getC().getType();
-      if (!isConcreteDistributed(target) || dot.getType() == target)
-        return;
-      auto targetTy = cast<RankedTensorType>(target);
-      auto resultTy = dyn_cast<RankedTensorType>(dot.getType());
-      if (!resultTy || resultTy.getShape() != targetTy.getShape() ||
-          resultTy.getElementType() != targetTy.getElementType()) {
-        dot.emitError("dot result has inconsistent accumulator payload type");
-        dotConflict = true;
-        return;
-      }
-      if (isConcreteDistributed(resultTy) && resultTy != targetTy) {
-        dot.emitError("dot result conflicts with concrete accumulator layout");
-        dotConflict = true;
-        return;
-      }
-      dot.getResult().setType(targetTy);
+      OpBuilder b(op);
+      Type targetType = RankedTensorType::get(
+          tensorTy.getShape(), tensorTy.getElementType(), targetEncoding);
+      Value converted =
+          RequireLayoutOp::create(b, op->getLoc(), targetType, operand.get());
+      operand.set(converted);
       changed = true;
-    });
-    if (dotConflict)
-      return failure();
-
-    // A helper argument can acquire its concrete layout above after the
-    // Python frontend has already built a loop with encoding-free region
-    // iter-arguments/results. Likewise, specializing a helper return can
-    // retype an scf.for result through the enclosing tt.return without
-    // updating the loop body. Repair all four pieces of each loop-carried
-    // value together: init, iter-arg, yield, and result.
-    bool loopConflict = false;
-    SmallVector<scf::ForOp> loops;
-    mod.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
-    for (scf::ForOp forOp : loops) {
-      Block *body = forOp.getBody();
-      auto yield =
-          body ? dyn_cast<scf::YieldOp>(body->getTerminator()) : scf::YieldOp();
-      unsigned numCarried = forOp.getNumRegionIterArgs();
-      if (!yield || forOp.getInitArgs().size() != numCarried ||
-          forOp.getNumResults() != numCarried ||
-          yield.getNumOperands() != numCarried)
-        continue;
-      for (unsigned i = 0; i < forOp.getNumRegionIterArgs(); ++i) {
-        SmallVector<Value> linked{
-            forOp.getInitArgs()[i],
-            forOp.getRegionIterArg(i),
-            yield.getOperand(i),
-            forOp.getResult(i),
-        };
-        Type target;
-        for (Value value : linked) {
-          Type candidate = value.getType();
-          if (!isConcreteDistributed(candidate))
-            continue;
-          if (target && target != candidate) {
-            forOp.emitError()
-                << "conflicting concrete layouts for loop-carried value " << i;
-            loopConflict = true;
-            break;
-          }
-          target = candidate;
-        }
-        if (loopConflict || !target)
-          continue;
-
-        auto targetTy = cast<RankedTensorType>(target);
-        for (Value value : linked) {
-          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
-          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
-              valueTy.getElementType() != targetTy.getElementType()) {
-            forOp.emitError() << "loop-carried value " << i
-                              << " has inconsistent tensor payload type";
-            loopConflict = true;
-            break;
-          }
-        }
-        if (loopConflict)
-          continue;
-
-        Value init = forOp.getInitArgs()[i];
-        if (init.getType() != target) {
-          OpBuilder b(forOp);
-          Value converted =
-              RequireLayoutOp::create(b, forOp.getLoc(), target, init);
-          forOp.setOperand(forOp.getNumControlOperands() + i, converted);
-          changed = true;
-        }
-        if (forOp.getRegionIterArg(i).getType() != target) {
-          forOp.getRegionIterArg(i).setType(target);
-          changed = true;
-        }
-        Value yielded = yield.getOperand(i);
-        if (yielded.getType() != target) {
-          OpBuilder b(yield);
-          Value converted =
-              RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
-          yield.setOperand(i, converted);
-          changed = true;
-        }
-        if (forOp.getResult(i).getType() != target) {
-          forOp.getResult(i).setType(target);
-          changed = true;
-        }
-      }
     }
-    if (loopConflict)
-      return failure();
+  }
+  return success(!traitConflict);
+}
 
-    // scf.while has two independently typed loop-carried domains. The op
-    // inits, before-region arguments, and after-region yield operands share
-    // one type; the condition arguments, after-region arguments, and op
-    // results share another. Keep each domain internally consistent without
-    // assuming that the before and after types are equal.
-    bool whileConflict = false;
-    SmallVector<scf::WhileOp> whileOps;
-    mod.walk([&](scf::WhileOp whileOp) { whileOps.push_back(whileOp); });
-    for (scf::WhileOp whileOp : whileOps) {
-      if (!whileOp.getBefore().hasOneBlock() ||
-          !whileOp.getAfter().hasOneBlock())
-        continue;
-      auto condition = dyn_cast<scf::ConditionOp>(
-          whileOp.getBefore().front().getTerminator());
-      auto yield =
-          dyn_cast<scf::YieldOp>(whileOp.getAfter().front().getTerminator());
-      unsigned numBefore = whileOp.getInits().size();
-      unsigned numAfter = whileOp.getNumResults();
-      if (!condition || !yield ||
-          whileOp.getBeforeArguments().size() != numBefore ||
-          yield.getNumOperands() != numBefore ||
-          condition.getArgs().size() != numAfter ||
-          whileOp.getAfterArguments().size() != numAfter)
-        continue;
+static LogicalResult reconcileDotLayouts(ModuleOp mod, bool &changed) {
+  // A concrete accumulator fixes a tt.dot result's layout. The Python
+  // frontend constructs both with encoding-free types, so a helper or
+  // predicated region may specialize C before D and trip DotOp's exact type
+  // verifier. Mirror the accumulator type here; operand requirements are
+  // synthesized later by TLXInsertRequireLayout.
+  bool conflict = false;
+  mod.walk([&](::mlir::triton::DotOp dot) {
+    Type target = dot.getC().getType();
+    if (!isConcreteDistributed(target) || dot.getType() == target)
+      return;
+    auto targetTy = cast<RankedTensorType>(target);
+    auto resultTy = dyn_cast<RankedTensorType>(dot.getType());
+    if (!resultTy || resultTy.getShape() != targetTy.getShape() ||
+        resultTy.getElementType() != targetTy.getElementType()) {
+      dot.emitError("dot result has inconsistent accumulator payload type");
+      conflict = true;
+      return;
+    }
+    if (isConcreteDistributed(resultTy) && resultTy != targetTy) {
+      dot.emitError("dot result conflicts with concrete accumulator layout");
+      conflict = true;
+      return;
+    }
+    dot.getResult().setType(targetTy);
+    changed = true;
+  });
+  return success(!conflict);
+}
 
-      auto findConcreteTarget = [&](ArrayRef<Value> linked, StringRef domain,
-                                    unsigned index) -> Type {
-        Type target;
-        for (Value value : linked) {
-          Type candidate = value.getType();
-          if (!isConcreteDistributed(candidate))
-            continue;
-          if (target && target != candidate) {
-            whileOp.emitError() << "conflicting concrete layouts for " << domain
-                                << " value " << index;
-            whileConflict = true;
-            return {};
-          }
-          target = candidate;
-        }
-        if (!target)
-          return {};
-
-        auto targetTy = cast<RankedTensorType>(target);
-        for (Value value : linked) {
-          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
-          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
-              valueTy.getElementType() != targetTy.getElementType()) {
-            whileOp.emitError() << domain << " value " << index
-                                << " has inconsistent tensor payload type";
-            whileConflict = true;
-            return {};
-          }
-        }
-        return target;
+// Reconcile concrete tensor types across the carried-value domains of the SCF
+// RegionBranch operations emitted by the Python frontend. The adapters remain
+// explicit because scf.while has two independently typed domains and each SCF
+// operation exposes different mutable incoming edges.
+static LogicalResult reconcileRegionCarriedLayouts(ModuleOp mod,
+                                                   bool &changed) {
+  // Repair all four pieces of each scf.for-carried value together: init,
+  // iter-arg, yield, and result.
+  SmallVector<scf::ForOp> loops;
+  mod.walk([&](scf::ForOp forOp) { loops.push_back(forOp); });
+  for (scf::ForOp forOp : loops) {
+    Block *body = forOp.getBody();
+    auto yield =
+        body ? dyn_cast<scf::YieldOp>(body->getTerminator()) : scf::YieldOp();
+    unsigned numCarried = forOp.getNumRegionIterArgs();
+    if (!yield || forOp.getInitArgs().size() != numCarried ||
+        forOp.getNumResults() != numCarried ||
+        yield.getNumOperands() != numCarried)
+      continue;
+    for (unsigned i = 0; i < numCarried; ++i) {
+      SmallVector<Value> linked{
+          forOp.getInitArgs()[i],
+          forOp.getRegionIterArg(i),
+          yield.getOperand(i),
+          forOp.getResult(i),
       };
+      Type target;
+      std::string valueName = "loop-carried value " + std::to_string(i);
+      if (failed(findConcreteCarriedType(linked, forOp, valueName, target)))
+        return failure();
+      if (!target)
+        continue;
 
-      for (unsigned i = 0; i < numBefore && !whileConflict; ++i) {
-        Value init = whileOp.getInits()[i];
-        BlockArgument beforeArg = whileOp.getBeforeArguments()[i];
-        Value yielded = yield.getOperand(i);
-        Type target = findConcreteTarget({init, beforeArg, yielded},
-                                         "while-before-carried", i);
-        if (!target)
-          continue;
-        if (init.getType() != target) {
-          OpBuilder b(whileOp);
-          Value converted =
-              RequireLayoutOp::create(b, whileOp.getLoc(), target, init);
-          whileOp->setOperand(i, converted);
-          changed = true;
-        }
-        if (beforeArg.getType() != target) {
-          beforeArg.setType(target);
-          changed = true;
-        }
-        if (yielded.getType() != target) {
-          OpBuilder b(yield);
-          Value converted =
-              RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
-          yield->setOperand(i, converted);
-          changed = true;
-        }
+      Value init = forOp.getInitArgs()[i];
+      if (init.getType() != target) {
+        OpBuilder b(forOp);
+        Value converted =
+            RequireLayoutOp::create(b, forOp.getLoc(), target, init);
+        forOp.setOperand(forOp.getNumControlOperands() + i, converted);
+        changed = true;
       }
-
-      for (unsigned i = 0; i < numAfter && !whileConflict; ++i) {
-        Value forwarded = condition.getArgs()[i];
-        BlockArgument afterArg = whileOp.getAfterArguments()[i];
-        Value result = whileOp.getResult(i);
-        Type target = findConcreteTarget({forwarded, afterArg, result},
-                                         "while-after-carried", i);
-        if (!target)
-          continue;
-        if (forwarded.getType() != target) {
-          OpBuilder b(condition);
-          Value converted =
-              RequireLayoutOp::create(b, condition.getLoc(), target, forwarded);
-          condition->setOperand(i + 1, converted);
-          changed = true;
-        }
-        if (afterArg.getType() != target) {
-          afterArg.setType(target);
-          changed = true;
-        }
-        if (result.getType() != target) {
-          result.setType(target);
-          changed = true;
-        }
+      if (forOp.getRegionIterArg(i).getType() != target) {
+        forOp.getRegionIterArg(i).setType(target);
+        changed = true;
+      }
+      Value yielded = yield.getOperand(i);
+      if (yielded.getType() != target) {
+        OpBuilder b(yield);
+        Value converted =
+            RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
+        yield.setOperand(i, converted);
+        changed = true;
+      }
+      if (forOp.getResult(i).getType() != target) {
+        forOp.getResult(i).setType(target);
+        changed = true;
       }
     }
-    if (whileConflict)
-      return failure();
+  }
 
-    // Keep scf.if result and yield edges in the same concrete layout domain.
-    // This is the branch analogue of the loop-carried repair above and is
-    // needed when a specialized helper result escapes only one branch.
-    bool ifConflict = false;
-    SmallVector<scf::IfOp> ifOps;
-    mod.walk([&](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
-    for (scf::IfOp ifOp : ifOps) {
-      if (ifOp.getNumResults() == 0)
-        continue;
-      if (!ifOp.getThenRegion().hasOneBlock() ||
-          !ifOp.getElseRegion().hasOneBlock())
-        continue;
-      auto thenYield =
-          dyn_cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
-      auto elseYield =
-          dyn_cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
-      if (!thenYield || !elseYield ||
-          thenYield.getNumOperands() != ifOp.getNumResults() ||
-          elseYield.getNumOperands() != ifOp.getNumResults())
-        continue;
-      for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
-        SmallVector<Value> linked{ifOp.getResult(i), thenYield.getOperand(i)};
-        if (elseYield)
-          linked.push_back(elseYield.getOperand(i));
-        Type target;
-        for (Value value : linked) {
-          Type candidate = value.getType();
-          if (!isConcreteDistributed(candidate))
-            continue;
-          if (target && target != candidate) {
-            ifOp.emitError()
-                << "conflicting concrete layouts for branch result " << i;
-            ifConflict = true;
-            break;
-          }
-          target = candidate;
-        }
-        if (ifConflict || !target)
-          continue;
+  // scf.while has two independently typed loop-carried domains. The op inits,
+  // before-region arguments, and after-region yield operands share one type;
+  // the condition arguments, after-region arguments, and op results share
+  // another. Keep each domain internally consistent without assuming that the
+  // before and after types are equal.
+  SmallVector<scf::WhileOp> whileOps;
+  mod.walk([&](scf::WhileOp whileOp) { whileOps.push_back(whileOp); });
+  for (scf::WhileOp whileOp : whileOps) {
+    if (!whileOp.getBefore().hasOneBlock() || !whileOp.getAfter().hasOneBlock())
+      continue;
+    auto condition =
+        dyn_cast<scf::ConditionOp>(whileOp.getBefore().front().getTerminator());
+    auto yield =
+        dyn_cast<scf::YieldOp>(whileOp.getAfter().front().getTerminator());
+    unsigned numBefore = whileOp.getInits().size();
+    unsigned numAfter = whileOp.getNumResults();
+    if (!condition || !yield ||
+        whileOp.getBeforeArguments().size() != numBefore ||
+        yield.getNumOperands() != numBefore ||
+        condition.getArgs().size() != numAfter ||
+        whileOp.getAfterArguments().size() != numAfter)
+      continue;
 
-        auto targetTy = cast<RankedTensorType>(target);
-        for (Value value : linked) {
-          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
-          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
-              valueTy.getElementType() != targetTy.getElementType()) {
-            ifOp.emitError() << "branch result " << i
-                             << " has inconsistent tensor payload type";
-            ifConflict = true;
-            break;
-          }
-        }
-        if (ifConflict)
-          continue;
-
-        if (ifOp.getResult(i).getType() != target) {
-          ifOp.getResult(i).setType(target);
-          changed = true;
-        }
-        auto repairYield = [&](scf::YieldOp yield) {
-          if (!yield || yield.getOperand(i).getType() == target)
-            return;
-          OpBuilder b(yield);
-          Value converted = RequireLayoutOp::create(b, yield.getLoc(), target,
-                                                    yield.getOperand(i));
-          yield->setOperand(i, converted);
-          changed = true;
-        };
-        repairYield(thenYield);
-        repairYield(elseYield);
+    for (unsigned i = 0; i < numBefore; ++i) {
+      Value init = whileOp.getInits()[i];
+      BlockArgument beforeArg = whileOp.getBeforeArguments()[i];
+      Value yielded = yield.getOperand(i);
+      Type target;
+      std::string valueName = "while-before-carried value " + std::to_string(i);
+      if (failed(findConcreteCarriedType({init, beforeArg, yielded}, whileOp,
+                                         valueName, target)))
+        return failure();
+      if (!target)
+        continue;
+      if (init.getType() != target) {
+        OpBuilder b(whileOp);
+        Value converted =
+            RequireLayoutOp::create(b, whileOp.getLoc(), target, init);
+        whileOp->setOperand(i, converted);
+        changed = true;
+      }
+      if (beforeArg.getType() != target) {
+        beforeArg.setType(target);
+        changed = true;
+      }
+      if (yielded.getType() != target) {
+        OpBuilder b(yield);
+        Value converted =
+            RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
+        yield->setOperand(i, converted);
+        changed = true;
       }
     }
-    if (ifConflict)
-      return failure();
 
-    // A warp-predicate result is a lane-wise merge of its init and yielded
-    // value. If either edge acquires a concrete distributed layout through a
-    // helper ABI or an explicit require_layout, repair all three types before
-    // the TTIR verifier runs. The region captures its values rather than using
-    // block arguments, so only the init/result/yield triple is linked here.
-    bool predicateConflict = false;
-    SmallVector<ttg::WarpPredicateOp> predicates;
-    mod.walk([&](ttg::WarpPredicateOp op) { predicates.push_back(op); });
-    for (ttg::WarpPredicateOp predicateOp : predicates) {
-      // Fixup runs before the module verifier. Leave malformed regions for the
-      // op verifier instead of dereferencing an absent or multi-block body.
-      if (!predicateOp.getRegion().hasOneBlock())
+    for (unsigned i = 0; i < numAfter; ++i) {
+      Value forwarded = condition.getArgs()[i];
+      BlockArgument afterArg = whileOp.getAfterArguments()[i];
+      Value result = whileOp.getResult(i);
+      Type target;
+      std::string valueName = "while-after-carried value " + std::to_string(i);
+      if (failed(findConcreteCarriedType({forwarded, afterArg, result}, whileOp,
+                                         valueName, target)))
+        return failure();
+      if (!target)
         continue;
-      auto yield = dyn_cast<ttg::PredicateYieldOp>(
-          predicateOp.getRegion().front().getTerminator());
-      if (!yield)
-        continue;
-      if (predicateOp.getInits().size() != predicateOp.getNumResults() ||
-          yield.getNumOperands() != predicateOp.getNumResults())
-        continue;
-      for (unsigned i = 0; i < predicateOp.getNumResults(); ++i) {
-        SmallVector<Value> linked{
-            predicateOp.getInits()[i],
-            predicateOp.getResult(i),
-            yield.getValues()[i],
-        };
-        Type target;
-        for (Value value : linked) {
-          Type candidate = value.getType();
-          if (!isConcreteDistributed(candidate))
-            continue;
-          if (target && target != candidate) {
-            predicateOp.emitError()
-                << "conflicting concrete layouts for predicated value " << i;
-            predicateConflict = true;
-            break;
-          }
-          target = candidate;
-        }
-        if (predicateConflict || !target)
-          continue;
-
-        auto targetTy = cast<RankedTensorType>(target);
-        for (Value value : linked) {
-          auto valueTy = dyn_cast<RankedTensorType>(value.getType());
-          if (!valueTy || valueTy.getShape() != targetTy.getShape() ||
-              valueTy.getElementType() != targetTy.getElementType()) {
-            predicateOp.emitError() << "predicated value " << i
-                                    << " has inconsistent tensor payload type";
-            predicateConflict = true;
-            break;
-          }
-        }
-        if (predicateConflict)
-          continue;
-
-        Value init = predicateOp.getInits()[i];
-        if (init.getType() != target) {
-          OpBuilder b(predicateOp);
-          Value converted =
-              RequireLayoutOp::create(b, predicateOp.getLoc(), target, init);
-          predicateOp->setOperand(i + 1, converted);
-          changed = true;
-        }
-        if (predicateOp.getResult(i).getType() != target) {
-          predicateOp.getResult(i).setType(target);
-          changed = true;
-        }
-        Value yielded = yield.getValues()[i];
-        if (yielded.getType() != target) {
-          OpBuilder b(yield);
-          Value converted =
-              RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
-          yield->setOperand(i, converted);
-          changed = true;
-        }
+      if (forwarded.getType() != target) {
+        OpBuilder b(condition);
+        Value converted =
+            RequireLayoutOp::create(b, condition.getLoc(), target, forwarded);
+        condition->setOperand(i + 1, converted);
+        changed = true;
+      }
+      if (afterArg.getType() != target) {
+        afterArg.setType(target);
+        changed = true;
+      }
+      if (result.getType() != target) {
+        result.setType(target);
+        changed = true;
       }
     }
-    if (predicateConflict)
+  }
+
+  // Keep scf.if result and yield edges in the same concrete layout domain.
+  SmallVector<scf::IfOp> ifOps;
+  mod.walk([&](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
+  for (scf::IfOp ifOp : ifOps) {
+    if (ifOp.getNumResults() == 0 || !ifOp.getThenRegion().hasOneBlock() ||
+        !ifOp.getElseRegion().hasOneBlock())
+      continue;
+    auto thenYield =
+        dyn_cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator());
+    auto elseYield =
+        dyn_cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator());
+    if (!thenYield || !elseYield ||
+        thenYield.getNumOperands() != ifOp.getNumResults() ||
+        elseYield.getNumOperands() != ifOp.getNumResults())
+      continue;
+    for (unsigned i = 0; i < ifOp.getNumResults(); ++i) {
+      SmallVector<Value> linked{
+          ifOp.getResult(i),
+          thenYield.getOperand(i),
+          elseYield.getOperand(i),
+      };
+      Type target;
+      std::string valueName = "branch result " + std::to_string(i);
+      if (failed(findConcreteCarriedType(linked, ifOp, valueName, target)))
+        return failure();
+      if (!target)
+        continue;
+
+      if (ifOp.getResult(i).getType() != target) {
+        ifOp.getResult(i).setType(target);
+        changed = true;
+      }
+      auto repairYield = [&](scf::YieldOp yield) {
+        if (yield.getOperand(i).getType() == target)
+          return;
+        OpBuilder b(yield);
+        Value converted = RequireLayoutOp::create(b, yield.getLoc(), target,
+                                                  yield.getOperand(i));
+        yield->setOperand(i, converted);
+        changed = true;
+      };
+      repairYield(thenYield);
+      repairYield(elseYield);
+    }
+  }
+  return success();
+}
+
+static LogicalResult reconcileWarpPredicateLayouts(ModuleOp mod,
+                                                   bool &changed) {
+  // A warp-predicate result is a lane-wise merge of its init and yielded
+  // value. If either edge acquires a concrete distributed layout through a
+  // helper ABI or an explicit require_layout, repair all three types before
+  // the TTIR verifier runs. The region captures its values rather than using
+  // block arguments, so only the init/result/yield triple is linked here.
+  SmallVector<ttg::WarpPredicateOp> predicates;
+  mod.walk([&](ttg::WarpPredicateOp op) { predicates.push_back(op); });
+  for (ttg::WarpPredicateOp predicateOp : predicates) {
+    // Fixup runs before the module verifier. Leave malformed regions for the
+    // op verifier instead of dereferencing an absent or multi-block body.
+    if (!predicateOp.getRegion().hasOneBlock())
+      continue;
+    auto yield = dyn_cast<ttg::PredicateYieldOp>(
+        predicateOp.getRegion().front().getTerminator());
+    if (!yield ||
+        predicateOp.getInits().size() != predicateOp.getNumResults() ||
+        yield.getNumOperands() != predicateOp.getNumResults())
+      continue;
+    for (unsigned i = 0; i < predicateOp.getNumResults(); ++i) {
+      SmallVector<Value> linked{
+          predicateOp.getInits()[i],
+          predicateOp.getResult(i),
+          yield.getValues()[i],
+      };
+      Type target;
+      std::string valueName = "predicated value " + std::to_string(i);
+      if (failed(
+              findConcreteCarriedType(linked, predicateOp, valueName, target)))
+        return failure();
+      if (!target)
+        continue;
+
+      Value init = predicateOp.getInits()[i];
+      if (init.getType() != target) {
+        OpBuilder b(predicateOp);
+        Value converted =
+            RequireLayoutOp::create(b, predicateOp.getLoc(), target, init);
+        predicateOp->setOperand(i + 1, converted);
+        changed = true;
+      }
+      if (predicateOp.getResult(i).getType() != target) {
+        predicateOp.getResult(i).setType(target);
+        changed = true;
+      }
+      Value yielded = yield.getValues()[i];
+      if (yielded.getType() != target) {
+        OpBuilder b(yield);
+        Value converted =
+            RequireLayoutOp::create(b, yield.getLoc(), target, yielded);
+        yield->setOperand(i, converted);
+        changed = true;
+      }
+    }
+  }
+  return success();
+}
+
+static LogicalResult reconcileConcreteLayouts(ModuleOp mod) {
+  bool changed = true;
+  unsigned iteration = 0;
+  constexpr unsigned kMaxIterations = 64;
+  while (changed) {
+    changed = false;
+    if (++iteration > kMaxIterations)
+      return mod.emitError(
+          "TLX concrete layout reconciliation did not converge");
+    if (failed(synchronizeConcreteHelperABI(mod, changed)) ||
+        failed(reconcileEncodingUniformOps(mod, changed)) ||
+        failed(reconcileDotLayouts(mod, changed)) ||
+        failed(reconcileRegionCarriedLayouts(mod, changed)) ||
+        failed(reconcileWarpPredicateLayouts(mod, changed)))
       return failure();
   }
   return success();
@@ -1837,7 +1774,7 @@ public:
     // arithmetic chain and bridge mismatched inputs at the consuming use. Runs
     // after the ttg.num-warps metadata above is set, since validating a pinned
     // #linear layout needs it. Concrete conversions resolve in make_ttgir.
-    if (failed(synchronizeConcreteHelperABI(mod)))
+    if (failed(reconcileConcreteLayouts(mod)))
       return signalPassFailure();
     if (failed(reconcileVerifierLayouts(mod)))
       return signalPassFailure();

--- a/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/InsertRequireLayout.cpp
@@ -291,9 +291,20 @@ static Attribute computeSharedEncFromDotEnc(ttg::DotOperandEncodingAttr dotEnc,
       using amdgpu::ISAFamily;
       if (llvm::is_contained({ISAFamily::CDNA4, ISAFamily::GFX1250},
                              targetFeatures.getISAFamily())) {
+        // A subview retains the parent allocation shape in its MemDescType.
+        // Build inferred padding against that allocation, because the padded
+        // encoding's linear component is verified against allocShape even
+        // when the local_load consumes only a smaller logical view.
+        auto composeType = type;
+        if (!isBufferLoadToLocal && type.getShape() != type.getAllocShape()) {
+          auto allocShape = type.getAllocShape();
+          composeType = ttg::MemDescType::get(
+              allocShape, type.getElementType(), type.getEncoding(),
+              type.getMemorySpace(), type.getMutableMemory(), allocShape);
+        }
         if (auto padded = composePaddedLayout(
                 targetFeatures, dotEnc.getOpIdx(), dotEnc.getKWidth(),
-                cast<ttg::TensorOrMemDesc>(type), paddedOrder, dotEnc,
+                cast<ttg::TensorOrMemDesc>(composeType), paddedOrder, dotEnc,
                 /*useAsyncCopy=*/true)) {
           // `composePaddedLayout` returns the bank-conflict-avoiding padded
           // layout, derived from the DOT (read) order. Its linear component is

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -160,6 +160,218 @@ public:
   }
 };
 
+// `ttg.warp_predicate` restricts EXEC before entering its region. A layout
+// conversion that redistributes values across waves therefore cannot remain in
+// the region: a skipped wave would not participate in the shuffle. Layout
+// inference commonly introduces exactly that shape around an MFMA body:
+//
+//   old init -> warp_predicate { ... MFMA value -> old layout -> yield }
+//
+// Move captured conversions before the EXEC restriction and move conversions
+// on yielded values across the region boundary. The latter changes the carried
+// type to the body's native layout and converts back after all waves have
+// reconverged. Since convert_layout preserves the logical tensor, the
+// old->new->old round trip also preserves every inactive lane's init value.
+class HoistWarpPredicateLayoutConversions
+    : public mlir::OpRewritePattern<ttg::WarpPredicateOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ttg::WarpPredicateOp predicateOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    bool changed = false;
+
+    auto yieldOp = dyn_cast<ttg::PredicateYieldOp>(
+        predicateOp.getRegion().front().getTerminator());
+    if (!yieldOp)
+      return failure();
+
+    auto predicateType =
+        dyn_cast<RankedTensorType>(predicateOp.getPredicate().getType());
+    std::optional<Attribute> predicateEncoding;
+    bool conflictingPredicateEncoding = false;
+    // Determine the physical row ownership before moving or retyping anything.
+    // One execution predicate cannot safely control carried row values whose
+    // native layouts assign those rows to different lanes.
+    for (auto [result, init, yielded] :
+         llvm::zip(predicateOp.getResults(), predicateOp.getInits(),
+                   yieldOp.getValues())) {
+      auto oldType = dyn_cast<RankedTensorType>(result.getType());
+      auto boundaryConvert = yielded.getDefiningOp<ttg::ConvertLayoutOp>();
+      auto bodyType =
+          boundaryConvert
+              ? dyn_cast<RankedTensorType>(boundaryConvert.getSrc().getType())
+              : RankedTensorType();
+      bool hasHoistableBoundary =
+          boundaryConvert && boundaryConvert->hasOneUse() && oldType &&
+          bodyType && oldType != bodyType &&
+          oldType.getShape() == bodyType.getShape() &&
+          oldType.getElementType() == bodyType.getElementType() &&
+          (init.getType() == oldType || init.getType() == bodyType) &&
+          yielded.getType() == oldType;
+      RankedTensorType nativeType = hasHoistableBoundary ? bodyType : oldType;
+      if (predicateType && nativeType &&
+          nativeType.getRank() >= predicateType.getRank() &&
+          llvm::equal(
+              predicateType.getShape(),
+              nativeType.getShape().take_front(predicateType.getRank()))) {
+        Attribute encoding = nativeType.getEncoding();
+        if (!isa<ttg::DistributedEncodingTrait>(encoding))
+          return predicateOp.emitError(
+              "expected distributed encodings on warp_predicate carried "
+              "tensors");
+        for (int rank = nativeType.getRank(); rank > predicateType.getRank();
+             --rank)
+          encoding = ttg::SliceEncodingAttr::get(
+              predicateOp.getContext(), rank - 1,
+              cast<ttg::DistributedEncodingTrait>(encoding));
+        if (!predicateEncoding) {
+          predicateEncoding = encoding;
+        } else {
+          auto selectedType = RankedTensorType::get(
+              predicateType.getShape(), predicateType.getElementType(),
+              *predicateEncoding);
+          auto candidateType =
+              RankedTensorType::get(predicateType.getShape(),
+                                    predicateType.getElementType(), encoding);
+          if (ttg::toLinearLayout(selectedType) !=
+              ttg::toLinearLayout(candidateType))
+            conflictingPredicateEncoding = true;
+        }
+      }
+    }
+    if (conflictingPredicateEncoding)
+      return predicateOp.emitError(
+          "carried row values require conflicting predicate layouts");
+
+    // Captured tensor conversions (for example Q -> dot operand layout) must
+    // execute with the full CTA active. Collect first because moving while
+    // walking the region invalidates the walk.
+    SmallVector<ttg::ConvertLayoutOp> capturedConversions;
+    predicateOp.getRegion().walk([&](ttg::ConvertLayoutOp convertOp) {
+      Region *sourceRegion = convertOp.getSrc().getParentRegion();
+      if (sourceRegion != &predicateOp.getRegion() &&
+          !predicateOp.getRegion().isAncestor(sourceRegion))
+        capturedConversions.push_back(convertOp);
+    });
+    for (ttg::ConvertLayoutOp convertOp : capturedConversions) {
+      rewriter.moveOpBefore(convertOp, predicateOp);
+      changed = true;
+    }
+
+    for (auto [index, result, init, yielded] :
+         llvm::enumerate(predicateOp.getResults(), predicateOp.getInits(),
+                         yieldOp.getValues())) {
+      auto boundaryConvert = yielded.getDefiningOp<ttg::ConvertLayoutOp>();
+      if (!boundaryConvert || !boundaryConvert->hasOneUse())
+        continue;
+
+      auto oldType = dyn_cast<RankedTensorType>(result.getType());
+      auto bodyType =
+          dyn_cast<RankedTensorType>(boundaryConvert.getSrc().getType());
+      if (!oldType || !bodyType || oldType == bodyType ||
+          oldType.getShape() != bodyType.getShape() ||
+          oldType.getElementType() != bodyType.getElementType() ||
+          (init.getType() != oldType && init.getType() != bodyType) ||
+          yielded.getType() != oldType)
+        continue;
+
+      // Convert the false-path value before EXEC is restricted.
+      Value convertedInit = init;
+      if (init.getType() == oldType) {
+        rewriter.setInsertionPoint(predicateOp);
+        convertedInit = ttg::ConvertLayoutOp::create(
+            rewriter, predicateOp.getLoc(), bodyType, init);
+      }
+
+      // Consecutive predicated regions can keep their carried values in the
+      // native body layout. Record ordinary consumers that still require the
+      // old type, and recognize an old->body bridge inserted when the sibling
+      // region happened to be rewritten first.
+      auto siblingAcceptsBodyType = [&](OpOperand &use) {
+        auto sibling = dyn_cast<ttg::WarpPredicateOp>(use.getOwner());
+        // Operand zero is the predicate, not a carried value.
+        if (!sibling || use.getOperandNumber() == 0)
+          return false;
+        unsigned siblingIndex = use.getOperandNumber() - 1;
+        if (siblingIndex >= sibling.getNumResults())
+          return false;
+        if (sibling.getResult(siblingIndex).getType() == bodyType)
+          return true;
+        if (sibling.getResult(siblingIndex).getType() != oldType ||
+            !sibling.getRegion().hasOneBlock())
+          return false;
+        auto siblingYield = dyn_cast<ttg::PredicateYieldOp>(
+            sibling.getRegion().front().getTerminator());
+        if (!siblingYield || siblingIndex >= siblingYield.getNumOperands())
+          return false;
+        auto siblingBoundary = siblingYield.getValues()[siblingIndex]
+                                   .getDefiningOp<ttg::ConvertLayoutOp>();
+        return siblingBoundary && siblingBoundary->hasOneUse() &&
+               siblingBoundary.getSrc().getType() == bodyType;
+      };
+      SmallVector<OpOperand *> oldLayoutUses;
+      SmallVector<ttg::ConvertLayoutOp> siblingBridges;
+      for (OpOperand &use : result.getUses()) {
+        if (siblingAcceptsBodyType(use))
+          continue;
+        auto convert = dyn_cast<ttg::ConvertLayoutOp>(use.getOwner());
+        if (convert && convert.getSrc() == result &&
+            convert.getType() == bodyType) {
+          siblingBridges.push_back(convert);
+          continue;
+        }
+        oldLayoutUses.push_back(&use);
+      }
+
+      rewriter.modifyOpInPlace(predicateOp, [&] {
+        predicateOp->setOperand(index + 1, convertedInit);
+        result.setType(bodyType);
+      });
+      rewriter.modifyOpInPlace(yieldOp, [&] {
+        yieldOp->setOperand(index, boundaryConvert.getSrc());
+      });
+
+      for (ttg::ConvertLayoutOp bridge : siblingBridges) {
+        rewriter.replaceAllUsesWith(bridge.getResult(), result);
+        rewriter.eraseOp(bridge);
+      }
+
+      // Restore the original type only for non-predicate consumers. A sibling
+      // warp_predicate is rewritten to the same body type and consumes the
+      // result directly, avoiding a redundant new->old->new round trip.
+      if (!oldLayoutUses.empty()) {
+        rewriter.setInsertionPointAfter(predicateOp);
+        Value convertedResult = ttg::ConvertLayoutOp::create(
+            rewriter, predicateOp.getLoc(), oldType, result);
+        for (OpOperand *use : oldLayoutUses)
+          use->set(convertedResult);
+      }
+
+      rewriter.eraseOp(boundaryConvert);
+      changed = true;
+    }
+
+    if (predicateType && predicateEncoding) {
+      auto wavePredicateType = RankedTensorType::get(
+          predicateType.getShape(), predicateType.getElementType(),
+          *predicateEncoding);
+      if (wavePredicateType != predicateType) {
+        rewriter.setInsertionPoint(predicateOp);
+        Value wavePredicate = ttg::ConvertLayoutOp::create(
+            rewriter, predicateOp.getLoc(), wavePredicateType,
+            predicateOp.getPredicate());
+        rewriter.modifyOpInPlace(
+            predicateOp, [&] { predicateOp->setOperand(0, wavePredicate); });
+        changed = true;
+      }
+    }
+
+    return success(changed);
+  }
+};
+
 static RankedTensorType getNewTensorType(RankedTensorType origType,
                                          Attribute encoding) {
   return RankedTensorType::get(origType.getShape(), origType.getElementType(),
@@ -625,6 +837,7 @@ public:
     patterns.add<ReleaseLayoutPattern>(context);
     patterns.add<FoldRetaggedLocalAllocLoad>(context);
     patterns.add<FoldLocalAllocLoadFallback>(context);
+    patterns.add<HoistWarpPredicateLayoutConversions>(context);
 
     if (applyPatternsGreedily(getOperation(), std::move(patterns)).failed())
       signalPassFailure();

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -235,8 +235,9 @@ public:
           auto candidateType =
               RankedTensorType::get(predicateType.getShape(),
                                     predicateType.getElementType(), encoding);
-          if (ttg::toLinearLayout(selectedType) !=
-              ttg::toLinearLayout(candidateType))
+          if (!ttg::isLayoutEquivalentIgnoringRegisterOrder(
+                  ttg::toLinearLayout(selectedType),
+                  ttg::toLinearLayout(candidateType)))
             conflictingPredicateEncoding = true;
         }
       }

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -401,7 +401,62 @@ static Attribute deepUnwrapTlxWrappers(Attribute attr) {
   return attr;
 }
 
+// A reshape may be built while its source still carries a deferred TLX
+// wrapper. Layout optimization can then retag the source while the wrapper
+// keeps the reshape's previously inferred destination stable. Once wrappers
+// are removed below, the concrete reshape must satisfy Triton's normal layout
+// inference again. Preserve the destination expected by existing consumers
+// with an explicit layout conversion. The conversion may exchange data across
+// threads when downstream layout optimization selected a different ownership.
+static LogicalResult
+repairUnwrappedReshapes(ArrayRef<::mlir::triton::ReshapeOp> reshapes) {
+  for (auto reshape : reshapes) {
+    RankedTensorType srcTy = reshape.getSrc().getType();
+    RankedTensorType oldDstTy = reshape.getType();
+    Attribute srcEnc = srcTy.getEncoding();
+    Attribute oldDstEnc = oldDstTy.getEncoding();
+    if (!srcEnc || !oldDstEnc)
+      continue;
+
+    auto *layout = dyn_cast<::mlir::triton::DialectInferLayoutInterface>(
+        &srcEnc.getDialect());
+    if (!layout)
+      return reshape.emitError(
+          "source layout does not support reshape inference after TLX layout "
+          "finalization");
+
+    Attribute inferredDstEnc = oldDstEnc;
+    if (failed(layout->inferReshapeOpEncoding(
+            srcTy.getShape(), srcEnc, oldDstTy.getShape(), inferredDstEnc,
+            reshape.getAllowReorder(), reshape.getLoc())))
+      return failure();
+    if (succeeded(layout->verifyLayoutsAreEqual(oldDstTy.getShape(),
+                                                inferredDstEnc, oldDstEnc,
+                                                /*loc=*/std::nullopt)))
+      continue;
+
+    RankedTensorType inferredDstTy = RankedTensorType::get(
+        oldDstTy.getShape(), oldDstTy.getElementType(), inferredDstEnc);
+    reshape.getResult().setType(inferredDstTy);
+    OpBuilder builder(reshape);
+    builder.setInsertionPointAfter(reshape);
+    auto convert = ttg::ConvertLayoutOp::create(builder, reshape.getLoc(),
+                                                oldDstTy, reshape.getResult());
+    reshape.getResult().replaceAllUsesExcept(convert.getResult(), convert);
+  }
+  return success();
+}
+
 static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
+  SmallVector<::mlir::triton::ReshapeOp> wrappedReshapes;
+  moduleOp.walk([&](::mlir::triton::ReshapeOp reshape) {
+    if (containsUserLayout(reshape.getSrc().getType()) ||
+        containsUserLayout(reshape.getType()) ||
+        containsNoVerifyLayout(reshape.getSrc().getType()) ||
+        containsNoVerifyLayout(reshape.getType()))
+      wrappedReshapes.push_back(reshape);
+  });
+
   mlir::AttrTypeReplacer replacer;
   replacer.addReplacement([](UserLayoutAttr wrapper) -> Attribute {
     return deepUnwrapTlxWrappers(wrapper);
@@ -432,6 +487,9 @@ static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
     if (resultType && dense.getType() != resultType)
       cst.setValueAttr(dense.reshape(resultType));
   });
+
+  if (failed(repairUnwrappedReshapes(wrappedReshapes)))
+    return failure();
 
   SmallVector<ttg::ConvertLayoutOp> identityConversions;
   moduleOp.walk([&](ttg::ConvertLayoutOp convert) {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -299,7 +299,12 @@ void init_triton_tlx_ir(py::module_ &m) {
       .def("create_release_layout",
            [](TritonOpBuilder &self, Value &v) -> Value {
              if (auto type = dyn_cast<RankedTensorType>(v.getType())) {
-               if (!type.getEncoding())
+               auto parentFunc =
+                   v.getParentRegion()->getParentOfType<tt::FuncOp>();
+               bool hasDeferredHelperLayout =
+                   v.getDefiningOp<tt::CallOp>() ||
+                   (parentFunc && parentFunc.getSymVisibility() == "private");
+               if (!type.getEncoding() && !hasDeferredHelperLayout)
                  throw std::runtime_error(
                      "release_layout requires an explicit source layout");
                auto newType = RankedTensorType::get(type.getShape(),
@@ -652,6 +657,29 @@ void init_triton_tlx_ir(py::module_ &m) {
                  context, version, warpsPerCta, instrShape, transposed,
                  cgaLayout, tilesPerWarp, elementBitWidth));
            })
+      .def(
+          "make_slice_encoding_attr",
+          [](TritonOpBuilder &self, unsigned dim,
+             Attribute parentEnc) -> Attribute {
+            auto context = self.getBuilder().getContext();
+            auto parent = dyn_cast<ttg::DistributedEncodingTrait>(parentEnc);
+            auto parentLayout = dyn_cast<ttg::LayoutEncodingTrait>(parentEnc);
+            if (!parent || !parentLayout)
+              throw std::runtime_error(
+                  "make_slice_encoding_attr: parent must be a ranked "
+                  "distributed layout");
+            unsigned rank = parentLayout.getRank();
+            if (rank <= 1)
+              throw std::runtime_error(
+                  "make_slice_encoding_attr: parent layout must have at "
+                  "least rank >= 2");
+            if (dim >= rank)
+              throw std::runtime_error(
+                  "make_slice_encoding_attr: slice dim=" + std::to_string(dim) +
+                  " must be less than the parent rank=" + std::to_string(rank));
+            return mlir::cast<Attribute>(
+                ttg::SliceEncodingAttr::get(context, dim, parent));
+          })
       .def("make_linear_encoding_attr",
            [](TritonOpBuilder &self, std::vector<std::vector<int>> regBases,
               std::vector<std::vector<int>> laneBases,
@@ -1362,6 +1390,21 @@ void init_triton_tlx_ir(py::module_ &m) {
       .def("create_warp_return_op",
            [](TritonOpBuilder &self) -> void {
              self.create<ttg::WarpReturnOp>();
+           })
+      .def(
+          "create_warp_predicate_op",
+          [](TritonOpBuilder &self, std::vector<Type> &resultTypes,
+             Value predicate, std::vector<Value> &inits,
+             bool waveUniform) -> Operation * {
+            UnitAttr waveUniformAttr =
+                waveUniform ? self.getBuilder().getUnitAttr() : UnitAttr();
+            return self.create<ttg::WarpPredicateOp>(resultTypes, predicate,
+                                                     inits, waveUniformAttr);
+          },
+          py::rv_policy::reference)
+      .def("create_predicate_yield_op",
+           [](TritonOpBuilder &self, std::vector<Value> &values) -> void {
+             self.create<ttg::PredicateYieldOp>(values);
            })
       .def(
           "create_async_load",

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -78,9 +78,9 @@ from .mma_ops import (
     dot_scaled,
     extract_slice,
     rematerialized_range,
-    release_layout,
     require_amd_wmma_layout,
     require_layout,
+    release_layout,
     tcgen05_commit,
 )
 from .types import (
@@ -98,6 +98,7 @@ from .types import (
     padded_shared_layout_encoding,
     shared_linear_layout_encoding,
     amd_mfma_layout,
+    slice_layout,
     dot_operand_layout,
     reuse_group,
     reuse_group_ir_type,
@@ -121,9 +122,11 @@ from .utility import (
     cluster_size_1d,
     dtype_of,
     get_fp8_format_name,
+    num_warps,
     size_of,
     stoch_round,
     thread_id,
+    warp_predicate,
 )
 from .mxfp8_utils import _to_mxfp8_block
 from .warp_ops import vote_ballot_sync, warp_all, warp_any, warp_redux
@@ -141,6 +144,7 @@ __all__ = [
     "padded_shared_layout_encoding",
     "shared_linear_layout_encoding",
     "amd_mfma_layout",
+    "slice_layout",
     "dot_operand_layout",
     "tensor_memory_layout_encoding",
     "TMemCTAMode",
@@ -231,11 +235,14 @@ __all__ = [
     "async_dot_scaled",
     "async_dot_wait",
     "require_layout",
+    "release_layout",
     "tcgen05_commit",
     # utility
     "cluster_cta_rank",
     "cluster_size_1d",
     "thread_id",
+    "num_warps",
+    "warp_predicate",
     "async_task_replica_id",
     "dtype_of",
     "get_fp8_format_name",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -240,7 +240,13 @@ def require_layout(
 
 @tl.builtin
 def release_layout(x, _semantic=None):
-    """Release a register tensor's explicit layout for a flexible consumer."""
+    """Release a register tensor's explicit layout for a flexible consumer.
+
+     The returned tensor has the same logical shape and element type as ``x``,
+     but downstream operations may choose their own layout.  Use this at a
+     helper or control-flow boundary when a source-scheduled fragment layout is
+     intentionally local to the preceding region.
+     """
     assert isinstance(x, tl.tensor) and x.type.is_block(), "x must be a distributed tensor"
     handle = _semantic.builder.create_release_layout(x.handle)
     return tl.tensor(handle, x.type)

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -374,6 +374,38 @@ class amd_mfma_layout(layout_encoding):
                                                    self.cga_layout, self.tiles_per_warp, self.element_bitwidth)
 
 
+class slice_layout(layout_encoding):
+    """Rank-reduced view of a distributed parent layout.
+
+    This is the explicit-layout counterpart of the encoding inferred for a
+    reduction result. Keeping the parent is important because a later
+    ``expand_dims`` reconstructs that parent layout.
+    """
+
+    def __init__(self, parent, dim):
+        super().__init__()
+        self.parent = tl._unwrap_if_constexpr(parent)
+        self.dim = int(dim)
+        if not isinstance(self.parent, layout_encoding):
+            raise TypeError("slice_layout parent must be a TLX layout encoding")
+        if self.dim < 0:
+            raise ValueError("slice_layout dim must be non-negative")
+
+    def to_ir(self, builder: ir.builder, shape=None, element_type=None) -> None:
+        del shape
+        parent = self.parent.to_ir(builder, element_type=element_type)
+        return builder.make_slice_encoding_attr(self.dim, parent)
+
+    def __repr__(self):
+        return f"slice_layout<dim={self.dim}, parent={self.parent!r}>"
+
+    def __eq__(self, other):
+        return isinstance(other, slice_layout) and self.dim == other.dim and self.parent == other.parent
+
+    def __hash__(self):
+        return hash((self.__class__.__name__, self.dim, self.parent))
+
+
 class dot_operand_layout(layout_encoding):
     """Explicit MFMA dot-operand view for a shared-memory local load."""
 

--- a/third_party/tlx/language/tlx/utility.py
+++ b/third_party/tlx/language/tlx/utility.py
@@ -1,4 +1,5 @@
 import re
+import builtins
 
 import triton.language.core as tl
 import triton.runtime.driver as driver
@@ -54,6 +55,90 @@ def thread_id(axis, _semantic=None):
     if axis not in (0, 1, 2):
         raise ValueError(f"thread_id axis must be 0, 1, or 2 but got {axis}")
     return tl.tensor(_semantic.builder.create_thread_id(axis), tl.int32)
+
+
+@tl.builtin
+def num_warps(_semantic=None):
+    """Return the number of warps executing the current kernel."""
+    return tl.constexpr(_semantic.builder.options.num_warps)
+
+
+@tl.builtin
+def warp_predicate(predicate, inits, body, args=(), wave_uniform=False, _semantic=None, _generator=None):
+    """Execute ``body`` under an AMD per-lane execution predicate.
+
+    A scalar predicate supplies the execution bit for the current physical
+    lane. For a tensor predicate, elements owned by one lane are OR-reduced to
+    that lane's execution bit. A wavefront skips ``body`` when none of its
+    lanes are active. Active lanes receive the values returned by
+    ``body(*inits, *args)``; inactive lanes keep ``inits``. The body must be an
+    ``@triton.jit`` function containing straight-line computation without
+    cross-wave synchronization. Bodies containing reductions, dots, or layout
+    shuffles must pass ``wave_uniform=True`` to declare that the predicate has
+    the same value for every lane in each wavefront. Cross-warp reductions and
+    other nested regions are rejected. The body must return exactly the same
+    number and types of tensors as ``inits``. A tensor predicate's shape must
+    match each carried tensor or a common leading shape (for example, one row
+    predicate for row-major matrices).
+
+    This operation has no cross-wave synchronization and is currently lowered
+    only by the AMD backend.
+    """
+    if isinstance(inits, tl.tensor):
+        inits = (inits, )
+    elif not isinstance(inits, (builtins.tuple, builtins.list, tl.tuple)):
+        raise TypeError("warp_predicate inits must be a tensor, tuple, or list")
+    if not isinstance(args, (builtins.tuple, builtins.list, tl.tuple)):
+        args = (args, )
+
+    inits = builtins.list(inits)
+    args = builtins.list(args)
+    if not inits:
+        raise ValueError("warp_predicate requires at least one carried value")
+    if not all(isinstance(value, tl.tensor) for value in inits):
+        raise TypeError("warp_predicate carried values must be tensors")
+
+    predicate = _semantic.to_tensor(predicate)
+    if predicate.dtype != tl.int1:
+        raise TypeError(f"warp_predicate predicate must have bool dtype, got {predicate.dtype}")
+    wave_uniform = tl._unwrap_if_constexpr(wave_uniform)
+    if not isinstance(wave_uniform, builtins.bool):
+        raise TypeError(f"warp_predicate wave_uniform must be a bool, got {type(wave_uniform).__name__}")
+
+    builder = _semantic.builder
+    block = builder.new_block()
+    insertion_point = builder.get_insertion_point()
+    try:
+        builder.set_insertion_point_to_start(block)
+        body_result = _generator.call_JitFunction(body, inits + args, kwargs={})
+        if isinstance(body_result, tl.tensor):
+            results = [body_result]
+        elif isinstance(body_result, (builtins.tuple, builtins.list, tl.tuple)):
+            results = builtins.list(body_result)
+        else:
+            raise TypeError("warp_predicate body must return a tensor, tuple, or list")
+        if len(results) != len(inits):
+            raise TypeError(f"warp_predicate body returned {len(results)} values for {len(inits)} carried values")
+        for index, (init, result) in enumerate(zip(inits, results)):
+            if not isinstance(result, tl.tensor):
+                raise TypeError(f"warp_predicate result {index} is not a tensor")
+            if result.type != init.type:
+                raise TypeError(f"warp_predicate result {index} has type {result.type}, expected {init.type}")
+        builder.create_predicate_yield_op([result.handle for result in results])
+    finally:
+        builder.restore_insertion_point(insertion_point)
+
+    result_types = [result.type.to_ir(builder) for result in results]
+    op = builder.create_warp_predicate_op(
+        result_types,
+        predicate.handle,
+        [init.handle for init in inits],
+        wave_uniform,
+    )
+    op.get_region(0).push_back(block)
+    builder.set_insertion_point_after(op)
+    merged = [tl.tensor(op.get_result(index), result.type) for index, result in enumerate(results)]
+    return merged[0] if len(merged) == 1 else builtins.tuple(merged)
 
 
 @tl.builtin

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -6,11 +6,25 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.core import _aggregate as aggregate
+from triton.language.extra.libdevice import fast_dividef
 
 CLUSTER_BUF_DEPTH = 2
 CLUSTER_PIPELINE_STAGES = tl.constexpr(4)
+LAZY_RESCALE_THRESHOLD = tl.constexpr(8.0)
+DIAGONAL_LAZY_RESCALE_THRESHOLD = tl.constexpr(4.0)
+DIAGONAL_LAZY_RESCALE_THRESHOLD_FP16 = tl.constexpr(8.0)
+CDNA_WAVE_SIZE = tl.constexpr(64)
+CDNA_MFMA_ROWS_PER_WAVE = tl.constexpr(32)
+
 _CLUSTER_PIPELINE_STAGE_COUNT = 4
 _CLUSTER_AUTOTUNE_NUM_WARPS = tuple(range(1, 9))
+_CLUSTER_STATIC_K_ROW_MIN_N = 4096
+_CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS = (("amdgpu-agpr-alloc", "0,0"), )
+_CLUSTER_SHORT_N512_LLVM_FN_ATTRS = (
+    ("amdgpu-no-dispatch-id", ""),
+    *_CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS,
+)
+_CLUSTER_SHORT_N1024_LLVM_FN_ATTRS = _CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS
 
 
 def _cluster_short_load_configs():
@@ -74,22 +88,22 @@ _CLUSTER_PERSISTENT_AUTOTUNE_KEY = [*_CLUSTER_AUTOTUNE_KEY, "NUM_SMS", "NUM_XCDS
 
 @triton.jit
 def _assume_strides(
-    stride_qz,
-    stride_qh,
-    stride_qm,
-    stride_qk,
-    stride_kz,
-    stride_kh,
-    stride_kn,
-    stride_kk,
-    stride_vz,
-    stride_vh,
-    stride_vn,
-    stride_vk,
-    stride_oz,
-    stride_oh,
-    stride_om,
-    stride_ok,
+    stride_qz: tl.constexpr,
+    stride_qh: tl.constexpr,
+    stride_qm: tl.constexpr,
+    stride_qk: tl.constexpr,
+    stride_kz: tl.constexpr,
+    stride_kh: tl.constexpr,
+    stride_kn: tl.constexpr,
+    stride_kk: tl.constexpr,
+    stride_vz: tl.constexpr,
+    stride_vh: tl.constexpr,
+    stride_vn: tl.constexpr,
+    stride_vk: tl.constexpr,
+    stride_oz: tl.constexpr,
+    stride_oh: tl.constexpr,
+    stride_om: tl.constexpr,
+    stride_ok: tl.constexpr,
 ):
     tl.assume(stride_qz >= 0)
     tl.assume(stride_qh >= 0)
@@ -107,6 +121,59 @@ def _assume_strides(
     tl.assume(stride_oh >= 0)
     tl.assume(stride_om > 0)
     tl.assume(stride_ok >= 0)
+
+
+@triton.jit
+def _split_cols(x):
+    """Split a matrix into logical column halves without changing values.
+
+    The reshape must retain Triton's default order-preserving contract.  In
+    particular, ``can_reorder=True`` would permit a different register
+    interpretation and no longer make this operation the inverse of
+    ``_concat_cols``.
+    """
+    tl.static_assert(x.shape[1] % 2 == 0)
+    x0, x1 = tl.split(x.reshape([x.shape[0], 2, x.shape[1] // 2]).permute(0, 2, 1))
+    return x0, x1
+
+
+@triton.jit
+def _concat_cols(x0, x1):
+    """Reassemble adjacent logical column halves without reordering them."""
+    tl.static_assert(x0.shape[0] == x1.shape[0])
+    tl.static_assert(x0.shape[1] == x1.shape[1])
+    x = tl.join(x0, x1).permute(0, 2, 1).reshape([x0.shape[0], x0.shape[1] + x1.shape[1]])
+    return x
+
+
+@triton.jit
+def _sum_rows_chain4(x, ROTATE_FINAL: tl.constexpr):
+    """Reduce four zero-copy column slices through one dependency chain."""
+    x_01, x_23 = _split_cols(x)
+    x_0, x_1 = _split_cols(x_01)
+    x_2, x_3 = _split_cols(x_23)
+    partial = x_0 + x_1
+    if ROTATE_FINAL:
+        partial = partial + x_3
+        partial = partial + x_2
+    else:
+        partial = partial + x_2
+        partial = partial + x_3
+    return tl.sum(partial, 1)
+
+
+@triton.jit
+def _sum_combine(a, b):
+    return a + b
+
+
+@aggregate
+class LazyProbabilityState:
+    p_0123: tl.tensor
+    p_4: tl.tensor
+    qk_5: tl.tensor
+    qk_6: tl.tensor
+    qk_7: tl.tensor
 
 
 @aggregate
@@ -155,9 +222,10 @@ class SoftmaxState:
             p = tl.math.exp2(qk_sm - m_new[:, None])
             alpha = tl.math.exp2(self.m_i - m_new)
         else:
-            m_ij = SoftmaxState._row_max(qk) * QK_SCALE
+            qk_sm = qk * QK_SCALE
+            m_ij = SoftmaxState._row_max(qk_sm)
             m_new = tl.maximum(self.m_i, m_ij, propagate_nan=tl.PropagateNan.ALL)
-            p = tl.math.exp2(qk * QK_SCALE - m_new[:, None])
+            p = tl.math.exp2(qk_sm - m_new[:, None])
             alpha = tl.math.exp2(self.m_i - m_new)
         return SoftmaxState(self.acc, self.l_i, m_new), p, alpha
 
@@ -168,6 +236,597 @@ class SoftmaxState:
         l_i = self.l_i * alpha + l_ij
         p_cast = p.to(out_dtype)
         return SoftmaxState(acc, l_i, self.m_i), p_cast
+
+    @triton.jit
+    def vec2_split_acc(self, acc_sub1, p, alpha, out_dtype: tl.constexpr):
+        """Apply VEC2 while keeping a D128 accumulator as two D64 tiles."""
+        tl.static_assert(self.acc.shape[1] == 64)
+        tl.static_assert(acc_sub1.shape[0] == self.acc.shape[0])
+        tl.static_assert(acc_sub1.shape[1] == self.acc.shape[1])
+        acc_sub0 = self.acc * alpha[:, None]
+        acc_sub1 = acc_sub1 * alpha[:, None]
+        l_ij = tl.sum(p, 1)
+        l_i = self.l_i * alpha + l_ij
+        p_cast = p.to(out_dtype)
+        return SoftmaxState(acc_sub0, l_i, self.m_i), acc_sub1, p_cast
+
+    @triton.jit
+    def vec1_lazy(self, qk, QK_SCALE: tl.constexpr):
+        """Form probabilities in a lazily advanced base-2 softmax frame."""
+        state, score_delta, advance = self.vec1_lazy_max(qk, QK_SCALE)
+        p = state.vec1_lazy_exp(qk, QK_SCALE)
+        return state, p, score_delta, advance
+
+    @triton.jit
+    def vec1_lazy_split(self, qk, QK_SCALE: tl.constexpr):
+        """Form five eighths of P and defer three score fragments."""
+        state, score_delta, advance = self.vec1_lazy_max(qk, QK_SCALE)
+        p_state = state.vec1_lazy_exp_split(qk, QK_SCALE)
+        return state, p_state, score_delta, advance
+
+    @triton.jit
+    def vec1_lazy_split4(self, qk, QK_SCALE: tl.constexpr):
+        """Form four eighths of P and carry the remaining score fragments."""
+        tl.static_assert(qk.shape[1] == 64)
+        state, score_delta, advance = self.vec1_lazy_max(qk, QK_SCALE)
+        qk_lo, qk_hi = _split_cols(qk)
+        qk_a, qk_b = _split_cols(qk_lo)
+        qk_c, qk_d = _split_cols(qk_hi)
+        qk_0, qk_1 = _split_cols(qk_a)
+        qk_2, qk_3 = _split_cols(qk_b)
+        qk_4, qk_5 = _split_cols(qk_c)
+        qk_6, qk_7 = _split_cols(qk_d)
+        m_i = tlx.release_layout(state.m_i)[:, None]
+        p_0 = tl.math.exp2(qk_0 * QK_SCALE - m_i)
+        p_1 = tl.math.exp2(qk_1 * QK_SCALE - m_i)
+        p_2 = tl.math.exp2(qk_2 * QK_SCALE - m_i)
+        p_3 = tl.math.exp2(qk_3 * QK_SCALE - m_i)
+        p_01 = _concat_cols(p_0, p_1)
+        p_23 = _concat_cols(p_2, p_3)
+        return (
+            state,
+            LazyProbabilityState(
+                _concat_cols(p_01, p_23),
+                qk_4,
+                qk_5,
+                qk_6,
+                qk_7,
+            ),
+            score_delta,
+            advance,
+        )
+
+    @triton.jit
+    def vec1_lazy_split_threshold(self, qk, QK_SCALE: tl.constexpr, THRESHOLD: tl.constexpr):
+        """Split lazy VEC1 with the threshold used by the causal diagonal."""
+        state, score_delta, advance = self.vec1_lazy_max_threshold(qk, QK_SCALE, THRESHOLD)
+        p_state = state.vec1_lazy_exp_split(qk, QK_SCALE)
+        return state, p_state, score_delta, advance
+
+    @triton.jit
+    def vec1_lazy_max(self, qk, QK_SCALE: tl.constexpr):
+        """Advance the lazy softmax frame while retaining the score tile."""
+        m_ij = SoftmaxState._row_max(qk * QK_SCALE)
+        score_delta = m_ij - self.m_i
+        advance = score_delta > LAZY_RESCALE_THRESHOLD
+        m_new = tl.where(advance, m_ij, self.m_i)
+        return SoftmaxState(self.acc, self.l_i, m_new), score_delta, advance
+
+    @triton.jit
+    def vec1_lazy_max_threshold(self, qk, QK_SCALE: tl.constexpr, THRESHOLD: tl.constexpr):
+        """Advance the lazy frame using a diagonal-specific threshold."""
+        m_ij = SoftmaxState._row_max(qk * QK_SCALE)
+        score_delta = m_ij - self.m_i
+        advance = score_delta > THRESHOLD
+        m_new = tl.where(advance, m_ij, self.m_i)
+        return SoftmaxState(self.acc, self.l_i, m_new), score_delta, advance
+
+    @triton.jit
+    def vec1_lazy_exp(self, qk, QK_SCALE: tl.constexpr):
+        return tl.math.exp2(qk * QK_SCALE - self.m_i[:, None])
+
+    @triton.jit
+    def vec1_lazy_exp_split(self, qk, QK_SCALE: tl.constexpr):
+        """Compute P[0:5] as N8 fragments and carry QK[5:8]."""
+        tl.static_assert(qk.shape[1] == 64)
+        mma: tl.constexpr = tlx.amd_mfma_layout(
+            version=4,
+            instr_shape=[32, 32, 16],
+            transposed=True,
+            warps_per_cta=[tlx.num_warps(), 1],
+        )
+        qk = tlx.require_layout(qk, mma, pin=True)
+        qk_lo, qk_hi = _split_cols(qk)
+        qk_a, qk_b = _split_cols(qk_lo)
+        qk_c, qk_d = _split_cols(qk_hi)
+        qk_0, qk_1 = _split_cols(qk_a)
+        qk_2, qk_3 = _split_cols(qk_b)
+        qk_4, qk_5 = _split_cols(qk_c)
+        qk_6, qk_7 = _split_cols(qk_d)
+        # Each N8 fragment has the order-preserving linear layout inferred by
+        # the split.  Release the row-state pin before broadcasting so the
+        # elementwise probability work follows that fragment layout.
+        m_i = tlx.release_layout(self.m_i)[:, None]
+        p_0 = tl.math.exp2(qk_0 * QK_SCALE - m_i)
+        p_1 = tl.math.exp2(qk_1 * QK_SCALE - m_i)
+        p_2 = tl.math.exp2(qk_2 * QK_SCALE - m_i)
+        p_3 = tl.math.exp2(qk_3 * QK_SCALE - m_i)
+        p_4 = tl.math.exp2(qk_4 * QK_SCALE - m_i)
+        p_01 = _concat_cols(p_0, p_1)
+        p_23 = _concat_cols(p_2, p_3)
+        return LazyProbabilityState(_concat_cols(p_01, p_23), p_4, qk_5, qk_6, qk_7)
+
+    @triton.jit
+    def vec2_lazy(self, p, out_dtype: tl.constexpr):
+        l_i = self.l_i + tl.sum(p, 1)
+        return SoftmaxState(self.acc, l_i, self.m_i), p.to(out_dtype)
+
+    @triton.jit
+    def vec2_lazy_split(
+        self,
+        p_state,
+        QK_SCALE: tl.constexpr,
+        out_dtype: tl.constexpr,
+        FP16_CAST_ROWSUM: tl.constexpr,
+        CHAIN_BF16_ROWSUM: tl.constexpr = 0,
+    ):
+        """Finish the deferred three eighths of P in the next DOT1 phase."""
+        m_i = tlx.release_layout(self.m_i)[:, None]
+        p_5 = tl.math.exp2(p_state.qk_5 * QK_SCALE - m_i)
+        p_6 = tl.math.exp2(p_state.qk_6 * QK_SCALE - m_i)
+        p_7 = tl.math.exp2(p_state.qk_7 * QK_SCALE - m_i)
+        p_45 = _concat_cols(p_state.p_4, p_5)
+        p_67 = _concat_cols(p_6, p_7)
+        p = _concat_cols(p_state.p_0123, _concat_cols(p_45, p_67))
+        p_cast = p.to(out_dtype)
+        if FP16_CAST_ROWSUM and out_dtype == tl.float16:
+            l_ij = tl.sum(p_cast, 1)
+        elif CHAIN_BF16_ROWSUM:
+            l_ij = _sum_rows_chain4(p, CHAIN_BF16_ROWSUM == 2)
+        else:
+            l_ij = tl.sum(p, 1)
+        l_i = self.l_i + l_ij
+        return SoftmaxState(self.acc, l_i, self.m_i), p_cast
+
+    @triton.jit
+    def vec2_lazy_split4(
+        self,
+        p_state,
+        QK_SCALE: tl.constexpr,
+        out_dtype: tl.constexpr,
+        FP16_CAST_ROWSUM: tl.constexpr,
+        CHAIN_BF16_ROWSUM: tl.constexpr = 0,
+    ):
+        """Finish four deferred score fragments from the BM128 prefix."""
+        m_i = tlx.release_layout(self.m_i)[:, None]
+        p_4 = tl.math.exp2(p_state.p_4 * QK_SCALE - m_i)
+        p_5 = tl.math.exp2(p_state.qk_5 * QK_SCALE - m_i)
+        p_6 = tl.math.exp2(p_state.qk_6 * QK_SCALE - m_i)
+        p_7 = tl.math.exp2(p_state.qk_7 * QK_SCALE - m_i)
+        p_45 = _concat_cols(p_4, p_5)
+        p_67 = _concat_cols(p_6, p_7)
+        p = _concat_cols(p_state.p_0123, _concat_cols(p_45, p_67))
+        p_cast = p.to(out_dtype)
+        if FP16_CAST_ROWSUM and out_dtype == tl.float16:
+            l_ij = tl.sum(p_cast, 1)
+        elif CHAIN_BF16_ROWSUM:
+            l_ij = _sum_rows_chain4(p, CHAIN_BF16_ROWSUM == 2)
+        else:
+            l_ij = tl.sum(p, 1)
+        l_i = self.l_i + l_ij
+        return SoftmaxState(self.acc, l_i, self.m_i), p_cast
+
+    @triton.jit
+    def rescale_lazy(self, score_delta, advance):
+        tl.static_assert(self.acc.shape[0] == 128 or self.acc.shape[0] == 256)
+        tl.static_assert(self.acc.shape[1] == 128)
+        tl.static_assert(self.l_i.shape[0] == self.acc.shape[0])
+        tl.static_assert(score_delta.shape[0] == self.acc.shape[0])
+        tl.static_assert(advance.shape[0] == self.acc.shape[0])
+        tl.static_assert(tlx.num_warps() == self.acc.shape[0] // 32)
+        acc_layout: tl.constexpr = tlx.amd_mfma_layout(
+            version=4,
+            instr_shape=[32, 32, 16],
+            transposed=True,
+            warps_per_cta=[tlx.num_warps(), 1],
+        )
+        row_layout: tl.constexpr = tlx.slice_layout(acc_layout, 1)
+        advance = tlx.require_layout(advance, row_layout, pin=False)
+        score_delta = tlx.require_layout(score_delta, row_layout, pin=False)
+        l_i = tlx.require_layout(self.l_i, row_layout, pin=False)
+        acc = tlx.require_layout(self.acc, acc_layout, pin=False)
+        alpha = tl.math.exp2(-score_delta)
+        alpha_2d = tlx.require_layout(alpha[:, None], acc_layout, pin=False)
+        acc, l_i = tlx.warp_predicate(
+            advance,
+            (acc, l_i),
+            _rescale_softmax_state,
+            args=(alpha, alpha_2d),
+        )
+        return SoftmaxState(acc, l_i, self.m_i)
+
+
+@triton.jit
+def _rescale_softmax_state(acc, l_i, alpha, alpha_2d):
+    """Apply a lane-local correction after layouts are fixed outside EXEC."""
+    return acc * alpha_2d, l_i * alpha
+
+
+@triton.jit
+def _attn_dot_pv_vec1_lazy(
+    state,
+    p_dot,
+    v_dot,
+    qk,
+    QK_SCALE: tl.constexpr,
+    SPLIT_VEC1: tl.constexpr,
+):
+    """Weave lazy row-max work through four native K16 P-by-V steps."""
+    tl.static_assert(state.acc.shape[0] == 128 or state.acc.shape[0] == 256)
+    tl.static_assert(state.acc.shape[1] == 128)
+    tl.static_assert(p_dot.shape[0] == state.acc.shape[0])
+    tl.static_assert(p_dot.shape[1] == 64)
+    tl.static_assert(v_dot.shape[0] == 64)
+    tl.static_assert(v_dot.shape[1] == 128)
+    tl.static_assert(qk.shape[0] == state.acc.shape[0])
+    tl.static_assert(qk.shape[1] == 64)
+    tl.static_assert(tlx.num_warps() == state.acc.shape[0] // 32)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    p_layout: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=4)
+    v_layout: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=4)
+    p_dot = tlx.require_layout(p_dot, p_layout, pin=False)
+    v_dot = tlx.require_layout(v_dot, v_layout, pin=False)
+    acc = tlx.require_layout(state.acc, mma, pin=False)
+    p0 = tlx.extract_slice(p_dot, [p_dot.shape[0], 16], [0, 0])
+    p1 = tlx.extract_slice(p_dot, [p_dot.shape[0], 16], [0, 16])
+    p2 = tlx.extract_slice(p_dot, [p_dot.shape[0], 16], [0, 32])
+    p3 = tlx.extract_slice(p_dot, [p_dot.shape[0], 16], [0, 48])
+    v0 = tlx.extract_slice(v_dot, [16, v_dot.shape[1]], [0, 0])
+    v1 = tlx.extract_slice(v_dot, [16, v_dot.shape[1]], [16, 0])
+    v2 = tlx.extract_slice(v_dot, [16, v_dot.shape[1]], [32, 0])
+    v3 = tlx.extract_slice(v_dot, [16, v_dot.shape[1]], [48, 0])
+
+    acc = tl.dot(p0, v0, acc)
+    if state.acc.shape[0] == 128:
+        acc = tl.dot(p1, v1, acc)
+        max_state, score_delta, advance = state.vec1_lazy_max(qk, QK_SCALE)
+    else:
+        max_state, score_delta, advance = state.vec1_lazy_max(qk, QK_SCALE)
+        acc = tl.dot(p1, v1, acc)
+    acc = tl.dot(p2, v2, acc)
+    acc = tl.dot(p3, v3, acc)
+    state = SoftmaxState(acc, state.l_i, max_state.m_i)
+    if SPLIT_VEC1:
+        p = state.vec1_lazy_exp_split(qk, QK_SCALE)
+    else:
+        p = state.vec1_lazy_exp(qk, QK_SCALE)
+    return state, p, score_delta, advance
+
+
+@triton.jit
+def _attn_dot_pv_mfma(acc, p_dot, v_dot):
+    """Keep a fallback P-by-V dot in the woven accumulator's layout."""
+    tl.static_assert(acc.shape[0] == 128 or acc.shape[0] == 256)
+    tl.static_assert(acc.shape[1] == 128)
+    tl.static_assert(p_dot.shape[0] == acc.shape[0])
+    tl.static_assert(p_dot.shape[1] == 64)
+    tl.static_assert(v_dot.shape[0] == 64)
+    tl.static_assert(v_dot.shape[1] == 128)
+    tl.static_assert(tlx.num_warps() == acc.shape[0] // 32)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    p_layout: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=4)
+    v_layout: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=4)
+    p_dot = tlx.require_layout(p_dot, p_layout, pin=False)
+    v_dot = tlx.require_layout(v_dot, v_layout, pin=False)
+    acc = tlx.require_layout(acc, mma, pin=False)
+    return tl.dot(p_dot, v_dot, acc)
+
+
+@triton.jit
+def _attn_dot_pv_mfma_split(acc, p_dot, v_dot):
+    """Accumulate one D64 half of the BM256/BN64/D128 P-by-V dot."""
+    tl.static_assert(acc.shape[0] == 256)
+    tl.static_assert(acc.shape[1] == 64)
+    tl.static_assert(p_dot.shape[0] == acc.shape[0])
+    tl.static_assert(p_dot.shape[1] == 64)
+    tl.static_assert(v_dot.shape[0] == 64)
+    tl.static_assert(v_dot.shape[1] == acc.shape[1])
+    tl.static_assert(tlx.num_warps() == 8)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    p_layout: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=4)
+    v_layout: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=4)
+    p_dot = tlx.require_layout(p_dot, p_layout, pin=False)
+    v_dot = tlx.require_layout(v_dot, v_layout, pin=False)
+    acc = tlx.require_layout(acc, mma, pin=False)
+    return tl.dot(p_dot, v_dot, acc)
+
+
+@triton.jit
+def _attn_dot_pv_mfma32(acc, p_dot, v_dot):
+    """P-by-V fallback for the low N32 half of a causal diagonal."""
+    tl.static_assert(acc.shape[0] == 128 or acc.shape[0] == 256)
+    tl.static_assert(acc.shape[1] == 128)
+    tl.static_assert(p_dot.shape[0] == acc.shape[0])
+    tl.static_assert(p_dot.shape[1] == 32)
+    tl.static_assert(v_dot.shape[0] == 32)
+    tl.static_assert(v_dot.shape[1] == 128)
+    tl.static_assert(tlx.num_warps() == acc.shape[0] // 32)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    p_layout: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=2)
+    v_layout: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=2)
+    p_dot = tlx.require_layout(p_dot, p_layout, pin=False)
+    v_dot = tlx.require_layout(v_dot, v_layout, pin=False)
+    acc = tlx.require_layout(acc, mma, pin=False)
+    return tl.dot(p_dot, v_dot, acc)
+
+
+@triton.jit
+def _attn_war_barrier(LIGHTWEIGHT: tl.constexpr):
+    """Rendezvous before an LDS overwrite, with no visibility fence for WAR."""
+    if LIGHTWEIGHT:
+        tl.inline_asm_elementwise(
+            "s_waitcnt lgkmcnt(0)\ns_barrier",
+            "=s",
+            [],
+            dtype=tl.int32,
+            is_pure=False,
+            pack=1,
+        )
+    else:
+        tl.debug_barrier()
+
+
+@triton.jit
+def _attn_qk_war_barrier_relaxed(qk):
+    """Anchor both N32 QK results before reusing their K slot."""
+    tl.static_assert(qk.shape[0] == 128 and qk.shape[1] == 64)
+    tl.static_assert(tlx.num_warps() == 4)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    qk = tlx.require_layout(qk, mma, pin=False)
+    # One zero-copy N8 view from each N32 result ties the rendezvous to the
+    # final MFMA that consumes the old K slot in every wave.
+    qk0 = tlx.extract_slice(qk, [qk.shape[0], 8], [0, 0])
+    qk1 = tlx.extract_slice(qk, [qk.shape[0], 8], [0, qk.shape[1] // 2])
+    tl.inline_asm_elementwise(
+        "s_barrier",
+        "=s,=s,=s,=s,v,v,v,v,v,v,v,v",
+        [qk0, qk1],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=4,
+    )
+
+
+@triton.jit
+def _attn_pv_war_barrier_relaxed(acc):
+    """Anchor every D32 P-by-V result before reusing its V slot."""
+    tl.static_assert(acc.shape[0] == 128 and acc.shape[1] == 128)
+    tl.static_assert(tlx.num_warps() == 4)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    acc = tlx.require_layout(acc, mma, pin=False)
+    # D128 P-by-V has four D32 accumulator groups. One zero-copy D8 view from
+    # each group makes the rendezvous depend on every final MFMA.
+    acc_0 = tlx.extract_slice(acc, [acc.shape[0], 8], [0, 0])
+    acc_1 = tlx.extract_slice(acc, [acc.shape[0], 8], [0, acc.shape[1] // 4])
+    acc_2 = tlx.extract_slice(acc, [acc.shape[0], 8], [0, acc.shape[1] // 2])
+    acc_3 = tlx.extract_slice(acc, [acc.shape[0], 8], [0, 3 * acc.shape[1] // 4])
+    tl.inline_asm_elementwise(
+        "s_barrier",
+        "=s,=s,=s,=s," + ",".join(["v"] * 16),
+        [acc_0, acc_1, acc_2, acc_3],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=4,
+    )
+
+
+@triton.jit
+def _attn_dot_qk_step8_vec2(
+    state,
+    p_state,
+    q,
+    kt_dot,
+    QK_SCALE: tl.constexpr,
+    FP16_CAST_ROWSUM: tl.constexpr,
+):
+    """Interleave the deferred lazy-softmax fragments with QK's K16 MFMAs.
+
+    CDNA4 lowers a regular ``tl.dot`` as one opaque reduction.  The Gluon
+    kernel instead issues the eight K=16 reductions separately and uses the
+    otherwise idle VALU slots to finish VEC2 between reductions 5--7.  Keep
+    the same schedule here, with the explicit CDNA4 operand layouts required
+    by ``amd_scheduled_mfma``.
+    """
+    tl.static_assert(q.shape[1] == 128)
+    tl.static_assert(kt_dot.shape[0] == 128)
+    tl.static_assert(kt_dot.shape[1] == 64)
+    tl.static_assert(q.shape[0] == 256)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    q_layout: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    kt_layout: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+    q = tlx.require_layout(q, q_layout, pin=False)
+    kt_dot = tlx.require_layout(kt_dot, kt_layout, pin=False)
+    qk = tlx.zeros((q.shape[0], kt_dot.shape[1]), tl.float32, layout=mma)
+
+    q0 = tlx.extract_slice(q, [q.shape[0], 16], [0, 0])
+    q1 = tlx.extract_slice(q, [q.shape[0], 16], [0, 16])
+    q2 = tlx.extract_slice(q, [q.shape[0], 16], [0, 32])
+    q3 = tlx.extract_slice(q, [q.shape[0], 16], [0, 48])
+    q4 = tlx.extract_slice(q, [q.shape[0], 16], [0, 64])
+    q5 = tlx.extract_slice(q, [q.shape[0], 16], [0, 80])
+    q6 = tlx.extract_slice(q, [q.shape[0], 16], [0, 96])
+    q7 = tlx.extract_slice(q, [q.shape[0], 16], [0, 112])
+    k0 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [0, 0])
+    k1 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [16, 0])
+    k2 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [32, 0])
+    k3 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [48, 0])
+    k4 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [64, 0])
+    k5 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [80, 0])
+    k6 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [96, 0])
+    k7 = tlx.extract_slice(kt_dot, [16, kt_dot.shape[1]], [112, 0])
+
+    # The source-scheduled MFMA primitive is currently BF16-only in TLX;
+    # explicit K16 ``tl.dot`` calls preserve the interleave for FP16 while
+    # retaining the native FP16 dot lowering.
+    qk = tl.dot(q0, k0, qk)
+    qk = tl.dot(q1, k1, qk)
+    qk = tl.dot(q2, k2, qk)
+    qk = tl.dot(q3, k3, qk)
+    qk = tl.dot(q4, k4, qk)
+
+    m_i = tlx.release_layout(state.m_i)[:, None]
+    p5 = tl.math.exp2(p_state.qk_5 * QK_SCALE - m_i)
+    qk = tl.dot(q5, k5, qk)
+    p6 = tl.math.exp2(p_state.qk_6 * QK_SCALE - m_i)
+    qk = tl.dot(q6, k6, qk)
+    p7 = tl.math.exp2(p_state.qk_7 * QK_SCALE - m_i)
+
+    p45 = _concat_cols(p_state.p_4, p5)
+    p67 = _concat_cols(p6, p7)
+    p = _concat_cols(p_state.p_0123, _concat_cols(p45, p67))
+    p_cast = p.to(q.dtype)
+    if FP16_CAST_ROWSUM and q.dtype == tl.float16:
+        # Gluon keeps the reassembled probability tile in the MFMA layout, so
+        # its FP16 row sum uses the same short local tree before the cross-lane
+        # reduction.  Pin that source layout until the reduction is complete;
+        # release only the rank-1 result at this helper boundary.
+        # The split fragments intentionally keep their inferred, order-
+        # preserving layouts.  Stop the reduction pin at this explicit
+        # conversion boundary instead of propagating it back through the
+        # logical split/concat chain.
+        p_reduce = tlx.require_layout(tlx.release_layout(p_cast), mma, pin=True)
+        tlx.assert_same_layout(p_reduce, mma)
+        l_ij = tl.reduce(p_reduce, 1, _sum_combine)
+        l_ij = tlx.release_layout(l_ij)
+    else:
+        l_ij = tl.sum(p, 1)
+    state = SoftmaxState(state.acc, state.l_i + l_ij, state.m_i)
+
+    qk = tl.dot(q7, k7, qk)
+    # Gluon keeps the score tile in its MFMA layout across the DOT1 -> DOT2
+    # handoff.  Pin the same contract here so the split/concat probability
+    # fragments reassemble trivially in that layout instead of selecting an
+    # unrelated linear layout and converting back for the FP16 row sum.
+    qk = tlx.require_layout(qk, mma, pin=True)
+    return state, p_cast, qk
+
+
+@triton.jit
+def _attn_inner_pipelined_lazy_step(
+    state,
+    p_c,
+    q,
+    kt_dot,
+    k_ptrs,
+    v_ptrs,
+    offs_n,
+    block_n,
+    k_buf,
+    v_buf,
+    stride_kn,
+    stride_vn,
+    QK_SCALE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    CUR_SLOT: tl.constexpr,
+    NEXT_SLOT: tl.constexpr,
+    SPLIT_VEC1: tl.constexpr,
+    STEP_PV_VEC1: tl.constexpr,
+    STEP_QK_VEC2: tl.constexpr,
+    FP16_CAST_ROWSUM: tl.constexpr,
+    CHAIN_BF16_ROWSUM: tl.constexpr,
+):
+    """Advance one aligned lazy-rescale tile with static LDS slots."""
+    ack_n = (block_n + 3) * BLOCK_N
+    acv_n = (block_n + 2) * BLOCK_N
+
+    with tlx.warp_pipeline_stage("dot1", priority=0):
+        if STEP_QK_VEC2:
+            state, p_dot, qk = _attn_dot_qk_step8_vec2(state, p_c, q, kt_dot, QK_SCALE, FP16_CAST_ROWSUM)
+        else:
+            qk = tl.dot(q, kt_dot)
+            if SPLIT_VEC1:
+                state, p_dot = state.vec2_lazy_split(
+                    p_c,
+                    QK_SCALE,
+                    q.dtype,
+                    FP16_CAST_ROWSUM,
+                    CHAIN_BF16_ROWSUM,
+                )
+            else:
+                state, p_dot = state.vec2_lazy(p_c, q.dtype)
+
+    tlx.async_load_wait_group(1)
+
+    with tlx.warp_pipeline_stage("mem1", priority=1):
+        v_dot = tlx.local_load(tlx.local_view(v_buf, CUR_SLOT), relaxed=True)
+        tok_k = tlx.async_load(k_ptrs + ack_n * stride_kn, tlx.local_view(k_buf, NEXT_SLOT))
+        tlx.async_load_commit_group([tok_k])
+
+    with tlx.warp_pipeline_stage("dot2", priority=0):
+        if STEP_PV_VEC1:
+            state, p_c, delta_c, advance_c = _attn_dot_pv_vec1_lazy(
+                state,
+                p_dot,
+                v_dot,
+                qk,
+                QK_SCALE,
+                SPLIT_VEC1,
+            )
+        else:
+            acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+            state = SoftmaxState(acc, state.l_i, state.m_i)
+            if SPLIT_VEC1:
+                state, p_c, delta_c, advance_c = state.vec1_lazy_split(qk, QK_SCALE)
+            else:
+                state, p_c, delta_c, advance_c = state.vec1_lazy(qk, QK_SCALE)
+
+    tlx.async_load_wait_group(1)
+
+    with tlx.warp_pipeline_stage("mem2", priority=1):
+        # Preserve the optimized Gluon lazy cadence exactly: consume K from
+        # LDS before issuing the independent V copy for this slot.  The
+        # V-before-K ordering belongs only to Gluon's non-lazy fallback path.
+        kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, CUR_SLOT)), relaxed=True)
+        tok_v = tlx.async_load(v_ptrs + acv_n * stride_vn, tlx.local_view(v_buf, CUR_SLOT))
+        tlx.async_load_commit_group([tok_v])
+        state = state.rescale_lazy(delta_c, advance_c)
+
+    return state, p_c, kt_dot
 
 
 @triton.jit
@@ -191,7 +850,86 @@ def _attn_inner_pipelined(
     BUF_DEPTH: tl.constexpr,
     MASK_STEPS: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
+    PREFETCH_CAUSAL_DIAGONAL: tl.constexpr,
 ):
+    # The long causal BM256 object owns four physical LDS slots for its
+    # diagonal pruning, but the unmasked steady-state pipeline itself is still
+    # a two-slot ping-pong schedule.  Keep that logical depth separate from
+    # the allocation depth so lazy softmax can run on the same object.
+    LAZY_BUF_DEPTH: tl.constexpr = 2
+    # N1024 BF16 loses overlap with the stock LLVM scheduler on the extended
+    # drain. Keep that class on its established exact-rescale control flow.
+    USE_LAZY_RESCALE: tl.constexpr = (
+        not MASK_STEPS and BLOCK_N == 64 and q.shape[1] == 128 and tlx.num_warps() == q.shape[0] // 32
+        and BUF_DEPTH >= LAZY_BUF_DEPTH and N_CTX % q.shape[0] == 0 and N_CTX % BLOCK_N == 0
+        and (q.shape[0] == 256 or (q.shape[0] == 128 and IS_CAUSAL and
+                                   (N_CTX == 8 * BLOCK_N or
+                                    (PREFETCH_CAUSAL_DIAGONAL and N_CTX == 16 * BLOCK_N and q.dtype == tl.float16)))))
+    # On the aligned short-causal classes, extend the steady-state loop through
+    # all but the final prefix tile.  The two-slot BM128 schedule hands off its
+    # complete diagonal ring; N2048 fills the two otherwise-unused BM256 slots
+    # while consuming that final prefix tile.
+    USE_ONE_TILE_TWO_SLOT_PREFIX_DRAIN: tl.constexpr = (PREFETCH_CAUSAL_DIAGONAL and USE_LAZY_RESCALE
+                                                        and BUF_DEPTH == LAZY_BUF_DEPTH and IS_CAUSAL
+                                                        and (N_CTX == 8 * BLOCK_N or N_CTX == 16 * BLOCK_N)
+                                                        and q.shape[0] == 128 and BLOCK_N == 64 and q.shape[1] == 128
+                                                        and tlx.num_warps() == 4)
+    USE_ONE_TILE_FOUR_SLOT_PREFIX_DRAIN: tl.constexpr = (PREFETCH_CAUSAL_DIAGONAL and USE_LAZY_RESCALE
+                                                         and BUF_DEPTH == LAZY_BUF_DEPTH and IS_CAUSAL and N_CTX == 2048
+                                                         and q.shape[0] == 256 and BLOCK_N == 64 and q.shape[1] == 128
+                                                         and tlx.num_warps() == 8)
+    USE_ONE_TILE_PREFIX_DRAIN: tl.constexpr = (USE_ONE_TILE_TWO_SLOT_PREFIX_DRAIN
+                                               or USE_ONE_TILE_FOUR_SLOT_PREFIX_DRAIN)
+    if PREFETCH_CAUSAL_DIAGONAL:
+        tl.static_assert(USE_ONE_TILE_PREFIX_DRAIN)
+        tl.static_assert(not MASK_STEPS)
+    # Deferring the final three N8 probability fragments benefits every
+    # eligible causal prefix and full-attention rows from N2048 onward.
+    SPLIT_VEC1: tl.constexpr = USE_LAZY_RESCALE and (IS_CAUSAL or N_CTX >= 2048)
+    # Weaving row-max work between native K16 PV steps is consistently useful
+    # for full attention and for causal rows once they reach N4096.
+    STEP_PV_VEC1: tl.constexpr = (USE_LAZY_RESCALE
+                                  and ((q.shape[0] == 256 and
+                                        (not IS_CAUSAL or q.dtype == tl.float16 or N_CTX // BLOCK_N >= 64)) or
+                                       (IS_CAUSAL and q.shape[0] == 128 and N_CTX == 512)))
+    # The reference CDNA4 kernel also overlaps the deferred VEC2 exponentials
+    # with QK's final three K16 reductions.  Restrict this first port to the
+    # aligned BM256/BN64 FP16 class where the operand/layout contract is exact.
+    STEP_QK_VEC2: tl.constexpr = (USE_LAZY_RESCALE and q.shape[0] == 256 and q.shape[1] == 128 and BLOCK_N == 64
+                                  and q.dtype == tl.float16
+                                  and (IS_CAUSAL and N_CTX >= 4096 or (not IS_CAUSAL and N_CTX >= 2048)))
+    # Match the Gluon numerator/denominator contract: FP16 reduces the rounded
+    # P operand that is consumed by P*V.  For BF16, its medium-row stage-three
+    # schedule uses the ordinary four-slice chain, while the N8192+ stage-four
+    # schedule rotates the final two additions.
+    FP16_CAST_ROWSUM: tl.constexpr = USE_LAZY_RESCALE and q.dtype == tl.float16
+    CHAIN_BF16_ROWSUM: tl.constexpr = (
+        2 if USE_LAZY_RESCALE and q.dtype == tl.bfloat16 and q.shape[0] == 256 and IS_CAUSAL and N_CTX >= 8192 else
+        1 if USE_LAZY_RESCALE and q.dtype == tl.bfloat16 and q.shape[0] == 256 and N_CTX // BLOCK_N >= 64 else 0)
+    DRAIN_STEP_PV_VEC1: tl.constexpr = STEP_PV_VEC1 and not IS_CAUSAL and N_CTX >= 8 * BLOCK_N
+    # Keep the BN64 accumulator in one MFMA layout for the complete helper.
+    # In particular, a masked tail can enter from a released prefix layout;
+    # allowing generic PV to choose a new layout inside its loop leaves an
+    # illegal blocked-to-MFMA loop-carried conversion.
+    EXPLICIT_PV_LAYOUT: tl.constexpr = (BLOCK_N == 64 and (q.shape[0] == 128 or q.shape[0] == 256) and q.shape[1] == 128
+                                        and tlx.num_warps() == q.shape[0] // 32)
+    # Match the Gluon fallback schedule: two persistent D64 accumulator tiles
+    # expose VEC1 between independent PV MFMA chains in the unmasked hot loop.
+    SPLIT_PV: tl.constexpr = (not MASK_STEPS and not USE_LAZY_RESCALE and BLOCK_N == 64 and q.shape[0] == 256
+                              and q.shape[1] == 128 and tlx.num_warps() == 8)
+    # BN32 has no lazy-rescale path. Explicit K16 operand layouts reduce the
+    # generic blocked-to-MFMA handoff on medium BM256 rows, but increase live
+    # state on the long rows, so keep the measured crossover local to N<=4096.
+    EXPLICIT_PV_LAYOUT32: tl.constexpr = (BLOCK_N == 32 and q.shape[0] == 256 and q.shape[1] == 128
+                                          and tlx.num_warps() == 8 and N_CTX <= 4096)
+    BF16_LIGHTWEIGHT_WAR: tl.constexpr = (IS_CAUSAL and N_CTX == 512 and q.shape[0] == 128 and BLOCK_N == 64
+                                          and tlx.num_warps() == 4 and q.dtype == tl.bfloat16)
+    RELAXED_QK_WAR: tl.constexpr = (USE_LAZY_RESCALE and IS_CAUSAL and q.shape[0] == 128 and q.shape[1] == 128
+                                    and tlx.num_warps() == 4 and q.dtype == tl.float16
+                                    and (N_CTX == 8 * BLOCK_N or N_CTX == 16 * BLOCK_N))
+    RELAXED_PV_WAR: tl.constexpr = (USE_LAZY_RESCALE and not MASK_STEPS and IS_CAUSAL and N_CTX == 8 * BLOCK_N
+                                    and q.shape[0] == 128 and BLOCK_N == 64 and q.shape[1] == 128
+                                    and tlx.num_warps() == 4 and q.dtype == tl.float16)
     # Prologue: prime the pipeline for output tile block_start.
     b0 = block_start
     n0 = b0 * BLOCK_N
@@ -214,19 +952,32 @@ def _attn_inner_pipelined(
     wait0 = tlx.async_load_wait_group(2)
     kt0 = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, 0)), token=wait0, relaxed=True)
     qk = tl.dot(q, kt0)
-    state, p_c, alpha_c = state.vec1(
-        qk,
-        b0 * BLOCK_N,
-        offs_m,
-        offs_n,
-        N_CTX,
-        QK_SCALE,
-        DIAG_OFFSET,
-        MASK_STEPS,
-        IS_CAUSAL,
-    )
-
-    tl.debug_barrier()
+    if USE_LAZY_RESCALE:
+        if SPLIT_VEC1:
+            state, p_c, _, _ = state.vec1_lazy_split(qk, QK_SCALE)
+        else:
+            state, p_c, _, _ = state.vec1_lazy(qk, QK_SCALE)
+        # The unmasked prefix starts from an empty accumulator. Its first
+        # correction is therefore equivalent to initializing the denominator
+        # to zero and can be omitted entirely.
+        state = SoftmaxState(state.acc, tl.zeros([q.shape[0]], tl.float32), state.m_i)
+    else:
+        state, p_c, alpha_c = state.vec1(
+            qk,
+            b0 * BLOCK_N,
+            offs_m,
+            offs_n,
+            N_CTX,
+            QK_SCALE,
+            DIAG_OFFSET,
+            MASK_STEPS,
+            IS_CAUSAL,
+        )
+    if RELAXED_QK_WAR:
+        # K2 may reuse K0 only after every wave has consumed both N32 results.
+        _attn_qk_war_barrier_relaxed(qk)
+    else:
+        tl.debug_barrier()
     n2 = (b0 + 2) * BLOCK_N
     if MASK_STEPS:
         tok_k2 = tlx.async_load(k_ptrs + n2 * stride_kn, tlx.local_view(k_buf, 0), mask=(n2 + offs_n)[:, None] < N_CTX)
@@ -241,86 +992,311 @@ def _attn_inner_pipelined(
         tok_v1 = tlx.async_load(v_ptrs + n1 * stride_vn, tlx.local_view(v_buf, 1))
     tlx.async_load_commit_group([tok_v1])
 
-    for block_n in tl.range(block_start, block_end - 3, num_stages=1):
-        cur_slot = (block_n - block_start) % BUF_DEPTH
-        nxt_slot = (block_n + 1 - block_start) % BUF_DEPTH
-        ack_n = (block_n + 3) * BLOCK_N
-        acv_n = (block_n + 2) * BLOCK_N
-        ahead_n = (block_n + 1) * BLOCK_N
+    if SPLIT_PV:
+        acc_sub0, acc_sub1 = _split_cols(state.acc)
+        state = SoftmaxState(acc_sub0, state.l_i, state.m_i)
 
-        with tlx.warp_pipeline_stage("dot1", priority=0):
-            qk = tl.dot(q, kt_dot)
-            state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
-
-        tlx.async_load_wait_group(1)
-
-        with tlx.warp_pipeline_stage("mem1", priority=1):
-            v_dot = tlx.local_load(tlx.local_view(v_buf, cur_slot), relaxed=True)
-            if MASK_STEPS:
-                tok_k = tlx.async_load(
-                    k_ptrs + ack_n * stride_kn,
-                    tlx.local_view(k_buf, nxt_slot),
-                    mask=(ack_n + offs_n)[:, None] < N_CTX,
-                )
-            else:
-                tok_k = tlx.async_load(k_ptrs + ack_n * stride_kn, tlx.local_view(k_buf, nxt_slot))
-            tlx.async_load_commit_group([tok_k])
-
-        with tlx.warp_pipeline_stage("dot2", priority=0):
-            acc = tl.dot(p_dot, v_dot, state.acc)
-            state = SoftmaxState(acc, state.l_i, state.m_i)
-            state, p_c, alpha_c = state.vec1(
-                qk,
-                ahead_n,
-                offs_m,
+    if USE_LAZY_RESCALE:
+        # Pair adjacent iterations so both ping-pong slots are compile-time
+        # constants and the backend can schedule across the complete cadence.
+        # The short-causal handoff drains one prefix tile; other schedules keep
+        # the established three-tile drain.
+        DRAIN_TILES: tl.constexpr = 1 if USE_ONE_TILE_PREFIX_DRAIN else 3
+        ODD_TAIL: tl.constexpr = (N_CTX // BLOCK_N - DRAIN_TILES) % 2 == 1
+        main_loop_pairs = (block_end - block_start - DRAIN_TILES) // 2
+        for pair_idx in tl.range(0, main_loop_pairs, num_stages=1):
+            block_n = block_start + pair_idx * 2
+            state, p_c, kt_dot = _attn_inner_pipelined_lazy_step(
+                state,
+                p_c,
+                q,
+                kt_dot,
+                k_ptrs,
+                v_ptrs,
                 offs_n,
-                N_CTX,
+                block_n,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
                 QK_SCALE,
-                DIAG_OFFSET,
-                MASK_STEPS,
-                IS_CAUSAL,
+                BLOCK_N,
+                0,
+                1,
+                SPLIT_VEC1,
+                STEP_PV_VEC1,
+                STEP_QK_VEC2,
+                FP16_CAST_ROWSUM,
+                CHAIN_BF16_ROWSUM,
+            )
+            state, p_c, kt_dot = _attn_inner_pipelined_lazy_step(
+                state,
+                p_c,
+                q,
+                kt_dot,
+                k_ptrs,
+                v_ptrs,
+                offs_n,
+                block_n + 1,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                QK_SCALE,
+                BLOCK_N,
+                1,
+                0,
+                SPLIT_VEC1,
+                STEP_PV_VEC1,
+                STEP_QK_VEC2,
+                FP16_CAST_ROWSUM,
+                CHAIN_BF16_ROWSUM,
             )
 
-        tlx.async_load_wait_group(1)
+        if ODD_TAIL:
+            block_n = block_start + main_loop_pairs * 2
+            state, p_c, kt_dot = _attn_inner_pipelined_lazy_step(
+                state,
+                p_c,
+                q,
+                kt_dot,
+                k_ptrs,
+                v_ptrs,
+                offs_n,
+                block_n,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                QK_SCALE,
+                BLOCK_N,
+                0,
+                1,
+                SPLIT_VEC1,
+                STEP_PV_VEC1,
+                STEP_QK_VEC2,
+                FP16_CAST_ROWSUM,
+                CHAIN_BF16_ROWSUM,
+            )
 
-        with tlx.warp_pipeline_stage("mem2", priority=1):
-            kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, cur_slot)), relaxed=True)
-            if MASK_STEPS:
-                tok_v = tlx.async_load(
-                    v_ptrs + acv_n * stride_vn,
-                    tlx.local_view(v_buf, cur_slot),
-                    mask=(acv_n + offs_n)[:, None] < N_CTX,
+    else:
+        for block_n in tl.range(block_start, block_end - 3, num_stages=1):
+            cur_slot = (block_n - block_start) % BUF_DEPTH
+            nxt_slot = (block_n + 1 - block_start) % BUF_DEPTH
+            ack_n = (block_n + 3) * BLOCK_N
+            acv_n = (block_n + 2) * BLOCK_N
+            ahead_n = (block_n + 1) * BLOCK_N
+
+            with tlx.warp_pipeline_stage("dot1", priority=0):
+                qk = tl.dot(q, kt_dot)
+                if SPLIT_PV:
+                    state, acc_sub1, p_dot = state.vec2_split_acc(acc_sub1, p_c, alpha_c, q.dtype)
+                else:
+                    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+
+            tlx.async_load_wait_group(1)
+
+            with tlx.warp_pipeline_stage("mem1", priority=1):
+                v_dot = tlx.local_load(tlx.local_view(v_buf, cur_slot), relaxed=True)
+                if MASK_STEPS:
+                    tok_k = tlx.async_load(
+                        k_ptrs + ack_n * stride_kn,
+                        tlx.local_view(k_buf, nxt_slot),
+                        mask=(ack_n + offs_n)[:, None] < N_CTX,
+                    )
+                else:
+                    tok_k = tlx.async_load(k_ptrs + ack_n * stride_kn, tlx.local_view(k_buf, nxt_slot))
+                tlx.async_load_commit_group([tok_k])
+
+            with tlx.warp_pipeline_stage("dot2", priority=0):
+                if SPLIT_PV:
+                    split_mma: tl.constexpr = tlx.amd_mfma_layout(
+                        version=4,
+                        instr_shape=[32, 32, 16],
+                        transposed=True,
+                        warps_per_cta=[tlx.num_warps(), 1],
+                    )
+                    split_v_layout: tl.constexpr = tlx.dot_operand_layout(1, split_mma, k_width=4)
+                    v_dot = tlx.require_layout(v_dot, split_v_layout, pin=False)
+                    v_sub0, v_sub1 = tl.split(v_dot.reshape([64, 2, 64]).permute(0, 2, 1))
+                    acc_sub0 = _attn_dot_pv_mfma_split(state.acc, p_dot, v_sub0)
+                    state = SoftmaxState(acc_sub0, state.l_i, state.m_i)
+                    state, p_c, alpha_c = state.vec1(
+                        qk,
+                        ahead_n,
+                        offs_m,
+                        offs_n,
+                        N_CTX,
+                        QK_SCALE,
+                        DIAG_OFFSET,
+                        MASK_STEPS,
+                        IS_CAUSAL,
+                    )
+                    acc_sub1 = _attn_dot_pv_mfma_split(acc_sub1, p_dot, v_sub1)
+                elif EXPLICIT_PV_LAYOUT32:
+                    acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+                elif EXPLICIT_PV_LAYOUT:
+                    acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+                else:
+                    acc = tl.dot(p_dot, v_dot, state.acc)
+                if not SPLIT_PV:
+                    state = SoftmaxState(acc, state.l_i, state.m_i)
+                    state, p_c, alpha_c = state.vec1(
+                        qk,
+                        ahead_n,
+                        offs_m,
+                        offs_n,
+                        N_CTX,
+                        QK_SCALE,
+                        DIAG_OFFSET,
+                        MASK_STEPS,
+                        IS_CAUSAL,
+                    )
+
+            tlx.async_load_wait_group(1)
+
+            with tlx.warp_pipeline_stage("mem2", priority=1):
+                if tlx.num_warps() == 8:
+                    if MASK_STEPS:
+                        tok_v = tlx.async_load(
+                            v_ptrs + acv_n * stride_vn,
+                            tlx.local_view(v_buf, cur_slot),
+                            mask=(acv_n + offs_n)[:, None] < N_CTX,
+                        )
+                    else:
+                        tok_v = tlx.async_load(v_ptrs + acv_n * stride_vn, tlx.local_view(v_buf, cur_slot))
+                    tlx.async_load_commit_group([tok_v])
+                    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, cur_slot)), relaxed=True)
+                else:
+                    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, cur_slot)), relaxed=True)
+                    if MASK_STEPS:
+                        tok_v = tlx.async_load(
+                            v_ptrs + acv_n * stride_vn,
+                            tlx.local_view(v_buf, cur_slot),
+                            mask=(acv_n + offs_n)[:, None] < N_CTX,
+                        )
+                    else:
+                        tok_v = tlx.async_load(v_ptrs + acv_n * stride_vn, tlx.local_view(v_buf, cur_slot))
+                    tlx.async_load_commit_group([tok_v])
+
+        if SPLIT_PV:
+            split_pv_layout: tl.constexpr = tlx.amd_mfma_layout(
+                version=4,
+                instr_shape=[32, 32, 16],
+                transposed=True,
+                warps_per_cta=[tlx.num_warps(), 1],
+            )
+            acc = tl.join(state.acc, acc_sub1).permute(0, 2, 1).reshape([state.acc.shape[0], 128])
+            acc = tlx.require_layout(acc, split_pv_layout, pin=False)
+            state = SoftmaxState(acc, state.l_i, state.m_i)
+
+    if USE_ONE_TILE_PREFIX_DRAIN:
+        # The extended odd tail completed every prefix tile except n-1.  Its
+        # final mem2 has K(diag0) resident in slot 0 and V(diag0) in flight,
+        # while mem1 has K(diag1) in flight in slot 1.  Consume the final
+        # prefix probability with V(n-1), then reuse that dead V slot for
+        # V(diag1).  The short diagonal helper drains these groups in order.
+        if USE_ONE_TILE_FOUR_SLOT_PREFIX_DRAIN:
+            # Slots 2/3 are outside the steady-state ping-pong ring.  Start
+            # their diagonal K/V pairs while the final prefix softmax and PV
+            # remain available to cover the copies.
+            for diagonal_slot in tl.static_range(2):
+                diagonal_n = (block_end + diagonal_slot + 2) * BLOCK_N
+                tok_k_diagonal = tlx.async_load(
+                    k_ptrs + diagonal_n * stride_kn,
+                    tlx.local_view(k_buf, diagonal_slot + 2),
                 )
-            else:
-                tok_v = tlx.async_load(v_ptrs + acv_n * stride_vn, tlx.local_view(v_buf, cur_slot))
-            tlx.async_load_commit_group([tok_v])
+                tlx.async_load_commit_group([tok_k_diagonal])
+                tok_v_diagonal = tlx.async_load(
+                    v_ptrs + diagonal_n * stride_vn,
+                    tlx.local_view(v_buf, diagonal_slot + 2),
+                )
+                tlx.async_load_commit_group([tok_v_diagonal])
+        if SPLIT_VEC1:
+            state, p_dot = state.vec2_lazy_split(
+                p_c,
+                QK_SCALE,
+                q.dtype,
+                FP16_CAST_ROWSUM,
+                CHAIN_BF16_ROWSUM,
+            )
+        else:
+            state, p_dot = state.vec2_lazy(p_c, q.dtype)
+        v_dot = tlx.local_load(tlx.local_view(v_buf, 1), relaxed=True)
+        acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+        if RELAXED_PV_WAR:
+            _attn_pv_war_barrier_relaxed(state.acc)
+        else:
+            _attn_war_barrier(BF16_LIGHTWEIGHT_WAR)
+        diagonal_v1_n = (block_end + 1) * BLOCK_N
+        tok_v_diagonal1 = tlx.async_load(
+            v_ptrs + diagonal_v1_n * stride_vn,
+            tlx.local_view(v_buf, 1),
+        )
+        tlx.async_load_commit_group([tok_v_diagonal1])
+        return state
 
     # Drain the last three output tiles without out-of-bounds global prefetches.
     nm3 = block_end - 3
     nm2 = block_end - 2
     nm1 = block_end - 1
-    s_nm3 = (nm3 - block_start) % BUF_DEPTH
-    s_nm2 = (nm2 - block_start) % BUF_DEPTH
-    s_nm1 = (nm1 - block_start) % BUF_DEPTH
+    DRAIN_BUF_DEPTH: tl.constexpr = LAZY_BUF_DEPTH if USE_LAZY_RESCALE else BUF_DEPTH
+    s_nm3 = (nm3 - block_start) % DRAIN_BUF_DEPTH
+    s_nm2 = (nm2 - block_start) % DRAIN_BUF_DEPTH
+    s_nm1 = (nm1 - block_start) % DRAIN_BUF_DEPTH
 
     qk = tl.dot(q, kt_dot)
     tlx.async_load_wait_group(2)
     v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm3), relaxed=True)
-    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
-    acc = tl.dot(p_dot, v_dot, state.acc)
-    state = SoftmaxState(acc, state.l_i, state.m_i)
-    state, p_c, alpha_c = state.vec1(
-        qk,
-        nm2 * BLOCK_N,
-        offs_m,
-        offs_n,
-        N_CTX,
-        QK_SCALE,
-        DIAG_OFFSET,
-        MASK_STEPS,
-        IS_CAUSAL,
-    )
-    tl.debug_barrier()
+    if USE_LAZY_RESCALE:
+        if SPLIT_VEC1:
+            state, p_dot = state.vec2_lazy_split(p_c, QK_SCALE, q.dtype, FP16_CAST_ROWSUM, CHAIN_BF16_ROWSUM)
+        else:
+            state, p_dot = state.vec2_lazy(p_c, q.dtype)
+    else:
+        state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    if USE_LAZY_RESCALE and DRAIN_STEP_PV_VEC1:
+        state, p_c, delta_c, advance_c = _attn_dot_pv_vec1_lazy(
+            state,
+            p_dot,
+            v_dot,
+            qk,
+            QK_SCALE,
+            SPLIT_VEC1,
+        )
+    else:
+        if EXPLICIT_PV_LAYOUT32:
+            acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+        elif EXPLICIT_PV_LAYOUT:
+            acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+        else:
+            acc = tl.dot(p_dot, v_dot, state.acc)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+    if USE_LAZY_RESCALE:
+        if not DRAIN_STEP_PV_VEC1:
+            if SPLIT_VEC1:
+                state, p_c, delta_c, advance_c = state.vec1_lazy_split(qk, QK_SCALE)
+            else:
+                state, p_c, delta_c, advance_c = state.vec1_lazy(qk, QK_SCALE)
+        state = state.rescale_lazy(delta_c, advance_c)
+    else:
+        state, p_c, alpha_c = state.vec1(
+            qk,
+            nm2 * BLOCK_N,
+            offs_m,
+            offs_n,
+            N_CTX,
+            QK_SCALE,
+            DIAG_OFFSET,
+            MASK_STEPS,
+            IS_CAUSAL,
+        )
+    if RELAXED_PV_WAR:
+        # The next copy may reuse this V slot only after all four D32 results.
+        _attn_pv_war_barrier_relaxed(state.acc)
+    else:
+        _attn_war_barrier(BF16_LIGHTWEIGHT_WAR)
     nm1_n = nm1 * BLOCK_N
     if MASK_STEPS:
         tok_vlast = tlx.async_load(
@@ -337,28 +1313,289 @@ def _attn_inner_pipelined(
     qk = tl.dot(q, kt_dot)
     tlx.async_load_wait_group(1)
     v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm2), relaxed=True)
-    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
-    acc = tl.dot(p_dot, v_dot, state.acc)
-    state = SoftmaxState(acc, state.l_i, state.m_i)
-    state, p_c, alpha_c = state.vec1(
+    if USE_LAZY_RESCALE:
+        if SPLIT_VEC1:
+            state, p_dot = state.vec2_lazy_split(p_c, QK_SCALE, q.dtype, FP16_CAST_ROWSUM, CHAIN_BF16_ROWSUM)
+        else:
+            state, p_dot = state.vec2_lazy(p_c, q.dtype)
+    else:
+        state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    if USE_LAZY_RESCALE and DRAIN_STEP_PV_VEC1:
+        state, p_c, delta_c, advance_c = _attn_dot_pv_vec1_lazy(
+            state,
+            p_dot,
+            v_dot,
+            qk,
+            QK_SCALE,
+            SPLIT_VEC1,
+        )
+    else:
+        if EXPLICIT_PV_LAYOUT32:
+            acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+        elif EXPLICIT_PV_LAYOUT:
+            acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+        else:
+            acc = tl.dot(p_dot, v_dot, state.acc)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+    if USE_LAZY_RESCALE:
+        if not DRAIN_STEP_PV_VEC1:
+            if SPLIT_VEC1:
+                state, p_c, delta_c, advance_c = state.vec1_lazy_split(qk, QK_SCALE)
+            else:
+                state, p_c, delta_c, advance_c = state.vec1_lazy(qk, QK_SCALE)
+        state = state.rescale_lazy(delta_c, advance_c)
+    else:
+        state, p_c, alpha_c = state.vec1(
+            qk,
+            nm1 * BLOCK_N,
+            offs_m,
+            offs_n,
+            N_CTX,
+            QK_SCALE,
+            DIAG_OFFSET,
+            MASK_STEPS,
+            IS_CAUSAL,
+        )
+
+    tlx.async_load_wait_group(0)
+    v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm1), relaxed=True)
+    if USE_LAZY_RESCALE:
+        if SPLIT_VEC1:
+            state, p_dot = state.vec2_lazy_split(p_c, QK_SCALE, q.dtype, FP16_CAST_ROWSUM, CHAIN_BF16_ROWSUM)
+        else:
+            state, p_dot = state.vec2_lazy(p_c, q.dtype)
+    else:
+        state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
+    if EXPLICIT_PV_LAYOUT32:
+        acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+    elif EXPLICIT_PV_LAYOUT:
+        acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+    else:
+        acc = tl.dot(p_dot, v_dot, state.acc)
+        state = SoftmaxState(acc, state.l_i, state.m_i)
+
+    PRESERVE_ALIGNED_CAUSAL_ACC_LAYOUT: tl.constexpr = (EXPLICIT_PV_LAYOUT and not MASK_STEPS and IS_CAUSAL
+                                                        and q.shape[0] == 256 and BLOCK_N == 64)
+    if (EXPLICIT_PV_LAYOUT32 or EXPLICIT_PV_LAYOUT) and not PRESERVE_ALIGNED_CAUSAL_ACC_LAYOUT:
+        state = SoftmaxState(tlx.release_layout(state.acc), state.l_i, state.m_i)
+
+    return state
+
+
+@triton.jit
+def _attn_predicated_causal_tile(
+    acc,
+    l_i,
+    m_i,
+    q,
+    offs_m,
+    k_tile,
+    v_tile,
+    wait,
+    start_n,
+    N_CTX: tl.constexpr,
+    QK_SCALE: tl.constexpr,
+    DIAG_OFFSET: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ENABLE_CLASS_DIAGONAL_LAZY: tl.constexpr,
+):
+    """Consume one diagonal tile inside a wave-uniform EXEC region."""
+    if BLOCK_N == 32:
+        k_tile = tlx.local_slice(k_tile, [0, 0], [32, q.shape[1]])
+        v_tile = tlx.local_slice(v_tile, [0, 0], [32, q.shape[1]])
+    offs_n = tl.arange(0, BLOCK_N)
+    kt_dot = tlx.local_load(tlx.local_trans(k_tile), token=wait, relaxed=True)
+    qk = tl.dot(q, kt_dot)
+    state = SoftmaxState(acc, l_i, m_i)
+    USE_CLASS_DIAGONAL_LAZY: tl.constexpr = (ENABLE_CLASS_DIAGONAL_LAZY and N_CTX <= 1024 and N_CTX % q.shape[0] == 0
+                                             and N_CTX % BLOCK_N == 0 and q.shape[0] == 128 and q.shape[1] == 128
+                                             and (BLOCK_N == 32 or BLOCK_N == 64) and tlx.num_warps() == 4)
+    if USE_CLASS_DIAGONAL_LAZY:
+        # The Gluon short-row path keeps the running max in a lazy frame on
+        # both diagonal tiles. Scale before masking so a zero scale cannot form
+        # ``-inf * 0`` and a negative scale cannot turn the mask sentinel into
+        # ``+inf``. The lazy helpers therefore consume an already-scaled tile.
+        kn = start_n + offs_n
+        qk = qk * QK_SCALE
+        qk = tl.where(
+            offs_m[:, None] + DIAG_OFFSET >= kn[None, :],
+            qk,
+            float("-inf"),
+        )
+        qk = tl.where(kn[None, :] < N_CTX, qk, float("-inf"))
+        threshold: tl.constexpr = (DIAGONAL_LAZY_RESCALE_THRESHOLD_FP16
+                                   if q.dtype == tl.float16 else DIAGONAL_LAZY_RESCALE_THRESHOLD)
+        if BLOCK_N == 64:
+            state, p_state, score_delta, advance = state.vec1_lazy_split_threshold(qk, 1.0, threshold)
+            state = state.rescale_lazy(score_delta, advance)
+            state, p_dot = state.vec2_lazy_split(p_state, 1.0, q.dtype, q.dtype == tl.float16)
+        else:
+            state, score_delta, advance = state.vec1_lazy_max_threshold(qk, 1.0, threshold)
+            p = state.vec1_lazy_exp(qk, 1.0)
+            state = state.rescale_lazy(score_delta, advance)
+            state, p_dot = state.vec2_lazy(p, q.dtype)
+    else:
+        state, p, alpha = state.vec1(
+            qk,
+            start_n,
+            offs_m,
+            offs_n,
+            N_CTX,
+            QK_SCALE,
+            DIAG_OFFSET,
+            True,
+            True,
+        )
+        state, p_dot = state.vec2(p, alpha, q.dtype)
+    # Delay V's register materialization until P is ready; this shortens its
+    # live range across QK and softmax and matches its immediate PV consumer.
+    v_dot = tlx.local_load(v_tile, token=wait, relaxed=True)
+    # The low-only causal wave is intentionally passed as a 32-column tile
+    # even when its parent diagonal tile is BN64.  Its accumulator still has
+    # the MFMA layout, so use the matching explicit PV fragment helper for
+    # both the lazy and ordinary softmax branches.
+    if BLOCK_N == 64:
+        acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+    else:
+        acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+    return acc, state.l_i, state.m_i
+
+
+@triton.jit
+def _attn_predicated_causal_tile_from_state(
+    _unused_acc,
+    _unused_l_i,
+    _unused_m_i,
+    acc,
+    l_i,
+    m_i,
+    q,
+    offs_m,
+    k_tile,
+    v_tile,
+    wait,
+    start_n,
+    N_CTX: tl.constexpr,
+    QK_SCALE: tl.constexpr,
+    DIAG_OFFSET: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    ENABLE_CLASS_DIAGONAL_LAZY: tl.constexpr,
+):
+    """Compute from read-only state while carrying independent merge values."""
+    return _attn_predicated_causal_tile(
+        acc,
+        l_i,
+        m_i,
+        q,
+        offs_m,
+        k_tile,
+        v_tile,
+        wait,
+        start_n,
+        N_CTX,
+        QK_SCALE,
+        DIAG_OFFSET,
+        BLOCK_N,
+        ENABLE_CLASS_DIAGONAL_LAZY,
+    )
+
+
+@triton.jit
+def _attn_predicated_causal_regs_bn32(
+    acc,
+    l_i,
+    m_i,
+    q,
+    offs_m,
+    kt_dot,
+    v_dot,
+    start_n,
+    N_CTX: tl.constexpr,
+    QK_SCALE: tl.constexpr,
+    DIAG_OFFSET: tl.constexpr,
+):
+    """Consume a BN32 diagonal tile after every wave has completed its LDS reads."""
+    tl.static_assert(q.shape[0] == 256)
+    tl.static_assert(q.shape[1] == 128)
+    tl.static_assert(kt_dot.shape[0] == 128)
+    tl.static_assert(kt_dot.shape[1] == 32)
+    tl.static_assert(v_dot.shape[0] == 32)
+    tl.static_assert(v_dot.shape[1] == 128)
+    tl.static_assert(tlx.num_warps() == 8)
+    offs_n = tl.arange(0, 32)
+    qk = tl.dot(q, kt_dot)
+    state = SoftmaxState(acc, l_i, m_i)
+    state, p, alpha = state.vec1(
         qk,
-        nm1 * BLOCK_N,
+        start_n,
         offs_m,
         offs_n,
         N_CTX,
         QK_SCALE,
         DIAG_OFFSET,
-        MASK_STEPS,
-        IS_CAUSAL,
+        True,
+        True,
     )
+    state, p_dot = state.vec2(p, alpha, q.dtype)
+    acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
+    return acc, state.l_i, state.m_i
 
+
+@triton.jit
+def _attn_inner_full2_lazy(
+    state,
+    q,
+    k_ptrs,
+    v_ptrs,
+    block_start,
+    k_buf,
+    v_buf,
+    stride_kn,
+    stride_vn,
+    QK_SCALE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Consume an aligned two-tile prefix in the BM128 lazy frame."""
     tlx.async_load_wait_group(0)
-    v_dot = tlx.local_load(tlx.local_view(v_buf, s_nm1), relaxed=True)
-    state, p_dot = state.vec2(p_c, alpha_c, q.dtype)
-    acc = tl.dot(p_dot, v_dot, state.acc)
+    for slot in tl.static_range(2):
+        start_n = (block_start + slot) * BLOCK_N
+        tok_k = tlx.async_load(k_ptrs + start_n * stride_kn, tlx.local_view(k_buf, slot))
+        tok_v = tlx.async_load(v_ptrs + start_n * stride_vn, tlx.local_view(v_buf, slot))
+        tlx.async_load_commit_group([tok_k, tok_v])
+
+    wait = tlx.async_load_wait_group(1)
+    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, 0)), token=wait, relaxed=True)
+    qk = tl.dot(q, kt_dot)
+    state, p_state, _, _ = state.vec1_lazy_split4(qk, QK_SCALE)
+    # The first prefix tile starts from an empty softmax frame, so its old
+    # denominator contributes exactly zero and needs no correction.
+    state = SoftmaxState(state.acc, tl.zeros([q.shape[0]], tl.float32), state.m_i)
+    state, p_dot = state.vec2_lazy_split4(
+        p_state,
+        QK_SCALE,
+        q.dtype,
+        q.dtype == tl.float16,
+    )
+    v_dot = tlx.local_load(tlx.local_view(v_buf, 0), token=wait, relaxed=True)
+    acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
     state = SoftmaxState(acc, state.l_i, state.m_i)
 
-    return state
+    wait = tlx.async_load_wait_group(0)
+    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, 1)), token=wait, relaxed=True)
+    qk = tl.dot(q, kt_dot)
+    state, p_state, score_delta, advance = state.vec1_lazy_split4(qk, QK_SCALE)
+    state = state.rescale_lazy(score_delta, advance)
+    state, p_dot = state.vec2_lazy_split4(
+        p_state,
+        QK_SCALE,
+        q.dtype,
+        q.dtype == tl.float16,
+    )
+    v_dot = tlx.local_load(tlx.local_view(v_buf, 1), token=wait, relaxed=True)
+    acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+    return SoftmaxState(tlx.release_layout(acc), state.l_i, state.m_i)
 
 
 @triton.jit
@@ -381,17 +1618,42 @@ def _attn_inner_short(
     BLOCK_N: tl.constexpr,
     BUF_DEPTH: tl.constexpr,
     USE_DIRECT_LOAD: tl.constexpr,
+    MASK_STEPS: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
+    PREFIX_DIAGONAL_HANDOFF: tl.constexpr,
 ):
     """Process ranges too short to safely fill the rotated four-stage pipeline."""
-    tlx.async_load_wait_group(0)
+    FOUR_SLOT_PREFIX_HANDOFF: tl.constexpr = (PREFIX_DIAGONAL_HANDOFF and not USE_DIRECT_LOAD and MASK_STEPS
+                                              and IS_CAUSAL and q.shape[0] == 256 and q.shape[1] == 128
+                                              and BLOCK_N == 64 and BUF_DEPTH == 2 and tlx.num_warps() == 8
+                                              and N_CTX == 2048)
+    if PREFIX_DIAGONAL_HANDOFF and not FOUR_SLOT_PREFIX_HANDOFF:
+        # Prefix handoff order is K1, V0, V1; K0 is already resident.  Drain
+        # through V0 and let diagonal tile 0 overlap the final V1 transfer.
+        tlx.async_load_wait_group(1)
+    else:
+        tlx.async_load_wait_group(0)
 
     num_blocks = block_end - block_start
+    PRUNE_CAUSAL_DIAGONAL: tl.constexpr = (MASK_STEPS and IS_CAUSAL and q.shape[1] == 128 and
+                                           (BLOCK_N == 64 or (BLOCK_N == 32 and q.shape[0] == 256 and N_CTX == 2048))
+                                           and N_CTX % q.shape[0] == 0 and N_CTX % BLOCK_N == 0
+                                           and ((q.shape[0] == 128 and tlx.num_warps() == 4 and N_CTX <= 1024) or
+                                                (q.shape[0] == 256 and tlx.num_warps() == 8)))
+    if PREFIX_DIAGONAL_HANDOFF:
+        tl.static_assert(not USE_DIRECT_LOAD)
+        tl.static_assert(PRUNE_CAUSAL_DIAGONAL)
+        tl.static_assert(BUF_DEPTH == 2 and BLOCK_N == 64)
+        tl.static_assert((q.shape[0] == 128 and q.shape[1] == 128 and tlx.num_warps() == 4 and
+                          (N_CTX == 8 * BLOCK_N or N_CTX == 16 * BLOCK_N)) or FOUR_SLOT_PREFIX_HANDOFF)
     if USE_DIRECT_LOAD:
         for block_offset in tl.range(0, num_blocks, num_stages=1):
             start_n = (block_start + block_offset) * BLOCK_N
-            mask = (start_n + offs_n)[:, None] < N_CTX
-            k = tl.load(k_ptrs + start_n * stride_kn, mask=mask, other=0.0)
+            if MASK_STEPS:
+                mask = (start_n + offs_n)[:, None] < N_CTX
+                k = tl.load(k_ptrs + start_n * stride_kn, mask=mask, other=0.0)
+            else:
+                k = tl.load(k_ptrs + start_n * stride_kn)
             qk = tl.dot(q, tl.trans(k))
             state, p, alpha = state.vec1(
                 qk,
@@ -401,49 +1663,343 @@ def _attn_inner_short(
                 N_CTX,
                 QK_SCALE,
                 DIAG_OFFSET,
-                True,
+                MASK_STEPS,
                 IS_CAUSAL,
             )
             state, p_dot = state.vec2(p, alpha, q.dtype)
-            v = tl.load(v_ptrs + start_n * stride_vn, mask=mask, other=0.0)
-            acc = tl.dot(p_dot, v, state.acc)
+            if MASK_STEPS:
+                v = tl.load(v_ptrs + start_n * stride_vn, mask=mask, other=0.0)
+            else:
+                v = tl.load(v_ptrs + start_n * stride_vn)
+            USE_MFMA_DIRECT_PV: tl.constexpr = (IS_CAUSAL and q.shape[0] == 256 and q.shape[1] == 128 and BLOCK_N == 64
+                                                and tlx.num_warps() == 8)
+            if USE_MFMA_DIRECT_PV:
+                acc = _attn_dot_pv_mfma(state.acc, p_dot, v)
+            else:
+                acc = tl.dot(p_dot, v, state.acc)
             state = SoftmaxState(acc, state.l_i, state.m_i)
     else:
-        for chunk_start in tl.range(0, num_blocks, BUF_DEPTH, num_stages=1):
-            for slot in tl.static_range(BUF_DEPTH):
-                block_offset = chunk_start + slot
-                if block_offset < num_blocks:
-                    start_n = (block_start + block_offset) * BLOCK_N
-                    mask = (start_n + offs_n)[:, None] < N_CTX
-                    tok_k = tlx.async_load(k_ptrs + start_n * stride_kn, tlx.local_view(k_buf, slot), mask=mask)
-                    tok_v = tlx.async_load(v_ptrs + start_n * stride_vn, tlx.local_view(v_buf, slot), mask=mask)
+        FOUR_SLOT_PRUNE: tl.constexpr = (PRUNE_CAUSAL_DIAGONAL and BLOCK_N == 64 and q.shape[0] == 256
+                                         and tlx.num_warps() == 8)
+        if FOUR_SLOT_PRUNE:
+            # Consume the aligned BM256 diagonal in four unique LDS slots.
+            # This avoids the two-slot ring's WAR rendezvous.  A nonzero
+            # N2048 block_start means the prefix already supplied all slots;
+            # early query tiles without a prefix still load them here.
+            need_diagonal_load = block_start == 0 if FOUR_SLOT_PREFIX_HANDOFF else True
+            if need_diagonal_load:
+                for slot in tl.static_range(4):
+                    start_n = (block_start + slot) * BLOCK_N
+                    tok_k = tlx.async_load(
+                        k_ptrs + start_n * stride_kn,
+                        tlx.local_view(k_buf, slot),
+                    )
+                    tok_v = tlx.async_load(
+                        v_ptrs + start_n * stride_vn,
+                        tlx.local_view(v_buf, slot),
+                    )
                     tlx.async_load_commit_group([tok_k, tok_v])
 
             wait = tlx.async_load_wait_group(0)
+            mma: tl.constexpr = tlx.amd_mfma_layout(
+                version=4,
+                instr_shape=[32, 32, 16],
+                transposed=True,
+                warps_per_cta=[tlx.num_warps(), 1],
+            )
+            mma_rows: tl.constexpr = tlx.slice_layout(mma, 1)
+            # Gluon carries both softmax row states in SliceLayout(mma, 1).
+            # Materialize TLX's otherwise-blocked running max before entering
+            # the wave-predicated loop so any register redistribution remains
+            # convergent and the predicated bodies need no CTA-wide scratch.
+            state = SoftmaxState(
+                state.acc,
+                tlx.require_layout(state.l_i, mma_rows, pin=True),
+                tlx.require_layout(state.m_i, mma_rows, pin=True),
+            )
+            wave = tlx.thread_id(0) // CDNA_WAVE_SIZE
+            wave = wave ^ ((wave // 4) * 3)
+            wave_m_last = (wave * CDNA_MFMA_ROWS_PER_WAVE + CDNA_MFMA_ROWS_PER_WAVE - 1 + DIAG_OFFSET)
+            # Keep one runtime loop body, matching Gluon's four-slot diagonal
+            # consumer.  Unrolling this loop duplicates both the BN64 and
+            # low-half BN32 MFMA bodies four times in the code object.
+            for diag_slot in tl.range(0, num_blocks, num_stages=1):
+                start_n = (block_start + diag_slot) * BLOCK_N
+                diagonal_start = start_n % q.shape[0]
+                active_full = wave_m_last >= diagonal_start + CDNA_MFMA_ROWS_PER_WAVE
+                active_lo = wave_m_last >= diagonal_start
+                active_lo_only = active_lo & ~active_full
+                acc, l_i, m_i = tlx.warp_predicate(
+                    active_full,
+                    (state.acc, state.l_i, state.m_i),
+                    _attn_predicated_causal_tile,
+                    args=(
+                        q,
+                        offs_m,
+                        tlx.local_view(k_buf, diag_slot),
+                        tlx.local_view(v_buf, diag_slot),
+                        wait,
+                        start_n,
+                        N_CTX,
+                        QK_SCALE,
+                        DIAG_OFFSET,
+                        BLOCK_N,
+                        True,
+                    ),
+                    wave_uniform=True,
+                )
+                state = SoftmaxState(acc, l_i, m_i)
+                next_acc, next_l_i, next_m_i = tlx.warp_predicate(
+                    active_lo_only,
+                    (
+                        tl.zeros_like(state.acc),
+                        tl.zeros_like(state.l_i),
+                        tl.zeros_like(state.m_i),
+                    ),
+                    _attn_predicated_causal_tile_from_state,
+                    args=(
+                        state.acc,
+                        state.l_i,
+                        state.m_i,
+                        q,
+                        offs_m,
+                        tlx.local_view(k_buf, diag_slot),
+                        tlx.local_view(v_buf, diag_slot),
+                        wait,
+                        start_n,
+                        N_CTX,
+                        QK_SCALE,
+                        DIAG_OFFSET,
+                        CDNA_MFMA_ROWS_PER_WAVE,
+                        True,
+                    ),
+                    wave_uniform=True,
+                )
+                state = SoftmaxState(
+                    tl.where(active_lo_only, next_acc, state.acc),
+                    tl.where(active_lo_only, next_l_i, state.l_i),
+                    tl.where(active_lo_only, next_m_i, state.m_i),
+                )
+            return state
+
+        # N512's two-slot diagonal is always consumed as a pair.  Preserve
+        # that target schedule for BF16/FP16 short classes while leaving
+        # longer and ragged ranges on the general loop shape.
+        PAIR_LOOP_UNROLL: tl.constexpr = 2 if N_CTX == 512 else 1
+        for chunk_start in tl.range(
+                0,
+                num_blocks,
+                BUF_DEPTH,
+                num_stages=1,
+                loop_unroll_factor=PAIR_LOOP_UNROLL,
+        ):
+            if not PREFIX_DIAGONAL_HANDOFF:
+                for slot in tl.static_range(BUF_DEPTH):
+                    block_offset = chunk_start + slot
+                    if block_offset < num_blocks:
+                        start_n = (block_start + block_offset) * BLOCK_N
+                        if MASK_STEPS and N_CTX % BLOCK_N != 0:
+                            mask = (start_n + offs_n)[:, None] < N_CTX
+                            tok_k = tlx.async_load(
+                                k_ptrs + start_n * stride_kn,
+                                tlx.local_view(k_buf, slot),
+                                mask=mask,
+                            )
+                            tok_v = tlx.async_load(
+                                v_ptrs + start_n * stride_vn,
+                                tlx.local_view(v_buf, slot),
+                                mask=mask,
+                            )
+                        else:
+                            tok_k = tlx.async_load(k_ptrs + start_n * stride_kn, tlx.local_view(k_buf, slot))
+                            tok_v = tlx.async_load(v_ptrs + start_n * stride_vn, tlx.local_view(v_buf, slot))
+                        tlx.async_load_commit_group([tok_k, tok_v])
+
+            if PRUNE_CAUSAL_DIAGONAL:
+                # Each K/V pair is one commit group. Start the first tile once
+                # its pair is ready and overlap the second pair's DMA with the
+                # first tile's matrix/softmax work.
+                wait = tlx.async_load_wait_group(BUF_DEPTH - 1)
+            else:
+                wait = tlx.async_load_wait_group(0)
 
             for slot in tl.static_range(BUF_DEPTH):
                 block_offset = chunk_start + slot
                 if block_offset < num_blocks:
                     start_n = (block_start + block_offset) * BLOCK_N
-                    kt_dot = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot)), token=wait, relaxed=True)
-                    v_dot = tlx.local_load(tlx.local_view(v_buf, slot), token=wait, relaxed=True)
-                    qk = tl.dot(q, kt_dot)
-                    state, p, alpha = state.vec1(
-                        qk,
-                        start_n,
-                        offs_m,
-                        offs_n,
-                        N_CTX,
-                        QK_SCALE,
-                        DIAG_OFFSET,
-                        True,
-                        IS_CAUSAL,
-                    )
-                    state, p_dot = state.vec2(p, alpha, q.dtype)
-                    acc = tl.dot(p_dot, v_dot, state.acc)
-                    state = SoftmaxState(acc, state.l_i, state.m_i)
+                    if PRUNE_CAUSAL_DIAGONAL and BLOCK_N == 32:
+                        if slot == 1:
+                            wait = tlx.async_load_wait_group(0)
+                        # Keep LDS consumption convergent. The barrier after
+                        # this pair prevents either slot from being refilled
+                        # until every wave has completed these register loads.
+                        kt_dot = tlx.local_load(
+                            tlx.local_trans(tlx.local_view(k_buf, slot)),
+                            token=wait,
+                            relaxed=True,
+                        )
+                        v_dot = tlx.local_load(
+                            tlx.local_view(v_buf, slot),
+                            token=wait,
+                            relaxed=True,
+                        )
+                        wave = tlx.thread_id(0) // CDNA_WAVE_SIZE
+                        wave = wave ^ ((wave // 4) * 3)
+                        wave_m_last = (wave * CDNA_MFMA_ROWS_PER_WAVE + CDNA_MFMA_ROWS_PER_WAVE - 1 + DIAG_OFFSET)
+                        diagonal_start = start_n % q.shape[0]
+                        active = wave_m_last >= diagonal_start
+                        acc, l_i, m_i = tlx.warp_predicate(
+                            active,
+                            (state.acc, state.l_i, state.m_i),
+                            _attn_predicated_causal_regs_bn32,
+                            args=(
+                                q,
+                                offs_m,
+                                kt_dot,
+                                v_dot,
+                                start_n,
+                                N_CTX,
+                                QK_SCALE,
+                                DIAG_OFFSET,
+                            ),
+                            wave_uniform=True,
+                        )
+                        state = SoftmaxState(acc, l_i, m_i)
 
-            tl.debug_barrier()
+                    if PRUNE_CAUSAL_DIAGONAL and BLOCK_N == 64:
+                        if slot == 1:
+                            wait = tlx.async_load_wait_group(0)
+                        # The four MFMA waves own consecutive 32-row bands.
+                        # A scalar predicate is uniform within each wave and
+                        # directly controls physical lanes, so acc and the two
+                        # row states may retain their independent layouts.
+                        wave = tlx.thread_id(0) // CDNA_WAVE_SIZE
+                        if q.shape[0] == 256:
+                            wave = wave ^ ((wave // 4) * 3)
+                        wave_m_last = (wave * CDNA_MFMA_ROWS_PER_WAVE + CDNA_MFMA_ROWS_PER_WAVE - 1 + DIAG_OFFSET)
+                        diagonal_start = start_n % q.shape[0]
+                        active_full = wave_m_last >= diagonal_start + CDNA_MFMA_ROWS_PER_WAVE
+                        active_lo = wave_m_last >= diagonal_start
+                        active_lo_only = active_lo & ~active_full
+                        STAGGER_FINAL_NORMALIZE: tl.constexpr = (PRUNE_CAUSAL_DIAGONAL and q.shape[0] == 128
+                                                                 and N_CTX <= 1024 and slot == 1)
+                        if STAGGER_FINAL_NORMALIZE:
+                            acc, l_i, m_i = tlx.warp_predicate(
+                                active_full,
+                                (state.acc, state.l_i, state.m_i),
+                                _attn_predicated_causal_tile,
+                                args=(
+                                    q,
+                                    offs_m,
+                                    tlx.local_view(k_buf, slot),
+                                    tlx.local_view(v_buf, slot),
+                                    wait,
+                                    start_n,
+                                    N_CTX,
+                                    QK_SCALE,
+                                    DIAG_OFFSET,
+                                    BLOCK_N,
+                                    True,
+                                ),
+                                wave_uniform=True,
+                            )
+                            state = SoftmaxState(acc, l_i, m_i)
+                            acc, l_i, m_i = tlx.warp_predicate(
+                                active_lo_only,
+                                (state.acc, state.l_i, state.m_i),
+                                _attn_predicated_causal_tile,
+                                args=(
+                                    q,
+                                    offs_m,
+                                    tlx.local_view(k_buf, slot),
+                                    tlx.local_view(v_buf, slot),
+                                    wait,
+                                    start_n,
+                                    N_CTX,
+                                    QK_SCALE,
+                                    DIAG_OFFSET,
+                                    CDNA_MFMA_ROWS_PER_WAVE,
+                                    True,
+                                ),
+                                wave_uniform=True,
+                            )
+                            state = SoftmaxState(
+                                acc * fast_dividef(1.0, l_i)[:, None],
+                                l_i,
+                                m_i,
+                            )
+                        else:
+                            acc, l_i, m_i = tlx.warp_predicate(
+                                active_full,
+                                (state.acc, state.l_i, state.m_i),
+                                _attn_predicated_causal_tile,
+                                args=(
+                                    q,
+                                    offs_m,
+                                    tlx.local_view(k_buf, slot),
+                                    tlx.local_view(v_buf, slot),
+                                    wait,
+                                    start_n,
+                                    N_CTX,
+                                    QK_SCALE,
+                                    DIAG_OFFSET,
+                                    BLOCK_N,
+                                    True,
+                                ),
+                                wave_uniform=True,
+                            )
+                            state = SoftmaxState(acc, l_i, m_i)
+                            acc, l_i, m_i = tlx.warp_predicate(
+                                active_lo_only,
+                                (state.acc, state.l_i, state.m_i),
+                                _attn_predicated_causal_tile,
+                                args=(
+                                    q,
+                                    offs_m,
+                                    tlx.local_view(k_buf, slot),
+                                    tlx.local_view(v_buf, slot),
+                                    wait,
+                                    start_n,
+                                    N_CTX,
+                                    QK_SCALE,
+                                    DIAG_OFFSET,
+                                    CDNA_MFMA_ROWS_PER_WAVE,
+                                    True,
+                                ),
+                                wave_uniform=True,
+                            )
+                            state = SoftmaxState(acc, l_i, m_i)
+                    elif not PRUNE_CAUSAL_DIAGONAL:
+                        kt_dot = tlx.local_load(
+                            tlx.local_trans(tlx.local_view(k_buf, slot)),
+                            token=wait,
+                            relaxed=True,
+                        )
+                        v_dot = tlx.local_load(tlx.local_view(v_buf, slot), token=wait, relaxed=True)
+                        qk = tl.dot(q, kt_dot)
+                        state, p, alpha = state.vec1(
+                            qk,
+                            start_n,
+                            offs_m,
+                            offs_n,
+                            N_CTX,
+                            QK_SCALE,
+                            DIAG_OFFSET,
+                            MASK_STEPS,
+                            IS_CAUSAL,
+                        )
+                        state, p_dot = state.vec2(p, alpha, q.dtype)
+                        if BLOCK_N == 64 and q.shape[1] == 128:
+                            acc = _attn_dot_pv_mfma(state.acc, p_dot, v_dot)
+                        else:
+                            acc = tl.dot(p_dot, v_dot, state.acc)
+                        state = SoftmaxState(acc, state.l_i, state.m_i)
+
+            if not PRUNE_CAUSAL_DIAGONAL or chunk_start + BUF_DEPTH < num_blocks:
+                # Only a later refill needs a cross-wave read-completion
+                # rendezvous. The final predicated chunk returns with no LDS
+                # overwrite, matching the Gluon short-tail schedule.
+                tl.debug_barrier()
 
     return state
 
@@ -482,6 +2038,7 @@ def _attn_cluster_tile(
     BUF_DEPTH: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     USE_DIRECT_LOAD: tl.constexpr,
+    USE_Q_LDS: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
 ):
     q_off = off_z * stride_qz + off_h * stride_qh
@@ -489,15 +2046,132 @@ def _attn_cluster_tile(
     v_off = off_z * stride_vz + off_h * stride_vh
     o_off = off_z * stride_oz + off_h * stride_oh
 
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    local_m = tl.arange(0, BLOCK_M)
+    BALANCE_CAUSAL_WAVES: tl.constexpr = (IS_CAUSAL and N_CTX % BLOCK_M == 0 and HEAD_DIM == 128 and BLOCK_M == 256)
+    if BALANCE_CAUSAL_WAVES:
+        # Keep the first four logical row bands forward and reverse the last
+        # four: [0, 1, 2, 3, 7, 6, 5, 4].
+        wave_m = local_m // 32
+        wave_m = wave_m ^ ((wave_m // 4) * 3)
+        local_m = wave_m * 32 + local_m % 32
+    offs_m = pid_m * BLOCK_M + local_m
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, HEAD_DIM)
 
-    q = tl.load(
-        Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk,
-        mask=offs_m[:, None] < N_CTX,
-        other=0.0,
-    )
+    q_ptrs = Q + q_off + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    ALIGNED_Q: tl.constexpr = N_CTX % BLOCK_M == 0
+    Q_REGISTER_CG: tl.constexpr = (ALIGNED_Q and BLOCK_M == 256 and HEAD_DIM == 128 and tlx.num_warps() == 8
+                                   and (BLOCK_N == 64 or N_CTX >= 8192))
+    # Stage Q through the same padded LDS representation used by the target
+    # Gluon kernel.  For the aligned BM256 causal diagonal, K/V use four
+    # 64x128 slots (64 KiB); aliasing Q's 256x128 tile with that allocation
+    # lets the allocator reclaim the Q storage before the ring is filled.
+    USE_Q_LDS_BM256: tl.constexpr = (IS_CAUSAL and ALIGNED_Q and BLOCK_M == 256 and BLOCK_N == 64 and HEAD_DIM == 128
+                                     and tlx.num_warps() == 8)
+    LAZY_RESCALE_CANDIDATE: tl.constexpr = (BLOCK_N == 64 and HEAD_DIM == 128
+                                            and ((BLOCK_M == 256 and tlx.num_warps() == 8) or
+                                                 (IS_CAUSAL and BLOCK_M == 128 and tlx.num_warps() == 4))
+                                            and N_CTX % BLOCK_M == 0 and N_CTX % BLOCK_N == 0)
+    SCORE_SCALE_BM256: tl.constexpr = (BLOCK_M == 256 and BLOCK_N == 64 and HEAD_DIM == 128 and tlx.num_warps() == 8
+                                       and ((IS_CAUSAL and N_CTX <= 4096) or
+                                            (not IS_CAUSAL and (N_CTX <= 512 or
+                                                                (Q.dtype.element_ty == tl.float16 and N_CTX <= 1024)))))
+    # Avoid scaling through the storage dtype when the factor magnifies: finite
+    # FP16 Q can overflow, and BF16 incurs extra logit error from the early cast.
+    Q_PRESCALE_DOES_NOT_MAGNIFY: tl.constexpr = QK_SCALE >= -1.0 and QK_SCALE <= 1.0
+    PRESCALE_Q: tl.constexpr = (
+        Q_PRESCALE_DOES_NOT_MAGNIFY and HEAD_DIM <= 128
+        and ((not IS_CAUSAL and Q.dtype.element_ty == tl.float16) or LAZY_RESCALE_CANDIDATE)
+        and not (IS_CAUSAL and BLOCK_M == 128 and BLOCK_N == 64 and HEAD_DIM == 128 and tlx.num_warps() == 4)
+        and not SCORE_SCALE_BM256)
+    if USE_Q_LDS or USE_Q_LDS_BM256:
+        tl.static_assert(IS_CAUSAL)
+        tl.static_assert(ALIGNED_Q)
+        if USE_Q_LDS:
+            tl.static_assert(BLOCK_M == 128)
+        else:
+            tl.static_assert(BLOCK_M == 256)
+            tl.static_assert(tlx.num_warps() == 8)
+        tl.static_assert(BLOCK_N == 64)
+        tl.static_assert(HEAD_DIM == 128)
+        # The short-class kernel drains this one-shot copy before K/V starts.
+        # Its 128x128 allocation is exactly the size of the two-slot 64x128 K
+        # ring, so make that non-overlapping lifetime explicit to the allocator.
+        q_shared_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+            [(1024, 8)],
+            [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [16, 0],
+                [32, 0],
+                [64, 0],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+            ],
+            [BLOCK_M, HEAD_DIM],
+        )
+        if USE_Q_LDS_BM256:
+            # BM256 follows Gluon's register-load -> shared-store path.  A
+            # direct async copy uses a different pointer distribution from
+            # this padded K-ring alias and silently permutes Q; the synchronous
+            # store lets the compiler map the existing register layout into
+            # the aliased LDS tile.
+            q_buf = tlx.local_alloc(
+                (BLOCK_M, HEAD_DIM),
+                Q.dtype.element_ty,
+                1,
+                reuse=k_buf,
+                layout=tlx.swizzled_layout(4, 3, 4, order=[1, 0]),
+            )
+            q = tl.load(q_ptrs, cache_modifier=".cg")
+            if PRESCALE_Q:
+                q = (q.to(tl.float32) * QK_SCALE).to(Q.dtype.element_ty)
+            tlx.local_store(tlx.local_view(q_buf, 0), q)
+            tl.debug_barrier()
+            q = tlx.local_load(tlx.local_view(q_buf, 0))
+        else:
+            q_buf = tlx.local_alloc(
+                (BLOCK_M, HEAD_DIM),
+                Q.dtype.element_ty,
+                1,
+                reuse=k_buf,
+                layout=q_shared_layout,
+            )
+            q_token = tlx.async_load(
+                q_ptrs,
+                tlx.local_view(q_buf, 0),
+                cache_modifier=".cg",
+            )
+            tlx.async_load_commit_group([q_token])
+            q_wait = tlx.async_load_wait_group(0)
+            q = tlx.local_load(tlx.local_view(q_buf, 0), token=q_wait)
+        # All waves must finish consuming aliased Q LDS before the first K DMA
+        # may overwrite either ring slot.
+        tl.debug_barrier()
+    elif Q_REGISTER_CG:
+        # Q is consumed once; on BN64 and the long BN32 rows, bypassing L1 lets
+        # neighboring query tiles retain K/V without the medium-row cache cost.
+        q = tl.load(q_ptrs, cache_modifier=".cg")
+    elif ALIGNED_Q:
+        q = tl.load(q_ptrs)
+    else:
+        q = tl.load(q_ptrs, mask=offs_m[:, None] < N_CTX, other=0.0)
+
+    # Gluon's BM256 register-load path prescales before its shared-memory
+    # store. Preserve that lifetime so the Q allocation can alias the K ring.
+    if PRESCALE_Q and not USE_Q_LDS_BM256:
+        q = (q.to(tl.float32) * QK_SCALE).to(Q.dtype.element_ty)
+    if PRESCALE_Q:
+        INNER_QK_SCALE: tl.constexpr = 1.0
+    else:
+        INNER_QK_SCALE: tl.constexpr = QK_SCALE
 
     DIAG_OFFSET: tl.constexpr = 0
 
@@ -508,10 +2182,15 @@ def _attn_cluster_tile(
 
     n_blocks_total: tl.constexpr = (N_CTX + BLOCK_N - 1) // BLOCK_N
     is_modulo_mn: tl.constexpr = N_CTX % BLOCK_N == 0 and N_CTX % BLOCK_M == 0
+    aligned_self_causal: tl.constexpr = IS_CAUSAL and is_modulo_mn and BLOCK_M % BLOCK_N == 0
 
     if IS_CAUSAL:
-        causal_end = ((pid_m + 1) * BLOCK_M + BLOCK_N - 1) // BLOCK_N
-        n_blocks = min(n_blocks_total, causal_end)
+        if aligned_self_causal:
+            # The launch bounds pid_m and all divisions are exact.
+            n_blocks = (pid_m + 1) * (BLOCK_M // BLOCK_N)
+        else:
+            causal_end = ((pid_m + 1) * BLOCK_M + BLOCK_N - 1) // BLOCK_N
+            n_blocks = min(n_blocks_total, causal_end)
         masked_blocks: tl.constexpr = BLOCK_M // BLOCK_N + (not is_modulo_mn)
     else:
         n_blocks = n_blocks_total
@@ -523,7 +2202,299 @@ def _attn_cluster_tile(
     # The rotated loop needs enough blocks to fill and drain all four stages.
     # Keep short ranges on the two-slot preload fallback, and fold tiny masked tails
     # into a larger masked pipeline range just like the original Gluon kernel.
-    if n_blocks > CLUSTER_PIPELINE_STAGES and (n_blocks - n_full) < CLUSTER_PIPELINE_STAGES and n_full != n_blocks:
+    SPLIT_PRUNED_CAUSAL_PREFIX: tl.constexpr = (not USE_DIRECT_LOAD and IS_CAUSAL and BLOCK_M == 128 and BLOCK_N == 64
+                                                and HEAD_DIM == 128 and tlx.num_warps() == 4 and N_CTX <= 1024
+                                                and is_modulo_mn)
+    BF16_LIGHTWEIGHT_WAR: tl.constexpr = (SPLIT_PRUNED_CAUSAL_PREFIX and N_CTX == 512 and q.dtype == tl.bfloat16)
+    USE_REGISTER_PREDICATED_BN32_DIAGONAL: tl.constexpr = (IS_CAUSAL and is_modulo_mn and BLOCK_M == 256
+                                                           and BLOCK_N == 32 and HEAD_DIM == 128
+                                                           and tlx.num_warps() == 8 and N_CTX == 2048)
+    USE_ALIGNED_BM256_BN64_CAUSAL: tl.constexpr = (IS_CAUSAL and is_modulo_mn and BLOCK_M == 256 and BLOCK_N == 64
+                                                   and HEAD_DIM == 128 and tlx.num_warps() == 8)
+    if USE_ALIGNED_BM256_BN64_CAUSAL:
+        # Gluon folds this shape to exactly one unmasked prefix body followed
+        # by its four-tile wave-predicated diagonal. Spell out that constexpr
+        # route so TLX does not retain the impossible masked-pipeline peers in
+        # the same code object.
+        diagonal_mma: tl.constexpr = tlx.amd_mfma_layout(
+            version=4,
+            instr_shape=[32, 32, 16],
+            transposed=True,
+            warps_per_cta=[tlx.num_warps(), 1],
+        )
+        # Both arms of the dynamic prefix guard must carry the same layout.
+        # Pin the empty state before the guard and preserve the prefix's final
+        # PV layout so the following wave predicate never needs an LDS bridge.
+        state = SoftmaxState(
+            tlx.require_layout(state.acc, diagonal_mma, pin=True),
+            state.l_i,
+            state.m_i,
+        )
+        FOUR_SLOT_PREFIX_HANDOFF: tl.constexpr = (not USE_DIRECT_LOAD and N_CTX == 2048)
+        if n_full >= CLUSTER_PIPELINE_STAGES:
+            state = _attn_inner_pipelined(
+                state,
+                q,
+                k_ptrs,
+                v_ptrs,
+                offs_m,
+                offs_n,
+                0,
+                n_full,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                N_CTX,
+                INNER_QK_SCALE,
+                DIAG_OFFSET,
+                BLOCK_N,
+                BUF_DEPTH,
+                False,
+                IS_CAUSAL,
+                FOUR_SLOT_PREFIX_HANDOFF,
+            )
+            masked_start = n_full
+        else:
+            masked_start = 0
+        if n_blocks > masked_start:
+            state = _attn_inner_short(
+                state,
+                q,
+                k_ptrs,
+                v_ptrs,
+                offs_m,
+                offs_n,
+                masked_start,
+                n_blocks,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                N_CTX,
+                INNER_QK_SCALE,
+                DIAG_OFFSET,
+                BLOCK_N,
+                BUF_DEPTH,
+                USE_DIRECT_LOAD,
+                True,
+                IS_CAUSAL,
+                FOUR_SLOT_PREFIX_HANDOFF,
+            )
+    elif SPLIT_PRUNED_CAUSAL_PREFIX:
+        USE_ONE_TILE_PREFIX_HANDOFF: tl.constexpr = (N_CTX == 8 * BLOCK_N
+                                                     or (N_CTX == 16 * BLOCK_N and q.dtype == tl.float16))
+        if USE_ONE_TILE_PREFIX_HANDOFF:
+            masked_start = 0
+            if n_full >= CLUSTER_PIPELINE_STAGES:
+                state = _attn_inner_pipelined(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    0,
+                    n_full,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    False,
+                    IS_CAUSAL,
+                    True,
+                )
+                masked_start = n_full
+                if n_blocks > masked_start:
+                    state = _attn_inner_short(
+                        state,
+                        q,
+                        k_ptrs,
+                        v_ptrs,
+                        offs_m,
+                        offs_n,
+                        masked_start,
+                        n_blocks,
+                        k_buf,
+                        v_buf,
+                        stride_kn,
+                        stride_vn,
+                        N_CTX,
+                        INNER_QK_SCALE,
+                        DIAG_OFFSET,
+                        BLOCK_N,
+                        BUF_DEPTH,
+                        USE_DIRECT_LOAD,
+                        True,
+                        IS_CAUSAL,
+                        True,
+                    )
+                masked_start = n_blocks
+            elif n_full == 2:
+                state = _attn_inner_full2_lazy(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    0,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    INNER_QK_SCALE,
+                    BLOCK_N,
+                )
+                # The diagonal immediately reuses both prefix slots.
+                _attn_war_barrier(BF16_LIGHTWEIGHT_WAR)
+                masked_start = n_full
+            elif n_full > 0:
+                state = _attn_inner_short(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    0,
+                    n_full,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    USE_DIRECT_LOAD,
+                    False,
+                    IS_CAUSAL,
+                    False,
+                )
+                masked_start = n_full
+            if n_blocks > masked_start:
+                state = _attn_inner_short(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    masked_start,
+                    n_blocks,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    USE_DIRECT_LOAD,
+                    True,
+                    IS_CAUSAL,
+                    False,
+                )
+        else:
+            # Preserve the established fallback control-flow shape for classes
+            # where the prefetched handoff is not performance-positive.
+            if n_full > CLUSTER_PIPELINE_STAGES:
+                state = _attn_inner_pipelined(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    0,
+                    n_full,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    False,
+                    IS_CAUSAL,
+                    False,
+                )
+                # The diagonal reuses both prefix slots. Rendezvous after the
+                # final relaxed LDS reads before either slot is overwritten.
+                _attn_war_barrier(BF16_LIGHTWEIGHT_WAR)
+            elif n_full == 2:
+                state = _attn_inner_full2_lazy(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    0,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    INNER_QK_SCALE,
+                    BLOCK_N,
+                )
+                # The diagonal immediately reuses both prefix slots.
+                _attn_war_barrier(BF16_LIGHTWEIGHT_WAR)
+            elif n_full > 0:
+                state = _attn_inner_short(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    0,
+                    n_full,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    USE_DIRECT_LOAD,
+                    False,
+                    IS_CAUSAL,
+                    False,
+                )
+            if n_blocks > n_full:
+                state = _attn_inner_short(
+                    state,
+                    q,
+                    k_ptrs,
+                    v_ptrs,
+                    offs_m,
+                    offs_n,
+                    n_full,
+                    n_blocks,
+                    k_buf,
+                    v_buf,
+                    stride_kn,
+                    stride_vn,
+                    N_CTX,
+                    INNER_QK_SCALE,
+                    DIAG_OFFSET,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    USE_DIRECT_LOAD,
+                    True,
+                    IS_CAUSAL,
+                    False,
+                )
+    elif n_blocks > CLUSTER_PIPELINE_STAGES and (n_blocks - n_full) < CLUSTER_PIPELINE_STAGES and n_full != n_blocks:
         state = _attn_inner_pipelined(
             state,
             q,
@@ -538,12 +2509,13 @@ def _attn_cluster_tile(
             stride_kn,
             stride_vn,
             N_CTX,
-            QK_SCALE,
+            INNER_QK_SCALE,
             DIAG_OFFSET,
             BLOCK_N,
             BUF_DEPTH,
             True,
             IS_CAUSAL,
+            False,
         )
     elif n_blocks > CLUSTER_PIPELINE_STAGES:
         if n_full > CLUSTER_PIPELINE_STAGES:
@@ -561,17 +2533,42 @@ def _attn_cluster_tile(
                 stride_kn,
                 stride_vn,
                 N_CTX,
-                QK_SCALE,
+                INNER_QK_SCALE,
                 DIAG_OFFSET,
                 BLOCK_N,
                 BUF_DEPTH,
                 False,
                 IS_CAUSAL,
+                False,
             )
 
         masked_start = n_full if n_full > CLUSTER_PIPELINE_STAGES else 0
         remaining_blocks = n_blocks - masked_start
-        if remaining_blocks > CLUSTER_PIPELINE_STAGES:
+        if USE_REGISTER_PREDICATED_BN32_DIAGONAL and remaining_blocks > 0:
+            state = _attn_inner_short(
+                state,
+                q,
+                k_ptrs,
+                v_ptrs,
+                offs_m,
+                offs_n,
+                masked_start,
+                n_blocks,
+                k_buf,
+                v_buf,
+                stride_kn,
+                stride_vn,
+                N_CTX,
+                INNER_QK_SCALE,
+                DIAG_OFFSET,
+                BLOCK_N,
+                BUF_DEPTH,
+                USE_DIRECT_LOAD,
+                True,
+                IS_CAUSAL,
+                False,
+            )
+        elif remaining_blocks > CLUSTER_PIPELINE_STAGES:
             state = _attn_inner_pipelined(
                 state,
                 q,
@@ -586,12 +2583,13 @@ def _attn_cluster_tile(
                 stride_kn,
                 stride_vn,
                 N_CTX,
-                QK_SCALE,
+                INNER_QK_SCALE,
                 DIAG_OFFSET,
                 BLOCK_N,
                 BUF_DEPTH,
                 True,
                 IS_CAUSAL,
+                False,
             )
         elif remaining_blocks > 0:
             state = _attn_inner_short(
@@ -608,12 +2606,14 @@ def _attn_cluster_tile(
                 stride_kn,
                 stride_vn,
                 N_CTX,
-                QK_SCALE,
+                INNER_QK_SCALE,
                 DIAG_OFFSET,
                 BLOCK_N,
                 BUF_DEPTH,
                 USE_DIRECT_LOAD,
+                True,
                 IS_CAUSAL,
+                False,
             )
     elif n_blocks > 0:
         state = _attn_inner_short(
@@ -630,17 +2630,141 @@ def _attn_cluster_tile(
             stride_kn,
             stride_vn,
             N_CTX,
-            QK_SCALE,
+            INNER_QK_SCALE,
             DIAG_OFFSET,
             BLOCK_N,
             BUF_DEPTH,
             USE_DIRECT_LOAD,
+            True,
             IS_CAUSAL,
+            False,
         )
 
-    acc = state.acc / state.l_i[:, None]
+    USE_FAST_SHORT_EPILOGUE: tl.constexpr = N_CTX <= 32 * BLOCK_N
+    USE_WARP_LOCAL_OUTPUT: tl.constexpr = (IS_CAUSAL and N_CTX % BLOCK_M == 0 and N_CTX == 4096 and BLOCK_M == 256
+                                           and (BLOCK_N == 32 or BLOCK_N == 64) and HEAD_DIM == 128
+                                           and tlx.num_warps() == 8 and Out.dtype.element_ty == tl.bfloat16)
+    NORMALIZED_IN_PRUNED_SHORT: tl.constexpr = SPLIT_PRUNED_CAUSAL_PREFIX
+    acc = state.acc
+    if not NORMALIZED_IN_PRUNED_SHORT:
+        if USE_FAST_SHORT_EPILOGUE:
+            # Output is rounded to FP16/BF16, so the native reciprocal's error
+            # is below the store precision while avoiding the corrected IEEE
+            # divide.
+            l_recip = fast_dividef(1.0, state.l_i)
+            acc = state.acc * l_recip[:, None]
+        else:
+            acc = state.acc / state.l_i[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
-    tl.store(o_ptrs, acc.to(Out.dtype.element_ty), mask=(offs_m[:, None] < N_CTX) & (offs_d[None, :] < HEAD_DIM))
+    out = acc.to(Out.dtype.element_ty)
+    if USE_Q_LDS:
+        # Swap the native MFMA column-4/column-8 ownership bits in-wave.  Each
+        # lane then owns eight adjacent values for a 128-bit store, without
+        # the full-tile LDS transpose selected by generic coalescing.
+        out_layout: tl.constexpr = tlx.layout(
+            shape=((32, 2, 4), (8, 8)),
+            stride=((128, 8, 4096), (1, 16)),
+        )
+        o_ptrs = tlx.require_layout(o_ptrs, out_layout)
+        out = tlx.require_layout(out, out_layout)
+    elif USE_WARP_LOCAL_OUTPUT:
+        # Eight-warp D128 store mapping: five row bits and one D8 lane bit
+        # belong to each wave, while three additional row bits select the
+        # eight-warp MFMA groups.  This is the shape/stride form of the
+        # reference's in-wave output permutation.
+        out_layout: tl.constexpr = tlx.layout(
+            shape=((32, 2, 8), (8, 8)),
+            stride=((128, 8, 4096), (1, 16)),
+        )
+        o_ptrs = tlx.require_layout(o_ptrs, out_layout)
+        out = tlx.require_layout(out, out_layout)
+    if N_CTX % BLOCK_M == 0:
+        tl.store(o_ptrs, out)
+    else:
+        tl.store(o_ptrs, out, mask=offs_m[:, None] < N_CTX)
+
+
+@triton.jit
+def _cluster_causal_query_tile(raw_pid_m, N_CTX: tl.constexpr, BLOCK_M: tl.constexpr):
+    # Later causal query tiles have more K/V blocks to process. Reverse the
+    # complete program-id range so that those heavier CTAs are dispatched first.
+    NUM_M_BLOCKS: tl.constexpr = (N_CTX + BLOCK_M - 1) // BLOCK_M
+    return NUM_M_BLOCKS - 1 - raw_pid_m
+
+
+@triton.jit
+def _cluster_direct_workgroup_window(
+    raw_off_h,
+    raw_pid_m,
+    H: tl.constexpr,
+    N_CTX: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    USE_24_HEAD_WINDOW: tl.constexpr,
+    USE_FACTORED_24: tl.constexpr,
+):
+    """Transpose bounded head/query windows without changing the work set."""
+    NUM_M_BLOCKS: tl.constexpr = (N_CTX + BLOCK_M - 1) // BLOCK_M
+    if IS_CAUSAL:
+        # TLX retains the measured H64 24/24/16 long-row phase. The Gluon
+        # 32-head causal window does not improve this pipeline.
+        WINDOW_HEADS: tl.constexpr = 24
+        USE_WINDOW: tl.constexpr = (BLOCK_M == 256 and NUM_M_BLOCKS >= 8 and USE_24_HEAD_WINDOW and WINDOW_HEADS < H
+                                    and (H % WINDOW_HEADS == 0 or H == 64))
+    else:
+        # Keep a 128-CTA locality set for the N2048/N4096 D128 classes where
+        # this TLX pipeline benefits from head/query transposition.
+        WINDOW_HEADS: tl.constexpr = max(1, 128 // NUM_M_BLOCKS)
+        USE_WINDOW: tl.constexpr = (BLOCK_M == 256 and NUM_M_BLOCKS >= 8 and NUM_M_BLOCKS <= 16 and WINDOW_HEADS < H
+                                    and H % WINDOW_HEADS == 0)
+
+    off_h = raw_off_h
+    pid_m = raw_pid_m
+    if USE_WINDOW:
+        linear_wg = raw_off_h + raw_pid_m * H
+        GROUP_SPAN: tl.constexpr = WINDOW_HEADS * NUM_M_BLOCKS
+        if H % WINDOW_HEADS == 0:
+            within_group = linear_wg % GROUP_SPAN
+            off_h = (linear_wg // GROUP_SPAN) * WINDOW_HEADS + within_group % WINDOW_HEADS
+            pid_m = within_group // WINDOW_HEADS
+        else:
+            # H64 is partitioned into two 24-head windows and one 16-head tail.
+            # Decode each range separately to keep this a bijection.
+            TAIL_HEADS: tl.constexpr = H - 2 * WINDOW_HEADS
+            if USE_FACTORED_24:
+                # Match the Gluon H64/G24 decoder.  Factoring 24 as 8*3
+                # avoids carrying the large-span quotient through the hot
+                # FP16 kernel while preserving the same 24/24/16 bijection.
+                FULL_GROUP_ROWS: tl.constexpr = 3 * NUM_M_BLOCKS // 8
+                TAIL_ROW_BEGIN: tl.constexpr = 2 * FULL_GROUP_ROWS
+                if raw_pid_m < FULL_GROUP_ROWS:
+                    packed = raw_off_h + raw_pid_m * H
+                    packed8 = packed // 8
+                    mapped_m = packed8 // 3
+                    off_h = packed % 8 + (packed8 - mapped_m * 3) * 8
+                    pid_m = mapped_m
+                elif raw_pid_m < TAIL_ROW_BEGIN:
+                    packed = raw_off_h + (raw_pid_m - FULL_GROUP_ROWS) * H
+                    packed8 = packed // 8
+                    mapped_m = packed8 // 3
+                    off_h = WINDOW_HEADS + packed % 8 + (packed8 - mapped_m * 3) * 8
+                    pid_m = mapped_m
+                else:
+                    packed = raw_off_h + (raw_pid_m - TAIL_ROW_BEGIN) * H
+                    off_h = 2 * WINDOW_HEADS + packed % TAIL_HEADS
+                    pid_m = packed // TAIL_HEADS
+            else:
+                FULL_HEADS: tl.constexpr = 2 * WINDOW_HEADS
+                FULL_SPAN: tl.constexpr = FULL_HEADS * NUM_M_BLOCKS
+                if linear_wg < FULL_SPAN:
+                    within_group = linear_wg % GROUP_SPAN
+                    off_h = (linear_wg // GROUP_SPAN) * WINDOW_HEADS + within_group % WINDOW_HEADS
+                    pid_m = within_group // WINDOW_HEADS
+                else:
+                    within_tail = linear_wg - FULL_SPAN
+                    off_h = FULL_HEADS + within_tail % TAIL_HEADS
+                    pid_m = within_tail // TAIL_HEADS
+    return off_h, pid_m
 
 
 @triton.jit
@@ -649,24 +2773,24 @@ def _attn_fwd_cluster_pipeline(
     K,
     V,
     Out,
-    stride_qz,
-    stride_qh,
+    stride_qz: tl.constexpr,
+    stride_qh: tl.constexpr,
     stride_qm,
     stride_qk,
-    stride_kz,
-    stride_kh,
+    stride_kz: tl.constexpr,
+    stride_kh: tl.constexpr,
     stride_kn,
     stride_kk,
-    stride_vz,
-    stride_vh,
+    stride_vz: tl.constexpr,
+    stride_vh: tl.constexpr,
     stride_vn,
     stride_vk,
-    stride_oz,
-    stride_oh,
+    stride_oz: tl.constexpr,
+    stride_oh: tl.constexpr,
     stride_om,
     stride_ok,
     Z,
-    H,
+    H: tl.constexpr,
     N_CTX: tl.constexpr,
     sm_scale: tl.constexpr,
     BLOCK_M: tl.constexpr,
@@ -675,7 +2799,185 @@ def _attn_fwd_cluster_pipeline(
     HEAD_DIM: tl.constexpr,
     USE_DIRECT_LOAD: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
+    STATIC_STRIDE_KN: tl.constexpr = -1,
 ):
+    if STATIC_STRIDE_KN >= 0:
+        tile_stride_kn = STATIC_STRIDE_KN
+    else:
+        tile_stride_kn = stride_kn
+
+    _assume_strides(
+        stride_qz,
+        stride_qh,
+        stride_qm,
+        stride_qk,
+        stride_kz,
+        stride_kh,
+        tile_stride_kn,
+        stride_kk,
+        stride_vz,
+        stride_vh,
+        stride_vn,
+        stride_vk,
+        stride_oz,
+        stride_oh,
+        stride_om,
+        stride_ok,
+    )
+
+    if IS_CAUSAL:
+        raw_off_h = tl.program_id(0)
+        raw_pid_m = tl.program_id(1)
+    else:
+        raw_pid_m = tl.program_id(0)
+        raw_off_h = tl.program_id(1)
+    NUM_M_BLOCKS: tl.constexpr = (N_CTX + BLOCK_M - 1) // BLOCK_M
+    USE_24_HEAD_WINDOW: tl.constexpr = (IS_CAUSAL and H == 64
+                                        and ((Q.dtype.element_ty == tl.float16 and NUM_M_BLOCKS >= 32) or
+                                             (Q.dtype.element_ty == tl.bfloat16 and NUM_M_BLOCKS >= 64)))
+    USE_FACTORED_24: tl.constexpr = (USE_24_HEAD_WINDOW and Q.dtype.element_ty == tl.float16 and NUM_M_BLOCKS % 8 == 0)
+    off_h, pid_m = _cluster_direct_workgroup_window(
+        raw_off_h,
+        raw_pid_m,
+        H,
+        N_CTX,
+        BLOCK_M,
+        IS_CAUSAL,
+        USE_24_HEAD_WINDOW,
+        USE_FACTORED_24,
+    )
+    if IS_CAUSAL:
+        pid_m = _cluster_causal_query_tile(pid_m, N_CTX, BLOCK_M)
+    off_z = tl.program_id(2)
+
+    # Only the aligned LDS diagonal specialization consumes four unique slots.
+    # Direct-load and ragged tiles use the regular two-slot ring.
+    FOUR_SLOT_PRUNE: tl.constexpr = (not USE_DIRECT_LOAD and IS_CAUSAL and BLOCK_M == 256 and BLOCK_N == 64
+                                     and HEAD_DIM == 128 and tlx.num_warps() == 8 and N_CTX % BLOCK_M == 0
+                                     and N_CTX % BLOCK_N == 0)
+    ALLOC_BUF_DEPTH: tl.constexpr = 4 if FOUR_SLOT_PRUNE else BUF_DEPTH
+    USE_TARGET_PADDED_KV: tl.constexpr = (HEAD_DIM == 128 and (BLOCK_N == 32 or BLOCK_N == 64) and tlx.num_warps() == 8)
+    if USE_TARGET_PADDED_KV:
+        if BLOCK_N == 64:
+            kv_offset_bases: tl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [16, 0],
+                [32, 0],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+            ]
+        else:
+            kv_offset_bases: tl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [16, 0],
+                [8, 0],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+            ]
+        k_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 8)], kv_offset_bases,
+                                                                              [BLOCK_N, HEAD_DIM])
+        v_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 32)], kv_offset_bases,
+                                                                              [BLOCK_N, HEAD_DIM])
+        k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, ALLOC_BUF_DEPTH, layout=k_layout)
+        v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, ALLOC_BUF_DEPTH, layout=v_layout)
+    else:
+        k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, ALLOC_BUF_DEPTH)
+        v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, ALLOC_BUF_DEPTH)
+    QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
+    _attn_cluster_tile(
+        pid_m,
+        off_z,
+        off_h,
+        Q,
+        K,
+        V,
+        Out,
+        k_buf,
+        v_buf,
+        stride_qz,
+        stride_qh,
+        stride_qm,
+        stride_qk,
+        stride_kz,
+        stride_kh,
+        tile_stride_kn,
+        stride_kk,
+        stride_vz,
+        stride_vh,
+        stride_vn,
+        stride_vk,
+        stride_oz,
+        stride_oh,
+        stride_om,
+        stride_ok,
+        N_CTX,
+        QK_SCALE,
+        BLOCK_M,
+        BLOCK_N,
+        BUF_DEPTH,
+        HEAD_DIM,
+        USE_DIRECT_LOAD,
+        False,
+        IS_CAUSAL,
+    )
+
+
+@triton.jit
+def _attn_fwd_cluster_short_causal_pipeline(
+    Q,
+    K,
+    V,
+    Out,
+    stride_qz: tl.constexpr,
+    stride_qh: tl.constexpr,
+    stride_qm: tl.constexpr,
+    stride_qk: tl.constexpr,
+    stride_kz: tl.constexpr,
+    stride_kh: tl.constexpr,
+    stride_kn: tl.constexpr,
+    stride_kk: tl.constexpr,
+    stride_vz: tl.constexpr,
+    stride_vh: tl.constexpr,
+    stride_vn: tl.constexpr,
+    stride_vk: tl.constexpr,
+    stride_oz: tl.constexpr,
+    stride_oh: tl.constexpr,
+    stride_om: tl.constexpr,
+    stride_ok: tl.constexpr,
+    Z,
+    H: tl.constexpr,
+    N_CTX: tl.constexpr,
+    sm_scale: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BUF_DEPTH: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    USE_DIRECT_LOAD: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    SPECIALIZE_QUERY_CLASSES: tl.constexpr,
+):
+    tl.static_assert(IS_CAUSAL)
+    tl.static_assert(HEAD_DIM == 128)
+    tl.static_assert(BLOCK_M == 128)
+    tl.static_assert(BLOCK_N == 64)
+    tl.static_assert(N_CTX <= 1024)
+    tl.static_assert(N_CTX % BLOCK_M == 0)
+
     _assume_strides(
         stride_qz,
         stride_qh,
@@ -695,52 +2997,97 @@ def _attn_fwd_cluster_pipeline(
         stride_ok,
     )
 
-    if IS_CAUSAL:
-        off_h = tl.program_id(0)
-        pid_m = tl.program_id(1)
-    else:
-        pid_m = tl.program_id(0)
-        off_h = tl.program_id(1)
+    off_h = tl.program_id(0)
+    query_class = tl.program_id(1)
     off_z = tl.program_id(2)
-
     k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, BUF_DEPTH)
     v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, BUF_DEPTH)
     QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
-    _attn_cluster_tile(
-        pid_m,
-        off_z,
-        off_h,
-        Q,
-        K,
-        V,
-        Out,
-        k_buf,
-        v_buf,
-        stride_qz,
-        stride_qh,
-        stride_qm,
-        stride_qk,
-        stride_kz,
-        stride_kh,
-        stride_kn,
-        stride_kk,
-        stride_vz,
-        stride_vh,
-        stride_vn,
-        stride_vk,
-        stride_oz,
-        stride_oh,
-        stride_om,
-        stride_ok,
-        N_CTX,
-        QK_SCALE,
-        BLOCK_M,
-        BLOCK_N,
-        BUF_DEPTH,
-        HEAD_DIM,
-        USE_DIRECT_LOAD,
-        IS_CAUSAL,
-    )
+    NUM_M_BLOCKS: tl.constexpr = N_CTX // BLOCK_M
+
+    if SPECIALIZE_QUERY_CLASSES:
+        # All classes share one launch so heavy and light CTAs stay interleaved.
+        # Each branch sees a constant query tile and drops unreachable work.
+        for i in tl.static_range(NUM_M_BLOCKS):
+            if query_class == i:
+                pid_m: tl.constexpr = NUM_M_BLOCKS - 1 - i
+                _attn_cluster_tile(
+                    pid_m,
+                    off_z,
+                    off_h,
+                    Q,
+                    K,
+                    V,
+                    Out,
+                    k_buf,
+                    v_buf,
+                    stride_qz,
+                    stride_qh,
+                    stride_qm,
+                    stride_qk,
+                    stride_kz,
+                    stride_kh,
+                    stride_kn,
+                    stride_kk,
+                    stride_vz,
+                    stride_vh,
+                    stride_vn,
+                    stride_vk,
+                    stride_oz,
+                    stride_oh,
+                    stride_om,
+                    stride_ok,
+                    N_CTX,
+                    QK_SCALE,
+                    BLOCK_M,
+                    BLOCK_N,
+                    BUF_DEPTH,
+                    HEAD_DIM,
+                    USE_DIRECT_LOAD,
+                    True,
+                    IS_CAUSAL,
+                )
+    else:
+        # Cloning eight N=1024 classes raises the unified register allocation
+        # past the two-wave boundary.  Keep the heavy-first mapping but share
+        # one dynamic tile body, as in the optimized source kernel.
+        pid_m = NUM_M_BLOCKS - 1 - query_class
+        _attn_cluster_tile(
+            pid_m,
+            off_z,
+            off_h,
+            Q,
+            K,
+            V,
+            Out,
+            k_buf,
+            v_buf,
+            stride_qz,
+            stride_qh,
+            stride_qm,
+            stride_qk,
+            stride_kz,
+            stride_kh,
+            stride_kn,
+            stride_kk,
+            stride_vz,
+            stride_vh,
+            stride_vn,
+            stride_vk,
+            stride_oz,
+            stride_oh,
+            stride_om,
+            stride_ok,
+            N_CTX,
+            QK_SCALE,
+            BLOCK_M,
+            BLOCK_N,
+            BUF_DEPTH,
+            HEAD_DIM,
+            USE_DIRECT_LOAD,
+            True,
+            IS_CAUSAL,
+        )
 
 
 @triton.jit
@@ -806,8 +3153,14 @@ def _attn_fwd_cluster_persistent_pipeline(
     local = pid // NUM_XCDS
     NUM_LOCAL: tl.constexpr = NUM_SMS // NUM_XCDS
 
-    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, BUF_DEPTH)
-    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, BUF_DEPTH)
+    # Match the non-persistent launcher: only the aligned LDS diagonal consumes
+    # four slots; direct-load and ragged tiles retain the normal ring depth.
+    FOUR_SLOT_PRUNE: tl.constexpr = (not USE_DIRECT_LOAD and IS_CAUSAL and BLOCK_M == 256 and BLOCK_N == 64
+                                     and HEAD_DIM == 128 and tlx.num_warps() == 8 and N_CTX % BLOCK_M == 0
+                                     and N_CTX % BLOCK_N == 0)
+    ALLOC_BUF_DEPTH: tl.constexpr = 4 if FOUR_SLOT_PRUNE else BUF_DEPTH
+    k_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), K.dtype.element_ty, ALLOC_BUF_DEPTH)
+    v_buf = tlx.local_alloc((BLOCK_N, HEAD_DIM), V.dtype.element_ty, ALLOC_BUF_DEPTH)
 
     QK_SCALE: tl.constexpr = sm_scale * 1.44269504089
     TILES_PER_UNIT: tl.constexpr = 2 if IS_CAUSAL else 1
@@ -866,6 +3219,7 @@ def _attn_fwd_cluster_persistent_pipeline(
                         BUF_DEPTH,
                         HEAD_DIM,
                         USE_DIRECT_LOAD,
+                        False,
                         IS_CAUSAL,
                     )
 
@@ -888,25 +3242,99 @@ _attn_fwd_cluster_persistent_pipeline_autotuned = triton.autotune(
 
 
 def _cluster_default_block_n(causal):
-    return 32 if causal else 64
+    return 64
+
+
+def _cluster_static_k_row_stride(q, k, causal, use_autotune, block_m, block_n, num_warps, waves_per_eu):
+    """Specialize K's physical row stride on the measured long noncausal path."""
+    n_ctx = q.shape[2]
+    head_dim = q.shape[3]
+    # The broader Gluon gate is not transferable to this stock-scheduled TLX
+    # object: causal and BF16 rows regress, while FP16 N>=4096 wins at both the
+    # standard and magnifying scales. Keep explicit configurations unchanged.
+    use_krow = (use_autotune and not causal and q.dtype == torch.float16 and q.shape[1] == k.shape[1]
+                and head_dim == 128 and n_ctx >= _CLUSTER_STATIC_K_ROW_MIN_N and n_ctx % 256 == 0 and block_m == 256
+                and block_n == 64 and num_warps == 8 and waves_per_eu == 2)
+    return k.stride(2) if use_krow else -1
+
+
+def _validate_cluster_inputs(q, k, v):
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        raise ValueError("cluster attention expects rank-4 [B, H, N, D] inputs")
+    if q.shape != k.shape or q.shape != v.shape:
+        raise ValueError("cluster attention currently requires Q, K, and V to have the same shape")
+    if q.dtype != k.dtype or q.dtype != v.dtype:
+        raise ValueError("cluster attention requires Q, K, and V to have the same dtype")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError(f"cluster attention supports only FP16/BF16, got {q.dtype}")
+    if q.device != k.device or q.device != v.device or not q.is_cuda:
+        raise ValueError("cluster attention requires Q, K, and V on the same GPU")
+    if any(size <= 0 for size in q.shape):
+        raise ValueError(f"cluster attention dimensions must be positive, got {tuple(q.shape)}")
+    if q.shape[-1] not in (64, 128):
+        raise ValueError(f"cluster attention supports head dimensions 64 and 128, got {q.shape[-1]}")
+    for name, tensor in (("Q", q), ("K", k), ("V", v)):
+        if tensor.stride(2) <= 0 or tensor.stride(3) < 0:
+            raise ValueError(f"cluster attention requires nonnegative {name} feature and positive sequence strides")
+
+
+def _validate_cluster_tiles(block_m, block_n):
+    if block_m not in (128, 256):
+        raise ValueError(f"cluster attention supports BLOCK_M 128 or 256, got {block_m}")
+    if block_n not in (32, 64):
+        raise ValueError(f"cluster attention supports BLOCK_N 32 or 64, got {block_n}")
 
 
 def flash_attn_cluster_pipeline(q, k, v, sm_scale, causal=False, **kw):
+    _validate_cluster_inputs(q, k, v)
+    B, H, N_CTX, D = q.shape
+    use_short_causal_defaults = (causal and D == 128 and N_CTX <= 1024 and N_CTX % 128 == 0 and "BLOCK_M" not in kw
+                                 and "BLOCK_N" not in kw and kw.get("num_warps", 4) == 4
+                                 and kw.get("num_stages", 3) == 3)
     mfma_m = 32
-    block_m = kw.pop("BLOCK_M", 256)
-    block_n = kw.pop("BLOCK_N", _cluster_default_block_n(causal))
+    block_m = kw.pop("BLOCK_M", 128 if use_short_causal_defaults else 256)
+    block_n = kw.pop(
+        "BLOCK_N",
+        64 if use_short_causal_defaults and block_m == 128 else _cluster_default_block_n(causal),
+    )
+    _validate_cluster_tiles(block_m, block_n)
     has_explicit_num_warps = "num_warps" in kw
     has_explicit_waves_per_eu = "waves_per_eu" in kw
     num_warps = kw.pop("num_warps", min(8, max(1, block_m // mfma_m)))
-    waves_per_eu = kw.pop("waves_per_eu", 0 if causal else 2)
+    waves_per_eu = kw.pop(
+        "waves_per_eu",
+        2 if (not causal or (block_m == 256 and num_warps == 8)) else 0,
+    )
     use_direct_load = kw.pop("USE_DIRECT_LOAD", None)
-    B, H, N_CTX, D = q.shape
-
     o = torch.empty_like(q)
     m_blocks = triton.cdiv(N_CTX, block_m)
     grid = (H, m_blocks, B) if causal else (m_blocks, H, B)
     use_autotune = (use_direct_load is None and not has_explicit_num_warps and not has_explicit_waves_per_eu and not kw)
-    kernel = _attn_fwd_cluster_pipeline_autotuned if use_autotune else _attn_fwd_cluster_pipeline
+    use_pruned_n2048_defaults = (use_autotune and causal and D == 128 and N_CTX == 2048 and block_m == 256
+                                 and block_n == 32 and num_warps == 8)
+    if use_pruned_n2048_defaults:
+        # The register-predicated diagonal has no direct-load peer to tune and
+        # its spill-free object wins with the target's stage-two plan.
+        use_autotune = False
+    # The class-specialized async schedule is validated for exactly four waves
+    # and three compiler stages; explicit alternatives retain the general path.
+    use_short_causal_classes = (causal and D == 128 and N_CTX <= 1024 and N_CTX % 128 == 0 and block_m == 128
+                                and block_n == 64 and num_warps == 4 and kw.get("num_stages", 3) == 3)
+    static_stride_kn = _cluster_static_k_row_stride(
+        q,
+        k,
+        causal,
+        use_autotune,
+        block_m,
+        block_n,
+        num_warps,
+        waves_per_eu,
+    )
+    if use_short_causal_classes:
+        kernel = _attn_fwd_cluster_short_causal_pipeline
+        use_autotune = False
+    else:
+        kernel = _attn_fwd_cluster_pipeline_autotuned if use_autotune else _attn_fwd_cluster_pipeline
     launch_meta = {
         "BLOCK_M": block_m,
         "BLOCK_N": block_n,
@@ -916,6 +3344,32 @@ def flash_attn_cluster_pipeline(q, k, v, sm_scale, causal=False, **kw):
         "waves_per_eu": waves_per_eu,
         **kw,
     }
+    # This port must remain correct and performant with the stock LLVM
+    # scheduler.  Keep Triton's experimental sched-group pass opt-in even if
+    # the process-wide environment knob is enabled.
+    launch_meta.setdefault("enable_sched_group_barrier_scheduler", False)
+    if use_short_causal_classes:
+        launch_meta.setdefault("num_stages", 3)
+        launch_meta["SPECIALIZE_QUERY_CLASSES"] = N_CTX <= 512
+        if N_CTX == 512:
+            launch_meta.setdefault("llvm_fn_attrs", _CLUSTER_SHORT_N512_LLVM_FN_ATTRS)
+        elif N_CTX == 1024:
+            launch_meta.setdefault("llvm_fn_attrs", _CLUSTER_SHORT_N1024_LLVM_FN_ATTRS)
+    else:
+        launch_meta["STATIC_STRIDE_KN"] = static_stride_kn
+        if D == 128 and block_m == 256 and num_warps == 8:
+            # Keeping both MFMA accumulators in VGPRs removes mixed AGPR/VGPR
+            # handoffs; the full-attention object also becomes spill-free.
+            launch_meta.setdefault(
+                "llvm_fn_attrs",
+                _CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS,
+            )
+    if causal and D == 128 and block_m == 256 and block_n == 32 and N_CTX == 4096:
+        # Reverse assignment wins the N4096 causal object. The spill-free
+        # N2048 pruned object instead selects the forward stage-two plan above.
+        launch_meta.setdefault("reverse_local_assignment", True)
+    if use_pruned_n2048_defaults:
+        launch_meta.setdefault("num_stages", 2)
     if not use_autotune:
         launch_meta.update({
             "USE_DIRECT_LOAD": False if use_direct_load is None else use_direct_load,
@@ -952,22 +3406,29 @@ def flash_attn_cluster_pipeline(q, k, v, sm_scale, causal=False, **kw):
 
 
 def flash_attn_cluster_persistent_pipeline(q, k, v, sm_scale, causal=False, **kw):
+    _validate_cluster_inputs(q, k, v)
     mfma_m = 32
     block_m = kw.pop("BLOCK_M", 256)
     block_n = kw.pop("BLOCK_N", _cluster_default_block_n(causal))
+    _validate_cluster_tiles(block_m, block_n)
     has_explicit_num_warps = "num_warps" in kw
     has_explicit_waves_per_eu = "waves_per_eu" in kw
     num_warps = kw.pop("num_warps", min(8, max(1, block_m // mfma_m)))
-    waves_per_eu = kw.pop("waves_per_eu", 0 if causal else 2)
+    waves_per_eu = kw.pop(
+        "waves_per_eu",
+        2 if (not causal or (block_m == 256 and num_warps == 8)) else 0,
+    )
     use_direct_load = kw.pop("USE_DIRECT_LOAD", None)
     B, H, N_CTX, D = q.shape
     num_xcds = kw.pop("NUM_XCDS", 8)
-    assert num_xcds > 0, f"cluster attention: NUM_XCDS must be positive, got {num_xcds}"
+    if num_xcds <= 0:
+        raise ValueError(f"cluster attention: NUM_XCDS must be positive, got {num_xcds}")
     cu_count = torch.cuda.get_device_properties(q.device).multi_processor_count
     num_sms = kw.pop("NUM_SMS", (cu_count // num_xcds) * num_xcds)
-    assert num_sms >= num_xcds, f"cluster attention: NUM_SMS ({num_sms}) must be >= NUM_XCDS ({num_xcds})"
-    assert num_sms % num_xcds == 0, (
-        f"cluster attention: NUM_SMS ({num_sms}) must be divisible by NUM_XCDS ({num_xcds})")
+    if num_sms < num_xcds:
+        raise ValueError(f"cluster attention: NUM_SMS ({num_sms}) must be >= NUM_XCDS ({num_xcds})")
+    if num_sms % num_xcds != 0:
+        raise ValueError(f"cluster attention: NUM_SMS ({num_sms}) must be divisible by NUM_XCDS ({num_xcds})")
 
     o = torch.empty_like(q)
     m_blocks = triton.cdiv(N_CTX, block_m)
@@ -987,6 +3448,11 @@ def flash_attn_cluster_persistent_pipeline(q, k, v, sm_scale, causal=False, **kw
         "waves_per_eu": waves_per_eu,
         **kw,
     }
+    launch_meta.setdefault("enable_sched_group_barrier_scheduler", False)
+    if not causal and D == 128 and block_m == 256 and num_warps == 8:
+        # The persistent causal schedule loses overlap with VGPR-only
+        # allocation, while full attention benefits from removing AGPR moves.
+        launch_meta.setdefault("llvm_fn_attrs", _CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS)
     if not use_autotune:
         launch_meta.update({
             "USE_DIRECT_LOAD": False if use_direct_load is None else use_direct_load,

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -18,7 +18,9 @@ CDNA_MFMA_ROWS_PER_WAVE = tl.constexpr(32)
 
 _CLUSTER_PIPELINE_STAGE_COUNT = 4
 _CLUSTER_AUTOTUNE_NUM_WARPS = tuple(range(1, 9))
-_CLUSTER_STATIC_K_ROW_MIN_N = 4096
+_CLUSTER_EXPLICIT_STAGE_PRIORITY_MAX_N = tl.constexpr(512)
+_CLUSTER_STATIC_FP16_K_ROW_MIN_N = 4096
+_CLUSTER_STATIC_BF16_K_ROW_MIN_N = 16384
 _CLUSTER_VGPR_ONLY_LLVM_FN_ATTRS = (("amdgpu-agpr-alloc", "0,0"), )
 _CLUSTER_SHORT_N512_LLVM_FN_ATTRS = (
     ("amdgpu-no-dispatch-id", ""),
@@ -148,10 +150,21 @@ def _concat_cols(x0, x1):
 
 @triton.jit
 def _sum_rows_chain4(x, ROTATE_FINAL: tl.constexpr):
-    """Reduce four zero-copy column slices through one dependency chain."""
-    x_01, x_23 = _split_cols(x)
-    x_0, x_1 = _split_cols(x_01)
-    x_2, x_3 = _split_cols(x_23)
+    """Reduce four MFMA-layout column slices through one dependency chain."""
+    tl.static_assert(x.shape[0] == CDNA_MFMA_ROWS_PER_WAVE * tlx.num_warps())
+    tl.static_assert(x.shape[1] % 4 == 0)
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[tlx.num_warps(), 1],
+    )
+    x = tlx.require_layout(x, mma, pin=True)
+    slice_shape: tl.constexpr = [x.shape[0], x.shape[1] // 4]
+    x_0 = tlx.extract_slice(x, slice_shape, [0, 0])
+    x_1 = tlx.extract_slice(x, slice_shape, [0, x.shape[1] // 4])
+    x_2 = tlx.extract_slice(x, slice_shape, [0, x.shape[1] // 2])
+    x_3 = tlx.extract_slice(x, slice_shape, [0, 3 * x.shape[1] // 4])
     partial = x_0 + x_1
     if ROTATE_FINAL:
         partial = partial + x_3
@@ -379,13 +392,22 @@ class SoftmaxState:
         p_67 = _concat_cols(p_6, p_7)
         p = _concat_cols(p_state.p_0123, _concat_cols(p_45, p_67))
         p_cast = p.to(out_dtype)
+        l_i = self.l_i
         if FP16_CAST_ROWSUM and out_dtype == tl.float16:
             l_ij = tl.sum(p_cast, 1)
         elif CHAIN_BF16_ROWSUM:
             l_ij = _sum_rows_chain4(p, CHAIN_BF16_ROWSUM == 2)
+            mma: tl.constexpr = tlx.amd_mfma_layout(
+                version=4,
+                instr_shape=[32, 32, 16],
+                transposed=True,
+                warps_per_cta=[tlx.num_warps(), 1],
+            )
+            row_layout: tl.constexpr = tlx.slice_layout(mma, 1)
+            l_i = tlx.require_layout(self.l_i, row_layout, pin=True)
         else:
             l_ij = tl.sum(p, 1)
-        l_i = self.l_i + l_ij
+        l_i = l_i + l_ij
         return SoftmaxState(self.acc, l_i, self.m_i), p_cast
 
     @triton.jit
@@ -769,12 +791,15 @@ def _attn_inner_pipelined_lazy_step(
     STEP_QK_VEC2: tl.constexpr,
     FP16_CAST_ROWSUM: tl.constexpr,
     CHAIN_BF16_ROWSUM: tl.constexpr,
+    USE_EXPLICIT_STAGE_PRIORITIES: tl.constexpr,
 ):
     """Advance one aligned lazy-rescale tile with static LDS slots."""
     ack_n = (block_n + 3) * BLOCK_N
     acv_n = (block_n + 2) * BLOCK_N
+    dot_priority: tl.constexpr = 0 if USE_EXPLICIT_STAGE_PRIORITIES else None
+    mem_priority: tl.constexpr = 1 if USE_EXPLICIT_STAGE_PRIORITIES else None
 
-    with tlx.warp_pipeline_stage("dot1", priority=0):
+    with tlx.warp_pipeline_stage("dot1", priority=dot_priority):
         if STEP_QK_VEC2:
             state, p_dot, qk = _attn_dot_qk_step8_vec2(state, p_c, q, kt_dot, QK_SCALE, FP16_CAST_ROWSUM)
         else:
@@ -792,12 +817,12 @@ def _attn_inner_pipelined_lazy_step(
 
     tlx.async_load_wait_group(1)
 
-    with tlx.warp_pipeline_stage("mem1", priority=1):
+    with tlx.warp_pipeline_stage("mem1", priority=mem_priority):
         v_dot = tlx.local_load(tlx.local_view(v_buf, CUR_SLOT), relaxed=True)
         tok_k = tlx.async_load(k_ptrs + ack_n * stride_kn, tlx.local_view(k_buf, NEXT_SLOT))
         tlx.async_load_commit_group([tok_k])
 
-    with tlx.warp_pipeline_stage("dot2", priority=0):
+    with tlx.warp_pipeline_stage("dot2", priority=dot_priority):
         if STEP_PV_VEC1:
             state, p_c, delta_c, advance_c = _attn_dot_pv_vec1_lazy(
                 state,
@@ -817,7 +842,7 @@ def _attn_inner_pipelined_lazy_step(
 
     tlx.async_load_wait_group(1)
 
-    with tlx.warp_pipeline_stage("mem2", priority=1):
+    with tlx.warp_pipeline_stage("mem2", priority=mem_priority):
         # Preserve the optimized Gluon lazy cadence exactly: consume K from
         # LDS before issuing the independent V copy for this slot.  The
         # V-before-K ordering belongs only to Gluon's non-lazy fallback path.
@@ -1003,6 +1028,9 @@ def _attn_inner_pipelined(
         # the established three-tile drain.
         DRAIN_TILES: tl.constexpr = 1 if USE_ONE_TILE_PREFIX_DRAIN else 3
         ODD_TAIL: tl.constexpr = (N_CTX // BLOCK_N - DRAIN_TILES) % 2 == 1
+        # The priority hints retain a small win on short rows, but constrain
+        # instruction interleaving once the steady-state loop grows longer.
+        USE_EXPLICIT_STAGE_PRIORITIES: tl.constexpr = N_CTX <= _CLUSTER_EXPLICIT_STAGE_PRIORITY_MAX_N
         main_loop_pairs = (block_end - block_start - DRAIN_TILES) // 2
         for pair_idx in tl.range(0, main_loop_pairs, num_stages=1):
             block_n = block_start + pair_idx * 2
@@ -1028,6 +1056,7 @@ def _attn_inner_pipelined(
                 STEP_QK_VEC2,
                 FP16_CAST_ROWSUM,
                 CHAIN_BF16_ROWSUM,
+                USE_EXPLICIT_STAGE_PRIORITIES,
             )
             state, p_c, kt_dot = _attn_inner_pipelined_lazy_step(
                 state,
@@ -1051,6 +1080,7 @@ def _attn_inner_pipelined(
                 STEP_QK_VEC2,
                 FP16_CAST_ROWSUM,
                 CHAIN_BF16_ROWSUM,
+                USE_EXPLICIT_STAGE_PRIORITIES,
             )
 
         if ODD_TAIL:
@@ -1077,6 +1107,7 @@ def _attn_inner_pipelined(
                 STEP_QK_VEC2,
                 FP16_CAST_ROWSUM,
                 CHAIN_BF16_ROWSUM,
+                USE_EXPLICIT_STAGE_PRIORITIES,
             )
 
     else:
@@ -2594,9 +2625,11 @@ def _attn_cluster_tile(
             # is below the store precision while avoiding the corrected IEEE
             # divide.
             l_recip = fast_dividef(1.0, state.l_i)
-            acc = state.acc * l_recip[:, None]
         else:
-            acc = state.acc / state.l_i[:, None]
+            # Keep the row reciprocal scalar until its broadcast multiply;
+            # dividing the full accumulator lengthens every column's chain.
+            l_recip = 1.0 / state.l_i
+        acc = state.acc * l_recip[:, None]
     o_ptrs = Out + o_off + offs_m[:, None] * stride_om + offs_d[None, :] * stride_ok
     out = acc.to(Out.dtype.element_ty)
     if USE_Q_LDS:
@@ -3191,12 +3224,13 @@ def _cluster_static_k_row_stride(q, k, causal, use_autotune, block_m, block_n, n
     """Specialize K's physical row stride on the measured long noncausal path."""
     n_ctx = q.shape[2]
     head_dim = q.shape[3]
-    # The broader Gluon gate is not transferable to this stock-scheduled TLX
-    # object: causal and BF16 rows regress, while FP16 N>=4096 wins at both the
-    # standard and magnifying scales. Keep explicit configurations unchanged.
-    use_krow = (use_autotune and not causal and q.dtype == torch.float16 and q.shape[1] == k.shape[1]
-                and head_dim == 128 and n_ctx >= _CLUSTER_STATIC_K_ROW_MIN_N and n_ctx % 256 == 0 and block_m == 256
-                and block_n == 64 and num_warps == 8 and waves_per_eu == 2)
+    # BF16 reaches its repeatable static-addressing crossover later than FP16.
+    measured_dtype_path = ((q.dtype == torch.float16 and n_ctx >= _CLUSTER_STATIC_FP16_K_ROW_MIN_N)
+                           or (q.dtype == torch.bfloat16 and n_ctx >= _CLUSTER_STATIC_BF16_K_ROW_MIN_N))
+    # Keep causal and explicit configurations dynamic: only the autotuned
+    # long-noncausal objects above have demonstrated a static-stride gain.
+    use_krow = (use_autotune and not causal and measured_dtype_path and q.shape[1] == k.shape[1] and head_dim == 128
+                and n_ctx % 256 == 0 and block_m == 256 and block_n == 64 and num_warps == 8 and waves_per_eu == 2)
     return k.stride(2) if use_krow else -1
 
 

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -1401,7 +1401,7 @@ def _attn_predicated_causal_tile(
     BLOCK_N: tl.constexpr,
     ENABLE_CLASS_DIAGONAL_LAZY: tl.constexpr,
 ):
-    """Consume one diagonal tile inside a wave-uniform EXEC region."""
+    """Consume one diagonal tile for an active wave."""
     if BLOCK_N == 32:
         k_tile = tlx.local_slice(k_tile, [0, 0], [32, q.shape[1]])
         v_tile = tlx.local_slice(v_tile, [0, 0], [32, q.shape[1]])
@@ -1461,46 +1461,6 @@ def _attn_predicated_causal_tile(
     else:
         acc = _attn_dot_pv_mfma32(state.acc, p_dot, v_dot)
     return acc, state.l_i, state.m_i
-
-
-@triton.jit
-def _attn_predicated_causal_tile_from_state(
-    _unused_acc,
-    _unused_l_i,
-    _unused_m_i,
-    acc,
-    l_i,
-    m_i,
-    q,
-    offs_m,
-    k_tile,
-    v_tile,
-    wait,
-    start_n,
-    N_CTX: tl.constexpr,
-    QK_SCALE: tl.constexpr,
-    DIAG_OFFSET: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    ENABLE_CLASS_DIAGONAL_LAZY: tl.constexpr,
-):
-    """Compute from read-only state while carrying independent merge values."""
-    return _attn_predicated_causal_tile(
-        acc,
-        l_i,
-        m_i,
-        q,
-        offs_m,
-        k_tile,
-        v_tile,
-        wait,
-        start_n,
-        N_CTX,
-        QK_SCALE,
-        DIAG_OFFSET,
-        BLOCK_N,
-        ENABLE_CLASS_DIAGONAL_LAZY,
-    )
-
 
 @triton.jit
 def _attn_predicated_causal_regs_bn32(
@@ -1710,30 +1670,27 @@ def _attn_inner_short(
             mma_rows: tl.constexpr = tlx.slice_layout(mma, 1)
             # Gluon carries both softmax row states in SliceLayout(mma, 1).
             # Materialize TLX's otherwise-blocked running max before entering
-            # the wave-predicated loop so any register redistribution remains
-            # convergent and the predicated bodies need no CTA-wide scratch.
+            # the wave-uniform loop so any register redistribution remains
+            # convergent and the conditional bodies need no CTA-wide scratch.
             state = SoftmaxState(
                 state.acc,
                 tlx.require_layout(state.l_i, mma_rows, pin=True),
                 tlx.require_layout(state.m_i, mma_rows, pin=True),
             )
-            wave = tlx.thread_id(0) // CDNA_WAVE_SIZE
-            wave = wave ^ ((wave // 4) * 3)
-            wave_m_last = (wave * CDNA_MFMA_ROWS_PER_WAVE + CDNA_MFMA_ROWS_PER_WAVE - 1 + DIAG_OFFSET)
+            vote_rows = tlx.require_layout(offs_m + DIAG_OFFSET, mma_rows, pin=True)
             # Keep one runtime loop body, matching Gluon's four-slot diagonal
             # consumer.  Unrolling this loop duplicates both the BN64 and
             # low-half BN32 MFMA bodies four times in the code object.
             for diag_slot in tl.range(0, num_blocks, num_stages=1):
                 start_n = (block_start + diag_slot) * BLOCK_N
-                diagonal_start = start_n % q.shape[0]
-                active_full = wave_m_last >= diagonal_start + CDNA_MFMA_ROWS_PER_WAVE
-                active_lo = wave_m_last >= diagonal_start
+                active_full = tlx.warp_any(vote_rows >= start_n + CDNA_MFMA_ROWS_PER_WAVE)
+                active_lo = tlx.warp_any(vote_rows >= start_n)
                 active_lo_only = active_lo & ~active_full
-                acc, l_i, m_i = tlx.warp_predicate(
-                    active_full,
-                    (state.acc, state.l_i, state.m_i),
-                    _attn_predicated_causal_tile,
-                    args=(
+                if active_full:
+                    acc, l_i, m_i = _attn_predicated_causal_tile(
+                        state.acc,
+                        state.l_i,
+                        state.m_i,
                         q,
                         offs_m,
                         tlx.local_view(k_buf, diag_slot),
@@ -1745,19 +1702,10 @@ def _attn_inner_short(
                         DIAG_OFFSET,
                         BLOCK_N,
                         True,
-                    ),
-                    wave_uniform=True,
-                )
-                state = SoftmaxState(acc, l_i, m_i)
-                next_acc, next_l_i, next_m_i = tlx.warp_predicate(
-                    active_lo_only,
-                    (
-                        tl.zeros_like(state.acc),
-                        tl.zeros_like(state.l_i),
-                        tl.zeros_like(state.m_i),
-                    ),
-                    _attn_predicated_causal_tile_from_state,
-                    args=(
+                    )
+                    state = SoftmaxState(acc, l_i, m_i)
+                if active_lo_only:
+                    acc, l_i, m_i = _attn_predicated_causal_tile(
                         state.acc,
                         state.l_i,
                         state.m_i,
@@ -1772,14 +1720,8 @@ def _attn_inner_short(
                         DIAG_OFFSET,
                         CDNA_MFMA_ROWS_PER_WAVE,
                         True,
-                    ),
-                    wave_uniform=True,
-                )
-                state = SoftmaxState(
-                    tl.where(active_lo_only, next_acc, state.acc),
-                    tl.where(active_lo_only, next_l_i, state.l_i),
-                    tl.where(active_lo_only, next_m_i, state.m_i),
-                )
+                    )
+                    state = SoftmaxState(acc, l_i, m_i)
             return state
 
         # N512's two-slot diagonal is always consumed as a pair.  Preserve
@@ -2213,7 +2155,7 @@ def _attn_cluster_tile(
                                                    and HEAD_DIM == 128 and tlx.num_warps() == 8)
     if USE_ALIGNED_BM256_BN64_CAUSAL:
         # Gluon folds this shape to exactly one unmasked prefix body followed
-        # by its four-tile wave-predicated diagonal. Spell out that constexpr
+        # by its four-tile wave-voted diagonal. Spell out that constexpr
         # route so TLX does not retain the impossible masked-pipeline peers in
         # the same code object.
         diagonal_mma: tl.constexpr = tlx.amd_mfma_layout(

--- a/third_party/tlx/tutorials/amd_fa_cluster.py
+++ b/third_party/tlx/tutorials/amd_fa_cluster.py
@@ -3158,9 +3158,10 @@ def _attn_fwd_cluster_persistent_pipeline(
                         pid_m = tl.where(idx % 2 == 0, half, NUM_M_BLOCKS - 1 - half)
                     else:
                         pid_m = idx
-                    # Safe to reuse the LDS slots across units: the outer loop
-                    # has num_stages=1 and _attn_cluster_tile drains all async
-                    # load groups before it returns.
+                    # The tile drains its async producer groups before it
+                    # returns. The barrier below separately closes the
+                    # consumer-to-refill hazard before these LDS slots are
+                    # reused by the next persistent tile.
                     _attn_cluster_tile(
                         pid_m,
                         off_z,
@@ -3197,6 +3198,7 @@ def _attn_fwd_cluster_persistent_pipeline(
                         False,
                         IS_CAUSAL,
                     )
+                    tl.debug_barrier()
 
 
 # Short cluster kernels can exhaust ROCm event resources in the entropy

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1779,12 +1779,18 @@ def test_amd_fa_cluster(causal, dtype, HEAD_DIM):
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize(
+    ("dtype", "N_CTX"),
+    [
+        pytest.param(torch.float16, 4096, id="fp16-n4096"),
+        pytest.param(torch.bfloat16, 16384, id="bf16-n16384"),
+    ],
+)
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
-def test_amd_fa_cluster_static_physical_k_row_stride():
+def test_amd_fa_cluster_static_physical_k_row_stride(dtype, N_CTX):
     """The selected constexpr K row stride preserves arbitrary physical padding."""
     torch.manual_seed(42)
-    B, H, N_CTX, D = 1, 1, 4096, 128
-    dtype = torch.float16
+    B, H, D = 1, 1, 128
     q = torch.randn(B, H, N_CTX, D + 5, device=DEVICE, dtype=dtype)[..., :D]
     k = torch.randn(B, H, N_CTX, D + 7, device=DEVICE, dtype=dtype)[..., :D]
     v = torch.randn(B, H, N_CTX, D + 9, device=DEVICE, dtype=dtype)[..., :D]
@@ -1812,10 +1818,11 @@ def test_amd_fa_cluster_magnifying_scale_preserves_finite_fp16_inputs(sm_scale):
     torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize("N_CTX", [1024, 4096], ids=["short", "long"])
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
-def test_amd_fa_cluster_magnifying_scale_retains_bf16_accuracy():
+def test_amd_fa_cluster_magnifying_scale_retains_bf16_accuracy(N_CTX):
     torch.manual_seed(1170)
-    B, H, N_CTX, D = 1, 4, 1024, 128
+    B, H, D = 1, 4, 128
     q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.bfloat16)
     k = torch.randn_like(q)
     v = torch.randn_like(q)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1779,6 +1779,225 @@ def test_amd_fa_cluster(causal, dtype, HEAD_DIM):
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_static_physical_k_row_stride():
+    """The selected constexpr K row stride preserves arbitrary physical padding."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 4096, 128
+    dtype = torch.float16
+    q = torch.randn(B, H, N_CTX, D + 5, device=DEVICE, dtype=dtype)[..., :D]
+    k = torch.randn(B, H, N_CTX, D + 7, device=DEVICE, dtype=dtype)[..., :D]
+    v = torch.randn(B, H, N_CTX, D + 9, device=DEVICE, dtype=dtype)[..., :D]
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=sm)
+
+    out = _amd_fa_cluster(q, k, v, sm, False)
+
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("sm_scale", [1.3, -1.3], ids=["positive", "negative"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_magnifying_scale_preserves_finite_fp16_inputs(sm_scale):
+    torch.manual_seed(123)
+    B, H, N_CTX, D = 1, 1, 1024, 64
+    q = torch.full((B, H, N_CTX, D), 35000.0, device=DEVICE, dtype=torch.float16)
+    k = torch.ones_like(q)
+    v = torch.randn_like(q)
+    expected = v.float().mean(dim=2, keepdim=True).expand_as(v).to(v.dtype)
+
+    out = _amd_fa_cluster(q, k, v, sm_scale, False, config={"USE_DIRECT_LOAD": False})
+
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_magnifying_scale_retains_bf16_accuracy():
+    torch.manual_seed(1170)
+    B, H, N_CTX, D = 1, 4, 1024, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, scale=1.3)
+
+    out = _amd_fa_cluster(q, k, v, 1.3, False, config={"USE_DIRECT_LOAD": False})
+
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("N_CTX", [384, 512, 1024])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_short_causal_classes(N_CTX, dtype):
+    torch.manual_seed(42)
+    B, H, D = 1, 8, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    out = _amd_fa_cluster(q, k, v, sm, True)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("sm_scale", [0.0, -0.125], ids=["zero", "negative"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_short_causal_nonpositive_scale(sm_scale):
+    """Causal mask sentinels remain valid for every accepted softmax scale."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 128, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.float16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm_scale)
+    out = _amd_fa_cluster(q, k, v, sm_scale, True)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_negative_scale_stays_finite():
+    """An unmasked score block remains stable when the accepted scale is negative."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 512, 128
+    q = torch.ones((B, H, N_CTX, D), device=DEVICE, dtype=torch.float16)
+    key_rows = torch.where(
+        (torch.arange(N_CTX, device=DEVICE) // 32) % 2 == 0,
+        4.0,
+        -4.0,
+    )
+    k = key_rows[None, None, :, None].expand(B, H, N_CTX, D).to(q.dtype).contiguous()
+    v = torch.randn_like(q)
+    sm_scale = -0.125
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm_scale)
+    out = _amd_fa_cluster(q, k, v, sm_scale, True)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+@pytest.mark.parametrize("N_CTX", [128, 512])
+def test_amd_fa_cluster_short_causal_direct_load(N_CTX):
+    """The direct-load short path normalizes its online-softmax numerator."""
+    torch.manual_seed(42)
+    B, H, D = 1, 1, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.float16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    config = {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 0,
+        "USE_DIRECT_LOAD": True,
+        "enable_sched_group_barrier_scheduler": False,
+    }
+    out = _amd_fa_cluster(q, k, v, sm, True, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("N_CTX", [128, 256, 512, 1024])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_persistent_short_causal_lds_normalizes_once(N_CTX, dtype):
+    """The persistent BM128 LDS path does not renormalize its predicated diagonal."""
+    torch.manual_seed(42)
+    B, H, D = 1, 1, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    config = {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "num_warps": 4,
+        "num_stages": 3,
+        "waves_per_eu": 0,
+        "USE_DIRECT_LOAD": False,
+        "NUM_SMS": 8,
+        "NUM_XCDS": 8,
+        "enable_sched_group_barrier_scheduler": False,
+    }
+    out = _amd_fa_cluster_persistent(q, k, v, sm, True, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_causal_bm256_direct_load():
+    """The causal BM256 direct path keeps P-by-V in the MFMA accumulator layout."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 256, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.float16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    config = {
+        "BLOCK_M": 256,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "USE_DIRECT_LOAD": True,
+        "enable_sched_group_barrier_scheduler": False,
+    }
+    out = _amd_fa_cluster(q, k, v, sm, True, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_n2048_four_slot_prefix_handoff(dtype):
+    """The BM256 prefix hands all four aligned diagonal tiles to the pruned tail."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 2048, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    config = {
+        "BLOCK_M": 256,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "USE_DIRECT_LOAD": False,
+        "enable_sched_group_barrier_scheduler": False,
+    }
+    out = _amd_fa_cluster(q, k, v, sm, True, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_lazy_rescale(dtype):
+    """The Gluon-derived split lazy-softmax path is correct without scheduling plugins."""
+    torch.manual_seed(42)
+    B, H, N_CTX, D = 1, 1, 4096, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=dtype)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    config = {
+        "BLOCK_M": 256,
+        "BLOCK_N": 64,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "USE_DIRECT_LOAD": False,
+        "enable_tree_reduction": True,
+        "enable_sched_group_barrier_scheduler": False,
+    }
+    out = _amd_fa_cluster(q, k, v, sm, True, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
 @pytest.mark.parametrize("persistent", [False, True], ids=["direct", "persistent"])
 @pytest.mark.parametrize("causal", [False, True], ids=["nocausal", "causal"])
 @pytest.mark.parametrize("use_direct_load", [None, False, True], ids=["autotune", "lds", "direct-load"])
@@ -1804,6 +2023,43 @@ def test_amd_fa_cluster_block_n_boundaries(persistent, causal, use_direct_load, 
     if persistent:
         config.update({"NUM_SMS": 16, "NUM_XCDS": 4})
     out = kernel(q, k, v, sm, causal, config=config)
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "persistent,N_CTX,use_autotune",
+    [
+        (False, 257, False),
+        (True, 129, False),
+        (False, 129, True),
+    ],
+    ids=["direct-ragged", "persistent-ragged", "direct-autotune-ragged"],
+)
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_fa_cluster_d128_ragged_boundaries(persistent, N_CTX, use_autotune):
+    """Ragged D128 tiles retain the two-slot ring used by the general path."""
+    torch.manual_seed(42)
+    B, H, D = 1, 1, 128
+    q = torch.randn(B, H, N_CTX, D, device=DEVICE, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    sm = 1.0 / math.sqrt(D)
+    ref = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, scale=sm)
+    kernel = _amd_fa_cluster_persistent if persistent else _amd_fa_cluster
+    config = {}
+    if not use_autotune:
+        config.update({
+            "BLOCK_M": 256,
+            "BLOCK_N": 64,
+            "num_warps": 8,
+            "num_stages": 3,
+            "waves_per_eu": 2,
+            "USE_DIRECT_LOAD": False,
+            "enable_sched_group_barrier_scheduler": False,
+        })
+    if persistent:
+        config.update({"NUM_SMS": 16, "NUM_XCDS": 4})
+    out = kernel(q, k, v, sm, True, config=config)
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
 
 

--- a/website/content/utilities.md
+++ b/website/content/utilities.md
@@ -95,6 +95,40 @@
     Prefer these semantic reductions when code only needs an all/any result.
     They do not expose a hardware ballot bit mask.
 
+- `tlx.warp_predicate(predicate, inits, body, args=(), wave_uniform=False)` **[AMD]**
+
+    Executes `body(*inits, *args)` with the hardware execution mask restricted
+    to lanes where `predicate` is true. Active lanes receive the values returned
+    by `body`; inactive lanes keep their corresponding values from `inits`. A
+    single carried tensor is returned directly, while multiple carried tensors
+    are returned as a tuple.
+
+    A scalar predicate controls its physical lane. For a tensor predicate, the
+    elements owned by each lane are OR-reduced to form that lane's execution
+    bit. Unlike `tlx.warp_all` and `tlx.warp_any`, this does not make the
+    predicate uniform across the wave.
+
+    ```python
+    @triton.jit
+    def scale_active(acc, scale):
+        return acc * scale
+
+    acc = tlx.warp_predicate(
+        active,
+        acc,
+        scale_active,
+        args=(scale,),
+    )
+    ```
+
+    `body` must be an `@triton.jit` function that returns the same number and
+    types of tensors as `inits`. It must contain straight-line computation and
+    no cross-wave synchronization. Reductions, dots, and layout shuffles are
+    allowed only with `wave_uniform=True`, which asserts that every lane in a
+    wave observes the same predicate. Cross-warp reductions, nested dynamic
+    control flow, and other nested regions are unsupported. This operation is
+    currently lowered only by the AMD backend.
+
 - `tlx.prefetch(pointer, level="L2", mask=None, tensormap=False)` **[sm90+]** issues a non-blocking prefetch hint for pointer-based scattered/gather loads. This complements `tlx.async_descriptor_prefetch_tensor` (which works on TMA tensor descriptors) by supporting raw pointer tensors.
   Additionally, if `tensormap` is specified to `True`, the API instead does a prefetch of tensor map object (TMA descriptor) and ignores other parameters other than `pointer`.
 

--- a/website/utilities.html
+++ b/website/utilities.html
@@ -93,6 +93,20 @@
 <pre><code class="language-python">    all_safe = tlx.warp_all(per_lane_safe)
     any_active = tlx.warp_any(per_lane_active)</code></pre>
 <p>Prefer these semantic reductions when code only needs an all/any result. They do not expose a hardware ballot bit mask.</p>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.warp_predicate(predicate, inits, body, args=(), wave_uniform=False)</code> <strong>[AMD]</strong></div></div>
+<p>Executes <code>body(*inits, *args)</code> with the hardware execution mask restricted to lanes where <code>predicate</code> is true. Active lanes receive the values returned by <code>body</code>; inactive lanes keep their corresponding values from <code>inits</code>. A single carried tensor is returned directly, while multiple carried tensors are returned as a tuple.</p>
+<p>A scalar predicate controls its physical lane. For a tensor predicate, the elements owned by each lane are OR-reduced to form that lane's execution bit. Unlike <code>tlx.warp_all</code> and <code>tlx.warp_any</code>, this does not make the predicate uniform across the wave.</p>
+<pre><code class="language-python">    @triton.jit
+    def scale_active(acc, scale):
+        return acc * scale
+
+    acc = tlx.warp_predicate(
+        active,
+        acc,
+        scale_active,
+        args=(scale,),
+    )</code></pre>
+<p><code>body</code> must be an <code>@triton.jit</code> function that returns the same number and types of tensors as <code>inits</code>. It must contain straight-line computation and no cross-wave synchronization. Reductions, dots, and layout shuffles are allowed only with <code>wave_uniform=True</code>, which asserts that every lane in a wave observes the same predicate. Cross-warp reductions, nested dynamic control flow, and other nested regions are unsupported. This operation is currently lowered only by the AMD backend.</p>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.prefetch(pointer, level=&quot;L2&quot;, mask=None, tensormap=False)</code> <strong>[sm90+]</strong> issues a non-blocking prefetch hint for pointer-based scattered/gather loads. This complements <code>tlx.async_descriptor_prefetch_tensor</code> (which works on TMA tensor descriptors) by supporting raw pointer tensors.</div></div>
 <p>Additionally, if <code>tensormap</code> is specified to <code>True</code>, the API instead does a prefetch of tensor map object (TMA descriptor) and ignores other parameters other than <code>pointer</code>.</p>
 <table><thead><tr><th>Level</th><th>PTX</th><th>Description</th></tr></thead><tbody><tr><td><code>&quot;L1&quot;</code></td><td><code>prefetch.global.L1</code></td><td>Prefetch into L1 and L2 cache</td></tr><tr><td><code>&quot;L2&quot;</code></td><td><code>prefetch.global.L2</code></td><td>Prefetch into L2 cache only (default)</td></tr></tbody></table>


### PR DESCRIPTION
This PR optimizes the existing gfx950 Flash Attention forward kernel introduced by [#1782](https://github.com/facebookexperimental/triton/pull/1782) and ported to the current TLX tutorial layout by [#1838](https://github.com/facebookexperimental/triton/pull/1838). It covers causal and non-causal FP16/BF16 attention with D64 or D128 heads while preserving the existing `attention` and `persistent_attention` entry points and the general fallback.

It implements the optimized schedule in source-level TLX and adds the reusable TLX/AMD primitives and compiler invariants needed to express it. The kernel uses Triton's stock LLVM scheduler; there is no attention-specific compiler lowering or custom LLVM scheduler.

## Implementation

- Aligned D128 gfx950 routes use a four-cluster rotated K/V pipeline, explicit asynchronous-copy groups, specialized drains, and a split QK/P-by-V MFMA schedule.
- Causal routes prune fully masked waves without placing cooperative copies or CTA-wide barriers in divergent control flow. N32 diagonal views, heavy-first traversal, balanced wave assignment, and bounded head locality are selected where applicable.
- Long causal D128 routes use lazy online-softmax rescaling and split reduction chains. BM128 short-causal classes cover aligned sequences through N1024, including direct-load and LDS paths, constant query classes, and non-positive scales.
- D128-specific layouts, cache policy, allocation choices, and warp-local epilogues are gated to supported configurations. Ragged boundaries, D64, and other configurations retain the general cluster-attention path.
- `tlx.warp_predicate` carries results across AMD EXEC-mask control flow while preserving inactive-lane values. Verification rejects bodies that could deadlock at CTA-wide synchronization or perform unsupported cross-wave reductions, while allowing proven warp-local reductions.
- Distributed slice and layout-release interfaces make register-lifetime boundaries explicit. Layout propagation, placeholder resolution, conversion cleanup, slice-layout verification, and compatible reduction vectorization enforce the required compiler contracts.

## Performance on MI350X

The table uses the D128, H64 shape matrix published for #1782, with batch size scaled so `B*N=16384`. The baseline is the published `cluster` result from the [#1782 MI350 results](https://github.com/facebookexperimental/triton/pull/1782#issuecomment-4753755294).

The #1782 harness and the final PR-head measurement both use `sm_scale=1/sqrt(128)`. The final head was measured on an idle MI350X with the stock scheduler (`DISABLE_LLVM_OPT=disable-machine-sink` and no `TRITON_AMD_TTGIR_SCHEDULE` override), using 500 ms warmup plus 500 ms measurement per point. Each TLX result is the geometric mean of forward- and reverse-order full-matrix sweeps. Causal TFLOP/s uses #1782's exact triangular `N*(N+1)/2` convention; speedups and geometric means use the unrounded measurements.

| Config `(dtype,B,H,N,D,mask)` | #1782 cluster TFLOP/s | TLX TFLOP/s | Speedup |
| --- | ---: | ---: | ---: |
| `(FP16,32,64,512,128,non-causal)` | 444.4 | 572.7 | **1.289x** |
| `(FP16,16,64,1024,128,non-causal)` | 557.9 | 688.6 | **1.234x** |
| `(FP16,8,64,2048,128,non-causal)` | 639.1 | 796.7 | **1.247x** |
| `(FP16,4,64,4096,128,non-causal)` | 711.0 | 850.0 | **1.195x** |
| `(FP16,2,64,8192,128,non-causal)` | 734.2 | 895.3 | **1.219x** |
| `(FP16,1,64,16384,128,non-causal)` | 720.7 | 930.7 | **1.291x** |
| `(FP16,32,64,512,128,causal)` | 234.8 | 396.0 | **1.686x** |
| `(FP16,16,64,1024,128,causal)` | 347.0 | 503.7 | **1.451x** |
| `(FP16,8,64,2048,128,causal)` | 454.8 | 638.4 | **1.404x** |
| `(FP16,4,64,4096,128,causal)` | 523.0 | 733.4 | **1.402x** |
| `(FP16,2,64,8192,128,causal)` | 480.4 | 838.8 | **1.746x** |
| `(FP16,1,64,16384,128,causal)` | 526.3 | 892.2 | **1.695x** |
| `(BF16,32,64,512,128,non-causal)` | 455.2 | 596.8 | **1.311x** |
| `(BF16,16,64,1024,128,non-causal)` | 577.2 | 749.8 | **1.299x** |
| `(BF16,8,64,2048,128,non-causal)` | 660.8 | 859.6 | **1.301x** |
| `(BF16,4,64,4096,128,non-causal)` | 735.6 | 922.0 | **1.253x** |
| `(BF16,2,64,8192,128,non-causal)` | 763.3 | 973.6 | **1.276x** |
| `(BF16,1,64,16384,128,non-causal)` | 772.5 | 1010.5 | **1.308x** |
| `(BF16,32,64,512,128,causal)` | 238.5 | 414.7 | **1.739x** |
| `(BF16,16,64,1024,128,causal)` | 355.0 | 484.2 | **1.364x** |
| `(BF16,8,64,2048,128,causal)` | 468.7 | 670.0 | **1.429x** |
| `(BF16,4,64,4096,128,causal)` | 550.9 | 780.4 | **1.417x** |
| `(BF16,2,64,8192,128,causal)` | 495.8 | 883.5 | **1.782x** |
| `(BF16,1,64,16384,128,causal)` | 548.1 | 949.8 | **1.733x** |

Geometric-mean TLX speedups:

- FP16 non-causal: **1.245x**
- FP16 causal: **1.557x**
- BF16 non-causal: **1.291x**
- BF16 causal: **1.567x**
- All 24 configurations: **1.408x**


The representative BF16 `(B=1,H=64,N=16384,D=128)` non-causal object uses 236 VGPRs, 37 SGPRs, and zero scratch. The full symmetric sweep reports 1010.5 TFLOP/s

## TODO

- Evaluate the opt-in gfx950 LLIR scheduler from [#2725](https://github.com/facebookexperimental/triton/pull/2725) once it is available on the base branch. Its Flash Attention path uses IGroupLP scheduling-group barriers to co-schedule independent MFMA and VALU regions. This PR keeps that path disabled and reports stock-scheduler results; enabling it requires a full 24-shape performance A/B plus correctness, VGPR-spill, scratch-traffic, and small-shape regression checks.
