### PR TITLE
[triton][TMA-Multicast] Support surviving while AutoWS (#2894)

### DIFF
--- a/docs/design/multi_cta_autows_requirements.md
+++ b/docs/design/multi_cta_autows_requirements.md
@@ -1,0 +1,226 @@
+# AutoWS requirements for multi-CTA operations
+
+## Summary
+
+This document extends the
+[multi-CTA control-flow contract](multi_cta_control_flow_contract.md) to
+compiler-driven warp specialization.
+
+AutoWS is a uniform transformation of the original CTA program. Until
+multi-CTA lowering runs during code partitioning, every CTA has the same
+partially transformed program, including the same task assignments, data
+partitions, and channels. Physical warp-specialize regions are created later.
+CTAs may evaluate the common program differently when the original program
+contains CTA-dependent values, but AutoWS does not choose a different program
+for each CTA rank.
+
+Multi-CTA lowering is the phase that intentionally introduces asymmetric CTA
+roles, such as a TMA multicast leader and its recipients. The design therefore
+needs to answer four questions:
+
+1. Which multi-CTA facts must be established before AutoWS, and which lowering
+   preconditions can be checked during AutoWS code partitioning?
+2. How does an AutoWS channel's ready/done synchronization protocol become
+   multi-CTA barrier handling?
+3. Under what conditions does a value transported through an AutoWS channel
+   retain the equality facts required by the control-flow contract?
+4. How must cluster communication account for independently executing
+   warp-group partitions within each CTA?
+
+The running example is a descriptor load selected for TMA multicast across
+ranks 0 and 1 of a `(2, 1, 1)` cluster.
+
+## Proof placement around AutoWS
+
+The compilation model is:
+
+```text
+one original CTA program
+  -> Multi-CTA Validation
+  -> uniform AutoWS task and data partitioning
+  -> channel discovery and buffer planning
+  -> multi-CTA lowering during code partitioning
+  -> physical warp specialization and token/barrier lowering
+```
+
+These phases do not create two versions of the kernel. Validation establishes
+the semantic facts. AutoWS lowering selects a supported strategy using the
+actual partition, channel, and buffer graph, then adds CTA roles and cross-CTA
+synchronization as part of code partitioning.
+
+### What code partitioning can use directly
+
+Lowering is most direct when a candidate operation has no incoming
+cross-partition data dependencies. The operation, its enclosing control flow,
+and the values covered by its multi-CTA proof must all be available in the
+owning partition. Code partitioning can then inspect:
+
+- the partition that owns each candidate operation;
+- its enclosing `scf.if`, `scf.for`, and `scf.while` operations and their task
+  assignments;
+- its direct SSA dependencies; and
+- pure expressions whose operands have established CTA-group equality.
+
+This commonly applies to producer operations. For example, a descriptor load in
+a producer partition can be analyzed directly when its enclosing conditions and
+loop bounds are captured from kernel arguments or rematerialized from
+group-uniform operands. The uniform transformation also makes its owning
+partition a static property of the program: the operation has the same owner in
+every CTA.
+
+This proof establishes the producer operation's control-flow trace. It is not
+sufficient to determine which cluster communication operations are required.
+That decision also depends on the consumer partitions, buffer lifetime, ready
+and done paths, and the hardware participation scope. If any controlling value
+reaches the producer through a channel, the stronger channel-provenance rules
+below apply instead.
+
+### Data dependencies through intermediate buffers
+
+When a value crosses warp-group partitions, AutoWS may replace the original SSA
+dependency with a synchronized intermediate SMEM or TMEM buffer. This applies
+to ordinary operation operands and to values that control whether or when an
+operation executes, including branch predicates and loop continuation or
+termination conditions.
+
+For example, a scheduler partition may compute whether a persistent loop has
+more work, store that condition in an intermediate buffer, and broadcast it to
+the other partitions. The channel proves that those partitions within one CTA
+observe the scheduler partition's value. It does not prove that scheduler
+partitions in different CTAs produced the same condition or exit on the same
+iteration.
+
+After this rewrite, a `local_load` exposes the immediate buffer dependency but
+not whether the original value came from a kernel argument, a CTA coordinate, a
+scheduler result, or mutable memory. Code partitioning may use that channel in a
+multi-CTA lowering only when it can associate the payload with an established
+equality fact and dynamic iteration. The local wait and load alone are
+insufficient.
+
+### Two-phase protocol
+
+The design has two stages:
+
+1. **Multi-CTA Validation.** This stage must run before any AutoWS pass. It
+   proves CTA-group equality, whole-path reachability, and loop exits while the
+   original SSA provenance is visible. It records which operations satisfy the
+   multi-CTA control-flow contract but does not introduce CTA roles or
+   synchronization.
+2. **AutoWS lowering.** This stage runs during code partitioning, after the
+   owning partitions and producer-consumer graph are known. It integrates the
+   multi-CTA operation with AutoWS token and barrier handling and is responsible
+   for producing correct cluster communication semantics. If the final
+   partition or channel shape has no supported lowering, this stage aborts the
+   optional multi-CTA transformation and retains the original per-CTA
+   operation.
+
+The later multi-CTA barrier-handling section describes the full/empty-path and
+backend synchronization requirements of AutoWS lowering in detail.
+
+If validation runs before data partitioning, AutoWS must retain a mapping from
+each validated source operation to any resulting clone or slice, including its
+execution count, tile, and pipeline epoch. If that mapping is unavailable, or
+if no lowering pattern understands the result, AutoWS lowering aborts the
+multi-CTA transformation.
+
+## Multi-CTA barrier handling
+
+The high-level challenge is that a multi-CTA operation cannot be lowered as an
+isolated instruction. Every dynamic multi-CTA operation conceptually
+participates in at least two coordinated events for its logical buffer or
+resource:
+
+- **Ready:** production is complete and every participating CTA may consume its
+  destination.
+- **Done:** every participating CTA has completed all uses of its destination,
+  so the producer may reuse the logical buffer slot.
+
+Both events are group-level properties. It is insufficient to prove only that
+the leader can issue an operation or that one recipient has completed. The
+lowering must connect the operation that produces ready state with the
+operation or operations that establish done state.
+
+Barrier handling includes both the abstract synchronization constructed during
+AutoWS code partitioning and the concrete barriers emitted by the backend. Code
+partitioning may call these states full and empty and represent them with
+tokens or logical semaphores. A later backend stage may use mbarriers or another
+hardware protocol. These are different implementations of the same ready/done
+protocol.
+
+### TMA multicast example
+
+For the `(2, 1, 1)` TMA multicast example, multicast completion is the ready
+event for the destination buffers in ranks 0 and 1. The corresponding done
+event comes from completion of the consumers of those buffers, often an MMA.
+The relevant lowering unit is therefore the complete ready/done barrier
+protocol, not the TMA instruction in isolation.
+
+### AutoWS lowering requirements
+
+AutoWS splits the original CTA program into regions that may start and make
+progress independently. Multi-CTA barrier lowering must preserve three
+properties across those regions:
+
+1. **Expected arrivals.** For each ready or done barrier, lowering must identify
+   the specialized regions and hardware threads expected to arrive. The
+   initialized arrival count and the emitted arrivals must still match after
+   code partitioning. If several regions participate in one logical CTA
+   arrival, lowering must coordinate them rather than accidentally counting the
+   CTA more than once or omitting it. This will actually happen in the same location
+   other barriers are updated but must be tracked, with the correct masks.
+2. **Barrier lifetime.** Barrier storage and state must remain live for every
+   specialized region that can use it, for the full duration of the kernel or
+   enclosing persistent loop. Correctness cannot depend on producer and
+   consumer regions launching or progressing concurrently.
+3. **Iteration-count agreement.** Every participating region and CTA must
+   execute the same ordered number of uses of the corresponding barrier. Code
+   partitioning must not make that count data-dependent in a way that can vary
+   between tiles, partitions, or CTA participants. Multi-CTA Validation covers
+   source-level exits; lowering must preserve that result when control flow is
+   distributed across specialized regions.
+
+This document assumes the existing AutoWS indexing and phase construction are
+valid. The requirement is agreement on the dynamic barrier-use count, not a new
+analysis of arbitrary indices or phase values. If lowering cannot establish the
+expected arrivals, lifetime, or iteration-count agreement, it must abort the
+optional multi-CTA transformation.
+
+Current AutoWS 2-CTA MMA is a narrow precedent. It inserts a pair-scoped remote
+mbarrier protocol after warp specialization, when the owning MMA partition is
+known. Both CTAs arrive on the even CTA's barrier, and only the even CTA waits
+and issues the cooperative MMA. This avoids placing a full-cluster barrier
+inside one consumer warp group, but still relies on the paired CTAs executing
+the same dynamic MMA and barrier instances.
+
+## Future work
+
+### Dead-tile participation
+
+Multi-CTA operations have a fixed participation width. The scheduled tile count
+along the grouping dimension must therefore be divisible by that width. For
+example, every dynamic 2-CTA GEMM requires two CTAs to participate, even when
+the logical matrix has work for only one CTA in the final pair. The schedule
+must add a **dead tile** to complete that pair.
+
+The question is not whether the CTA assigned the dead tile may opt out. It is
+how that CTA can participate in the required multi-CTA operation without
+producing an incorrect result. The current implementation keeps it on the normal
+cooperative execution path and requires its input and output data harmless. This
+includes masking on any store or any intermediate value.
+
+This differs from ordinary edge masking. A partially valid tile still produces
+some logical output, but there are known issues with trying to write fully
+past the bounds with TMA stores (although this may just be a bug),
+
+The current 2-CTA matmul test demonstrates this for `M = 128` and
+`BLOCK_M = 128`. Its launch wrapper starts two CTAs even though there is only
+one logical M tile. Both CTAs execute the same K loop, descriptor loads,
+cross-CTA synchronization, and 2-CTA MMA. The second CTA's A tile is entirely
+out of bounds, so the descriptor load supplies padding values. The non-AutoWS
+kernel suppresses its output with a masked store; the AutoWS kernel relies on
+descriptor-store bounds behavior. The dead CTA therefore performs dummy work
+rather than skipping the collective operation.
+
+This is not yet in scope, but this will be an important followup for solidifying all
+stable multi-cta handling. For AutoWS this may be relevant if need to perf the multi-CTA
+op (e.g. load for TMA-multicast), but may not need to perform the rest of the kernel.

--- a/docs/design/multi_cta_grid_requirements.md
+++ b/docs/design/multi_cta_grid_requirements.md
@@ -1,0 +1,225 @@
+# Multi-CTA grid requirements
+
+## Summary
+
+This document complements the
+[multi-CTA control-flow contract](multi_cta_control_flow_contract.md) and the
+[AutoWS requirements](multi_cta_autows_requirements.md). It defines two
+additional pieces of the multi-CTA correctness contract:
+
+1. a launcher-side verification process for checking that a launch grid is
+   compatible with the compiled kernel's required cluster shape; and
+2. rules for handling tiles that have no logical work but must exist to complete
+   a multi-CTA participation group.
+
+Cluster verification and dead-tile safety are separate proofs. A divisible grid
+ensures that CUDA can form complete physical clusters. It does not prove that a
+padded CTA uses safe data or follows the required collective trace. Conversely,
+a kernel with safe dead-tile behavior is not launchable if the physical grid
+cannot be partitioned into its required clusters.
+
+For non-persistent kernels, each launched CTA has one statically determined tile
+assignment, so launch-grid verification also constrains the tile schedule. For
+persistent kernels, verification instead applies at kernel granularity. Because
+a whole cluster is scheduled together, the total number of launched CTAs must
+be divisible by the flat cluster size `Cx * Cy * Cz`. Correctness of the
+dynamic tile assignments remains a separate kernel-level scheduler obligation.
+
+## Terminology and running example
+
+Let:
+
+- `L = (Lx, Ly, Lz)` be the logical tile grid;
+- `G = (Gx, Gy, Gz)` be the final physical CTA grid passed to CUDA; and
+- `C = (Cx, Cy, Cz)` be the exact required cluster shape.
+
+For `ctas_per_cga`, `G` is already the total CTA grid. Other frontend options
+may express a grid in logical programs and expand it before launch. Verification
+always operates on the final physical CTA grid, after any such expansion.
+
+A **dead tile** is a physical tile assignment with no corresponding logical
+output. Dead tiles are schedule padding, not partially valid edge tiles. For
+example, a 2-CTA GEMM grouped along X requires an even number of X tiles. If the
+logical M-tile count is three, the kernel must launch four X CTAs:
+
+```text
+logical tiles:   [0] [1] [2]
+physical CTAs:   [0] [1] [2] [dead]
+2-CTA groups:     \___/     \_______/
+```
+
+The last CTA has no logical output, but it is still the second participant in
+the cooperative operation for the final pair.
+
+## Component 1: Launcher-side cluster verification
+
+### Why the check belongs at launch
+
+The compiler knows the required cluster shape, but a Triton launch grid may be a
+runtime function of tensor shapes and autotuning parameters. Compilation alone
+therefore cannot prove that every invocation supplies a compatible grid.
+
+CUDA ultimately rejects invalid cluster launches, but relying on a driver error
+provides a late and implementation-dependent diagnostic. Triton should verify
+the contract before allocating launch-scoped resources or invoking CUDA.
+
+### Required launch metadata
+
+A compiled kernel containing a multi-CTA operation must expose one normalized,
+exact cluster requirement to the launcher:
+
+- the required physical cluster shape `C`;
+- whether the user-provided grid already counts physical CTAs or must first be
+  expanded; and
+- whether the kernel requires exact clustering.
+
+All multi-CTA operations in one kernel must be compatible with that requirement.
+The compiler must reject or avoid forming an operation that requires a different
+physical cluster shape.
+
+### Verification process
+
+For every launch of a kernel with an exact cluster requirement, the launcher
+must perform the following checks:
+
+1. Verify per-dimension divisibility:
+
+   ```text
+   Gx % Cx == 0
+   Gy % Cy == 0
+   Gz % Cz == 0
+   ```
+
+   For a persistent kernel, the corresponding kernel-granularity requirement
+   is:
+
+   ```text
+   (Gx * Gy * Gz) % (Cx * Cy * Cz) == 0
+   ```
+
+   This flat-count check makes explicit that the launch contains an integral
+   number of schedulable clusters. It does not replace the per-dimension checks
+   when the required cluster shape is multidimensional.
+2. Verify that the target device and launch resources support the required
+   cluster shape. The CUDA driver remains the final authority, but the launcher
+   should report the incompatibility as a cluster-requirement error rather than
+   an unexplained launch failure.
+
+The launcher must not silently round `G`. Rounding creates new CTA program IDs,
+which is a semantic transformation: the kernel must map them to dead tiles,
+make their memory accesses safe, suppress their side effects, and keep them on
+the collective trace. The launcher cannot infer those properties from cluster
+metadata.
+
+Failure of either check is a launch-time error for the selected compiled
+kernel. The diagnostic must identify the physical grid `G` and required cluster
+shape `C`, along with any known target or resource incompatibility. Kernel
+caching, recompilation, and selection of a different compiled variant are
+outside this contract and must not be relied upon to bypass these checks.
+
+### What this proves
+
+Successful verification proves only that the physical grid can be partitioned
+into complete clusters of the required shape. Because the compiler has already
+proved that each multi-CTA participation group is contained within that shape,
+no group is truncated at the edge of the launch grid.
+
+It does not prove:
+
+- that the logical tile count fills the physical grid;
+- that padded program IDs are mapped to safe dead tiles;
+- that dead-tile loads, stores, atomics, or other side effects are safe; or
+- that participating CTAs execute compatible control flow.
+
+Those are kernel and compiler obligations described below and in the
+multi-CTA control-flow contract.
+
+## Component 2: Dead-tile handling
+
+### Dead-tile execution
+
+Ordinary masking and dead-tile participation are different:
+
+- A **partially valid tile** has some logical output. The kernel executes the
+  tile and masks individual out-of-bounds elements.
+- A **dead tile** has no logical output. It exists only to complete a physical
+  cluster or multi-CTA participation group.
+
+Most kernels handle partially valid edge tiles, but that does not imply that
+they safely handle a fully dead tile. A kernel may fail when an operation
+receives a tile with no in-bounds elements. For example, a TMA store can crash
+when the tile's lower bound lies past the tensor's upper bound. It is currently
+unclear whether this is an implementation bug or an API gap.
+
+### Kernel-author responsibilities
+
+For the initial design, the kernel author or launch wrapper must:
+
+- round the logical grid to complete physical clusters;
+- map padded program IDs to dead tiles without wrapping them onto unrelated
+  live work;
+- provide safe values for every load performed by a dead tile, using descriptor
+  out-of-bounds fill or explicit masks as appropriate;
+- ensure padded values are semantically harmless for the collective operation;
+- suppress every externally visible dead-tile effect, including output stores,
+  atomics, counters, queue updates, and debugging writes; and
+- structure control flow and tile-validity handling so the compiler can prove
+  that dead CTAs remain on the same ordered multi-CTA and barrier trace as their
+  live partners.
+
+The author must not assume that output masking makes input accesses or
+intermediate side effects safe.
+
+### Compiler support
+
+Kernel constructs such as CTA-dependent early exits can prevent the compiler
+from proving that every participant reaches an operation that could otherwise
+use multiple CTAs. When an author introduces such constructs, additional kernel
+structure or compiler-visible information may be required before the compiler
+can safely form a multi-CTA operation. Until that participation can be proved,
+the affected operation must remain single-CTA.
+
+### 2-CTA GEMM example
+
+For a non-persistent GEMM grouped along M, the launch wrapper can construct a
+complete grid as follows:
+
+```python
+logical_m_tiles = triton.cdiv(M, BLOCK_M)
+grid_m = triton.cdiv(logical_m_tiles, 2) * 2
+```
+
+When `logical_m_tiles` is odd, the last CTA is dead. Both CTAs in its pair still
+execute the same K-loop iterations, descriptor loads, 2-CTA MMA operations, and
+barrier epochs. The dead CTA's input loads return safe padding, and an explicit
+output mask prevents it from writing outside the output tensor.
+
+This is safe:
+
+```text
+both CTAs: load -> arrive/wait -> 2-CTA MMA -> repeat
+dead CTA:  suppress final output writes
+```
+
+This is not safe:
+
+```text
+live CTA:  load -> arrive/wait -> 2-CTA MMA
+dead CTA:  return or continue to the next tile
+```
+
+### Expected failure modes
+
+| Contract violation | Likely symptom |
+|---|---|
+| Physical grid is not divisible by the exact cluster shape | CUDA launch rejection; using a non-cluster fallback would violate the compiled kernel contract |
+| A dead CTA returns or skips a collective operation | Barrier wait that never completes or a kernel hang |
+| A dead AutoWS partition skips a ready/done event | Channel epoch drift, stale buffers, or an intermittent hang |
+| Dead-tile inputs are not padded or masked | Out-of-bounds access, illegal memory access, or invalid MMA data |
+| Padding values are not neutral for the operation | Silent corruption of a live partner's result |
+| Dead-tile stores, atomics, or counters are not suppressed | Out-of-bounds writes, duplicated work, or corrupted scheduler state |
+
+The most dangerous failures are not necessarily immediate launch errors. A
+missing barrier arrival or mismatched AutoWS epoch can depend on scheduling and
+appear as an intermittent hang, while a non-neutral padded operand can silently
+corrupt otherwise in-bounds output.

--- a/docs/design/triton-clc-tile-scheduler.md
+++ b/docs/design/triton-clc-tile-scheduler.md
@@ -293,9 +293,11 @@ only handles the CLC-response completion barrier local to the producer.
 Materialization (producer partition, depth-1):
 
 1. Allocate the response buffer (`memdesc<2xi64>`) and one **completion mbarrier**
-   at function scope; init / inval. For explicit clusters, also allocate an
-   **empty mbarrier** on which all CTAs arrive after consuming a response.
-2. `clc_try_cancel_async` → `ttng.clc_try_cancel(resp, bar)` + `barrier_expect(bar, 16)`.
+   at function scope; init / inval. For explicit clusters, also allocate a
+   **ready mbarrier**.
+2. `clc_try_cancel_async` → `barrier_expect(bar, 16)`; for explicit clusters,
+   each producer task signals rank zero's ready mbarrier and rank zero waits;
+   then `ttng.clc_try_cancel(resp, bar)` issues the request.
 3. `clc_read %tok` → `wait_barrier(bar, phase)` + `ttng.clc_load_result(resp)` +
    `ttng.clc_is_canceled` (→ `isValid`) + `ttng.clc_get_program_id` (→ x/y/z).
 
@@ -306,14 +308,14 @@ ensures the response is read before the next iteration reuses its buffer, so onl
 the full (data-ready) completion mbarrier is needed.
 
 With `ctas_per_cga`, program order within one CTA does not prevent rank zero
-from starting the next request before peer CTAs have consumed the multicast
-response. Materialization therefore adds an empty mbarrier initialized with the
-physical cluster size. After a successful `clc_read`, every CTA arrives on rank
-zero's empty barrier through a remote view. Before the next request, only rank
-zero waits on its local empty barrier. The first wait uses the opposite phase
-and passes immediately; subsequent waits prevent response-buffer reuse until
-all cluster members have finished. The final failed cancellation skips the
-remote arrivals because no later request will reuse the buffer.
+from issuing a multicast request before peer CTAs have armed their completion
+mbarriers. Materialization therefore adds a ready mbarrier initialized with the
+physical cluster size. Before every request, each CTA executes
+`barrier_expect`, fences its shared state, and performs one task-local arrival
+on rank zero's ready mbarrier. Rank zero waits with the current carried phase
+before issuing the request. This rendezvous also proves every CTA consumed the
+previous response before its completion barrier is reused. The task-local
+arrival deliberately omits an additional implicit CTA-wide synchronization.
 
 **Require the phase to be a loop-carried variable, toggled before each advance.**
 Materialization adds an `i32`/`i1` phase iter_arg to the persistent `scf.while`,
@@ -415,14 +417,15 @@ requires drain-on-exit because the CLC claim is destructive.
   `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp`.
   Wired into the NVIDIA Blackwell `make_ttgir` — split + hoist before WS,
   materialize after; the AutoWS broadcast runs inside WS.
-- **Restriction:** explicit `ctas_per_cga` clusters are supported, while
+- **Restriction:** explicit `ctas_per_cga` clusters are supported without
+  AutoWS. Clustered CLC AutoWS falls back to the unspecialized CLC path;
   Triton's distinct `num_ctas > 1` program-id model remains unsupported.
 - **Tests:** `python/test/unit/language/test_triton_clc.py` (frontend IR checks +
   non-WS Blackwell execution + materialized-TTGIR) and, in
   `test_tutorial09_warp_specialization.py`,
-  `test_tutorial09_matmul_tma_clc_persistent_while_loop_warp_specialize` (Blackwell
-  warp-specialized CLC GEMM: asserts `ttg.warp_specialize` + `ttng.clc_try_cancel`
-  and correctness).
+  `test_tutorial09_matmul_tma_clc_persistent_while_loop_warp_specialize`
+  (single-CTA Blackwell warp-specialized CLC GEMM) plus clustered non-AutoWS and
+  AutoWS-fallback correctness cases.
 
 ## Future work
 

--- a/docs/design/triton_tma_multicast.md
+++ b/docs/design/triton_tma_multicast.md
@@ -243,30 +243,28 @@ The implementation flows through the compiler as follows:
    descriptor-encoding optimization. For each enabled `tt.descriptor_load`, it
    computes program-ID dependencies and records the proven broadcast axes in
    the internal `tt.multicast_axes` attribute.
-3. TMA lowering and software-pipelining preserve that attribute, allocate one
-   completion barrier slot per recipient group, and insert cluster barriers
+3. TMA lowering and software-pipelining preserve that attribute, allocate a
+   local completion barrier in every recipient CTA, and insert cluster barriers
    around the multicast transaction. Loads with different broadcast axes are
-   kept in different pipeline groups. Native `tl.range(...,
-   warp_specialize=True)` lowering carries the same plan through its load
-   partitions.
-4. NVIDIA LLVM lowering derives a rank-dependent 16-bit recipient mask from the
-   cluster shape and broadcast axes. Only the lowest-ranked CTA in each group
-   issues `cp.async.bulk.tensor...multicast::cluster` and waits on the
-   corresponding cluster-visible completion barrier; the following cluster
-   barrier releases the other recipients.
+   kept in different pipeline groups. Native and Meta warp-specialized lowering
+   carry the same plan through their load partitions and memory channels.
+4. TMA lowering derives a rank-dependent recipient mask from the cluster shape
+   and broadcast axes, stores it in `multicastTargets`, and predicates the copy
+   on the lowest-ranked CTA in each group. The elected CTA issues
+   `cp.async.bulk.tensor...multicast::cluster`; hardware completes the
+   corresponding local barrier in every target CTA. Each recipient waits on
+   its local barrier before the following cluster rendezvous.
 
 The planner accepts only tiled `tt.descriptor_load` operations, an exact
 power-of-two `ctas_per_cga` shape containing 2 to 16 CTAs, and index/control-flow
-expressions whose program-ID dependencies it can prove. It conservatively
-rejects memory-derived or atomic tile IDs, CLC operations, divergent surrounding
-control flow, unsupported expression kinds, and Meta AutoWS (`ttg.use-meta-ws`).
-CLC and dynamic-persistent schedules are unsupported because their regular
-Triton schedulers do not yet support multi-CTA execution. When those schedulers
-gain multi-CTA support, the multicast analysis must be extended to understand
-their cluster-level work assignment and prove which per-CTA tiles remain shared.
-It currently selects every proven broadcast axis and has no cost model or
-user-facing optimization remarks. Selection can be inspected in TTGIR through
-`tt.multicast_axes` and in PTX through `.multicast::cluster`.
+expressions whose program-ID dependencies it can prove. It understands CLC
+schedule results and cluster-uniform `scf.for`/`scf.while` control flow, and it
+preserves plans through Meta AutoWS channels. It conservatively rejects
+memory-derived or atomic tile IDs, cluster-divergent control flow, and
+unsupported expression kinds. It currently selects every proven broadcast axis
+and has no cost model or user-facing optimization remarks. Selection can be
+inspected in TTGIR through `tt.multicast_axes`, on lowered TMA operations through
+`multicastTargets`, and in PTX through `.multicast::cluster`.
 
 The internal attribute is a compiler contract, not a user API. Standard Triton
 users grant permission through the kernel option or load override; they do not

--- a/docs/design/triton_tma_multicast.md
+++ b/docs/design/triton_tma_multicast.md
@@ -234,15 +234,19 @@ tile expressions between CTA ranks.
 
 The implementation flows through the compiler as follows:
 
-1. The Python frontend records a load-local `tt.multicast` boolean when
-   `TensorDescriptor.load(..., multicast=...)` overrides the kernel policy. The
-   NVIDIA backend records the kernel default as `ttg.multicast` and the exact
-   physical cluster shape through `ctas_per_cga` module attributes.
+1. The Python frontend resolves each
+   `TensorDescriptor.load(..., multicast=...)` policy against the selected
+   kernel configuration and records the ODS-declared `multicast` boolean on
+   `tt.descriptor_load`. Every descriptor load therefore has a complete `true`
+   or `false` policy in IR. The planner reads the exact physical shape from the
+   existing cluster dimension attributes.
 2. `TritonNvidiaGPUTMAMulticastPass`, implemented in
    `lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp`, runs after
    descriptor-encoding optimization. For each enabled `tt.descriptor_load`, it
-   computes program-ID dependencies and records the proven broadcast axes in
-   the internal `tt.multicast_axes` attribute.
+   reads the ODS-declared policy, computes program-ID dependencies, and records
+   the proven broadcast axes in the internal `tt.multicast_axes` attribute.
+   The load retains its `multicast` policy and carries `tt.multicast_axes`
+   only when the planner proves a valid multicast plan.
 3. TMA lowering and software-pipelining preserve that attribute, allocate a
    local completion barrier in every recipient CTA, and insert cluster barriers
    around the multicast transaction. Loads with different broadcast axes are
@@ -256,7 +260,7 @@ The implementation flows through the compiler as follows:
    its local barrier before the following cluster rendezvous.
 
 The planner accepts only tiled `tt.descriptor_load` operations, an exact
-power-of-two `ctas_per_cga` shape containing 2 to 16 CTAs, and index/control-flow
+power-of-two physical cluster shape containing 2 to 16 CTAs, and index/control-flow
 expressions whose program-ID dependencies it can prove. It understands CLC
 schedule results and cluster-uniform `scf.for`/`scf.while` control flow, and it
 preserves plans through Meta AutoWS channels. It conservatively rejects

--- a/include/triton/Dialect/Triton/IR/TMAMulticast.h
+++ b/include/triton/Dialect/Triton/IR/TMAMulticast.h
@@ -1,0 +1,13 @@
+#ifndef TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_
+#define TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_
+
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton {
+
+inline constexpr llvm::StringLiteral kMulticastAttrName = "multicast";
+inline constexpr llvm::StringLiteral kMulticastAxesAttrName =
+    "tt.multicast_axes";
+} // namespace mlir::triton
+
+#endif // TRITON_DIALECT_TRITON_IR_TMAMULTICAST_H_

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1208,7 +1208,8 @@ def TT_DescriptorLoadOp
           DefaultValuedAttr<TT_CacheModifierAttr,
                             "::mlir::triton::CacheModifier::NONE">:$cache,
           DefaultValuedAttr<TT_EvictionPolicyAttr,
-                            "::mlir::triton::EvictionPolicy::NORMAL">:$evict);
+                            "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+          DefaultValuedAttr<BoolAttr, "false">:$multicast);
 
   let results = (outs TT_Tensor:$result);
 

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -77,6 +77,7 @@ std::optional<int> maybeLookupNumWarps(Block *block);
 int lookupThreadsPerWarp(OpBuilder &rewriter);
 int lookupNumCTAs(OpBuilder &rewriter);
 int lookupNumCTAs(Operation *op);
+int lookupPhysicalNumCTAs(Operation *op);
 
 // Record/query whether the module contains exactly one `ttg.warp_specialize`
 // op via the `ttg.single-warp-specialize` module attribute. `hasSingle...`

--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -114,9 +114,14 @@ DenseMap<Operation *, int> deserializeLatencies(Operation *op);
 
 // Create an allocation for multibuffered scalars.
 Value createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
-                        unsigned numBuffers);
+                        unsigned numBuffers,
+                        gpu::CGAEncodingAttr cgaLayout = {});
+gpu::CGAEncodingAttr
+getTMAMulticastBarrierLayout(Operation *op,
+                             DenseI32ArrayAttr multicastAxes = {});
 // Create an allocation and init the mbarriers.
-Value createBarrierAlloc(Operation *op, int numBarriers, int arriveCount = 1);
+Value createBarrierAlloc(Operation *op, int numBarriers, int arriveCount = 1,
+                         gpu::CGAEncodingAttr cgaLayout = {});
 // Create an allocation that can hold distance number of tensor shapes.
 Value createAlloc(Operation *insertBefore, RankedTensorType ty, Location loc,
                   gpu::SharedEncodingTrait sharedEnc, unsigned distance);

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -131,6 +131,14 @@ def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::M
   ];
 }
 
+def TritonNvidiaGPUTMAMulticastPass : Pass<"triton-nvidia-plan-tma-multicast", "mlir::ModuleOp"> {
+  let summary = "Plan compiler-selected TMA multicast groups";
+  let description = [{
+    Annotates eligible descriptor loads with cluster axes across which their
+    source tile is statically invariant.
+  }];
+}
+
 def TritonNvidiaGPUTMAStoreBufferReusePass
     : Pass<"triton-nvidia-tma-store-buffer-reuse", "mlir::ModuleOp"> {
   let summary = "Reuse SMEM buffers across sequential TMA stores";

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -127,7 +127,9 @@ def TritonNvidiaGPUTMALoweringPass : Pass<"triton-nvidia-tma-lowering", "mlir::M
   }];
 
   let dependentDialects = [
-    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect"
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvgpu::NVGPUDialect",
+    "mlir::arith::ArithDialect"
   ];
 }
 

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h
@@ -1,0 +1,39 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_TMAMULTICAST_H
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_TMAMULTICAST_H
+
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+
+namespace mlir {
+class ModuleOp;
+class Value;
+namespace triton {
+class DescriptorLoadOp;
+namespace nvidia_gpu {
+
+struct TMAClusterGeometry {
+  llvm::SmallVector<int, 3> dims;
+
+  static FailureOr<TMAClusterGeometry> get(ModuleOp module);
+  unsigned size() const;
+  llvm::SmallVector<int, 3> coordinates(unsigned rank) const;
+  uint16_t maskFor(unsigned rank,
+                   const llvm::SmallBitVector &broadcastAxes) const;
+  unsigned leaderFor(unsigned rank,
+                     const llvm::SmallBitVector &broadcastAxes) const;
+};
+
+struct TMAMulticastPlan {
+  TMAClusterGeometry geometry;
+  llvm::SmallBitVector broadcastAxes;
+};
+
+FailureOr<TMAMulticastPlan> analyzeTMAMulticast(DescriptorLoadOp load);
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -1911,6 +1912,16 @@ LogicalResult verifyDescriptorLoadStoreOp(Operation *op,
 }
 
 LogicalResult DescriptorLoadOp::verify() {
+  if (auto axes =
+          getOperation()->getAttrOfType<DenseI32ArrayAttr>(
+              kMulticastAxesAttrName)) {
+    if (axes.empty())
+      return emitOpError("tt.multicast_axes must not be empty");
+    for (int32_t axis : axes.asArrayRef()) {
+      if (axis < 0 || axis >= 3)
+        return emitOpError("tt.multicast_axes values must be in [0, 2]");
+    }
+  }
   return verifyDescriptorLoadStoreOp(*this, getDesc().getType(), getType());
 }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3858,10 +3858,13 @@ struct TritonGPUVerifyTensorLayoutInterface
 
     int moduleCTAsPerCGA = lookupNumCTAs(op);
     int layoutCTAsPerCGA = getNumCTAs(layout);
-    if (layoutCTAsPerCGA != moduleCTAsPerCGA) {
+    int physicalCTAsPerCGA = lookupPhysicalNumCTAs(op);
+    if (layoutCTAsPerCGA != moduleCTAsPerCGA &&
+        layoutCTAsPerCGA != physicalCTAsPerCGA) {
       return makeErr() << layout << ".\nLayout has " << layoutCTAsPerCGA
-                       << " CTAs per CGA, but the context requires "
-                       << moduleCTAsPerCGA << " CTAs per CGA.";
+                       << " CTAs per CGA, but the context requires either "
+                       << moduleCTAsPerCGA << " logical or "
+                       << physicalCTAsPerCGA << " physical CTAs per CGA.";
     }
     return success();
   }
@@ -4489,6 +4492,17 @@ int triton::gpu::lookupNumCTAs(OpBuilder &rewriter) {
       rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
   assert(op && "cannot check number of CTAs outside of module");
   return triton::gpu::TritonGPUDialect::getNumCTAs(cast<ModuleOp>(op));
+}
+
+int triton::gpu::lookupPhysicalNumCTAs(Operation *op) {
+  auto mod = dyn_cast<ModuleOp>(op);
+  if (!mod)
+    mod = op->getParentOfType<ModuleOp>();
+  if (!mod)
+    return lookupNumCTAs(op);
+  auto dims = TritonGPUDialect::getClusterDims(mod);
+  int physicalNumCTAs = dims[0] * dims[1] * dims[2];
+  return physicalNumCTAs > 1 ? physicalNumCTAs : lookupNumCTAs(op);
 }
 
 bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -3,6 +3,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -233,14 +234,19 @@ void createTMAAsyncLoad(scf::ForOp forOp, tt::DescriptorLoadOp loadOp,
                         Value alloc, Value insertIdx, Value extractIdx,
                         Value barrier, Operation *waitOp,
                         CoarseSchedule &schedule) {
-  return createTMAAsyncCopy(forOp, loadOp, loadOp.getDesc(), alloc, insertIdx,
-                            extractIdx, barrier, waitOp, schedule,
-                            [&](OpBuilderForStage &builder, Value desc,
-                                Value barrier, Value view, Value pred) {
-                              ttng::AsyncTMACopyGlobalToLocalOp::create(
-                                  builder, loadOp.getLoc(), desc,
-                                  loadOp.getIndices(), barrier, view, pred);
-                            });
+  return createTMAAsyncCopy(
+      forOp, loadOp, loadOp.getDesc(), alloc, insertIdx, extractIdx, barrier,
+      waitOp, schedule,
+      [&](OpBuilderForStage &builder, Value desc, Value barrier, Value view,
+          Value pred) {
+        if (loadOp->hasAttr(tt::kMulticastAxesAttrName))
+          ttng::ClusterBarrierOp::create(builder, loadOp.getLoc());
+        auto copy = ttng::AsyncTMACopyGlobalToLocalOp::create(
+            builder, loadOp.getLoc(), desc, loadOp.getIndices(), barrier, view,
+            pred);
+        if (Attribute axes = loadOp->getAttr(tt::kMulticastAxesAttrName))
+          copy->setAttr(tt::kMulticastAxesAttrName, axes);
+      });
 }
 
 void createTMAAsyncGather(scf::ForOp forOp, tt::DescriptorGatherOp gatherOp,
@@ -360,6 +366,9 @@ void createTMABarrierAndWait(
       if (isTMALoad(nextOp) && asyncLoads.count(nextOp)) {
         if (asyncLoads[nextOp].stageDiff != numBuffers)
           break;
+        if (nextOp->getAttr(tt::kMulticastAxesAttrName) !=
+            group.front()->getAttr(tt::kMulticastAxesAttrName))
+          break;
         if (group.size() > 0 && schedule[group[0]] == schedule[nextOp]) {
           addToGroup(nextOp);
         }
@@ -395,11 +404,14 @@ void createTMABarrierAndWait(
         builder, barrierAlloc, loadGroup.extractIdx);
     auto wait =
         ttng::WaitBarrierOp::create(builder, barrierViewWait, loadGroup.phase);
+    Operation *completion = wait;
+    if (group.front()->hasAttr(tt::kMulticastAxesAttrName))
+      completion = ttng::ClusterBarrierOp::create(builder, forOp.getLoc());
 
     // Update the async loads info.
     for (Operation *op : group) {
       asyncLoads[op].barrier = barrier;
-      asyncLoads[op].waitOp = wait;
+      asyncLoads[op].waitOp = completion;
     }
   }
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -201,6 +202,11 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     prefetchOp.getPredMutable().assign(mask);
     return op;
   }
+  // Cluster barriers are collective and cannot be predicated. Static
+  // multicast candidates have CTA-uniform loop control, so every cluster
+  // member executes the same pipelined prologue and epilogue barriers.
+  if (isa<ttng::ClusterBarrierOp>(op))
+    return op;
   if (auto predicatedOp = dyn_cast<tt::PredicatedOpInterface>(op)) {
     rewriter.setInsertionPoint(op);
     Value mask =
@@ -389,28 +395,69 @@ DenseMap<Operation *, int> mlir::triton::deserializeLatencies(Operation *op) {
 }
 
 Value mlir::triton::createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
-                                      unsigned numBuffers) {
+                                      unsigned numBuffers,
+                                      ttg::CGAEncodingAttr cgaLayout) {
   MLIRContext *ctx = rewriter.getContext();
   unsigned numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(
       rewriter.getBlock()->getParentOp()->getParentOfType<ModuleOp>());
   Attribute sharedMemorySpace =
       ttg::SharedMemorySpaceAttr::get(rewriter.getContext());
-  auto barrierCGALayout = ttg::CGAEncodingAttr::get1DLayout(ctx, numCTAs);
+  auto barrierCGALayout =
+      cgaLayout ? cgaLayout : ttg::CGAEncodingAttr::get1DLayout(ctx, numCTAs);
+  unsigned numSlots = product(barrierCGALayout.getCTASplitNum());
   auto barrierEncoding =
       ttg::SwizzledSharedEncodingAttr::get(ctx, 1, 1, 1, {0}, barrierCGALayout);
   ttg::MemDescType memDescType = ttg::MemDescType::get(
-      {numBuffers, numCTAs}, type, barrierEncoding, sharedMemorySpace,
+      {numBuffers, numSlots}, type, barrierEncoding, sharedMemorySpace,
       /*mutableMemory=*/true);
   return ttg::LocalAllocOp::create(rewriter, memDescType, Value());
 }
 
+ttg::CGAEncodingAttr
+mlir::triton::getTMAMulticastBarrierLayout(Operation *op,
+                                           DenseI32ArrayAttr multicastAxes) {
+  if (!multicastAxes)
+    multicastAxes =
+        op->getAttrOfType<DenseI32ArrayAttr>(tt::kMulticastAxesAttrName);
+  if (!multicastAxes)
+    return {};
+
+  auto module = op->getParentOfType<ModuleOp>();
+  auto dims = ttg::TritonGPUDialect::getClusterDims(module);
+  llvm::SmallBitVector broadcastAxes(3);
+  for (int32_t axis : multicastAxes.asArrayRef()) {
+    if (axis < 0 || axis >= 3) {
+      op->emitError("tt.multicast_axes values must be in [0, 2]");
+      return {};
+    }
+    broadcastAxes.set(axis);
+  }
+
+  auto *ctx = op->getContext();
+  auto kBlock = StringAttr::get(ctx, "block");
+  LinearLayout::BasesT bases;
+  unsigned groupBit = 0;
+  for (unsigned axis = 0; axis < 3; ++axis) {
+    assert(llvm::isPowerOf2_32(dims[axis]));
+    for (unsigned bit = 0; bit < llvm::Log2_32(dims[axis]); ++bit) {
+      std::vector<int32_t> basis(1, 0);
+      if (!broadcastAxes.test(axis))
+        basis[0] = 1u << groupBit++;
+      bases[kBlock].push_back(std::move(basis));
+    }
+  }
+  return ttg::CGAEncodingAttr::get(
+      ctx, LinearLayout(std::move(bases), standardOutDimNames(ctx, 1)));
+}
+
 // Create an allocation and init the mbarriers.
 Value mlir::triton::createBarrierAlloc(Operation *op, int numBarriers,
-                                       int arriveCount) {
+                                       int arriveCount,
+                                       ttg::CGAEncodingAttr cgaLayout) {
   ImplicitLocOpBuilder rewriter(op->getLoc(), op);
 
-  Value barrierAlloc =
-      createScalarAlloc(rewriter, rewriter.getI64Type(), numBarriers);
+  Value barrierAlloc = createScalarAlloc(rewriter, rewriter.getI64Type(),
+                                         numBarriers, cgaLayout);
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(rewriter, barrierAlloc, i);
     ttng::InitBarrierOp::create(rewriter, barrierView, arriveCount);

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1954,7 +1954,7 @@ SmallVector<Value> getTiedArgs(Operation *op, int resultIdx) {
 
 LogicalResult verifyBarrierType(Operation *op,
                                 mlir::triton::gpu::MemDescType barrierType) {
-  auto numCTAs = triton::gpu::lookupNumCTAs(op);
+  auto numCTAs = triton::gpu::lookupPhysicalNumCTAs(op);
   if (!(barrierType.getElementType().isInteger(64) &&
         barrierType.getRank() == 1 && barrierType.getShape()[0] <= numCTAs))
     return op->emitOpError("barrier allocation must be a descriptor of "

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/LoadMMASpecialization.cpp
@@ -6,6 +6,7 @@
 #include "mlir/Pass/Pass.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h"
@@ -350,9 +351,13 @@ static void lowerTMACopy(PartitionBuilder &b, Partition &loadPartition,
                          Value barrier, Value view) {
   Value truePred = b.boolCst(true);
   if (auto load = dyn_cast<DescriptorLoadOp>(op)) {
-    b.createInto<ttng::AsyncTMACopyGlobalToLocalOp>(
+    if (load->hasAttr(triton::kMulticastAxesAttrName))
+      b.createInto<ttng::ClusterBarrierOp>(loadPartition, stageCluster);
+    auto copy = b.createInto<ttng::AsyncTMACopyGlobalToLocalOp>(
         loadPartition, stageCluster, load.getDesc(), load.getIndices(), barrier,
         view, truePred);
+    if (Attribute axes = load->getAttr(triton::kMulticastAxesAttrName))
+      copy->setAttr(triton::kMulticastAxesAttrName, axes);
   } else {
     auto gather = cast<DescriptorGatherOp>(op);
     b.createInto<ttng::AsyncTMAGatherOp>(
@@ -395,6 +400,8 @@ LogicalResult PipelinedLoadGroup::lowerLoads(PartitionSet &partitions,
     StageCluster userStageCluster = getStageCluster(liveBeforeOp);
     b.createInto<ttng::WaitBarrierOp>(userPartition, userStageCluster,
                                       curLoadBar, phase);
+    if (firstLoad->loadOp->hasAttr(triton::kMulticastAxesAttrName))
+      b.createInto<ttng::ClusterBarrierOp>(userPartition, userStageCluster);
 
     SmallVector<Operation *> liveUntilOps;
     for (PipelinedLoad &load : loads) {
@@ -868,8 +875,22 @@ LogicalResult lowerLoops(scf::ForOp &loop, MutableArrayRef<PipelinedLoad> loads,
     liveBeforeGroups[load.liveBeforeOps].push_back(std::move(load));
   }
   SmallVector<PipelinedLoadGroup> loadGroups;
-  for (auto &loads : llvm::make_second_range(liveBeforeGroups))
-    loadGroups.push_back({std::move(loads)});
+  for (auto &loads : llvm::make_second_range(liveBeforeGroups)) {
+    SmallVector<PipelinedLoadGroup> axisGroups;
+    for (PipelinedLoad &load : loads) {
+      Attribute axes =
+          load.loadOp->getAttr(triton::kMulticastAxesAttrName);
+      auto group = llvm::find_if(axisGroups, [&](PipelinedLoadGroup &group) {
+        return group.loads.front().loadOp->getAttr(
+                   triton::kMulticastAxesAttrName) == axes;
+      });
+      if (group == axisGroups.end())
+        axisGroups.push_back({{std::move(load)}});
+      else
+        group->loads.push_back(std::move(load));
+    }
+    llvm::append_range(loadGroups, std::move(axisGroups));
+  }
 
   // Multi-buffer and lower the loads.
   for (PipelinedLoadGroup &group : loadGroups)

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -458,14 +458,16 @@ SmallVector<uint16_t> getTensorCoreBarrierBroadcastMasks(Operation *op) {
 }
 
 Value getMemEffectCTAs(ImplicitLocOpBuilder &b, Operation *op) {
-  if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
-    if (tmaLoad.getMulticast())
-      return getMulticastRecipientCTAs(b, tmaLoad.getResult());
-  }
   if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    if (Value targets = copyOp.getMulticastTargets())
+      return targets;
     if (copyOp.getMulticast())
       return getMulticastRecipientCTAs(b, copyOp.getResult());
     return currentCTAMask(b);
+  }
+  if (auto tmaLoad = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
+    if (tmaLoad.getMulticast())
+      return getMulticastRecipientCTAs(b, tmaLoad.getResult());
   }
   if (auto gatherOp = dyn_cast<ttng::AsyncTMAGatherOp>(op);
       gatherOp && gatherOp.getMulticast())
@@ -531,6 +533,8 @@ Value getBarrierRecipientCTAs(ImplicitLocOpBuilder &b, Operation *op) {
   if (auto arriveOp = dyn_cast<ttng::AsyncCopyMbarrierArriveOp>(op))
     return getLeaderCTA(b, arriveOp.getBarrier());
   if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    if (Value targets = copyOp.getMulticastTargets())
+      return targets;
     if (copyOp.getMulticast())
       return getMulticastBarrierRecipientCTAs(b, copyOp.getResult(),
                                               copyOp.getBarrier());

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -29,6 +29,7 @@
 #include "tlx/dialect/include/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -488,14 +489,17 @@ LogicalResult ClusterWaitOp::verify() {
 }
 
 static LogicalResult verifyClusterIsMultiCTA(Operation *op) {
-  int numCTAs = triton::gpu::lookupNumCTAs(op);
+  int numCTAs = triton::gpu::lookupPhysicalNumCTAs(op);
   if (numCTAs <= 1)
-    return op->emitOpError("requires ttg.num-ctas > 1");
+    return op->emitOpError("requires a multi-CTA cluster");
   return success();
 }
 
 // -- ClusterBarrierOp --
 LogicalResult ClusterBarrierOp::verify() {
+  // AutoWS may place this op inside warp-specialized regions and guarantees
+  // that every required warp group participates. Rejecting the region here
+  // would also reject valid compiler-generated synchronization.
   if (failed(verifyClusterIsMultiCTA(getOperation())))
     return failure();
   auto func = getOperation()->getParentOfType<FunctionOpInterface>();
@@ -568,7 +572,7 @@ LogicalResult ArriveBarrierOp::verify() {
   if (isMulticast()) {
     if (getPerThread())
       return emitOpError("multicast arrive does not support perThread");
-    int numCTAs = triton::gpu::lookupNumCTAs(getOperation());
+    int numCTAs = triton::gpu::lookupPhysicalNumCTAs(getOperation());
     if (numCTAs <= 1)
       return emitOpError("multicast arrive requires num_ctas > 1");
     if (getCtaMask() > static_cast<uint32_t>(numCTAs - 1))
@@ -686,16 +690,31 @@ static LogicalResult verifyBarrierCGALayout(Operation *op, Value barrier,
 }
 
 static LogicalResult verifyTMABarrierLayout(Operation *op, Value barrier) {
+  auto axes = op->getAttrOfType<DenseI32ArrayAttr>(
+      ::mlir::triton::kMulticastAxesAttrName);
+  if (axes) {
+    if (axes.empty())
+      return op->emitOpError("tt.multicast_axes must not be empty");
+    for (int32_t axis : axes.asArrayRef()) {
+      if (axis < 0 || axis >= 3)
+        return op->emitOpError(
+            "tt.multicast_axes values must be in [0, 2]");
+    }
+  }
+
+  auto ctx = op->getContext();
+  int numCTAs = gpu::lookupNumCTAs(op);
+  auto oneCTACGALayout = CGAEncodingAttr::get1DLayout(ctx, numCTAs);
+  if (axes)
+    return verifyBarrierCGALayout(op, barrier, oneCTACGALayout, "TMA barrier");
+
   auto twoCTAsAttr =
       op->getParentOfType<ModuleOp>()->getAttrOfType<BoolAttr>(AttrTwoCTAsName);
   if (!twoCTAsAttr)
     return success();
 
-  auto ctx = op->getContext();
-  int numCTAs = gpu::lookupNumCTAs(op);
   auto barrierTy = cast<MemDescType>(barrier.getType());
   auto actualCGALayout = getCGALayout(barrierTy.getEncoding());
-  auto oneCTACGALayout = CGAEncodingAttr::get1DLayout(ctx, numCTAs);
   if (actualCGALayout == oneCTACGALayout)
     return success();
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CLCLowering.cpp
@@ -11,7 +11,7 @@
 //                               mbarrier + low-level try_cancel/expect (issue)
 //                               and wait/load/decode (read), with a
 //                               loop-carried phase. Explicit clusters also get
-//                               an empty barrier that guards response reuse.
+//                               a ready barrier that guards response reuse.
 //
 // Stage 3 (AutoWS handling) is intentionally NOT here; it lands in a follow-up
 // branch and slots between Stage 2 and Stage 4. The CUDA-style ctas_per_cga
@@ -158,7 +158,8 @@ struct CLCMaterializePass
     Location loc = read.getLoc();
     OpBuilder b(whileOp);
     Type i32 = b.getI32Type();
-    int clusterSize = getExplicitClusterSize(read->getParentOfType<ModuleOp>());
+    ModuleOp mod = read->getParentOfType<ModuleOp>();
+    int clusterSize = getExplicitClusterSize(mod);
 
     // Loop-carried phase, initialized to 0.
     Value zero =
@@ -172,13 +173,65 @@ struct CLCMaterializePass
     // Explicit clusters also use a second barrier to rendezvous before reuse.
     b.setInsertionPoint(newLoop);
     Value resp = createClcResponseAlloc(b, loc);
-    Value barAlloc = createBarrierAlloc(newLoop, /*numBarriers=*/1);
-    Value bar = createSingleBufferView(b, barAlloc, 0);
-    Value emptyBar;
-    if (clusterSize > 1) {
-      Value emptyBarAlloc =
-          createBarrierAlloc(newLoop, /*numBarriers=*/1, clusterSize);
-      emptyBar = createSingleBufferView(b, emptyBarAlloc, 0);
+    Value bar;
+    Value readyBar;
+    bool readyArrivePerThread = false;
+    auto wsOp = issue->getParentOfType<ttg::WarpSpecializeOp>();
+    if (clusterSize > 1 && wsOp) {
+      int threadsPerWarp = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
+      int readyArriveCount =
+          clusterSize * ttg::lookupNumWarps(issue) * threadsPerWarp;
+      readyArrivePerThread = true;
+
+      ImplicitLocOpBuilder wb(wsOp.getLoc(), wsOp);
+      Value barriers = createScalarAlloc(wb, wb.getI64Type(), 2);
+      Value completionInit = createSingleBufferView(wb, barriers, 0);
+      InitBarrierOp::create(wb, completionInit, /*count=*/1);
+      Value readyInit = createSingleBufferView(wb, barriers, 1);
+      InitBarrierOp::create(wb, readyInit, readyArriveCount);
+
+      wb.setInsertionPointAfter(wsOp);
+      for (int i = 0; i < 2; ++i) {
+        Value invalView = createSingleBufferView(wb, barriers, i);
+        InvalBarrierOp::create(wb, invalView);
+      }
+      ttg::LocalDeallocOp::create(wb, barriers);
+
+      if (!wsOp.getDefaultRegion().isAncestor(issue->getParentRegion())) {
+        Region *issuePartition = nullptr;
+        for (Region *region : wsOp.getPartitionRegions())
+          if (region->isAncestor(issue->getParentRegion())) {
+            issuePartition = region;
+            break;
+          }
+        if (!issuePartition)
+          return issue.emitError("CLC issue not found in a warp-specialize "
+                                 "partition region");
+
+        auto partOp = wsOp.getPartitionOp();
+        partOp->insertOperands(partOp->getNumOperands(), barriers);
+        Value captured;
+        for (Region *region : wsOp.getPartitionRegions()) {
+          BlockArgument arg =
+              region->addArgument(barriers.getType(), wsOp.getLoc());
+          if (region == issuePartition)
+            captured = arg;
+        }
+        OpBuilder vb(issue);
+        bar = createSingleBufferView(vb, captured, 0);
+        readyBar = createSingleBufferView(vb, captured, 1);
+      } else {
+        bar = createSingleBufferView(b, barriers, 0);
+        readyBar = createSingleBufferView(b, barriers, 1);
+      }
+    } else {
+      Value barAlloc = createBarrierAlloc(newLoop, /*numBarriers=*/1);
+      bar = createSingleBufferView(b, barAlloc, 0);
+      if (clusterSize > 1) {
+        Value readyBarAlloc =
+            createBarrierAlloc(newLoop, /*numBarriers=*/1, clusterSize);
+        readyBar = createSingleBufferView(b, readyBarAlloc, 0);
+      }
     }
 
     // Forward the phase from the before-region into the after-region and read
@@ -191,23 +244,32 @@ struct CLCMaterializePass
 
     // Materialize the issue: barrier_expect + clc_try_cancel.
     OpBuilder ib(issue);
-    if (emptyBar) {
-      // The first wait passes immediately because an initialized mbarrier has
-      // phase 0. Later waits block until every CTA has consumed the previous
-      // multicast response and arrived on the lead CTA's empty barrier.
+    Value pred = arith::ConstantIntOp::create(ib, issue.getLoc(), /*value=*/1,
+                                              /*width=*/1);
+    BarrierExpectOp::create(ib, issue.getLoc(), bar, kClcResponseBytes, pred);
+    if (readyBar) {
+      // Every peer completion barrier must be armed before rank zero issues
+      // the multicast request. Under warp specialization, every thread in the
+      // owner partition contributes one arrival.
+      FenceAsyncSharedOp::create(ib, issue.getLoc(), /*bCluster=*/false);
       Value rank =
           mlir::triton::nvgpu::ClusterCTAIdOp::create(ib, issue.getLoc(), i32);
       Value zero = arith::ConstantIntOp::create(ib, issue.getLoc(), 0, 32);
       Value isLeader = arith::CmpIOp::create(
           ib, issue.getLoc(), arith::CmpIPredicate::eq, rank, zero);
-      Value one = arith::ConstantIntOp::create(ib, issue.getLoc(), 1, 32);
-      Value emptyPhase =
-          arith::XOrIOp::create(ib, issue.getLoc(), phaseAfter, one);
-      WaitBarrierOp::create(ib, issue.getLoc(), emptyBar, emptyPhase, isLeader);
+      auto readyBarTy = cast<ttg::MemDescType>(readyBar.getType());
+      auto remoteBarTy = ttg::MemDescType::get(
+          readyBarTy.getShape(), readyBarTy.getElementType(),
+          readyBarTy.getEncoding(),
+          SharedClusterMemorySpaceAttr::get(ib.getContext()),
+          readyBarTy.getMutableMemory(), readyBarTy.getAllocShape());
+      Value remoteReadyBar = MapToRemoteBufferOp::create(
+          ib, issue.getLoc(), remoteBarTy, readyBar, zero);
+      ArriveBarrierOp::create(ib, issue.getLoc(), remoteReadyBar,
+                              /*count=*/1,
+                              /*perThread=*/readyArrivePerThread);
+      WaitBarrierOp::create(ib, issue.getLoc(), readyBar, phaseAfter, isLeader);
     }
-    Value pred = arith::ConstantIntOp::create(ib, issue.getLoc(), /*value=*/1,
-                                              /*width=*/1);
-    BarrierExpectOp::create(ib, issue.getLoc(), bar, kClcResponseBytes, pred);
     CLCTryCancelOp::create(ib, issue.getLoc(), resp, bar);
 
     // Materialize the read: wait_barrier + clc_load_result + decode.
@@ -218,25 +280,6 @@ struct CLCMaterializePass
     Value x = CLCGetProgramIdOp::create(rb, loc, clcResult, 0);
     Value y = CLCGetProgramIdOp::create(rb, loc, clcResult, 1);
     Value z = CLCGetProgramIdOp::create(rb, loc, clcResult, 2);
-    if (emptyBar) {
-      // Remote mbarrier waits are illegal, so all CTAs arrive on rank zero's
-      // empty barrier and only rank zero waits on its local view above. Skip
-      // the final arrival when cancellation failed because the loop exits and
-      // the response storage will not be reused.
-      // TODO: Represent this response-buffer release with an explicit op that
-      // links resp and emptyBar, then let ProxyFenceInsertion place the fence.
-      FenceAsyncSharedOp::create(rb, loc, /*bCluster=*/false);
-      Value zero = arith::ConstantIntOp::create(rb, loc, 0, 32);
-      auto emptyBarTy = cast<ttg::MemDescType>(emptyBar.getType());
-      auto remoteBarTy = ttg::MemDescType::get(
-          emptyBarTy.getShape(), emptyBarTy.getElementType(),
-          emptyBarTy.getEncoding(),
-          SharedClusterMemorySpaceAttr::get(rb.getContext()),
-          emptyBarTy.getMutableMemory(), emptyBarTy.getAllocShape());
-      Value remoteEmptyBar =
-          MapToRemoteBufferOp::create(rb, loc, remoteBarTy, emptyBar, zero);
-      ArriveBarrierOp::create(rb, loc, remoteEmptyBar, /*count=*/1, isValid);
-    }
     read->replaceAllUsesWith(ValueRange{isValid, x, y, z});
     read->erase();
     issue->erase();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TMemBarrierInsertion.cpp
   TensorMemoryAllocation.cpp
   TMALowering.cpp
+  TMAMulticast.cpp
   TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -3,14 +3,18 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "third_party/nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+#include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -36,14 +40,17 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
       sharedMemorySpace, /*mutableMemory=*/true);
   auto alloc =
       gpu::LocalAllocOp::create(rewriter, loc, memDescType).getResult();
+  bool multicast = op->hasAttr(::mlir::triton::kMulticastAxesAttrName);
   auto numCTAs = gpu::lookupNumCTAs(op);
   auto barrierCGALayout =
       gpu::CGAEncodingAttr::get1DLayout(tensorType.getContext(), numCTAs);
+  auto numBarrierSlots = product(barrierCGALayout.getCTASplitNum());
   auto barrierEncoding = gpu::SwizzledSharedEncodingAttr::get(
       tensorType.getContext(), 1, 1, 1, {0}, barrierCGALayout);
   gpu::MemDescType barrierMemDescType =
-      gpu::MemDescType::get({numCTAs}, rewriter.getI64Type(), barrierEncoding,
-                            sharedMemorySpace, /*mutableMemory=*/true);
+      gpu::MemDescType::get({numBarrierSlots}, rewriter.getI64Type(),
+                            barrierEncoding, sharedMemorySpace,
+                            /*mutableMemory=*/true);
   Value barrierAlloc =
       gpu::LocalAllocOp::create(rewriter, loc, barrierMemDescType);
   InitBarrierOp::create(rewriter, loc, barrierAlloc, 1);
@@ -56,6 +63,8 @@ lowerTMALoad(Operation *op, RankedTensorType tensorType, Value desc,
   createLoad(desc, barrierAlloc, alloc, pred);
   Value phase = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
   WaitBarrierOp::create(rewriter, loc, barrierAlloc, phase);
+  if (multicast)
+    ClusterBarrierOp::create(rewriter, loc);
   InvalBarrierOp::create(rewriter, loc, barrierAlloc);
   replaceUsesWithLocalLoad(rewriter, op->getResult(0), alloc);
   op->erase();
@@ -69,11 +78,74 @@ public:
                                 PatternRewriter &rewriter) const override {
     auto createLoad = [&](Value desc, Value barrierAlloc, Value alloc,
                           Value pred) {
-      triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
+      if (op->hasAttr(::mlir::triton::kMulticastAxesAttrName))
+        triton::nvidia_gpu::ClusterBarrierOp::create(rewriter, op.getLoc());
+      auto copy = triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
           rewriter, op.getLoc(), desc, op.getIndices(), barrierAlloc, alloc,
           pred);
+      if (Attribute axes =
+              op->getAttr(::mlir::triton::kMulticastAxesAttrName))
+        copy->setAttr(::mlir::triton::kMulticastAxesAttrName, axes);
     };
     lowerTMALoad(op, op.getType(), op.getDesc(), createLoad, rewriter);
+    return success();
+  }
+};
+
+class MaterializeTMAMulticastTargets
+    : public OpRewritePattern<AsyncTMACopyGlobalToLocalOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(AsyncTMACopyGlobalToLocalOp op,
+                                PatternRewriter &rewriter) const override {
+    auto axesAttr = op->getAttrOfType<DenseI32ArrayAttr>(
+        ::mlir::triton::kMulticastAxesAttrName);
+    if (!axesAttr || op.getMulticastTargets())
+      return failure();
+
+    llvm::SmallBitVector axes(3);
+    for (int32_t axis : axesAttr.asArrayRef()) {
+      if (axis < 0 || axis >= 3)
+        return op.emitOpError("tt.multicast_axes values must be in [0, 2]");
+      axes.set(axis);
+    }
+    if (axes.none())
+      return op.emitOpError("tt.multicast_axes must not be empty");
+
+    auto geometry =
+        TMAClusterGeometry::get(op->getParentOfType<ModuleOp>());
+    if (failed(geometry))
+      return op.emitOpError(
+          "tt.multicast_axes requires exact physical cluster geometry");
+
+    Location loc = op.getLoc();
+    Type i32 = rewriter.getI32Type();
+    Value rank = triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc, i32);
+    Value mask = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+    Value leaderRank = arith::ConstantIntOp::create(rewriter, loc, 0, 32);
+    for (unsigned candidate = 0; candidate < geometry->size(); ++candidate) {
+      Value candidateRank =
+          arith::ConstantIntOp::create(rewriter, loc, candidate, 32);
+      Value isCandidate = arith::CmpIOp::create(
+          rewriter, loc, arith::CmpIPredicate::eq, rank, candidateRank);
+      Value candidateMask = arith::ConstantIntOp::create(
+          rewriter, loc, geometry->maskFor(candidate, axes), 32);
+      Value candidateLeader = arith::ConstantIntOp::create(
+          rewriter, loc, geometry->leaderFor(candidate, axes), 32);
+      mask = arith::SelectOp::create(rewriter, loc, isCandidate, candidateMask,
+                                     mask);
+      leaderRank = arith::SelectOp::create(
+          rewriter, loc, isCandidate, candidateLeader, leaderRank);
+    }
+
+    Value isLeader = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::eq, rank, leaderRank);
+    Value pred = arith::AndIOp::create(rewriter, loc, op.getPred(), isLeader);
+    rewriter.modifyOpInPlace(op, [&] {
+      op.getMulticastTargetsMutable().assign(mask);
+      op.getPredMutable().assign(pred);
+    });
     return success();
   }
 };
@@ -229,9 +301,9 @@ public:
     ModuleOp m = getOperation();
 
     mlir::RewritePatternSet patterns(context);
-    patterns.add<TMALoadLowering, TMAGatherLowering, TMAStoreLowering,
-                 TMAScatterLowering, TMAReduceLowering, TMACreateDescLowering>(
-        context);
+    patterns.add<TMALoadLowering, MaterializeTMAMulticastTargets,
+                 TMAGatherLowering, TMAStoreLowering, TMAScatterLowering,
+                 TMAReduceLowering, TMACreateDescLowering>(context);
     if (applyPatternsGreedily(m, std::move(patterns)).failed())
       signalPassFailure();
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.cpp
@@ -1,0 +1,316 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace mlir;
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+namespace {
+
+bool isPolicyEnabled(tt::DescriptorLoadOp load) {
+  return load.getMulticast();
+}
+
+class ProgramIdDependencyAnalysis {
+public:
+  explicit ProgramIdDependencyAnalysis(ArrayRef<int> clusterDims)
+      : clusterDims(clusterDims) {}
+
+  FailureOr<llvm::SmallBitVector> get(Value value) {
+    if (auto it = cache.find(value); it != cache.end())
+      return it->second;
+    bool isRoot = active.empty();
+    if (isRoot)
+      backEdgeEpoch = 0;
+    unsigned epochAtEntry = backEdgeEpoch;
+    // A loop-carried back-edge contributes no new dependency to this monotone
+    // union. Do not cache intermediate values while the cycle is open: their
+    // result does not yet include the loop argument's initial dependencies.
+    if (!active.insert(value).second) {
+      ++backEdgeEpoch;
+      return llvm::SmallBitVector(3);
+    }
+
+    FailureOr<llvm::SmallBitVector> result = analyze(value);
+    active.erase(value);
+    if (succeeded(result) && (isRoot || epochAtEntry == backEdgeEpoch))
+      cache.try_emplace(value, *result);
+    return result;
+  }
+
+private:
+  FailureOr<llvm::SmallBitVector> analyze(Value value) {
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      Operation *parent = arg.getOwner()->getParentOp();
+      if (isa<tt::FuncOp>(parent))
+        return llvm::SmallBitVector(3);
+      if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+        if (arg == forOp.getInductionVar()) {
+          auto lowerDeps = get(forOp.getLowerBound());
+          auto stepDeps = get(forOp.getStep());
+          if (failed(lowerDeps) || failed(stepDeps))
+            return failure();
+          *lowerDeps |= *stepDeps;
+          return *lowerDeps;
+        }
+        unsigned index = arg.getArgNumber() - 1;
+        return mergeLoopValues(
+            forOp.getInitArgs()[index],
+            forOp.getBody()->getTerminator()->getOperand(index));
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+        unsigned index = arg.getArgNumber();
+        if (arg.getOwner() == whileOp.getBeforeBody())
+          return mergeLoopValues(
+              whileOp.getInits()[index],
+              whileOp.getAfterBody()->getTerminator()->getOperand(index));
+        return get(
+            whileOp.getBeforeBody()->getTerminator()->getOperand(index + 1));
+      }
+      return failure();
+    }
+
+    Operation *op = value.getDefiningOp();
+    if (!op)
+      return failure();
+    if (auto pid = dyn_cast<tt::GetProgramIdOp>(op)) {
+      llvm::SmallBitVector deps(3);
+      deps.set(static_cast<unsigned>(pid.getAxis()));
+      return deps;
+    }
+    if (isa<ttng::CLCAdvanceOp, ttng::CLCReadOp>(op)) {
+      unsigned resultNumber = cast<OpResult>(value).getResultNumber();
+      llvm::SmallBitVector deps(3);
+      // A clustered CLC claim has one group-uniform validity bit followed by
+      // per-CTA X/Y/Z coordinates reconstructed from the claimed cluster base.
+      if (resultNumber != 0)
+        deps.set(resultNumber - 1);
+      return deps;
+    }
+    if (isa<arith::ConstantOp, tt::GetNumProgramsOp>(op))
+      return llvm::SmallBitVector(3);
+
+    auto analyzeClusterQuotient = [&](Value lhs, Value rhs)
+        -> FailureOr<llvm::SmallBitVector> {
+      auto pid = lhs.getDefiningOp<tt::GetProgramIdOp>();
+      auto constant = rhs.getDefiningOp<arith::ConstantOp>();
+      auto divisor = constant
+                         ? dyn_cast<IntegerAttr>(constant.getValue())
+                         : IntegerAttr();
+      if (!pid || !divisor)
+        return failure();
+      unsigned axis = static_cast<unsigned>(pid.getAxis());
+      if (divisor.getInt() != clusterDims[axis])
+        return failure();
+      // Physical clusters are aligned to their shape, so dividing a physical
+      // program coordinate by the exact cluster dimension yields the same
+      // cluster coordinate for every CTA in that cluster.
+      return llvm::SmallBitVector(3);
+    };
+    if (auto div = dyn_cast<arith::DivSIOp>(op)) {
+      auto deps = analyzeClusterQuotient(div.getLhs(), div.getRhs());
+      if (succeeded(deps))
+        return deps;
+    }
+    if (auto div = dyn_cast<arith::DivUIOp>(op)) {
+      auto deps = analyzeClusterQuotient(div.getLhs(), div.getRhs());
+      if (succeeded(deps))
+        return deps;
+    }
+
+    // TODO: Model CLC and mutable-memory dependencies using the latest
+    // schedule instead of rejecting them conservatively.
+    if (isa<ttng::CLCTryCancelOp, ttng::CLCLoadResultOp,
+            ttng::CLCIsCanceledOp, ttng::CLCGetProgramIdOp,
+            ttng::CLCTryCancelAsyncOp, ttng::CLCQueryCancelOp,
+            tt::AtomicRMWOp, tt::AtomicCASOp, tt::LoadOp>(op))
+      return failure();
+    if (!isa<arith::ArithDialect>(op->getDialect()) &&
+        !isa<tt::SplatOp, tt::BroadcastOp, tt::ExpandDimsOp,
+             tt::MakeTensorDescOp, ttng::ReinterpretTensorDescOp>(op))
+      return failure();
+    if (!isMemoryEffectFree(op))
+      return failure();
+
+    llvm::SmallBitVector deps(3);
+    for (Value operand : op->getOperands()) {
+      auto operandDeps = get(operand);
+      if (failed(operandDeps))
+        return failure();
+      deps |= *operandDeps;
+    }
+    return deps;
+  }
+
+  FailureOr<llvm::SmallBitVector> mergeLoopValues(Value init, Value next) {
+    auto initDeps = get(init);
+    auto nextDeps = get(next);
+    if (failed(initDeps) || failed(nextDeps))
+      return failure();
+    *initDeps |= *nextDeps;
+    return *initDeps;
+  }
+
+  DenseMap<Value, llvm::SmallBitVector> cache;
+  llvm::SmallPtrSet<Value, 16> active;
+  llvm::SmallVector<int, 3> clusterDims;
+  unsigned backEdgeEpoch = 0;
+};
+
+} // namespace
+
+namespace mlir::triton::nvidia_gpu {
+
+FailureOr<TMAClusterGeometry> TMAClusterGeometry::get(ModuleOp module) {
+  TMAClusterGeometry geometry{ttg::TritonGPUDialect::getClusterDims(module)};
+  if (geometry.dims.size() != 3 ||
+      llvm::any_of(geometry.dims, [](int dim) { return dim <= 0; }) ||
+      llvm::any_of(geometry.dims,
+                   [](int dim) { return !llvm::isPowerOf2_32(dim); }) ||
+      geometry.size() <= 1 || geometry.size() > 16)
+    return failure();
+  return geometry;
+}
+
+unsigned TMAClusterGeometry::size() const {
+  return static_cast<unsigned>(dims[0] * dims[1] * dims[2]);
+}
+
+llvm::SmallVector<int, 3> TMAClusterGeometry::coordinates(unsigned rank) const {
+  llvm::SmallVector<int, 3> coord(3);
+  coord[0] = rank % dims[0];
+  rank /= dims[0];
+  coord[1] = rank % dims[1];
+  coord[2] = rank / dims[1];
+  return coord;
+}
+
+uint16_t
+TMAClusterGeometry::maskFor(unsigned rank,
+                            const llvm::SmallBitVector &broadcastAxes) const {
+  auto source = coordinates(rank);
+  uint16_t mask = 0;
+  for (unsigned candidate = 0; candidate < size(); ++candidate) {
+    auto target = coordinates(candidate);
+    bool sameGroup = true;
+    for (unsigned axis = 0; axis < 3; ++axis)
+      if (!broadcastAxes.test(axis) && source[axis] != target[axis])
+        sameGroup = false;
+    if (sameGroup)
+      mask |= uint16_t(1u << candidate);
+  }
+  return mask;
+}
+
+unsigned
+TMAClusterGeometry::leaderFor(unsigned rank,
+                              const llvm::SmallBitVector &broadcastAxes) const {
+  uint16_t mask = maskFor(rank, broadcastAxes);
+  return llvm::countr_zero(static_cast<unsigned>(mask));
+}
+
+FailureOr<TMAMulticastPlan> analyzeTMAMulticast(tt::DescriptorLoadOp load) {
+  if (!isPolicyEnabled(load))
+    return failure();
+  auto module = load->getParentOfType<ModuleOp>();
+  auto func = load->getParentOfType<tt::FuncOp>();
+  if (!func || !tt::isKernel(func) || !func.getBody().hasOneBlock())
+    return failure();
+  auto geometry = TMAClusterGeometry::get(module);
+  if (failed(geometry))
+    return failure();
+
+  ProgramIdDependencyAnalysis analysis(geometry->dims);
+  llvm::SmallBitVector varyingAxes(3);
+  for (Value index : load.getIndices()) {
+    auto deps = analysis.get(index);
+    if (failed(deps))
+      return failure();
+    varyingAxes |= *deps;
+  }
+
+  // Pid-invariant indices are not sufficient: a descriptor whose base / shape /
+  // strides derive from program_id (e.g. `base + pid * stride`) can be loaded at
+  // identical indices across CTAs yet address different tiles, so multicasting
+  // the leader's tile would corrupt the others. Fold the descriptor operand's
+  // pid-dependence into varyingAxes as well; a computed descriptor whose
+  // invariance the analysis cannot prove fails here and the load is rejected
+  // (no multicast) rather than being assumed broadcastable.
+  auto descDeps = analysis.get(load.getDesc());
+  if (failed(descDeps))
+    return failure();
+  varyingAxes |= *descDeps;
+
+  llvm::SmallBitVector broadcastAxes(3);
+  llvm::SmallBitVector synchronizationAxes(3);
+  for (unsigned axis = 0; axis < 3; ++axis)
+    if (geometry->dims[axis] > 1) {
+      synchronizationAxes.set(axis);
+      if (!varyingAxes.test(axis))
+        broadcastAxes.set(axis);
+    }
+
+  for (Operation *parent = load->getParentOp();
+       parent && !isa<tt::FuncOp>(parent); parent = parent->getParentOp()) {
+    SmallVector<Value> controls;
+    if (auto ifOp = dyn_cast<scf::IfOp>(parent))
+      controls.push_back(ifOp.getCondition());
+    else if (auto forOp = dyn_cast<scf::ForOp>(parent))
+      controls.append(
+          {forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep()});
+    else if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+      auto condition =
+          cast<scf::ConditionOp>(whileOp.getBeforeBody()->getTerminator());
+      controls.push_back(condition.getCondition());
+    } else if (parent->getNumRegions() != 0)
+      return failure();
+    for (Value control : controls) {
+      auto deps = analysis.get(control);
+      // Lowering brackets multicast with full-cluster barriers, including axes
+      // outside a data recipient subgroup.
+      if (failed(deps) || deps->anyCommon(synchronizationAxes))
+        return failure();
+    }
+  }
+
+  if (broadcastAxes.none())
+    return failure();
+  return TMAMulticastPlan{*geometry, broadcastAxes};
+}
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUTMAMULTICASTPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+class TritonNvidiaGPUTMAMulticastPass
+    : public impl::TritonNvidiaGPUTMAMulticastPassBase<
+          TritonNvidiaGPUTMAMulticastPass> {
+  void runOnOperation() override {
+    getOperation().walk([](tt::DescriptorLoadOp load) {
+      load->removeAttr(tt::kMulticastAxesAttrName);
+      if (!load.getMulticast())
+        return;
+      auto plan = analyzeTMAMulticast(load);
+      if (failed(plan))
+        return;
+      SmallVector<int32_t> axes;
+      for (int axis : plan->broadcastAxes.set_bits())
+        axes.push_back(axis);
+      load->setAttr(tt::kMulticastAxesAttrName,
+                    DenseI32ArrayAttr::get(load.getContext(), axes));
+    });
+  }
+};
+
+} // namespace mlir::triton::nvidia_gpu

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1747,10 +1747,8 @@ void init_triton_ir(py::module &&m) {
              auto descTy = cast<triton::TensorDescType>(desc.getType());
              auto resTy = descTy.getSignlessBlockType();
              auto op = self.create<DescriptorLoadOp>(
-                 resTy, desc, indices, cacheModifier, evictionPolicy);
-             if (multicast)
-               op->setAttr("tt.multicast",
-                           self.getBuilder().getBoolAttr(*multicast));
+                 resTy, desc, indices, cacheModifier, evictionPolicy,
+                 multicast.value_or(false));
              return op;
            })
       .def("create_descriptor_gather",

--- a/python/test/unit/cuda/test_no_compile_launcher.py
+++ b/python/test/unit/cuda/test_no_compile_launcher.py
@@ -7,6 +7,8 @@ produce identical results to the default C-compiled launcher. Tests cover:
 3. Device-side TMA tensor descriptors (tensordesc_meta entries are dicts)
 """
 
+import re
+
 import pytest
 import torch
 
@@ -15,8 +17,10 @@ import triton.language as tl
 from triton import knobs
 from triton._internal_testing import (
     is_cuda,
+    is_hopper_or_newer,
     requires_tma,
 )
+from triton.backends.nvidia.ctypes_launcher import _validate_exact_cluster_grid
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 
@@ -63,6 +67,61 @@ def test_no_compile_launcher_add(device, fresh_triton_cache):
 
     torch.testing.assert_close(out_ctypes, expected)
     torch.testing.assert_close(out_ctypes, out_c)
+
+
+@triton.jit
+def _pid_write(out_ptr, GX: tl.constexpr, GY: tl.constexpr):
+    pid_x = tl.program_id(0)
+    pid_y = tl.program_id(1)
+    pid_z = tl.program_id(2)
+    offset = pid_x + GX * (pid_y + GY * pid_z)
+    tl.store(out_ptr + offset, offset)
+
+
+@pytest.mark.parametrize(
+    "num_ctas,cluster_dims",
+    [
+        (0, (1, 1, 1)),
+        (1, (2, 0, 2)),
+        (1, (2, -1, 2)),
+        (1, (2, 2)),
+    ],
+)
+def test_no_compile_launcher_rejects_invalid_cluster_metadata(num_ctas, cluster_dims):
+    with pytest.raises(ValueError, match="Invalid Triton cluster metadata"):
+        _validate_exact_cluster_grid((4, 2, 4), num_ctas, cluster_dims)
+
+
+def test_no_compile_launcher_multidim_cluster(device, fresh_triton_cache):
+    _skip_if_not_cuda()
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
+    grid = (4, 2, 4)
+    out = torch.full((grid[0] * grid[1] * grid[2], ), -1, device=device, dtype=torch.int32)
+    _pid_write.device_caches.clear()
+    with knobs.nvidia.scope():
+        knobs.nvidia.use_no_compile_launcher = True
+        _pid_write[grid](out, grid[0], grid[1], ctas_per_cga=(2, 2, 2))
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.arange(out.numel(), device=device, dtype=torch.int32))
+
+
+@pytest.mark.parametrize("grid", [(3, 2, 4), (4, 3, 4), (4, 2, 3)])
+def test_no_compile_launcher_rejects_incomplete_cluster(device, fresh_triton_cache, grid):
+    _skip_if_not_cuda()
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
+    out = torch.empty((grid[0] * grid[1] * grid[2], ), device=device, dtype=torch.int32)
+    _pid_write.device_caches.clear()
+    with knobs.nvidia.scope():
+        knobs.nvidia.use_no_compile_launcher = True
+        with pytest.raises(
+            ValueError,
+            match=rf"physical grid {re.escape(str(grid))}.*required cluster shape \(2, 2, 2\)",
+        ):
+            _pid_write[grid](out, grid[0], grid[1], ctas_per_cga=(2, 2, 2))
 
 
 # ---------------------------------------------------------------------------

--- a/python/test/unit/language/test_triton_clc.py
+++ b/python/test/unit/language/test_triton_clc.py
@@ -225,9 +225,19 @@ def test_clc_cluster_materializes_multicast_request():
     counts = torch.zeros(1024, device="cuda", dtype=torch.int32)
     steals = torch.zeros(1, device="cuda", dtype=torch.int32)
     delay = torch.zeros(1, device="cuda", dtype=torch.int32)
-    kernel = _clc_cluster_count_kernel[(1024, 1, 1)](counts, steals, delay, 1024, 1, ctas_per_cga=(2, 1, 1),
+    kernel = _clc_cluster_count_kernel[(512, 2, 1)](counts, steals, delay, 512, 2, ctas_per_cga=(2, 2, 1),
                                                      launch_cluster=True)
+    ttgir = kernel.asm["ttgir"]
     ptx = kernel.asm["ptx"]
+    expect_pos = ttgir.index("ttng.barrier_expect")
+    rendezvous_pos = ttgir.index("ttng.arrive_barrier", expect_pos)
+    ready_pos = ttgir.index("ttng.wait_barrier", rendezvous_pos)
+    request_pos = ttgir.index("ttng.clc_try_cancel", rendezvous_pos)
+    assert expect_pos < rendezvous_pos < ready_pos < request_pos
+    assert "perThread" not in ttgir[rendezvous_pos:ready_pos]
     assert "multicast::cluster::all" in ptx
     assert "mapa.shared::cluster" in ptx
     assert "mbarrier.arrive.shared::cluster" in ptx
+    assert counts.min().item() == 1, "some CTA in a canceled cluster was never claimed"
+    assert counts.max().item() == 1, "some CTA in a canceled cluster was claimed more than once"
+    assert steals.item() > 0, "the test did not exercise a successful cluster cancellation"

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -165,6 +165,64 @@ def matmul_kernel_tma_persistent_ws(
 
 
 # ============================================================================
+# Kernel 2a: persistent TMA matmul with a guarded epilogue
+# Programs are arranged into 2-D tile groups. The same program shape can run as
+# independent CTAs or as CUDA clusters that multicast the A and B TMA loads.
+# ============================================================================
+@triton.jit
+def matmul_kernel_tma_persistent_guarded_epilogue_ws(
+    a_desc,
+    b_desc,
+    c_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    CTA_GROUP_M: tl.constexpr,
+    CTA_GROUP_N: tl.constexpr,
+):
+    dtype = tl.float16
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+
+    program_m = tl.program_id(0)
+    program_n = tl.program_id(1)
+    group_m = program_m // CTA_GROUP_M
+    group_n = program_n // CTA_GROUP_N
+    local_m = program_m % CTA_GROUP_M
+    local_n = program_n % CTA_GROUP_N
+
+    num_group_m = tl.cdiv(num_pid_m, CTA_GROUP_M)
+    num_group_n = tl.cdiv(num_pid_n, CTA_GROUP_N)
+    group_id = group_m * num_group_n + group_n
+    num_groups = num_group_m * num_group_n
+    group_stride = (tl.num_programs(0) // CTA_GROUP_M) * (tl.num_programs(1) // CTA_GROUP_N)
+
+    for tile_group_id in tl.range(group_id, num_groups, group_stride, warp_specialize=True):
+        tile_group_m = tile_group_id // num_group_n
+        tile_group_n = tile_group_id % num_group_n
+        pid_m = tile_group_m * CTA_GROUP_M + local_m
+        pid_n = tile_group_n * CTA_GROUP_N + local_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        # Padded programs must remain on the collective path; only externally
+        # visible output is predicated on the logical tile being in bounds.
+        if (pid_m < num_pid_m) & (pid_n < num_pid_n):
+            c_desc.store([offs_am, offs_bn], accumulator.to(dtype))
+
+
+# ============================================================================
 # Kernel 2b: matmul_kernel_tma_static_persistent_ws_while
 # Static persistent TMA matmul whose persistent outer loop is a while loop.
 # Work assignment is still static: each CTA processes tile_id += NUM_SMS.
@@ -919,6 +977,83 @@ def test_tutorial09_matmul_tma_persistent_warp_specialize(
         # Verify correctness
         ref_out = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(dtype)
         torch.testing.assert_close(ref_out, C, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Test 2a: Padded persistent groups keep their guarded epilogue with and without
+# being bound into a physical CUDA cluster.
+# ============================================================================
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+@pytest.mark.parametrize("clustered", [False, True], ids=["independent-ctas", "2x2-cluster"])
+def test_tutorial09_matmul_tma_persistent_guarded_epilogue_warp_specialize(clustered):
+    block_m = 128
+    block_n = 128
+    block_k = 64
+    cta_group_m = 2
+    cta_group_n = 2
+    M = 5 * block_m
+    N = 3 * block_n
+    K = 256
+    dtype = torch.float16
+    device = "cuda"
+
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=dtype, device=device)
+    b = torch.randn((N, K), dtype=dtype, device=device)
+    c = torch.empty((M, N), dtype=dtype, device=device)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), [block_m, block_k])
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), [block_n, block_k])
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), [block_m, block_n])
+
+    num_group_m = triton.cdiv(triton.cdiv(M, block_m), cta_group_m)
+    num_group_n = triton.cdiv(triton.cdiv(N, block_n), cta_group_n)
+    launched_group_m = min(num_group_m, 2)
+    grid = (launched_group_m * cta_group_m, num_group_n * cta_group_n)
+    launch_options = {"num_stages": 3, "num_warps": 4, "multicast": clustered}
+    if clustered:
+        launch_options["ctas_per_cga"] = (cta_group_m, cta_group_n, 1)
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        kernel = matmul_kernel_tma_persistent_guarded_epilogue_ws[grid](
+            a_desc,
+            b_desc,
+            c_desc,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=block_m,
+            BLOCK_SIZE_N=block_n,
+            BLOCK_SIZE_K=block_k,
+            CTA_GROUP_M=cta_group_m,
+            CTA_GROUP_N=cta_group_n,
+            **launch_options,
+        )
+
+    ttir = kernel.asm["ttir"]
+    ttir_dot_pos = ttir.index("tt.dot")
+    ttir_guard_pos = ttir.index("scf.if", ttir_dot_pos)
+    ttir_store_pos = ttir.index("tt.descriptor_store", ttir_guard_pos)
+    assert ttir_dot_pos < ttir_guard_pos < ttir_store_pos
+
+    ttgir = kernel.asm["ttgir"]
+    store_pos = ttgir.index("ttng.async_tma_copy_local_to_global")
+    epilogue_guard_pos = ttgir.rindex("scf.if", 0, store_pos)
+    tmem_load_pos = ttgir.index("ttng.tmem_load", epilogue_guard_pos, store_pos)
+    completion_wait_pos = ttgir.rindex("ttng.wait_barrier", 0, epilogue_guard_pos)
+    completion_arrive_pos = ttgir.index("ttng.arrive_barrier", store_pos)
+    assert completion_wait_pos < epilogue_guard_pos < tmem_load_pos < store_pos < completion_arrive_pos
+    assert ("multicast::cluster" in kernel.asm["ptx"]) == clustered
+
+    torch.cuda.synchronize()
+    ref = torch.matmul(a.to(torch.float32), b.T.to(torch.float32)).to(dtype)
+    torch.testing.assert_close(c, ref, atol=0.03, rtol=0.03)
 
 
 # ============================================================================

--- a/python/test/unit/language/test_tutorial09_warp_specialization.py
+++ b/python/test/unit/language/test_tutorial09_warp_specialization.py
@@ -223,6 +223,64 @@ def matmul_kernel_tma_persistent_guarded_epilogue_ws(
 
 
 # ============================================================================
+# Kernel 2a-surviving: guarded clustered matmul with a persistent while loop.
+# ============================================================================
+@triton.jit
+def matmul_kernel_tma_persistent_guarded_epilogue_surviving_while_ws(
+    a_desc,
+    b_desc,
+    c_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    CTA_GROUP_M: tl.constexpr,
+    CTA_GROUP_N: tl.constexpr,
+):
+    dtype = tl.float16
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+
+    program_m = tl.program_id(0)
+    program_n = tl.program_id(1)
+    group_m = program_m // CTA_GROUP_M
+    group_n = program_n // CTA_GROUP_N
+    local_m = program_m % CTA_GROUP_M
+    local_n = program_n % CTA_GROUP_N
+
+    num_group_m = tl.cdiv(num_pid_m, CTA_GROUP_M)
+    num_group_n = tl.cdiv(num_pid_n, CTA_GROUP_N)
+    tile_group_id = group_m * num_group_n + group_n
+    num_groups = num_group_m * num_group_n
+    group_stride = (tl.num_programs(0) // CTA_GROUP_M) * (tl.num_programs(1) // CTA_GROUP_N)
+    valid = tile_group_id < num_groups
+
+    while tl.condition(valid, warp_specialize=True):
+        tile_group_m = tile_group_id // num_group_n
+        tile_group_n = tile_group_id % num_group_n
+        pid_m = tile_group_m * CTA_GROUP_M + local_m
+        pid_n = tile_group_n * CTA_GROUP_N + local_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+
+        if (pid_m < num_pid_m) & (pid_n < num_pid_n):
+            c_desc.store([offs_am, offs_bn], accumulator.to(dtype))
+
+        tile_group_id += group_stride
+        valid = tile_group_id < num_groups
+
+
+# ============================================================================
 # Kernel 2b: matmul_kernel_tma_static_persistent_ws_while
 # Static persistent TMA matmul whose persistent outer loop is a while loop.
 # Work assignment is still static: each CTA processes tile_id += NUM_SMS.
@@ -1050,6 +1108,74 @@ def test_tutorial09_matmul_tma_persistent_guarded_epilogue_warp_specialize(clust
     completion_arrive_pos = ttgir.index("ttng.arrive_barrier", store_pos)
     assert completion_wait_pos < epilogue_guard_pos < tmem_load_pos < store_pos < completion_arrive_pos
     assert ("multicast::cluster" in kernel.asm["ptx"]) == clustered
+
+    torch.cuda.synchronize()
+    ref = torch.matmul(a.to(torch.float32), b.T.to(torch.float32)).to(dtype)
+    torch.testing.assert_close(c, ref, atol=0.03, rtol=0.03)
+
+
+# ============================================================================
+# Test 2a-surviving: clustered multicast with a persistent while loop.
+# ============================================================================
+@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
+def test_tutorial09_matmul_tma_persistent_guarded_epilogue_surviving_while_autows():
+    block_m = 128
+    block_n = 128
+    block_k = 64
+    cta_group_m = 2
+    cta_group_n = 2
+    M = 5 * block_m
+    N = 3 * block_n
+    K = 256
+    dtype = torch.float16
+    device = "cuda"
+
+    torch.manual_seed(42)
+    a = torch.randn((M, K), dtype=dtype, device=device)
+    b = torch.randn((N, K), dtype=dtype, device=device)
+    c = torch.empty((M, N), dtype=dtype, device=device)
+
+    def alloc_fn(size, align, stream):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), [block_m, block_k])
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), [block_n, block_k])
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), [block_m, block_n])
+
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        kernel = matmul_kernel_tma_persistent_guarded_epilogue_surviving_while_ws[(cta_group_m, cta_group_n)](
+            a_desc,
+            b_desc,
+            c_desc,
+            M,
+            N,
+            K,
+            BLOCK_SIZE_M=block_m,
+            BLOCK_SIZE_N=block_n,
+            BLOCK_SIZE_K=block_k,
+            CTA_GROUP_M=cta_group_m,
+            CTA_GROUP_N=cta_group_n,
+            num_stages=3,
+            num_warps=4,
+            ctas_per_cga=(cta_group_m, cta_group_n, 1),
+            multicast=True,
+        )
+
+    ttir = kernel.asm["ttir"]
+    ttir_dot_pos = ttir.index("tt.dot")
+    ttir_guard_pos = ttir.index("scf.if", ttir_dot_pos)
+    assert "scf.while" in ttir
+    assert ttir_dot_pos < ttir_guard_pos
+
+    ttgir = kernel.asm["ttgir"]
+    assert "scf.while" in ttgir
+    assert "ttg.warp_specialize" in ttgir
+    assert "ttng.tc_gen5_mma" in ttgir or "ttng.warp_group_dot" in ttgir
+    assert "ttng.async_tma_copy_global_to_local" in ttgir
+    assert "multicast::cluster" in kernel.asm["ptx"]
 
     torch.cuda.synchronize()
     ref = torch.matmul(a.to(torch.float32), b.T.to(torch.float32)).to(dtype)

--- a/python/test/unit/runtime/test_dispatcher_core.py
+++ b/python/test/unit/runtime/test_dispatcher_core.py
@@ -10,6 +10,7 @@ numerics and the converged path directly.
 
 import contextlib
 import os
+import re
 
 import pytest
 import torch
@@ -175,16 +176,35 @@ def test_dispatcher_core_multidim_cluster():
     CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION. A wrong/missing cluster dim would
     conflict with the PTX .reqnctapercluster baked into the cubin and fail the
     launch; every program writing its linear id proves all CTAs in the
-    (2,1,3) cluster ran."""
+    (2,2,2) cluster ran."""
     from triton._internal_testing import is_hopper_or_newer
 
     if not is_hopper_or_newer():
         pytest.skip("clusters need Hopper or newer")
 
-    GX, GY, GZ = 4, 2, 3  # each divisible by the (2,1,3) cluster dims
+    GX, GY, GZ = 4, 2, 4
     out = torch.full((GX * GY * GZ, ), -1, device="cuda", dtype=torch.int32)
     with force_dispatcher():
-        _disp_pid_write[(GX, GY, GZ)](out, GX, GY, ctas_per_cga=(2, 1, 3))
+        _disp_pid_write[(GX, GY, GZ)](out, GX, GY, ctas_per_cga=(2, 2, 2))
     torch.cuda.synchronize()
     expected = torch.arange(GX * GY * GZ, device="cuda", dtype=torch.int32)
     torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("grid", [(3, 2, 4), (4, 3, 4), (4, 2, 3)])
+def test_dispatcher_rejects_incomplete_exact_cluster(grid):
+    from triton._internal_testing import is_hopper_or_newer
+
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
+    GX, GY, GZ = grid
+    out = torch.full((GX * GY * GZ, ), -1, device="cuda", dtype=torch.int32)
+    with force_dispatcher():
+        with pytest.raises(
+                ValueError,
+                match=(rf"physical grid {re.escape(str(grid))}.*required cluster shape "
+                       r"\(2, 2, 2\)"),
+        ):
+            _disp_pid_write[(GX, GY, GZ)](out, GX, GY, ctas_per_cga=(2, 2, 2))

--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -17,7 +17,7 @@ import torch
 import triton
 import triton.language as tl
 from triton import knobs
-from triton._internal_testing import is_cuda
+from triton._internal_testing import is_cuda, is_hopper_or_newer
 
 
 @contextlib.contextmanager
@@ -104,6 +104,21 @@ def test_launchkernel_path_empty_grid():
     torch.cuda.synchronize()
     # out must be untouched (kernel never ran)
     torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
+    assert counter["calls"] > 0, "launchKernel path was not exercised"
+
+
+@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
+def test_launchkernel_rejects_incomplete_exact_cluster():
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
+    with force_launch_kernel_path() as counter:
+        with pytest.raises(
+                ValueError,
+                match=(r"physical grid \(3, 1, 1\).*required cluster shape "
+                       r"\(2, 1, 1\)"),
+        ):
+            _nop_kernel[(3, )](ctas_per_cga=(2, 1, 1))
     assert counter["calls"] > 0, "launchKernel path was not exercised"
 
 

--- a/python/test/unit/runtime/test_launch_metadata.py
+++ b/python/test/unit/runtime/test_launch_metadata.py
@@ -17,7 +17,7 @@ from triton.backends.nvidia.driver import (
     expand_signature,
     make_kernel_signature,
 )
-from triton._internal_testing import is_cuda
+from triton._internal_testing import is_cuda, is_hopper_or_newer
 from triton.compiler.compiler import ASTSource, compile as triton_compile, make_backend
 from triton.knobs import HookChain
 
@@ -46,11 +46,11 @@ def kernel_with_constant(X, N, BLOCK: tl.constexpr):
     tl.store(X + offs, x + 1, mask=mask)
 
 
-def _compile_kernel(fn, signature, constexprs=None, attrs=None):
+def _compile_kernel(fn, signature, constexprs=None, attrs=None, options=None):
     """Helper to compile a kernel and return the CompiledKernel."""
     target = triton.runtime.driver.active.get_current_target()
     src = ASTSource(fn=fn, signature=signature, constexprs=constexprs, attrs=attrs)
-    return triton_compile(src, target=target)
+    return triton_compile(src, target=target, options=options)
 
 
 @pytest.mark.parametrize("dtype", ["*fp32"])
@@ -322,6 +322,9 @@ def test_launcher_src_emits_cluster_dims():
     shared core can build CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for the
     ctas_per_cga path (converged onto triton_launch_kernel, not a separate
     launcher)."""
+    if not is_hopper_or_newer():
+        pytest.skip("clusters need Hopper or newer")
+
     import os
     import tempfile
 
@@ -337,6 +340,7 @@ def test_launcher_src_emits_cluster_dims():
                 add_kernel,
                 signature={"X": "*fp32", "Y": "*fp32", "OUT": "*fp32", "N": "i32"},
                 constexprs={"BLOCK": 1024},
+                options={"ctas_per_cga": (2, 2, 2)},
             )
         finally:
             if prev_cache is None:
@@ -344,10 +348,25 @@ def test_launcher_src_emits_cluster_dims():
             else:
                 os.environ["TRITON_CACHE_DIR"] = prev_cache
     src = compiled.asm["launcher_src"]
-    assert ".cluster_dims = {" in src
-    # Sanity: still emits the 1-D num_ctas path inputs too (both are present;
-    # the core gives num_ctas priority over cluster_dims).
-    assert ".num_ctas = " in src
+    assert compiled.metadata.ctas_per_cga == (2, 2, 2)
+    assert compiled.launch_metadata_schema["cluster_dims"] == [2, 2, 2]
+    assert ".cluster_dims = {2, 2, 2}," in src
+    assert ".num_ctas = 1," in src
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"num_ctas": 0},
+        {"cluster_dims": (2, 0, 2)},
+        {"cluster_dims": (2, -1, 2)},
+        {"ctas_per_cga": (2, 2)},
+    ],
+)
+def test_cluster_options_reject_invalid_shapes(options):
+    target = triton.runtime.driver.active.get_current_target()
+    with pytest.raises(ValueError):
+        make_backend(target).parse_options(options)
 
 
 def test_launcher_src_has_abi_version_comment():

--- a/python/triton/language/schedule.py
+++ b/python/triton/language/schedule.py
@@ -157,6 +157,11 @@ class DynamicPersistent1DScheduler(_CountingTileScheduler):
     are distributed by demand rather than a fixed stride. The host allocates
     ``tile_counter`` (a 1-element int32 device tensor) initialized to the number of
     launched programs. ``is_valid`` is the count-based one from ``_CountingTileScheduler``.
+
+    TODO: Multi-CTA scheduling must claim one cluster-level work item and
+    expand it with the static cluster-local coordinate. Independent per-CTA
+    atomic claims cannot establish the shared tile identity required by TMA
+    multicast.
     """
     _x: tl.tensor
     _y: tl.tensor

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1113,6 +1113,8 @@ class TritonSemantic(Generic[TensorTy]):
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
         if multicast is not None and not isinstance(multicast, bool):
             raise TypeError(f"multicast must be a constexpr bool or None, got {multicast}")
+        if multicast is None:
+            multicast = getattr(self.builder.options, "multicast", False)
         x = self.builder.create_descriptor_load(
             desc.handle,
             offsets,

--- a/test/Conversion/nvgpu_invalid.mlir
+++ b/test/Conversion/nvgpu_invalid.mlir
@@ -1,11 +1,13 @@
 // RUN: triton-opt -split-input-file %s -verify-diagnostics
 
-// Meta Triton permits cluster synchronization inside warp-specialized regions. TLX
-// and automatic warp specialization rely on this behavior.
+// Meta Triton does not reject ttng.cluster_arrive, ttng.cluster_wait, or
+// ttng.cluster_barrier inside ttg.warp_specialize. AutoWS and TLX place them
+// there, and their conversions lower them with all-warps wrapping. A cluster
+// barrier must still execute in a multi-CTA cluster.
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   llvm.func @cluster_barrier_num_ctas_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
+    // expected-error @below {{requires a multi-CTA cluster}}
     ttng.cluster_barrier
     llvm.return
   }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -224,10 +224,47 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.num-ctas" = 2 : i32, "ttg
 
 // -----
 
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1], [2]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 2 : i32, "ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: arrive_barrier_multicast_2d
+  // CHECK: [[FALLBACK_PRED:%.*]] = llvm.and {{.*}}, %arg1
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // CHECK-NOT: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK-NOT: multicast::cluster::32b
+  // RUBIN-PTX87-LABEL: arrive_barrier_multicast_2d
+  // RUBIN-PTX87: [[FALLBACK_PRED:%.*]] = llvm.and {{.*}}, %arg1
+  // RUBIN-PTX87: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // RUBIN-PTX87: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // RUBIN-PTX87: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // RUBIN-PTX87: mbarrier.arrive.release.cluster.shared::cluster.b64 _, [${{.*}}], 3;{{.*}}[[FALLBACK_PRED]]
+  // RUBIN-PTX87-NOT: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // RUBIN-PTX87-NOT: multicast::cluster::32b
+  // RUBIN-LABEL: arrive_barrier_multicast_2d
+  // RUBIN: [[NATIVE_PRED:%.*]] = llvm.and {{.*}}, %arg1
+  // RUBIN: [[NATIVE_MASK_BASE:%.*]] = llvm.mlir.constant(15 : i32) : i32
+  // RUBIN: [[NATIVE_MASK:%.*]] = llvm.shl [[NATIVE_MASK_BASE]], %{{.*}} : i32
+  // RUBIN: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64 _, [$1], 3, $2;{{.*}}[[NATIVE_PRED]]{{.*}}[[NATIVE_MASK]]
+  // RUBIN-NOT: mbarrier.arrive.release.cluster.shared::cluster.multicast::cluster::32b.b64
+  // RUBIN-NOT: mbarrier.arrive.release.cluster.shared::cluster.b64
+  tt.func public @arrive_barrier_multicast_2d(%alloc: !ttg.memdesc<4xi64, #shared0, #smem, mutable>, %pred: i1) {
+    ttng.init_barrier %alloc, 4 : !ttg.memdesc<4xi64, #shared0, #smem, mutable>
+    ttng.arrive_barrier %alloc, 3, %pred {ctaMask = 3 : i32} : !ttg.memdesc<4xi64, #shared0, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: async_clc_try_cancel
+  // RUBIN-PTX87-LABEL: async_clc_try_cancel
+  // RUBIN-LABEL: async_clc_try_cancel
   // CHECK: clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
   tt.func @async_clc_try_cancel(%alloc: !ttg.memdesc<1xi64, #shared0, #smem, mutable>, %clc_response: !ttg.memdesc<1xui128, #shared0, #smem, mutable>) {
     ttng.async_clc_try_cancel %alloc, %clc_response : !ttg.memdesc<1xi64, #shared0, #smem, mutable>, !ttg.memdesc<1xui128, #shared0, #smem, mutable>
@@ -1090,6 +1127,34 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
       // CHECK: llvm.and %[[NEXT_COUNTER]]
       // CHECK: st.shared.b32
       // CHECK: nvvm.barrier
+      ttng.cluster_barrier
+      ttg.warp_yield
+    }
+    partition0() num_warps(4) {
+      ttg.warp_return
+    } : () -> ()
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 4 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.shared = 0 : i32,
+  "ttg.threads-per-warp" = 32 : i32
+} {
+  // CHECK-LABEL: @cluster_barrier_inside_warp_specialize_physical_cluster
+  // CHECK-COUNT-2: mbarrier.init.shared::cta.b64 [$1], 7;
+  // CHECK: llvm.mlir.constant(7 : i32)
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  tt.func @cluster_barrier_inside_warp_specialize_physical_cluster() {
+    ttg.warp_specialize()
+    default {
       ttng.cluster_barrier
       ttg.warp_yield
     }

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject_clustered_clc.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject_clustered_clc.mlir
@@ -1,0 +1,37 @@
+// RUN: triton-opt %s | FileCheck %s
+// RUN: not triton-opt %s --nvgpu-test-ws-atomic-broadcast 2>&1 | FileCheck %s --check-prefix=ERROR
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s --check-prefix=FALLBACK --implicit-check-not=async_task_id --implicit-check-not=ttg.partition --implicit-check-not=ttg.warp_specialize
+
+// A clustered CLC fetch must reject AutoWS even when task propagation assigns
+// the read to only one partition.
+// CHECK-LABEL: @reject_clustered_clc
+// ERROR: error: clustered CLC AutoWS is unsupported for explicit cluster shape 2x2x1
+// FALLBACK-LABEL: @reject_clustered_clc
+// FALLBACK: scf.while
+// FALLBACK: ttng.clc_try_cancel_async
+// FALLBACK: ttng.clc_read
+// FALLBACK: scf.yield
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.ctas-per-cga" = true,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:100"
+} {
+  tt.func public @reject_clustered_clc() {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %r0, %r1, %r2, %r3 = scf.while (%valid = %true, %x = %c0_i32, %y = %c0_i32, %z = %c0_i32) : (i1, i32, i32, i32) -> (i1, i32, i32, i32) {
+      scf.condition(%valid) %valid, %x, %y, %z : i1, i32, i32, i32
+    } do {
+    ^bb0(%valid: i1, %x: i32, %y: i32, %z: i32):
+      %tok = ttng.clc_try_cancel_async {async_task_id = array<i32: 0>} : !ttg.async.token
+      %next_valid, %next_x, %next_y, %next_z = ttng.clc_read %tok {async_task_id = array<i32: 0>} : !ttg.async.token -> i1, i32, i32, i32
+      scf.yield %next_valid, %next_x, %next_y, %next_z : i1, i32, i32, i32
+    } attributes {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transactional_fallback.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transactional_fallback.mlir
@@ -1,0 +1,37 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s --implicit-check-not=async_task_id --implicit-check-not=ttg.partition --implicit-check-not=ttg.warp_specialize --implicit-check-not=atomic_bcast_slot --implicit-check-not=tt.unsplat
+
+// An eligible loop-carried atomic is visited before the clustered CLC read.
+// Rejecting the CLC path must not leave the earlier atomic broadcast transform
+// in the function.
+// CHECK-LABEL: @mixed_atomic_and_clustered_clc
+// CHECK-COUNT-1: tt.atomic_rmw
+// CHECK: ttng.clc_try_cancel_async
+// CHECK: ttng.clc_read
+// CHECK: scf.yield
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.ctas-per-cga" = true,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:100"
+} {
+  tt.func public @mixed_atomic_and_clustered_clc(%counter: !tt.ptr<i32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %results:5 = scf.while (%tile = %c0, %valid = %true, %x = %c0, %y = %c0, %z = %c0) : (i32, i1, i32, i32, i32) -> (i32, i1, i32, i32, i32) {
+      scf.condition(%valid) %tile, %valid, %x, %y, %z : i32, i1, i32, i32, i32
+    } do {
+    ^bb0(%tile: i32, %valid: i1, %x: i32, %y: i32, %z: i32):
+      %next_tile = tt.atomic_rmw add, acq_rel, gpu, %counter, %c1, %true {async_task_id = array<i32: 0, 1>} : (!tt.ptr<i32>, i32, i1) -> i32
+      %token = ttng.clc_try_cancel_async {async_task_id = array<i32: 0>} : !ttg.async.token
+      %next_valid, %next_x, %next_y, %next_z = ttng.clc_read %token {async_task_id = array<i32: 0>} : !ttg.async.token -> i1, i32, i32, i32
+      scf.yield %next_tile, %next_valid, %next_x, %next_y, %next_z : i32, i1, i32, i32, i32
+    } attributes {async_task_id = array<i32: 0, 1>}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
@@ -1,12 +1,13 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100" | FileCheck %s
+// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" --nvgpu-warp-specialization="capability=100" | FileCheck %s
 
 // Regression guard for the empty-producer assertion (bug #7 in
 // .llms/rules/partition-scheduler-bugs.md): the `producerTaskIds.size() == 1`
 // assertion in CodePartitionUtility.cpp `createChannelPost`.
 //
 // Real FA3 backward kernel (same body as partition-scheduling-meta-fa-bwd.mlir)
-// driven through the full warp-specialization pipeline so it reaches
-// `createChannelPost`. `separateLocalAllocWithSrc` splits a shared alloc that
+// driven through partition scheduling and the full warp-specialization
+// pipeline so it reaches `createChannelPost`. `separateLocalAllocWithSrc`
+// splits a shared alloc that
 // carries no async_task_id, leaving a `local_store` with an empty producer
 // set; the `if (producerTaskIds.empty()) return;` guard skips it (a producer
 // with no partition needs no channel). Without the guard the `else` branch

--- a/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multicast.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multicast.mlir
@@ -1,0 +1,79 @@
+// RUN: triton-opt %s --nvgpu-test-ws-code-partition=num-buffers=2 | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s -mlir-disable-threading \
+// RUN:   --nvgpu-warp-specialization='capability=100 num-stages=2 smem-budget=232448' \
+// RUN:   --triton-nvidia-tma-lowering --tritongpu-allocate-warp-groups --convert-scf-to-cf \
+// RUN:   --allocate-shared-memory-nv='compute-capability=100 ptx-version=87' \
+// RUN:   --convert-triton-gpu-to-llvm='compute-capability=100 ptx-version=87' \
+// RUN:   --initialize-ws-cluster-barriers='compute-capability=100 ptx-version=87' \
+// RUN:   --canonicalize --cse --convert-nv-gpu-to-llvm --convert-warp-specialize-to-llvm \
+// RUN:   -reconcile-unrealized-casts | FileCheck %s --check-prefix=LLVM
+
+// A multicast TMA producer needs a full-cluster reuse rendezvous, and every
+// consumer task needs an independent full-cluster ready rendezvous.
+
+// CHECK-LABEL: @tma_multicast
+// CHECK-NOT: ttng.cluster_barrier
+// CHECK: ttng.arrive_barrier %[[REUSE:.*]], 1
+// CHECK-SAME: ctaMask = 3 : i32
+// CHECK: ttng.wait_barrier %[[REUSE]],
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK-SAME: tt.multicast_axes = array<i32: 1>
+// CHECK: ttng.arrive_barrier %[[READY0:.*]], 1
+// CHECK-SAME: ctaMask = 3 : i32
+// CHECK: ttng.wait_barrier %[[READY0]],
+// CHECK: ttng.arrive_barrier %[[READY1:.*]], 1
+// CHECK-SAME: ctaMask = 3 : i32
+// CHECK: ttng.wait_barrier %[[READY1]],
+
+// LLVM-LABEL: @tma_multicast
+// LLVM: %[[REUSE_PRED:.*]] = llvm.zext {{.*}} {async_task_id = array<i32: 1>
+// LLVM: %[[REUSE_ID:.*]] = llvm.mlir.constant(2 : i32) : i32
+// LLVM-NEXT: %[[REUSE_THREADS:.*]] = llvm.mlir.constant(128 : i32) : i32
+// LLVM-NEXT: nvvm.barrier id = %[[REUSE_ID]] number_of_threads = %[[REUSE_THREADS]]
+// LLVM: %[[READY0_PRED:.*]] = llvm.zext {{.*}} {async_task_id = array<i32: 2>
+// LLVM: %[[READY0_ID:.*]] = llvm.mlir.constant(3 : i32) : i32
+// LLVM-NEXT: %[[READY0_THREADS:.*]] = llvm.mlir.constant(128 : i32) : i32
+// LLVM-NEXT: nvvm.barrier id = %[[READY0_ID]] number_of_threads = %[[READY0_THREADS]]
+// LLVM: nvvm.cluster.wait {aligned}
+// LLVM: %[[READY1_ID:.*]] = llvm.mlir.constant(0 : i32) : i32
+// LLVM-NEXT: %[[READY1_THREADS:.*]] = llvm.mlir.constant(128 : i32) : i32
+// LLVM-NEXT: nvvm.barrier id = %[[READY1_ID]] number_of_threads = %[[READY1_THREADS]]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:100"
+} {
+  tt.func public @tma_multicast(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %out0: !tt.ptr<f16>, %out1: !tt.ptr<f16>) attributes {noinline = false} {
+    %pid = tt.get_program_id x : i32
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %ptrs0 = tt.splat %out0 {async_task_id = array<i32: 1>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %ptrs1 = tt.splat %out1 {async_task_id = array<i32: 2>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    %i0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : index
+    %i1 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 1 : index
+    %i4 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 4 : index
+    %buffer = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    scf.for %iv = %i0 to %i4 step %i1 {
+      %tile = tt.descriptor_load %desc[%pid, %c0] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 1>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      ttg.local_store %tile, %buffer {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %local0 = ttg.local_load %buffer {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+      %consumer0 = arith.addf %local0, %local0 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked>
+      %local1 = ttg.local_load %buffer {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> tensor<128x64xf16, #blocked>
+      %consumer1 = arith.subf %local1, %local1 {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked>
+      tt.store %ptrs0, %consumer0 {async_task_id = array<i32: 1>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+      tt.store %ptrs1, %consumer1 {async_task_id = array<i32: 2>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+      scf.yield
+    } {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_no_task_bailout.mlir
+++ b/test/Hopper/WarpSpecialization/ws_no_task_bailout.mlir
@@ -1,0 +1,22 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="capability=90 num-stages=2" | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @native_ws_marker_without_tasks
+  // CHECK: tt.descriptor_load
+  // CHECK-NOT: nvws.descriptor_load
+  // CHECK-NOT: tt.warp_specialize
+  tt.func public @native_ws_marker_without_tasks(
+      %src: !tt.tensordesc<128x64xf16, #shared>,
+      %dst: !tt.tensordesc<128x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    scf.for %i = %c0 to %c1 step %c1 : i32 {
+      %tile = tt.descriptor_load %src[%c0, %c0] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      tt.descriptor_store %dst[%c0, %c0], %tile : !tt.tensordesc<128x64xf16, #shared>, tensor<128x64xf16, #blocked>
+    } {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_persistent_sibling_tmem_channel.mlir
+++ b/test/Hopper/WarpSpecialization/ws_persistent_sibling_tmem_channel.mlir
@@ -1,0 +1,146 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="num-stages=2 capability=100 smem-budget=232448" | FileCheck %s
+
+// The MMA producer is in the inner K loop while the TMEM consumer is in a
+// sibling epilogue condition. The completion wait must be lifted before the
+// condition because padded CTAs skip its body but still execute the MMA.
+
+// CHECK-LABEL: @matmul_kernel_tma_persistent_ws
+// CHECK: ttg.warp_specialize
+// CHECK: default
+// CHECK: scf.for {{.*}} iter_args(%[[DEFAULT_D_COUNT:arg[0-9]+]] = %{{.*}}) -> (i64)
+// CHECK: ttng.wait_barrier
+// CHECK: scf.if
+// CHECK-NOT: ttng.wait_barrier
+// CHECK: ttng.tmem_load
+// CHECK: }
+// CHECK: ttng.arrive_barrier
+// CHECK: arith.addi %[[DEFAULT_D_COUNT]], %c1_i64
+// CHECK: partition0
+// CHECK: scf.for {{.*}} iter_args(%[[D_COUNT:arg[0-9]+]] = %{{.*}}, %[[K_COUNT:arg[0-9]+]] = %{{.*}}) -> (i64, i64)
+// CHECK: ttng.wait_barrier
+// CHECK: scf.for
+// CHECK: ttng.tc_gen5_mma
+// CHECK: scf.yield
+// CHECK: }
+// CHECK: ttng.tc_gen5_commit
+// CHECK: arith.addi %[[D_COUNT]], %c1_i64
+// CHECK: scf.yield {{.*}}, %{{.*}}#1 : i64, i64
+
+// A consumer in an earlier sibling region reads the previous TMEM value. The
+// forward-only sibling protocol cannot represent that loop-carried edge, so
+// AutoWS must leave the function unspecialized. The endpoints intentionally
+// use distinct views of the same root allocation.
+// CHECK-LABEL: @reversed_sibling_tmem_channel
+// CHECK-NOT: warp_specialize
+// CHECK-NOT: async_task_id
+// CHECK-NOT: ttg.partition
+// CHECK: ttng.tc_gen5_mma
+// CHECK-NOT: warp_specialize
+// CHECK-NOT: async_task_id
+// CHECK-NOT: ttg.partition
+// CHECK: tt.return
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 2 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = false} {
+  tt.func public @matmul_kernel_tma_persistent_ws(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<128x64xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %true = arith.constant true
+    %c127_i32 = arith.constant 127 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = arith.addi %arg15, %c127_i32 : i32
+    %1 = arith.divsi %0, %c128_i32 : i32
+    %2 = arith.addi %arg16, %c127_i32 : i32
+    %3 = arith.divsi %2, %c128_i32 : i32
+    %4 = arith.addi %arg17, %c63_i32 : i32
+    %5 = arith.divsi %4, %c64_i32 : i32
+    %6 = tt.get_program_id x : i32
+    %7 = arith.remsi %6, %c2_i32 : i32
+    %8 = tt.get_program_id y : i32
+    %9 = arith.remsi %8, %c2_i32 : i32
+    %10 = arith.divsi %6, %c2_i32 : i32
+    %11 = arith.divsi %8, %c2_i32 : i32
+    %12 = arith.addi %1, %c1_i32 : i32
+    %13 = arith.divsi %12, %c2_i32 : i32
+    %14 = arith.addi %3, %c1_i32 : i32
+    %15 = arith.divsi %14, %c2_i32 : i32
+    %16 = arith.muli %10, %15 : i32
+    %17 = arith.addi %16, %11 : i32
+    %18 = arith.muli %13, %15 : i32
+    %19 = tt.get_num_programs x : i32
+    %20 = arith.divsi %19, %c2_i32 : i32
+    %21 = tt.get_num_programs y : i32
+    %22 = arith.divsi %21, %c2_i32 : i32
+    %23 = arith.muli %20, %22 : i32
+    scf.for %arg18 = %17 to %18 step %23  : i32 {
+      %24 = arith.divsi %arg18, %15 : i32
+      %25 = arith.muli %24, %c2_i32 : i32
+      %26 = arith.addi %25, %7 : i32
+      %27 = arith.remsi %arg18, %15 : i32
+      %28 = arith.muli %27, %c2_i32 : i32
+      %29 = arith.addi %28, %9 : i32
+      %30 = arith.muli %26, %c128_i32 : i32
+      %31 = arith.muli %29, %c128_i32 : i32
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %32 = ttng.tmem_store %cst, %result[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %33:2 = scf.for %arg19 = %c0_i32 to %5 step %c1_i32 iter_args(%arg20 = %false, %arg21 = %32) -> (i1, !ttg.async.token)  : i32 {
+        %38 = arith.muli %arg19, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+        %39 = tt.descriptor_load %arg0[%30, %38] {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 1>, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %40 = ttg.local_alloc %39 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %41 = tt.descriptor_load %arg5[%31, %38] {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 0>, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %42 = ttg.local_alloc %41 {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %43 = ttg.memdesc_trans %42 {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+        %44 = ttng.tc_gen5_mma %40, %43, %result[%arg21], %arg20, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 0 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %44 : i1, !ttg.async.token
+      } {tt.scheduled_max_stage = 1 : i32}
+      %34 = arith.cmpi slt, %26, %1 : i32
+      %35 = arith.cmpi slt, %29, %3 : i32
+      %36 = arith.andi %34, %35 : i1
+      %37 = scf.if %36 -> (!ttg.async.token) {
+        %result_0, %token_1 = ttng.tmem_load %result[%33#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %38 = arith.truncf %result_0 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %39 = ttg.convert_layout %38 {ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x128xf16, #blocked1>
+        %40 = ttg.local_alloc %39 {ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %41 = ttng.async_tma_copy_local_to_global %arg10[%30, %31] %40 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %41   {ttg.partition = array<i32: 0>} : !ttg.async.token
+        scf.yield {ttg.partition = array<i32: 0>} %token_1 : !ttg.async.token
+      } else {
+        scf.yield {ttg.partition = array<i32: 0>} %33#1 : !ttg.async.token
+      }
+    } {tt.data_partition_factor = 1 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "load"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+
+  tt.func public @reversed_sibling_tmem_channel(
+      %a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    scf.for %outer = %c0_i32 to %c1_i32 step %c1_i32 : i32 {
+      %acc, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      scf.if %true {
+        %load_view = ttg.memdesc_index %acc[%c0_i32] {ttg.partition = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %value, %load_token = ttng.tmem_load %load_view[%token] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      }
+      scf.for %k = %c0_i32 to %c1_i32 step %c1_i32 iter_args(%mma_token = %token) -> (!ttg.async.token) : i32 {
+        %mma_view = ttg.memdesc_index %acc[%c0_i32] {ttg.partition = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %next = ttng.tc_gen5_mma %a, %b, %mma_view[%mma_token], %false, %true {ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %next : !ttg.async.token
+      }
+    } {tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm"], ttg.warp_specialize.tag = 1 : i32}
+    tt.return
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_surviving_while_multicast.mlir
+++ b/test/Hopper/WarpSpecialization/ws_surviving_while_multicast.mlir
@@ -1,0 +1,123 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=2 smem-budget=232448 tma-store-pipelining=true" | FileCheck %s
+
+// CHECK-LABEL: @surviving_while_multicast
+// CHECK: ttg.warp_specialize
+// CHECK: default {
+// CHECK: scf.while {{.*}} : (i32, i1, i64, i64) -> (i32, i64, i64)
+// CHECK: scf.if
+// CHECK: partition0
+// CHECK: scf.while {{.*}} : (i32, i1, i64, i64) -> (i32, i64, i64)
+// CHECK: ttng.tc_gen5_mma
+// CHECK-NOT: scf.if
+// CHECK: ttg.warp_return
+// CHECK: partition1
+// CHECK: scf.while {{.*}} : (i32, i1, i64, i64) -> (i32, i64, i64)
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK-SAME: tt.multicast_axes = array<i32: 1>
+// CHECK: ttng.async_tma_copy_global_to_local
+// CHECK-SAME: tt.multicast_axes = array<i32: 0>
+// CHECK-NOT: scf.if
+// CHECK: ttg.warp_return
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  ttg.early_tma_store_lowering = true,
+  ttg.min_reg_auto_ws = 24 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.target = "cuda:100",
+  "ttg.threads-per-warp" = 32 : i32,
+  "ttng.two-ctas" = false
+} {
+  tt.func public @surviving_while_multicast(
+      %a_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %b_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %c_desc: !tt.tensordesc<128x128xf16, #shared>,
+      %m: i32, %n: i32, %k: i32) {
+    %false = arith.constant false
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %m_rounded = arith.addi %m, %c127_i32 : i32
+    %num_m = arith.divsi %m_rounded, %c128_i32 : i32
+    %n_rounded = arith.addi %n, %c127_i32 : i32
+    %num_n = arith.divsi %n_rounded, %c128_i32 : i32
+    %k_rounded = arith.addi %k, %c63_i32 : i32
+    %num_k = arith.divsi %k_rounded, %c64_i32 : i32
+    %pid_m = tt.get_program_id x : i32
+    %local_m = arith.remsi %pid_m, %c2_i32 : i32
+    %pid_n = tt.get_program_id y : i32
+    %local_n = arith.remsi %pid_n, %c2_i32 : i32
+    %cluster_m = arith.divsi %pid_m, %c2_i32 : i32
+    %cluster_n = arith.divsi %pid_n, %c2_i32 : i32
+    %num_n_plus = arith.addi %num_n, %c1_i32 : i32
+    %num_cluster_n = arith.divsi %num_n_plus, %c2_i32 : i32
+    %cluster_base = arith.muli %cluster_m, %num_cluster_n : i32
+    %tile_id = arith.addi %cluster_base, %cluster_n : i32
+    %num_m_plus = arith.addi %num_m, %c1_i32 : i32
+    %num_cluster_m = arith.divsi %num_m_plus, %c2_i32 : i32
+    %num_tiles = arith.muli %num_cluster_m, %num_cluster_n : i32
+    %grid_m = tt.get_num_programs x : i32
+    %clusters_m = arith.divsi %grid_m, %c2_i32 : i32
+    %grid_n = tt.get_num_programs y : i32
+    %clusters_n = arith.divsi %grid_n, %c2_i32 : i32
+    %tile_stride = arith.muli %clusters_m, %clusters_n : i32
+    %valid = arith.cmpi slt, %tile_id, %num_tiles : i32
+    %result = scf.while (%tile = %tile_id, %keep_going = %valid) : (i32, i1) -> i32 {
+      scf.condition(%keep_going) %tile : i32
+    } do {
+    ^bb0(%tile: i32):
+      %tile_m = arith.divsi %tile, %num_cluster_n : i32
+      %macro_m = arith.muli %tile_m, %c2_i32 : i32
+      %out_m = arith.addi %macro_m, %local_m : i32
+      %tile_n = arith.remsi %tile, %num_cluster_n : i32
+      %macro_n = arith.muli %tile_n, %c2_i32 : i32
+      %out_n = arith.addi %macro_n, %local_n : i32
+      %offs_m = arith.muli %out_m, %c128_i32 : i32
+      %offs_n = arith.muli %out_n, %c128_i32 : i32
+      %acc, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %init = ttng.tmem_store %zero, %acc[%token], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %loop:2 = scf.for %ki = %c0_i32 to %num_k step %c1_i32 iter_args(%used = %false, %acc_token = %init) -> (i1, !ttg.async.token) : i32 {
+        %offs_k = arith.muli %ki, %c64_i32 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+        %a = tt.descriptor_load %a_desc[%offs_m, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 1>, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %a_alloc = ttg.local_alloc %a {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b = tt.descriptor_load %b_desc[%offs_n, %offs_k] {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 0>, ttg.partition = array<i32: 2>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+        %b_alloc = ttg.local_alloc %b {loop.cluster = 0 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %b_trans = ttg.memdesc_trans %b_alloc {loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared1, #smem>
+        %next_token = ttng.tc_gen5_mma %a_alloc, %b_trans, %acc[%acc_token], %used, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32, tt.self_latency = 0 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield %true, %next_token : i1, !ttg.async.token
+      } {tt.scheduled_max_stage = 1 : i32}
+      %loaded, %load_token = ttng.tmem_load %acc[%loop#1] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %valid_m = arith.cmpi slt, %out_m, %num_m : i32
+      %valid_n = arith.cmpi slt, %out_n, %num_n : i32
+      %store = arith.andi %valid_m, %valid_n : i1
+      scf.if %store {
+        %narrow = arith.truncf %loaded {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %layout = ttg.convert_layout %narrow {ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x128xf16, #blocked1>
+        %staging = ttg.local_alloc %layout {ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %store_token = ttng.async_tma_copy_local_to_global %c_desc[%offs_m, %offs_n] %staging {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %store_token {ttg.partition = array<i32: 0>} : !ttg.async.token
+      } {ttg.partition = array<i32: 0>}
+      %next_tile = arith.addi %tile, %tile_stride : i32
+      %next_valid = arith.cmpi slt, %next_tile, %num_tiles : i32
+      scf.yield %next_tile, %next_valid : i32, i1
+    } attributes {tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "load"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/test/TLX/insert_cluster_sync_ops.mlir
+++ b/test/TLX/insert_cluster_sync_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt -split-input-file --allocate-shared-memory-nv --convert-triton-gpu-to-llvm=compute-capability=100 --verify-diagnostics %s| FileCheck %s
+// RUN: triton-opt -split-input-file --triton-nvidia-tma-lowering --allocate-shared-memory-nv --convert-triton-gpu-to-llvm=compute-capability=100 --verify-diagnostics %s| FileCheck %s
 
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -238,6 +238,40 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
     %2 = ttng.map_to_remote_buffer %1, %c0_i32 : !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
     ttng.arrive_barrier %2, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#tma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 1 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.target = "cuda:100",
+  "ttg.threads-per-warp" = 32 : i32
+} {
+  // CHECK-LABEL: @planned_multicast_bar_init
+  tt.func public @planned_multicast_bar_init(
+      %desc: !tt.tensordesc<64x64xf16, #tma>) attributes {noinline = false} {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %buffer = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #tma, #smem, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // CHECK: mbarrier.init.shared::cta.b64
+    // CHECK: fence.mbarrier_init.release.cluster
+    // CHECK-NEXT: nvvm.cluster.arrive.relaxed {aligned}
+    // CHECK-NEXT: nvvm.cluster.wait {aligned}
+    // CHECK: mbarrier.arrive.expect_tx.shared::cta
+    // CHECK: cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.barrier_expect %bar, 8192, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buffer, %bar, %true {tt.multicast_axes = array<i32: 0>} : !tt.tensordesc<64x64xf16, #tma>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64x64xf16, #tma, #smem, mutable>
     tt.return
   }
 }

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -327,6 +327,39 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1], CGALayout = [[0, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @outstanding_commits_explicit_multicast_tma_recipients
+  tt.func public @outstanding_commits_explicit_multicast_tma_recipients(
+      %desc: !tt.tensordesc<32x32xf32, #shared>,
+      %ptr: tensor<32x32x!tt.ptr<f32>, #blocked>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // CHECK: %[[TARGETS:.*]] = arith.constant 3 : i32
+    %targets = arith.constant 3 : i32
+    %shmem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    ttng.barrier_expect %bar, 4096, %true : !ttg.memdesc<2xi64, #shared1, #smem, mutable>
+    %cta = tti.experimental_cluster_cta_id : i32
+    %non_issuer_cta = arith.cmpi eq, %cta, %c1_i32 : i32
+    %mask = tt.splat %non_issuer_cta : i1 -> tensor<32x32xi1, #blocked>
+    ttg.async_copy_global_to_local %ptr, %shmem mask %mask : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
+    ttg.async_commit_group
+    // CHECK: tt.call @__triton_consan_check_outstanding_commits{{.*}}({{.*}}, %[[TARGETS]])
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized{{.*}}({{.*}}, %[[TARGETS]])
+    // CHECK: ttng.async_tma_copy_global_to_local {{.*}}, %[[TARGETS]]
+    ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %shmem, %bar, %true, %targets : !tt.tensordesc<32x32xf32, #shared>, !ttg.memdesc<2xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32, CGALayout = [[0, 0]]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
 #offset_parent = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [1, 0], CGALayout = [[0, 0]]}>
 #offsets = #ttg.slice<{dim = 0, parent = #offset_parent}>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32, "ttng.two-ctas" = true, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {

--- a/test/TritonGPU/load-mma-specialization.mlir
+++ b/test/TritonGPU/load-mma-specialization.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -verify-diagnostics --tritongpu-hoist-tmem-alloc -tritongpu-partition-scheduling -tritongpu-load-mma-specialization -sccp -int-range-optimizations -canonicalize -cse -tritongpu-remove-layout-conversions | FileCheck %s --check-prefix=MC
 // -tritongpu-hoist-tmem-alloc | FileCheck %s --check-prefix=TMEM
 // --check-prefix=FUNC RUN: triton-opt %s -split-input-file
 // -allow-unregistered-dialect -verify-diagnostics --tritongpu-hoist-tmem-alloc
@@ -66,7 +67,7 @@
     {swizzlingByteWidth = 128, transposed = false, elementBitWidth = 8,        \
     fp4Padded = true }>
 
-module attributes{"ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
+module attributes{"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
 
   // FUNC-LABEL: @warp_specialize_tma_matmul
 
@@ -84,6 +85,7 @@ module attributes{"ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
   // CHECK-SAME: [[OFF_N:%arg[0-9]+]]
   // CHECK-SAME: [[A_DESC:%arg[0-9]+]]
   // CHECK-SAME: [[B_DESC:%arg[0-9]+]]
+  // MC-LABEL: @warp_specialize_tma_matmul
   tt.func @warp_specialize_tma_matmul(
       % k_tiles : i32, % off_m : i32, % off_n : i32,
       % a_desc : !tt.tensordesc<128x64xf16, #shared>,
@@ -145,23 +147,36 @@ module attributes{"ttg.num-warps" = 4 :i32, ttg.target = "cuda:100"} {
     // CHECK-NEXT: [[OPER_MBAR:%.*]] = ttg.memdesc_index [[OPER_MBARS]]{{\[}}[[IDX]]{{\]}}
     // CHECK-NEXT: ttng.barrier_expect [[OPER_MBAR]], 32768 {ttg.partition = array<i32: 2>}
 
+    // MC: ttng.wait_barrier %[[MC_READY:.*]], %[[MC_PHASE:.*]] {ttg.partition = array<i32: 2>}
+    // MC: ttng.barrier_expect %[[MC_OPER:.*]], 32768 {ttg.partition = array<i32: 2>}
+
     // CHECK-NEXT: [[A_BUF:%.*]] = ttg.memdesc_index [[A_BUFS]]{{\[}}[[IDX]]{{\]}}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[A_DESC]][[[OFF_M]], [[OFF_K]]] [[A_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
-    %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #oper_layout>
+    // MC-NEXT: %[[MC_A_BUF:.*]] = ttg.memdesc_index
+    // MC-NEXT: ttng.cluster_barrier {ttg.partition = array<i32: 2>}
+    // MC-NEXT: ttng.async_tma_copy_global_to_local {{.*}} %[[MC_A_BUF]], %[[MC_OPER]], {{.*}} {tt.multicast_axes = array<i32: 0>, ttg.partition = array<i32: 2>}
+    %a_reg = tt.descriptor_load %a_desc[%off_m, %off_k] {tt.multicast_axes = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #oper_layout>
     // CHECK-NEXT: [[B_BUF:%.*]] = ttg.memdesc_index [[B_BUFS]]{{\[}}[[IDX]]{{\]}}
     // CHECK-NEXT: ttng.async_tma_copy_global_to_local [[B_DESC]][[[OFF_N]], [[OFF_K]]] [[B_BUF]], [[OPER_MBAR]], [[TRUE]] {ttg.partition = array<i32: 2>}
-    %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #oper_layout>
+    // MC-NEXT: %[[MC_B_BUF:.*]] = ttg.memdesc_index
+    // MC-NEXT: ttng.cluster_barrier {ttg.partition = array<i32: 2>}
+    // MC-NEXT: ttng.async_tma_copy_global_to_local {{.*}} %[[MC_B_BUF]], %[[MC_OPER]], {{.*}} {tt.multicast_axes = array<i32: 0>, ttg.partition = array<i32: 2>}
+    %b_reg = tt.descriptor_load %b_desc[%off_n, %off_k] {tt.multicast_axes = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #oper_layout>
 
     %a_shared = ttg.local_alloc %a_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %b_shared = ttg.local_alloc %b_reg : (tensor<128x64xf16, #oper_layout>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     // CHECK-NEXT: [[B_T:%.*]] = ttg.memdesc_trans [[B_BUF]] {order = array<i32: 1, 0>, ttg.partition = array<i32: 1>}
     // CHECK-NEXT: ttng.wait_barrier [[OPER_MBAR]], [[PHASE]] {ttg.partition = array<i32: 1>}
+    // MC: %[[MC_B_T:.*]] = ttg.memdesc_trans %[[MC_B_BUF]]
+    // MC-NEXT: ttng.wait_barrier %[[MC_OPER]], %[[MC_PHASE]] {ttg.partition = array<i32: 1>}
+    // MC-NEXT: ttng.cluster_barrier {ttg.partition = array<i32: 1>}
     %b_T_shared = ttg.memdesc_trans %b_shared {order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem> -> !ttg.memdesc<64x128xf16, #shared_trans, #smem>
     %c_tmem, %c_tok = ttng.tmem_alloc %acc : (tensor<128x128xf32, #acc_layout>) -> (!ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     // CHECK-NEXT: [[IS_LAST:%.*]] = arith.cmpi eq, [[K]], [[LAST_ITER]]
     // CHECK-NEXT: [[ACC_BUF1:%.*]] = ttg.memdesc_index
     // CHECK-NEXT: [[DONE_MBAR1:%.*]] = ttg.memdesc_index
     // CHECK-NEXT: [[MMA_TOK:%.*]] = ttng.tc_gen5_mma [[A_BUF]], [[B_T]], [[ACC_BUF1]][], [[TRUE]], [[TRUE]], [[READY_MBAR]][%true], [[DONE_MBAR1]][[[IS_LAST]]] {is_async, ttg.partition = array<i32: 1>}
+    // MC: ttng.tc_gen5_mma %[[MC_A_BUF]], %[[MC_B_T]]
     %mma_tok = ttng.tc_gen5_mma %a_shared, %b_T_shared, %c_tmem[%c_tok], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_trans, #smem>, !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable>
 
     %c, %load_tok = ttng.tmem_load %c_tmem[%mma_tok] : !ttg.memdesc<128x128xf32, #acc_tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #acc_layout>

--- a/test/TritonGPU/pipeline-lower-loop.mlir
+++ b/test/TritonGPU/pipeline-lower-loop.mlir
@@ -727,7 +727,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #A = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #nvmma_64 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
 
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, ttg.target = "cuda:90"} {
 // CHECK-LABEL: @tma_load_lowering
 // CHECK-DAG: %[[TRUE:.*]] = arith.constant {{.*}} true
 // CHECK-DAG: %[[MINUS_ONE:.*]] = arith.constant -1 : i32
@@ -752,9 +752,11 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
 // CHECK:   %[[BAR_INS:.*]] = ttg.memdesc_index %[[BARRIER]]{{\[}}%[[INS_NEXT]]{{\]}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK:   ttng.barrier_expect %[[BAR_INS]], 8192 {loop.cluster = 2 : i32, loop.stage = 0 : i32}, %[[TRUE]]
 // CHECK:   %[[A_INS:.*]] = ttg.memdesc_index %[[A]]{{\[}}%[[INS_NEXT]]{{\]}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
-// CHECK:   ttng.async_tma_copy_global_to_local {{.*}}[{{.*}}] %[[A_INS]], %[[BAR_INS]], %[[TRUE]] {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK-NEXT: ttng.cluster_barrier {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK-NEXT: ttng.async_tma_copy_global_to_local {{.*}}[{{.*}}] %[[A_INS]], %[[BAR_INS]], %[[TRUE]] {loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 0>}
 // CHECK:   %[[BAR_EXT:.*]] = ttg.memdesc_index %[[BARRIER]]{{\[}}%[[EXT_NEXT]]{{\]}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   ttng.wait_barrier %[[BAR_EXT]], %[[PHASE_NEXT]] {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK-NEXT: ttng.cluster_barrier {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   %[[A_EXT:.*]] = ttg.memdesc_index %[[A]]{{\[}}%[[EXT_NEXT]]{{\]}} {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   %[[A_LOAD:.*]] = ttg.local_load %[[A_EXT]] {loop.cluster = 0 : i32, loop.stage = 2 : i32}
 // CHECK:   "use"(%[[A_LOAD]]) {loop.cluster = 0 : i32, loop.stage = 2 : i32}
@@ -769,7 +771,7 @@ tt.func @tma_load_lowering(%lb : index, %ub : index, %step : index,
                  %desc : !tt.tensordesc<128x32xf16, #nvmma_64>,
                  %offs : i32) -> () {
   scf.for %iv = %lb to %ub step %step : index {
-    %a = tt.descriptor_load %desc[%offs, %offs] {loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x32xf16, #nvmma_64> -> tensor<128x32xf16, #A>
+    %a = tt.descriptor_load %desc[%offs, %offs] {loop.cluster = 2 : i32, loop.stage = 0 : i32, tt.multicast_axes = array<i32: 0>} : !tt.tensordesc<128x32xf16, #nvmma_64> -> tensor<128x32xf16, #A>
     "use"(%a) {loop.cluster = 0 : i32, loop.stage = 2 : i32} : (tensor<128x32xf16, #A>) -> ()
   } {tt.scheduled_max_stage = 2 : i32}
   tt.return

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -128,7 +128,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @tmem_layout_cta_mismatch() {
-    // expected-error @+1 {{Layout has 1 CTAs per CGA, but the context requires 2 CTAs per CGA.}}
+    // expected-error @+1 {{Layout has 1 CTAs per CGA, but the context requires either 2 logical or 2 physical CTAs per CGA.}}
     %0 = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     tt.return
   }
@@ -221,6 +221,34 @@ tt.func @async_tma_gather(%desc: !tt.tensordesc<1x128xbf16, #shared>, %x_offsets
   ttng.async_tma_gather %desc[%x_offsets, %y_offset] %result, %bar, %pred : !tt.tensordesc<1x128xbf16, #shared>, tensor<32xi32, #blocked>, i32, !ttg.memdesc<2xi32, #shared1, #ttg.shared_memory, mutable>, !ttg.memdesc<32x128xbf16, #shared, #ttg.shared_memory, mutable>, i1
   tt.return
 }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @descriptor_load_invalid_multicast_axis(
+      %desc: !tt.tensordesc<128x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{tt.multicast_axes values must be in [0, 2]}}
+    %0 = tt.descriptor_load %desc[%c0, %c0] {tt.multicast_axes = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @descriptor_load_empty_multicast_axes(
+      %desc: !tt.tensordesc<128x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    // expected-error @+1 {{tt.multicast_axes must not be empty}}
+    %0 = tt.descriptor_load %desc[%c0, %c0] {tt.multicast_axes = array<i32>} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
 }
 
 // -----
@@ -539,6 +567,24 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.tw
 
 // -----
 
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @planned_multicast_requires_local_barrier_layout(
+      %arg0: !tt.tensordesc<64x128xf16, #nvmma>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+    // expected-error @below {{TMA barrier cga_layout must be [[1]], got [[0]]}}
+    ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %1, %true {tt.multicast_axes = array<i32: 0>} : !tt.tensordesc<64x128xf16, #nvmma>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0], [0, 1]]}>
 #barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0], [0]]}>
 #smem = #ttg.shared_memory
@@ -789,15 +835,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// NOTE: Meta Triton intentionally does NOT reject ttng.cluster_arrive / ttng.cluster_wait
-// inside ttg.warp_specialize (Meta Triton's autows/TLX pipelines place them there and the
-// conversion lowers them with all-warps wrapping). Only ttng.cluster_barrier is
-// rejected. The arrive/wait warp-specialize invalid cases from upstream #9456 are
-// therefore omitted here.
+// Meta Triton does not reject ttng.cluster_arrive, ttng.cluster_wait, or
+// ttng.cluster_barrier inside ttg.warp_specialize. AutoWS and TLX place them
+// there, and their conversions lower them with all-warps wrapping. The
+// warp-specialize invalid cases from upstream #9456 are therefore omitted. A
+// cluster barrier must still execute in a multi-CTA cluster.
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
   tt.func @cluster_barrier_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
+    // expected-error @below {{requires a multi-CTA cluster}}
     ttng.cluster_barrier
     tt.return
   }

--- a/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s --triton-nvidia-plan-tma-multicast | FileCheck %s
+// RUN: triton-opt %s --triton-nvidia-plan-tma-multicast --triton-nvidia-tma-lowering | FileCheck %s --check-prefix=LOWERING
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -144,6 +145,20 @@ module attributes {
       %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
     }
     tt.return
+  }
+
+  // LOWERING-LABEL: @lowering_preserves_plan
+  // CHECK-LABEL: @lowering_preserves_plan
+  tt.func public @lowering_preserves_plan(
+      %b: !tt.tensordesc<128x64xf16, #shared>) -> tensor<128x64xf16, #blocked> {
+    %y = tt.get_program_id y : i32
+    %k = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}tt.multicast_axes = array<i32: 0>}
+    // LOWERING: ttng.cluster_barrier
+    // LOWERING: arith.cmpi eq
+    // LOWERING: ttng.async_tma_copy_global_to_local {{.*}}tt.multicast_axes = array<i32: 0>}
+    %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return %bv : tensor<128x64xf16, #blocked>
   }
 
   // CHECK-LABEL: @clc_cluster_schedule

--- a/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
@@ -1,0 +1,251 @@
+// RUN: triton-opt %s --triton-nvidia-plan-tma-multicast | FileCheck %s
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 4 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  ttg.target = "cuda:90",
+  "ttg.threads-per-warp" = 32 : i32
+} {
+  // CHECK-LABEL: @rectangular
+  tt.func public @rectangular(
+      %a: !tt.tensordesc<128x64xf16, #shared>,
+      %b: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %k = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %av = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 0>}
+    %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @no_reuse
+  tt.func public @no_reuse(%a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%x, %y] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @per_load_disable
+  tt.func public @per_load_disable(%a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %k = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%x, %k] {multicast = false} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @dynamic_tile
+  tt.func public @dynamic_tile(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %counter: !tt.ptr<i32>) {
+    %tile = tt.load %counter : !tt.ptr<i32>
+    %k = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%tile, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @divergent_loop
+  tt.func public @divergent_loop(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    scf.for %i = %c0 to %y step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // The load's recipient groups span Y at a fixed X, but lowering uses a
+  // full-cluster barrier. An X-dependent branch is therefore unsafe even
+  // though it is uniform within each data recipient group.
+  // CHECK-LABEL: @subgroup_uniform_cluster_divergent
+  tt.func public @subgroup_uniform_cluster_divergent(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %is_x0 = arith.cmpi eq, %x, %c0 : i32
+    scf.if %is_x0 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_condition
+  tt.func public @cluster_uniform_condition(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %enabled: i1) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    scf.if %enabled {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @induction_dependency
+  tt.func public @induction_dependency(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c4 = arith.constant 4 : i32
+    scf.for %i = %x to %c4 step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%i, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // Dividing each physical program coordinate by its exact cluster dimension
+  // produces a cluster-uniform work id suitable for a persistent loop bound.
+  // CHECK-LABEL: @cluster_uniform_quotient
+  tt.func public @cluster_uniform_quotient(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %x = tt.get_program_id x : i32
+    %y = tt.get_program_id y : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %c4 = arith.constant 4 : i32
+    %cluster_x = arith.divsi %x, %c2 : i32
+    %cluster_y = arith.divui %y, %c4 : i32
+    %start = arith.addi %cluster_x, %cluster_y : i32
+    scf.for %i = %start to %limit step %c1 : i32 {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %v = tt.descriptor_load %a[%x, %i] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @wrong_cluster_divisor
+  tt.func public @wrong_cluster_divisor(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %x = tt.get_program_id x : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c3 = arith.constant 3 : i32
+    %bad_cluster_x = arith.divui %x, %c3 : i32
+    scf.for %i = %bad_cluster_x to %limit step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%x, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @clc_cluster_schedule
+  tt.func public @clc_cluster_schedule(
+      %a: !tt.tensordesc<128x64xf16, #shared>,
+      %b: !tt.tensordesc<128x64xf16, #shared>) {
+    %true = arith.constant true
+    %x0 = tt.get_program_id x : i32
+    %y0 = tt.get_program_id y : i32
+    %z0 = tt.get_program_id z : i32
+    %k = arith.constant 0 : i32
+    %results:4 = scf.while (%valid = %true, %x = %x0, %y = %y0, %z = %z0) :
+        (i1, i32, i32, i32) -> (i1, i32, i32, i32) {
+      scf.condition(%valid) %valid, %x, %y, %z : i1, i32, i32, i32
+    } do {
+    ^bb0(%valid: i1, %x: i32, %y: i32, %z: i32):
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %av = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 0>}
+      %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      %next_valid, %next_x, %next_y, %next_z = ttng.clc_advance : i1, i32, i32, i32
+      scf.yield %next_valid, %next_x, %next_y, %next_z : i1, i32, i32, i32
+    }
+    tt.return
+  }
+}
+
+module attributes {
+  "ttg.cluster-dim-x" = 1 : i32,
+  "ttg.cluster-dim-y" = 1 : i32,
+  "ttg.cluster-dim-z" = 2 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @z_axis_broadcast
+  tt.func public @z_axis_broadcast(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %c0 = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 2>}
+    %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_dependent
+  tt.func public @z_axis_dependent(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    // CHECK-NOT: tt.multicast_axes
+    %v = tt.descriptor_load %a[%z, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_uniform_quotient
+  tt.func public @z_axis_uniform_quotient(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c2 = arith.constant 2 : i32
+    %cluster_z = arith.divui %z, %c2 : i32
+    scf.for %i = %cluster_z to %limit step %c1 : i32 {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 2>}
+      %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @z_axis_wrong_divisor
+  tt.func public @z_axis_wrong_divisor(
+      %a: !tt.tensordesc<128x64xf16, #shared>, %limit: i32) {
+    %z = tt.get_program_id z : i32
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %c3 = arith.constant 3 : i32
+    %bad_cluster_z = arith.divui %z, %c3 : i32
+    scf.for %i = %bad_cluster_z to %limit step %c1 : i32 {
+      // CHECK-NOT: tt.multicast_axes
+      %v = tt.descriptor_load %a[%c0, %c0] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+}
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @meta_ws_plan
+  tt.func public @meta_ws_plan(
+      %a: !tt.tensordesc<128x64xf16, #shared>) {
+    %x = tt.get_program_id x : i32
+    %k = arith.constant 0 : i32
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %v = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_analysis.mlir
@@ -184,6 +184,22 @@ module attributes {
     }
     tt.return
   }
+
+  // CHECK-LABEL: @clc_read_cluster_schedule
+  tt.func public @clc_read_cluster_schedule(
+      %a: !tt.tensordesc<128x64xf16, #shared>,
+      %b: !tt.tensordesc<128x64xf16, #shared>) {
+    %k = arith.constant 0 : i32
+    %token = ttng.clc_try_cancel_async : !ttg.async.token
+    %valid, %x, %y, %z = ttng.clc_read %token : !ttg.async.token -> i1, i32, i32, i32
+    scf.if %valid {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %av = tt.descriptor_load %a[%x, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 0>}
+      %bv = tt.descriptor_load %b[%y, %k] {multicast = true} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
 }
 
 module attributes {

--- a/test/TritonNvidiaGPU/tma_multicast_computed_descriptors.mlir
+++ b/test/TritonNvidiaGPU/tma_multicast_computed_descriptors.mlir
@@ -1,0 +1,163 @@
+// RUN: triton-opt %s --triton-nvidia-plan-tma-multicast | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+
+module attributes {
+  "ttg.cluster-dim-x" = 2 : i32,
+  "ttg.cluster-dim-y" = 2 : i32,
+  "ttg.cluster-dim-z" = 1 : i32,
+  "ttg.num-ctas" = 1 : i32,
+  "ttg.num-warps" = 4 : i32,
+  "ttg.threads-per-warp" = 32 : i32,
+  ttg.target = "cuda:90"
+} {
+  // CHECK-LABEL: @invariant_computed_descriptors
+  tt.func public @invariant_computed_descriptors(
+      %base: !tt.ptr<f16>, %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %desc = tt.make_tensor_descriptor %base, [%c128_i32, %c64_i32],
+        [%c64_i64, %c1_i64] : !tt.ptr<f16>,
+        !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    %reinterpreted = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+    %1 = tt.descriptor_load %reinterpreted[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // The recipient group spans Y at a fixed X, but lowering synchronizes the
+  // full cluster. An X-dependent branch must therefore remain non-multicast.
+  // CHECK-LABEL: @subgroup_uniform_cluster_divergent
+  tt.func public @subgroup_uniform_cluster_divergent(
+      %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %is_x0 = arith.cmpi eq, %pid_x, %c0_i32 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    scf.if %is_x0 {
+      // CHECK-NOT: tt.multicast_axes
+      // CHECK: tt.descriptor_load
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_condition
+  tt.func public @cluster_uniform_condition(
+      %raw_desc: !tt.ptr<i8>, %enabled: i1) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    scf.if %enabled {
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_divergent_while_condition
+  tt.func public @cluster_divergent_while_condition(
+      %raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    %result = scf.while (%keep = %true) : (i1) -> i1 {
+      %next = arith.cmpi eq, %pid_x, %c0_i32 : i32
+      scf.condition(%next) %next : i1
+    } do {
+    ^bb0(%keep: i1):
+      // CHECK-NOT: tt.multicast_axes
+      // CHECK: tt.descriptor_load
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield %keep : i1
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @cluster_uniform_while_condition
+  tt.func public @cluster_uniform_while_condition(
+      %raw_desc: !tt.ptr<i8>, %enabled: i1) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    %result = scf.while (%keep = %enabled) : (i1) -> i1 {
+      scf.condition(%keep) %keep : i1
+    } do {
+    ^bb0(%keep: i1):
+      // CHECK: tt.descriptor_load {{.*}}multicast = true{{.*}}tt.multicast_axes = array<i32: 1>}
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield %keep : i1
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @pid_dependent_descriptor
+  tt.func public @pid_dependent_descriptor(
+      %base0: !tt.ptr<f16>, %base1: !tt.ptr<f16>) {
+    %pid_x = tt.get_program_id x : i32
+    %pid_y = tt.get_program_id y : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c64_i64 = arith.constant 64 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %is_y0 = arith.cmpi eq, %pid_y, %c0_i32 : i32
+    %base = arith.select %is_y0, %base0, %base1 : !tt.ptr<f16>
+    %desc = tt.make_tensor_descriptor %base, [%c128_i32, %c64_i32],
+        [%c64_i64, %c1_i64] : !tt.ptr<f16>,
+        !tt.tensordesc<128x64xf16, #shared>
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unsupported_region
+  tt.func public @unsupported_region(%raw_desc: !tt.ptr<i8>) {
+    %pid_x = tt.get_program_id x : i32
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK: scf.execute_region
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    scf.execute_region {
+      %0 = tt.descriptor_load %desc[%pid_x, %c0_i32] {multicast = true} :
+          !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      scf.yield
+    }
+    tt.return
+  }
+
+  // CHECK-LABEL: @private_helper
+  tt.func private @private_helper(%raw_desc: !tt.ptr<i8>, %offset: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %desc = ttng.reinterpret_tensor_descriptor %raw_desc :
+        !tt.ptr<i8> to !tt.tensordesc<128x64xf16, #shared>
+    // CHECK-NOT: tt.multicast_axes
+    // CHECK: tt.descriptor_load
+    %0 = tt.descriptor_load %desc[%offset, %c0_i32] {multicast = true} :
+        !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -878,6 +878,7 @@ class CUDABackend(BaseBackend):
                 and opt.ctas_per_cga is not None):
             nvidia.passes.hopper.add_2cta_transform_loads(pm)
         nvidia.passes.ttnvgpuir.add_optimize_descriptor_encoding(pm)
+        nvidia.passes.ttnvgpuir.add_tma_multicast(pm)
         passes.ttir.add_loop_aware_cse(pm)
         if capability // 10 in [8, 9]:
             passes.ttgpuir.add_fuse_nested_loops(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -184,6 +184,11 @@ def _check_reg_auto_ws_alignment(name: str, value: Optional[int]) -> None:
         raise ValueError(f"{name} must be divisible by 8, got {value}")
 
 
+def _validate_cluster_shape(name: str, shape: tuple[int, ...]) -> None:
+    if len(shape) != 3 or any(dim <= 0 for dim in shape):
+        raise ValueError(f"{name} must contain exactly three positive dimensions, got {shape}")
+
+
 @dataclass(frozen=True)
 class CUDAOptions:
     num_warps: int = 4
@@ -257,15 +262,22 @@ class CUDAOptions:
         _check_reg_auto_ws_alignment("minRegAutoWS", self.minRegAutoWS)
         _check_reg_auto_ws_alignment("maxRegAutoWS", self.maxRegAutoWS)
 
+        if self.num_ctas <= 0:
+            raise ValueError(f"num_ctas must be positive, got {self.num_ctas}")
+        _validate_cluster_shape("cluster_dims", self.cluster_dims)
+        if self.ctas_per_cga is not None:
+            _validate_cluster_shape("ctas_per_cga", self.ctas_per_cga)
+
         # If ctas_per_cga is set, it overrides cluster_dims with CUDA semantics:
         # ctas_per_cga defines the cluster shape for regrouping grid CTAs.
         # num_ctas must be 1 when using ctas_per_cga since it's incompatible with
         # the multiplicative semantics of num_ctas.
         if self.ctas_per_cga is not None:
             # Ensure cluster_dims is all 1s to prevent conflicting cluster specifications.
-            assert (self.cluster_dims == (1, 1, 1) or self.cluster_dims == self.ctas_per_cga), (
-                f"When using ctas_per_cga, cluster_dims must be default (1,1,1) or match ctas_per_cga to avoid conflicting "
-                f"cluster specifications. Got cluster_dims={self.cluster_dims}")
+            if self.cluster_dims != (1, 1, 1) and self.cluster_dims != self.ctas_per_cga:
+                raise ValueError(
+                    "When using ctas_per_cga, cluster_dims must be default (1,1,1) or match ctas_per_cga to avoid "
+                    f"conflicting cluster specifications. Got cluster_dims={self.cluster_dims}")
 
             object.__setattr__(self, "cluster_dims", self.ctas_per_cga)
             object.__setattr__(self, "num_ctas", 1)
@@ -345,11 +357,15 @@ class CUDABackend(BaseBackend):
         return CUDAOptions(**args)
 
     def pack_metadata(self, metadata):
+        cluster = getattr(metadata, "cluster_dims", None) or (1, 1, 1)
         preferred = getattr(metadata, "preferred_ctas_per_cga", None) or (0, 0, 0)
         return (
             metadata.num_warps,
             metadata.num_ctas,
             metadata.shared,
+            cluster[0],
+            cluster[1],
+            cluster[2],
             preferred[0],
             preferred[1],
             preferred[2],
@@ -363,8 +379,8 @@ class CUDABackend(BaseBackend):
         alongside the cubin as ``asm["launch_metadata"]`` and is intended to replace the
         implicit metadata bag that downstream consumers currently probe with hasattr guards.
 
-        The schema is purely additive — existing ``pack_metadata()`` / ``make_launcher()``
-        paths are not affected.
+        The schema is purely additive and does not replace the existing packed metadata
+        consumed by the JIT launchers.
         """
 
         def _get(key, default=None):

--- a/third_party/nvidia/backend/ctypes_launcher.py
+++ b/third_party/nvidia/backend/ctypes_launcher.py
@@ -100,6 +100,21 @@ _cuCtxSetCurrent = None
 _cuPointerGetAttribute = None
 
 
+def _validate_exact_cluster_grid(
+    grid: tuple[int, int, int], num_ctas: int, cluster_dims: tuple[int, ...]
+) -> None:
+    if num_ctas <= 0 or len(cluster_dims) != 3 or any(dim <= 0 for dim in cluster_dims):
+        raise ValueError(f"Invalid Triton cluster metadata: num_ctas={num_ctas}, cluster_dims={cluster_dims}")
+    required = (num_ctas, 1, 1) if num_ctas > 1 else tuple(cluster_dims)
+    if required == (1, 1, 1):
+        return
+    physical_grid = (grid[0] * num_ctas, grid[1], grid[2])
+    if any(size % cluster != 0 for size, cluster in zip(physical_grid, required)):
+        raise ValueError(
+            f"Triton cluster requirement failed: physical grid {physical_grid} "
+            f"is not divisible by required cluster shape {required}")
+
+
 def _ensure_cuda_context():
     global _libcuda, _cuCtxGetCurrent, _cuDeviceGet, _cuDevicePrimaryCtxRetain, _cuCtxSetCurrent
     if _libcuda is None:
@@ -387,6 +402,9 @@ def make_ctypes_launcher(constants, signature, tensordesc_meta):
             num_warps,
             num_ctas,
             shared_memory,
+            clusterDimX,
+            clusterDimY,
+            clusterDimZ,
             _preferredClusterDimX,
             _preferredClusterDimY,
             _preferredClusterDimZ,
@@ -400,6 +418,14 @@ def make_ctypes_launcher(constants, signature, tensordesc_meta):
             if launch_exit_hook is not None:
                 launch_exit_hook(launch_metadata)
             return
+
+        _validate_exact_cluster_grid(
+            (gridX, gridY, gridZ), num_ctas, (clusterDimX, clusterDimY, clusterDimZ))
+        has_exact_cluster = num_ctas > 1 or clusterDimX > 1 or clusterDimY > 1 or clusterDimZ > 1
+
+        actual_gridX = gridX * num_ctas
+        actual_gridY = gridY
+        actual_gridZ = gridZ
 
         # Process global_scratch
         global_scratch = CUdeviceptr(0)
@@ -430,10 +456,6 @@ def make_ctypes_launcher(constants, signature, tensordesc_meta):
         launch_attrs = (CUlaunchAttribute * 4)()
         num_attrs = 0
 
-        actual_gridX = gridX * num_ctas
-        actual_gridY = gridY
-        actual_gridZ = gridZ
-
         if launch_pdl:
             launch_attrs[num_attrs].id = (CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION)
             launch_attrs[num_attrs].value.value = 1
@@ -444,14 +466,18 @@ def make_ctypes_launcher(constants, signature, tensordesc_meta):
             launch_attrs[num_attrs].value.value = 1
             num_attrs += 1
 
-        if launch_cluster or num_ctas != 1:
-            # Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas path.
-            # For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster handles it.
+        if launch_cluster or has_exact_cluster:
             if num_ctas > 1:
                 launch_attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION
                 launch_attrs[num_attrs].value.clusterDim.x = num_ctas
                 launch_attrs[num_attrs].value.clusterDim.y = 1
                 launch_attrs[num_attrs].value.clusterDim.z = 1
+                num_attrs += 1
+            elif has_exact_cluster:
+                launch_attrs[num_attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION
+                launch_attrs[num_attrs].value.clusterDim.x = clusterDimX
+                launch_attrs[num_attrs].value.clusterDim.y = clusterDimY
+                launch_attrs[num_attrs].value.clusterDim.z = clusterDimZ
                 num_attrs += 1
 
             launch_attrs[num_attrs].id = (CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE)

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -1230,6 +1230,7 @@ static inline cuLaunchKernelEx_t ensureLaunchHandle(void) {
 
 static void _launch(int gridX, int gridY, int gridZ, int num_warps,
                     int num_ctas, int launch_cooperative_grid, int launch_pdl,
+                    int clusterDimX, int clusterDimY, int clusterDimZ,
                     int preferredClusterDimX, int preferredClusterDimY,
                     int preferredClusterDimZ, int shared_memory,
                     CUstream stream, CUfunction function, void **params) {
@@ -1277,16 +1278,22 @@ static void _launch(int gridX, int gridY, int gridZ, int num_warps,
       ++num_attrs;
     }
 
-    if (num_ctas != 1 || preferredClusterDimX > 0) {
-      // Only set CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION for Triton's num_ctas
-      // path. For ctas_per_cga path (num_ctas == 1), PTX's .reqnctapercluster
-      // handles it.
+    if (num_ctas != 1 || clusterDimX > 1 || clusterDimY > 1 ||
+        clusterDimZ > 1 || preferredClusterDimX > 0) {
       if (num_ctas > 1) {
         CUlaunchAttribute clusterAttr = {};
         clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
         clusterAttr.value.clusterDim.x = num_ctas;
         clusterAttr.value.clusterDim.y = 1;
         clusterAttr.value.clusterDim.z = 1;
+        launchAttr[num_attrs] = clusterAttr;
+        ++num_attrs;
+      } else if (clusterDimX > 1 || clusterDimY > 1 || clusterDimZ > 1) {
+        CUlaunchAttribute clusterAttr = {};
+        clusterAttr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+        clusterAttr.value.clusterDim.x = clusterDimX;
+        clusterAttr.value.clusterDim.y = clusterDimY;
+        clusterAttr.value.clusterDim.z = clusterDimZ;
         launchAttr[num_attrs] = clusterAttr;
         ++num_attrs;
       }
@@ -1775,7 +1782,8 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   uint64_t _function;
   int launch_cooperative_grid;
   int launch_pdl;
-  int num_warps, num_ctas, shared_memory, preferredClusterDimX,
+  int num_warps, num_ctas, shared_memory, clusterDimX, clusterDimY, clusterDimZ,
+      preferredClusterDimX,
       preferredClusterDimY, preferredClusterDimZ;
   PyObject *launch_metadata = NULL;
   PyObject *launch_enter_hook = NULL;
@@ -1787,9 +1795,10 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   PyObject *kernel_args = NULL;
   PyObject *auto_tma_recipes_obj = NULL;
   if (!PyArg_ParseTuple(
-          args, "iiiKKpp(iiiiii)OOOOOOy*OO", &gridX, &gridY, &gridZ, &_stream,
+          args, "iiiKKpp(iiiiiiiii)OOOOOOy*OO", &gridX, &gridY, &gridZ, &_stream,
           &_function, &launch_cooperative_grid, &launch_pdl, &num_warps,
-          &num_ctas, &shared_memory, &preferredClusterDimX,
+          &num_ctas, &shared_memory, &clusterDimX, &clusterDimY, &clusterDimZ,
+          &preferredClusterDimX,
           &preferredClusterDimY, &preferredClusterDimZ, &launch_metadata,
           &launch_enter_hook, &launch_exit_hook, &global_scratch_obj,
           &profile_scratch_obj, &arg_annotations, &signature,
@@ -1800,6 +1809,27 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   // launch entry hook.
   if (!launchHook(launch_enter_hook, launch_metadata)) {
     goto cleanup;
+  }
+
+  {
+    const uint32_t launch_grid[3] = {(uint32_t)gridX, (uint32_t)gridY,
+                                     (uint32_t)gridZ};
+    CUresult grid_status = triton_validate_exact_cluster_grid(
+        launch_grid, num_ctas,
+        (const int[3]){clusterDimX, clusterDimY, clusterDimZ});
+    if (grid_status != CUDA_SUCCESS) {
+      uint32_t required[3];
+      triton_get_exact_cluster_shape(
+          num_ctas, (const int[3]){clusterDimX, clusterDimY, clusterDimZ},
+          required);
+      PyErr_Format(PyExc_ValueError,
+                   "Triton cluster requirement failed: physical grid "
+                   "(%llu, %d, %d) is not divisible by required cluster "
+                   "shape (%u, %u, %u)",
+                   (unsigned long long)gridX * (unsigned long long)num_ctas,
+                   gridY, gridZ, required[0], required[1], required[2]);
+      goto cleanup;
+    }
   }
 
   uint8_t *extractor_data = (uint8_t *)signature.buf;
@@ -1852,18 +1882,14 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   desc.shared_mem = (unsigned)shared_memory;
   desc.launch_pdl = launch_pdl;
   desc.launch_cooperative_grid = launch_cooperative_grid;
-  /* Behavior-preserving vs the legacy _launch: that path requested cluster
-   * attributes iff (num_ctas != 1 || preferredClusterDimX > 0). Here we only
-   * carry the preferred-dim bit; the shared core also fires on num_ctas > 1,
-   * so the combined condition reproduces the legacy set. (The JIT launcher has
-   * no separate compile-time launch_cluster signal -- unlike TritonCC/AOT-T,
-   * which pass it explicitly from make_launcher_src metadata.) */
-  desc.launch_cluster = (preferredClusterDimX > 0) ? 1 : 0;
-  // JIT variadic launcher uses the 1-D num_ctas cluster + preferred-cluster
-  // hint only; it never emits an explicit multi-dim CLUSTER_DIMENSION.
-  desc.cluster_dims[0] = 0;
-  desc.cluster_dims[1] = 0;
-  desc.cluster_dims[2] = 0;
+  desc.launch_cluster =
+      (clusterDimX > 1 || clusterDimY > 1 || clusterDimZ > 1 ||
+       preferredClusterDimX > 0)
+          ? 1
+          : 0;
+  desc.cluster_dims[0] = clusterDimX;
+  desc.cluster_dims[1] = clusterDimY;
+  desc.cluster_dims[2] = clusterDimZ;
   desc.preferred_cluster_dims[0] = preferredClusterDimX;
   desc.preferred_cluster_dims[1] = preferredClusterDimY;
   desc.preferred_cluster_dims[2] = preferredClusterDimZ;
@@ -2138,8 +2164,9 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
         _fb_params[i] = (char *)args_buf + pdescs[i].offset;
       Py_BEGIN_ALLOW_THREADS;
       _launch(gridX, gridY, gridZ, num_warps, num_ctas, launch_cooperative_grid,
-              launch_pdl, preferredClusterDimX, preferredClusterDimY,
-              preferredClusterDimZ, shared_memory, (CUstream)_stream,
+              launch_pdl, clusterDimX, clusterDimY, clusterDimZ,
+              preferredClusterDimX, preferredClusterDimY, preferredClusterDimZ,
+              shared_memory, (CUstream)_stream,
               (CUfunction)_function, _fb_params);
       Py_END_ALLOW_THREADS;
       if (!PyErr_Occurred())
@@ -2253,6 +2280,7 @@ typedef struct {
   PyObject_HEAD vectorcallfunc vectorcall;
   CUfunction function;
   unsigned grid_mult;   /* num_ctas — grid_x multiplied by this */
+  int cluster_dims[3];
   unsigned block_dim_x; /* 32 * num_warps */
   unsigned shared_mem;
   CUlaunchAttribute launch_attrs[6];
@@ -2639,9 +2667,13 @@ static inline CUresult td_relaunch(TritonDispatcher *d, unsigned gx,
    * grids such as (1 << 26, 64, 1), which would silently skip the launch. */
   if (gx == 0 || gy == 0 || gz == 0)
     return CUDA_SUCCESS;
+  const uint32_t grid[3] = {gx, gy, gz};
+  CUresult grid_status = triton_validate_exact_cluster_grid(
+      grid, (int)d->grid_mult, d->cluster_dims);
+  if (grid_status != CUDA_SUCCESS)
+    return grid_status;
   if (d->use_core_launch) {
     /* Converged path: launch through the shared core in launch.h. */
-    const uint32_t grid[3] = {gx, gy, gz};
     return triton_launch_kernel(grid, stream, d->function,
                                 (void *)d->arg_storage, &d->core_desc);
   }
@@ -2718,6 +2750,9 @@ static PyObject *TritonDispatcher_new(PyTypeObject *type, PyObject *args,
   self->vectorcall = TritonDispatcher_vectorcall;
   self->function = (CUfunction)(uintptr_t)func_ptr;
   self->grid_mult = (unsigned)num_ctas;
+  self->cluster_dims[0] = cluster_dim_x;
+  self->cluster_dims[1] = cluster_dim_y;
+  self->cluster_dims[2] = cluster_dim_z;
   self->block_dim_x = 32 * (unsigned)num_warps;
   self->shared_mem = (unsigned)shared_mem;
   self->has_global_scratch = has_global_scratch;
@@ -2982,6 +3017,22 @@ static PyObject *TritonDispatcher_vectorcall(PyObject *callable,
   unsigned gx = (unsigned)gx_l;
   unsigned gy = (unsigned)gy_l;
   unsigned gz = (unsigned)gz_l;
+
+  const uint32_t grid[3] = {gx, gy, gz};
+  CUresult grid_status = triton_validate_exact_cluster_grid(
+      grid, (int)self->grid_mult, self->cluster_dims);
+  if (grid_status != CUDA_SUCCESS) {
+    uint32_t required[3];
+    triton_get_exact_cluster_shape((int)self->grid_mult, self->cluster_dims,
+                                   required);
+    PyErr_Format(PyExc_ValueError,
+                 "Triton cluster requirement failed: physical grid "
+                 "(%llu, %u, %u) is not divisible by required cluster shape "
+                 "(%u, %u, %u)",
+                 (unsigned long long)gx * self->grid_mult, gy, gz, required[0],
+                 required[1], required[2]);
+    return NULL;
+  }
 
   CUstream stream = (CUstream)(uintptr_t)PyLong_AsUnsignedLongLong(args[3]);
 

--- a/third_party/nvidia/backend/launch.h
+++ b/third_party/nvidia/backend/launch.h
@@ -486,6 +486,51 @@ static inline CUresult triton_construct_tma_desc_cached(
  * triton_launch_kernel — THE one function all consumers call.
  * ------------------------------------------------------------------------- */
 
+static inline int triton_get_exact_cluster_shape(
+    int num_ctas, const int cluster_dims[3], uint32_t required[3]) {
+  required[0] = required[1] = required[2] = 1;
+  if (num_ctas > 1) {
+    required[0] = (uint32_t)num_ctas;
+    return 1;
+  }
+  if (cluster_dims[0] <= 0 || cluster_dims[1] <= 0 ||
+      cluster_dims[2] <= 0)
+    return -1;
+  if (cluster_dims[0] == 1 && cluster_dims[1] == 1 &&
+      cluster_dims[2] == 1)
+    return 0;
+  required[0] = (uint32_t)cluster_dims[0];
+  required[1] = (uint32_t)cluster_dims[1];
+  required[2] = (uint32_t)cluster_dims[2];
+  return 1;
+}
+
+static inline CUresult triton_validate_exact_cluster_grid(
+    const uint32_t grid[3], int num_ctas, const int cluster_dims[3]) {
+  uint32_t required[3];
+  int has_exact_cluster =
+      triton_get_exact_cluster_shape(num_ctas, cluster_dims, required);
+  if (has_exact_cluster < 0 || num_ctas <= 0)
+    return CUDA_ERROR_INVALID_VALUE;
+  if (has_exact_cluster == 0)
+    return CUDA_SUCCESS;
+
+  unsigned long long physical[3] = {
+      (unsigned long long)grid[0] * (unsigned long long)num_ctas,
+      (unsigned long long)grid[1], (unsigned long long)grid[2]};
+  for (unsigned axis = 0; axis < 3; ++axis) {
+    if (physical[axis] % required[axis] != 0) {
+      fprintf(stderr,
+              "[triton] ERROR: physical grid (%llu, %llu, %llu) is not "
+              "divisible by required cluster shape (%u, %u, %u)\n",
+              physical[0], physical[1], physical[2], required[0], required[1],
+              required[2]);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
 /**
  * Shared launch core (NVIDIA/CUDA only): constructs TMA descriptors, builds the
  * params[] array and launch attributes, then issues cuLaunchKernelEx.
@@ -531,6 +576,9 @@ static inline CUresult triton_launch_kernel_impl(
    * avoids cuLaunchKernelEx rejecting a zero-sized grid. */
   if (grid[0] == 0 || grid[1] == 0 || grid[2] == 0)
     return CUDA_SUCCESS;
+
+  TRITON_CUDA_CHECK(triton_validate_exact_cluster_grid(
+      grid, desc->num_ctas, desc->cluster_dims));
 
   triton_cuLaunchKernelEx_fn launch_fn = triton_get_launch_kernel_ex();
   if (!launch_fn)
@@ -652,7 +700,19 @@ static inline CUresult triton_launch_kernel_impl(
   config.attrs = attrs;
   config.numAttrs = num_attrs;
 
-  return launch_fn(&config, function, params, NULL);
+  CUresult result = launch_fn(&config, function, params, NULL);
+  if (result != CUDA_SUCCESS) {
+    uint32_t required[3];
+    if (triton_get_exact_cluster_shape(desc->num_ctas, desc->cluster_dims,
+                                       required) > 0) {
+      fprintf(stderr,
+              "[triton] ERROR: CUDA rejected launch of physical grid "
+              "(%u, %u, %u) with required cluster shape (%u, %u, %u): %d\n",
+              config.gridDimX, config.gridDimY, config.gridDimZ, required[0],
+              required[1], required[2], (int)result);
+    }
+  }
+  return result;
 }
 
 static inline CUresult

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -46,6 +46,70 @@ static OpPrintingFlags getOpPrintingFlagsWithLoc() {
   return flags;
 }
 
+static bool hasUnsupportedCrossRegionTmemChannel(triton::FuncOp funcOp) {
+  bool unsupported = false;
+  funcOp.walk([&](triton::nvidia_gpu::TMEMAllocOp alloc) {
+    SmallVector<Value> worklist{alloc.getResult()};
+    DenseSet<Value> visited;
+    SmallVector<Operation *> producers;
+    SmallVector<Operation *> consumers;
+    DenseSet<Operation *> seenProducers;
+    DenseSet<Operation *> seenConsumers;
+    while (!worklist.empty()) {
+      Value value = worklist.pop_back_val();
+      if (!visited.insert(value).second)
+        continue;
+      for (Operation *user : value.getUsers()) {
+        if (auto mma = dyn_cast<triton::nvidia_gpu::MMAv5OpInterface>(user)) {
+          if (mma.getAccumulator() == value) {
+            if (seenProducers.insert(user).second)
+              producers.push_back(user);
+            // An accumulator MMA may also read the preceding value. Treat it
+            // conservatively as a consumer; self-pairs are ignored below.
+            if (seenConsumers.insert(user).second)
+              consumers.push_back(user);
+          } else if (seenConsumers.insert(user).second) {
+            consumers.push_back(user);
+          }
+        } else if (auto load = dyn_cast<triton::nvidia_gpu::TMEMLoadOp>(user)) {
+          if (load.getSrc() == value && seenConsumers.insert(user).second)
+            consumers.push_back(user);
+        } else if (auto store =
+                       dyn_cast<triton::nvidia_gpu::TMEMStoreOp>(user)) {
+          if (store.getDst() == value && seenProducers.insert(user).second)
+            producers.push_back(user);
+        }
+        if (!isa<triton::gpu::MemDescIndexOp, triton::gpu::MemDescSubsliceOp,
+                 triton::gpu::MemDescReinterpretOp, triton::gpu::MemDescTransOp,
+                 triton::gpu::MemDescReshapeOp>(user))
+          continue;
+        for (Value result : user->getResults())
+          if (isa<triton::gpu::MemDescType>(result.getType()))
+            worklist.push_back(result);
+      }
+    }
+
+    for (Operation *producer : producers) {
+      for (Operation *consumer : consumers) {
+        if (producer == consumer ||
+            producer->getBlock() == consumer->getBlock())
+          continue;
+        SmallVector<AsyncTaskId> producerTasks = getAsyncTaskIds(producer);
+        SmallVector<AsyncTaskId> consumerTasks = getAsyncTaskIds(consumer);
+        if (producerTasks.empty() || consumerTasks.empty() ||
+            producerTasks == consumerTasks)
+          continue;
+        if (!isSupportedCrossRegionChannel(producer, consumer)) {
+          unsupported = true;
+          return WalkResult::interrupt();
+        }
+      }
+    }
+    return WalkResult::advance();
+  });
+  return unsupported;
+}
+
 static LogicalResult cleanupWarpSpecializedLoops(Operation *op) {
   runDeadIterArgElimination(op);
   RewritePatternSet patterns(op->getContext());
@@ -190,6 +254,12 @@ public:
       return bailOut(funcOp);
     }
 
+    if (hasUnsupportedCrossRegionTmemChannel(funcOp)) {
+      LDBG("Warp specialization does not support this cross-region TMEM "
+           "channel topology. Skipping.");
+      return bailOut(funcOp);
+    }
+
     // Cross-partition run-once, loop-carried "claim the next tile" support for
     // dynamic-persistent kernels. Handles both the `tt.atomic_rmw` tile counter
     // and the CLC tile-scheduler fetch (`ttng.clc_read`) with the same idea:
@@ -259,7 +329,10 @@ public:
       dumpAfter(moduleOp, "doValidateTMAStoreAnnotations");
     }
 
-    doCodePartition(funcOp, numStages);
+    if (failed(doCodePartition(funcOp, numStages))) {
+      signalPassFailure();
+      return;
+    }
     dumpAfter(moduleOp, "doCodePartition");
 
     if (pingpongAutoWS) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -176,6 +176,20 @@ public:
     }
     dumpAfter(moduleOp, "doTaskIdPropagate");
 
+    bool hasAssignedTask = false;
+    funcOp->walk([&](Operation *op) {
+      if (op->hasAttr(kAsyncTaskIdAttrName) ||
+          op->hasAttr(triton::gpu::kPartitionAttrName)) {
+        hasAssignedTask = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (!hasAssignedTask) {
+      LDBG("Warp specialization has no assigned tasks. Skipping.");
+      return bailOut(funcOp);
+    }
+
     // Cross-partition run-once, loop-carried "claim the next tile" support for
     // dynamic-persistent kernels. Handles both the `tt.atomic_rmw` tile counter
     // and the CLC tile-scheduler fetch (`ttng.clc_read`) with the same idea:

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -42,6 +42,62 @@ void removeWarpSpecMetadata(triton::FuncOp funcOp) {
   });
 }
 
+std::pair<Operation *, Operation *> getCommonBlockAnchors(Operation *a,
+                                                          Operation *b) {
+  DenseMap<Block *, Operation *> aAnchors;
+  for (Operation *op = a; op && !isa<triton::FuncOp>(op);
+       op = op->getParentOp())
+    aAnchors.try_emplace(op->getBlock(), op);
+  for (Operation *op = b; op && !isa<triton::FuncOp>(op);
+       op = op->getParentOp()) {
+    auto it = aAnchors.find(op->getBlock());
+    if (it != aAnchors.end())
+      return {it->second, op};
+  }
+  return {nullptr, nullptr};
+}
+
+static Operation *getEffectiveParentOp(Operation *op) {
+  Operation *parent = op->getParentOp();
+  while (parent && isa<ttng::SubtiledRegionOp>(parent))
+    parent = parent->getParentOp();
+  return parent;
+}
+
+RegionRelationInfo getRegionRelationInfo(Operation *a, Operation *b) {
+  if (a->getBlock() == b->getBlock())
+    return {RegionRelation::SameBlock};
+
+  for (Operation *op = a; op && !isa<triton::FuncOp>(op);
+       op = op->getParentOp()) {
+    if (getEffectiveParentOp(op) == getEffectiveParentOp(b))
+      return {RegionRelation::AIsNested};
+  }
+  for (Operation *op = b; op && !isa<triton::FuncOp>(op);
+       op = op->getParentOp()) {
+    if (getEffectiveParentOp(op) == getEffectiveParentOp(a))
+      return {RegionRelation::BIsNested};
+  }
+
+  auto [aAnchor, bAnchor] = getCommonBlockAnchors(a, b);
+  if (aAnchor && bAnchor && aAnchor != bAnchor &&
+      aAnchor->getBlock() == bAnchor->getBlock())
+    return {RegionRelation::Siblings, aAnchor, bAnchor};
+  return {RegionRelation::Unsupported};
+}
+
+bool isSupportedCrossRegionChannel(Operation *producer, Operation *consumer) {
+  if (!producer || !consumer)
+    return false;
+  RegionRelationInfo info = getRegionRelationInfo(producer, consumer);
+  if (info.relation == RegionRelation::Unsupported)
+    return false;
+  if (info.relation != RegionRelation::Siblings)
+    return true;
+  return isa<ttng::MMAv5OpInterface>(producer) && info.aAnchor &&
+         info.bAnchor && !info.bAnchor->isBeforeInBlock(info.aAnchor);
+}
+
 // Check whether two channels belong to the same consumer group.
 // Mirrors the merge conditions in insertAsyncComm (WSCodePartition.cpp):
 //   same getDstOp(), same consumer task IDs, same full consumer set.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -1504,10 +1504,10 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
                                  Value barrierAlloc, Value bufferIdx) {
   ttg::MemDescType allocType = cast<ttg::MemDescType>(barrierAlloc.getType());
-  ttg::MemDescType barrierTy =
-      ttg::MemDescType::get({1}, builder.getI64Type(), allocType.getEncoding(),
-                            allocType.getMemorySpace(),
-                            /*mutableMemory=*/true);
+  SmallVector<int64_t> barrierShape(allocType.getShape().drop_front());
+  ttg::MemDescType barrierTy = ttg::MemDescType::get(
+      barrierShape, builder.getI64Type(), allocType.getEncoding(),
+      allocType.getMemorySpace(), /*mutableMemory=*/true);
 
   // Create barrierForTMA from barrierAlloc.
   auto output = builder.createWithAsyncTaskIds<ttg::MemDescIndexOp>(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -35,6 +35,31 @@ constexpr llvm::StringLiteral kAtomicBroadcastCopiesAttrName =
 // the single canonical set consumed by all reject paths.
 void removeWarpSpecMetadata(triton::FuncOp funcOp);
 
+// Return the nearest ancestors of two operations that reside in a common
+// block. Returns null anchors when no such block exists below the function.
+std::pair<Operation *, Operation *> getCommonBlockAnchors(Operation *a,
+                                                          Operation *b);
+
+enum class RegionRelation {
+  SameBlock,
+  AIsNested,
+  BIsNested,
+  Siblings,
+  Unsupported,
+};
+
+struct RegionRelationInfo {
+  RegionRelation relation;
+  Operation *aAnchor = nullptr;
+  Operation *bAnchor = nullptr;
+};
+
+RegionRelationInfo getRegionRelationInfo(Operation *a, Operation *b);
+
+// Return whether the code partitioner supports a channel between these
+// endpoints without changing their relative control-flow placement.
+bool isSupportedCrossRegionChannel(Operation *producer, Operation *consumer);
+
 enum class DataChannelKind : int {
   SMEM = 0,
   TMEM = 1,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -179,6 +179,11 @@ struct CommChannel {
   // Producer barrier is only needed when the producer op itself can update the
   // barrier inline, such as the TMA load.
   std::optional<Value> producerBarrier;
+  // Full-cluster rendezvous used before a multicast producer reuses a slot.
+  std::optional<Value> multicastReuseBarrier;
+  // Each consumer partition needs an independent ready rendezvous after the
+  // multicast completion wait.
+  DenseMap<int, Value> multicastReadyBarriers;
   // Consumer barrier is only needed when the consumer op itself can update the
   // barrier inline, such as MMAv5 ops.
   DenseMap<int, Value> consumerBarriers;
@@ -311,8 +316,10 @@ Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
 Operation *
 optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                  SmallVector<triton::nvws::DescriptorLoadOp> &tmaLoads,
-                 Value barrierAlloc, Value bufferIdx, Value bufferIdxExtract,
-                 Value phase, Operation *headProducer, Operation *headConsumer,
+                 Value barrierAlloc, Value multicastReuseBarrier,
+                 const DenseMap<int, Value> &multicastReadyBarriers,
+                 Value bufferIdx, Value bufferIdxExtract, Value phase,
+                 Operation *headProducer, Operation *headConsumer,
                  Operation *headConsumerSameLevel,
                  ArrayRef<int> additionalConsumerTaskIds = {},
                  DictionaryAttr consumerWaitConstraints = {});

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSAtomicBroadcast.cpp
@@ -68,6 +68,14 @@ static SmallVector<AsyncTaskId> getAllPartitions(scf::WhileOp whileOp) {
   return getAsyncTaskIds(whileOp.getOperation());
 }
 
+static bool hasExplicitCluster(Operation *op) {
+  ModuleOp mod = op->getParentOfType<ModuleOp>();
+  if (ttg::TritonGPUDialect::getNumCTAs(mod) != 1)
+    return false;
+  auto dims = ttg::TritonGPUDialect::getClusterDims(mod);
+  return dims[0] * dims[1] * dims[2] > 1;
+}
+
 // Return the enclosing persistent `scf.while` whose after-region terminator
 // (`scf.yield`) directly forwards `result` as a loop-carried value, or nullptr.
 // This is what makes the atomic result "loop-carried": its value drives the
@@ -259,7 +267,20 @@ enum class CLCWSCase {
   Reject       // unsupported -> bail out of WS
 };
 
-static CLCWSCase classifyCLC(ttng::CLCReadOp readOp, scf::WhileOp &whileOut) {
+static CLCWSCase classifyCLC(ttng::CLCReadOp readOp, scf::WhileOp &whileOut,
+                             bool emitRejectionDiagnostics) {
+  if (hasExplicitCluster(readOp)) {
+    if (emitRejectionDiagnostics) {
+      auto dims = ttg::TritonGPUDialect::getClusterDims(
+          readOp->getParentOfType<ModuleOp>());
+      readOp.emitError("clustered CLC AutoWS is unsupported for explicit "
+                       "cluster shape ")
+          << dims[0] << "x" << dims[1] << "x" << dims[2];
+    }
+    LDBG("reject: clustered CLC fetch cannot be warp-specialized");
+    return CLCWSCase::Reject;
+  }
+
   SmallVector<AsyncTaskId> taskIds = getAsyncTaskIds(readOp.getOperation());
   if (taskIds.size() <= 1)
     return CLCWSCase::PassThrough;
@@ -402,7 +423,13 @@ static LogicalResult transformCLC(triton::FuncOp funcOp, ttng::CLCReadOp readOp,
 // async_task_ids), leaving the kernel unspecialized-but-compilable — one source
 // of truth for the reject teardown shared with the other AutoWS bail-outs.
 LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
-                                     int tilePrefetchDepth) {
+                                     int tilePrefetchDepth,
+                                     bool emitRejectionDiagnostics) {
+  SmallVector<std::pair<tt::AtomicRMWOp, scf::WhileOp>> atomicTransforms;
+  SmallVector<std::pair<ttng::CLCReadOp, scf::WhileOp>> clcTransforms;
+
+  // Classify every candidate before mutating the function. A later rejection
+  // must not leave broadcast IR created for an earlier eligible producer.
   // Atomic global tile counter.
   SmallVector<tt::AtomicRMWOp> atomics;
   funcOp.walk([&](tt::AtomicRMWOp op) { atomics.push_back(op); });
@@ -415,11 +442,7 @@ LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
       LDBG("Warp specialization does not support this atomic shape. Skipping.");
       return failure();
     case AtomicWSCase::Transform:
-      if (failed(
-              transformAtomic(funcOp, atomicOp, whileOp, tilePrefetchDepth))) {
-        LDBG("atomic broadcast transform failed; skipping WS.");
-        return failure();
-      }
+      atomicTransforms.emplace_back(atomicOp, whileOp);
       break;
     }
   }
@@ -429,18 +452,29 @@ LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
   funcOp.walk([&](ttng::CLCReadOp op) { reads.push_back(op); });
   for (auto readOp : reads) {
     scf::WhileOp whileOp;
-    switch (classifyCLC(readOp, whileOp)) {
+    switch (classifyCLC(readOp, whileOp, emitRejectionDiagnostics)) {
     case CLCWSCase::PassThrough:
       break;
     case CLCWSCase::Reject:
       LDBG("Warp specialization does not support this CLC fetch. Skipping.");
       return failure();
     case CLCWSCase::Transform:
-      if (failed(transformCLC(funcOp, readOp, whileOp))) {
-        LDBG("CLC broadcast transform failed; skipping WS.");
-        return failure();
-      }
+      clcTransforms.emplace_back(readOp, whileOp);
       break;
+    }
+  }
+
+  for (auto [atomicOp, whileOp] : atomicTransforms) {
+    if (failed(
+            transformAtomic(funcOp, atomicOp, whileOp, tilePrefetchDepth))) {
+      LDBG("atomic broadcast transform failed; skipping WS.");
+      return failure();
+    }
+  }
+  for (auto [readOp, whileOp] : clcTransforms) {
+    if (failed(transformCLC(funcOp, readOp, whileOp))) {
+      LDBG("CLC broadcast transform failed; skipping WS.");
+      return failure();
     }
   }
   return success();
@@ -464,7 +498,8 @@ public:
 
   void runOnOperation() override {
     getOperation()->walk([&](triton::FuncOp funcOp) {
-      if (failed(doDynamicTileBroadcast(funcOp, tilePrefetchDepth)))
+      if (failed(doDynamicTileBroadcast(funcOp, tilePrefetchDepth,
+                                        /*emitRejectionDiagnostics=*/true)))
         signalPassFailure();
     });
   }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -8,6 +8,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
@@ -667,6 +668,19 @@ scf::ForOp createNewLoop(scf::ForOp forOp, scf::ForOp &parentForOp,
 // Go through channels, and get a set of region ops containing channels.
 void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
                                 DenseSet<Operation *> &regionsWithChannels) {
+  auto getCommonEnclosingLoop = [](Operation *a, Operation *b) -> Operation * {
+    if (!a || !b)
+      return nullptr;
+    DenseSet<Operation *> aLoops;
+    for (Operation *op = a->getParentOp(); op; op = op->getParentOp())
+      if (isa<LoopLikeOpInterface>(op))
+        aLoops.insert(op);
+    for (Operation *op = b->getParentOp(); op; op = op->getParentOp())
+      if (aLoops.contains(op))
+        return op;
+    return nullptr;
+  };
+
   for (auto *channel : channels) {
     // A defunct channel's alloc was folded into a reuse representative and
     // erased; its allocOp/endpoints are dangling, so skip it (the
@@ -696,6 +710,15 @@ void collectRegionsWithChannels(const SmallVector<Channel *> &channels,
           // rotates once per persistent iteration, so the while carries it.
           if (auto whileOp = dyn_cast<scf::WhileOp>(pOp))
             regionsWithChannels.insert(pOp);
+        }
+        if (auto *commonLoop = getCommonEnclosingLoop(channel->getSrcOp(),
+                                                      channel->getDstOp())) {
+          if (auto forOp = dyn_cast<scf::ForOp>(commonLoop)) {
+            if (!hasLoopCarriedAccToken(tmemChannel->allocOp, forOp))
+              regionsWithChannels.insert(commonLoop);
+          } else {
+            regionsWithChannels.insert(commonLoop);
+          }
         }
         continue;
       }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -19,6 +19,7 @@
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Partition.h"
@@ -750,7 +751,8 @@ getTaskTopRegion(triton::FuncOp funcOp,
 namespace {
 
 Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
-                         StringRef srcName = "", unsigned arriveCount = 1) {
+                         StringRef srcName = "", unsigned arriveCount = 1,
+                                ttg::CGAEncodingAttr cgaLayout = {}) {
   OpBuilder builder(funcOp);
   builder.setInsertionPointToStart(&(funcOp.getBody().front()));
   Attribute sharedMemorySpace =
@@ -760,16 +762,20 @@ Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
   if (!srcName.empty())
     loc = NameLoc::get(StringAttr::get(context, srcName), loc);
   auto numCTAs = triton::gpu::lookupNumCTAs(funcOp);
-  auto barrierCGALayout = ttg::CGAEncodingAttr::get1DLayout(context, numCTAs);
+  auto barrierCGALayout =
+      cgaLayout ? cgaLayout
+                : ttg::CGAEncodingAttr::get1DLayout(context, numCTAs);
+  auto numBarrierSlots = product(barrierCGALayout.getCTASplitNum());
   auto barrierEncoding = ttg::SwizzledSharedEncodingAttr::get(
       context, 1, 1, 1, {0}, barrierCGALayout);
   Type barrierMemDescType =
-      ttg::MemDescType::get({distance, numCTAs}, builder.getI64Type(),
+      ttg::MemDescType::get({distance, numBarrierSlots}, builder.getI64Type(),
                             barrierEncoding, sharedMemorySpace,
                             /*mutableMemory=*/true);
   Type singleBarrierMemDescType =
-      ttg::MemDescType::get({numCTAs}, builder.getI64Type(), barrierEncoding,
-                            sharedMemorySpace, /*mutableMemory=*/true);
+      ttg::MemDescType::get({numBarrierSlots}, builder.getI64Type(),
+                            barrierEncoding, sharedMemorySpace,
+                            /*mutableMemory=*/true);
   Value barrierAlloc = mlir::triton::gpu::LocalAllocOp::create(
       builder, loc, barrierMemDescType, Value());
   barrierAlloc.getDefiningOp()->setAttr(kWarpSpecializeGeneratedBarrierAttrName,
@@ -1124,29 +1130,65 @@ void createToken(
     CommChannel commChannel;
     auto producerOp = it->second.front()->getSrcOp();
     auto dstOp = it->second.front()->getDstOp();
+    SmallVector<Channel *> channelsForComm;
+    if (reuseGrp >= 0) {
+      auto *group = config->getGroup(reuseGrp);
+      channelsForComm.append(group->channels.begin(), group->channels.end());
+    } else {
+      channelsForComm.push_back(channel);
+    }
 
     // Pre-allocate TMA barrier if any channel in the group has a TMA producer.
     // Also check all channels in the reuse group, not just the consumer group.
-    bool hasTMAProducer = false;
+    SetVector<Operation *> tmaProducerOps;
+    auto collectTMAProducer = [&](Channel *candidate) {
+      if (Operation *load = findTMAProducer(candidate))
+        tmaProducerOps.insert(load);
+    };
     // First check channels grouped by consumer
-    for (auto *c : it->second) {
-      if (findTMAProducer(c)) {
-        hasTMAProducer = true;
-        break;
-      }
-    }
+    for (auto *c : it->second)
+      collectTMAProducer(c);
     // Also check all channels in the reuse group (if applicable)
-    if (!hasTMAProducer && reuseGrp >= 0) {
-      for (auto *c : config->getGroup(reuseGrp)->channels) {
-        if (findTMAProducer(c)) {
-          hasTMAProducer = true;
-          break;
+    if (reuseGrp >= 0)
+      for (auto *c : config->getGroup(reuseGrp)->channels)
+        collectTMAProducer(c);
+    SmallVector<ttnvws::DescriptorLoadOp> tmaProducers =
+        llvm::map_to_vector(tmaProducerOps, [](Operation *load) {
+          return cast<ttnvws::DescriptorLoadOp>(load);
+        });
+    Attribute multicastAxes;
+    if (!tmaProducers.empty()) {
+      multicastAxes =
+          tmaProducers.front()->getAttr(tt::kMulticastAxesAttrName);
+      bool compatible = llvm::all_of(tmaProducers, [&](auto load) {
+        return load->getAttr(tt::kMulticastAxesAttrName) == multicastAxes;
+      });
+      if (!compatible) {
+        for (auto load : tmaProducers)
+          load->removeAttr(tt::kMulticastAxesAttrName);
+        multicastAxes = {};
+      }
+      commChannel.producerBarrier =
+          createBarrierAlloc(funcOp, channel->getNumBuffers(), channel->srcName);
+      if (multicastAxes) {
+        auto dims = ttg::TritonGPUDialect::getClusterDims(
+            tmaProducers.front()->getParentOfType<ModuleOp>());
+        unsigned clusterSize = product(dims);
+        auto identityLayout = getTMAMulticastBarrierLayout(
+            tmaProducers.front(),
+            DenseI32ArrayAttr::get(funcOp.getContext(), {}));
+        commChannel.multicastReuseBarrier = createBarrierAlloc(
+            funcOp, channel->getNumBuffers(), channel->srcName, clusterSize,
+            identityLayout);
+        for (Channel *commSourceChannel : channelsForComm) {
+          for (int taskId : commSourceChannel->relation.second) {
+            if (!commChannel.multicastReadyBarriers.count(taskId))
+              commChannel.multicastReadyBarriers[taskId] = createBarrierAlloc(
+                  funcOp, channel->getNumBuffers(), channel->srcName,
+                  clusterSize, identityLayout);
+          }
         }
       }
-    }
-    if (hasTMAProducer) {
-      commChannel.producerBarrier = createBarrierAlloc(
-          funcOp, channel->getNumBuffers(), channel->srcName);
     }
     // If channel is from an MMAv5 op, pre-allocate the inline barrier used by
     // its commit path.
@@ -1156,14 +1198,6 @@ void createToken(
           funcOp, channel->getNumBuffers(), channel->srcName);
       hasProdBar = true;
     }
-    SmallVector<Channel *> channelsForComm;
-    if (reuseGrp >= 0) {
-      auto *group = config->getGroup(reuseGrp);
-      channelsForComm.append(group->channels.begin(), group->channels.end());
-    } else {
-      channelsForComm.push_back(channel);
-    }
-
     // Check if the channel group needs token-based synchronization.
     // Reuse groups share one CommChannel, so this must consider every channel
     // in the group. Otherwise the representative channel can drop consumer task
@@ -4481,6 +4515,8 @@ void insertAsyncComm(
               WSBarrierAttr::kDirectionForward)
               .build(funcOp.getContext());
       optimizeTMALoads(builder, tmaLoads, *commChannel.producerBarrier,
+                       commChannel.multicastReuseBarrier.value_or(Value()),
+                       commChannel.multicastReadyBarriers,
                        bufferIdx, bufferIdx, phase, tmaHeadProducer,
                        headConsumer, consumerWaitPoint,
                        additionalConsumerTaskIds, waitConstraints);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -752,7 +752,7 @@ namespace {
 
 Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance,
                          StringRef srcName = "", unsigned arriveCount = 1,
-                                ttg::CGAEncodingAttr cgaLayout = {}) {
+                         ttg::CGAEncodingAttr cgaLayout = {}) {
   OpBuilder builder(funcOp);
   builder.setInsertionPointToStart(&(funcOp.getBody().front()));
   Attribute sharedMemorySpace =
@@ -1158,8 +1158,7 @@ void createToken(
         });
     Attribute multicastAxes;
     if (!tmaProducers.empty()) {
-      multicastAxes =
-          tmaProducers.front()->getAttr(tt::kMulticastAxesAttrName);
+      multicastAxes = tmaProducers.front()->getAttr(tt::kMulticastAxesAttrName);
       bool compatible = llvm::all_of(tmaProducers, [&](auto load) {
         return load->getAttr(tt::kMulticastAxesAttrName) == multicastAxes;
       });
@@ -1168,8 +1167,8 @@ void createToken(
           load->removeAttr(tt::kMulticastAxesAttrName);
         multicastAxes = {};
       }
-      commChannel.producerBarrier =
-          createBarrierAlloc(funcOp, channel->getNumBuffers(), channel->srcName);
+      commChannel.producerBarrier = createBarrierAlloc(
+          funcOp, channel->getNumBuffers(), channel->srcName);
       if (multicastAxes) {
         auto dims = ttg::TritonGPUDialect::getClusterDims(
             tmaProducers.front()->getParentOfType<ModuleOp>());
@@ -1177,9 +1176,9 @@ void createToken(
         auto identityLayout = getTMAMulticastBarrierLayout(
             tmaProducers.front(),
             DenseI32ArrayAttr::get(funcOp.getContext(), {}));
-        commChannel.multicastReuseBarrier = createBarrierAlloc(
-            funcOp, channel->getNumBuffers(), channel->srcName, clusterSize,
-            identityLayout);
+        commChannel.multicastReuseBarrier =
+            createBarrierAlloc(funcOp, channel->getNumBuffers(),
+                               channel->srcName, clusterSize, identityLayout);
         for (Channel *commSourceChannel : channelsForComm) {
           for (int taskId : commSourceChannel->relation.second) {
             if (!commChannel.multicastReadyBarriers.count(taskId))
@@ -2544,28 +2543,10 @@ void insertAsyncComm(
       }
       op = op->getParentOp();
     }
-    llvm_unreachable("Failed to find consumer's same level Op with producer");
-  };
-
-  // 0: same scope, -1: A in nested scope, 1: B in nested scope
-  auto isAinNestedRegion = [&](Operation *A, Operation *B) -> int {
-    if (A->getBlock() == B->getBlock())
-      return 0;
-    Operation *op = A;
-    while (!isa<triton::FuncOp>(op)) {
-      if (getEffectiveParentOp(op) == getEffectiveParentOp(B)) {
-        return -1;
-      }
-      op = op->getParentOp();
-    }
-    op = B;
-    while (!isa<triton::FuncOp>(op)) {
-      if (getEffectiveParentOp(op) == getEffectiveParentOp(A)) {
-        return 1;
-      }
-      op = op->getParentOp();
-    }
-    llvm_unreachable("error in isAinNestedRegion");
+    Operation *anchor = getCommonBlockAnchors(p, c).second;
+    if (anchor)
+      return anchor;
+    llvm_unreachable("failed to find a same-level channel endpoint");
   };
 
   mlir::DominanceInfo dom(funcOp);
@@ -2934,12 +2915,14 @@ void insertAsyncComm(
       return false;
     };
     Operation *nestedInsertionTarget = nullptr;
+    Operation *siblingConsumerAnchor = nullptr;
     // Check to see if producer and consumer are in the same block.
     bool producerInNestedRegion = false, consumerInNestedRegion = false;
     if (headProducer->getBlock() != headConsumer->getBlock()) {
       LDBG("different blocks for channel " << masterChannel->uniqID);
-      int regionCmp = isAinNestedRegion(headProducer, headConsumer);
-      if (regionCmp < 0) {
+      RegionRelationInfo regionInfo =
+          getRegionRelationInfo(headProducer, headConsumer);
+      if (regionInfo.relation == RegionRelation::AIsNested) {
         // A/producer in nested region. Lift up headProducer till it is
         // in the same scope as headConsumer.
         //
@@ -2973,11 +2956,19 @@ void insertAsyncComm(
                "producers supported");
         nestedInsertionTarget = getSameLevelOp(headConsumer, headProducer);
         producerInNestedRegion = true;
-      } else if (regionCmp > 0) {
+      } else if (regionInfo.relation == RegionRelation::BIsNested) {
         // B/consumer in nested region. Lift up headConsumer till it is
         // in the same scope as headProducer.
         nestedInsertionTarget = getSameLevelOp(tmaHeadProducer, headConsumer);
         consumerInNestedRegion = true;
+      } else if (regionInfo.relation == RegionRelation::Siblings) {
+        assert(isSupportedCrossRegionChannel(headProducer, headConsumer) &&
+               "sibling channel must pass preflight validation");
+        nestedInsertionTarget = regionInfo.aAnchor;
+        siblingConsumerAnchor = regionInfo.bAnchor;
+        producerInNestedRegion = true;
+      } else {
+        llvm_unreachable("cross-region channel must pass preflight validation");
       }
     } else {
       // Check to see if consumer appears later than producer (loop-carried).
@@ -3715,8 +3706,10 @@ void insertAsyncComm(
                 funcOp.getContext(), masterChannel->relation.first,
                 WSBarrierAttr::kDirectionForward)
                 .build(funcOp.getContext());
+        Operation *completionConsumer =
+            siblingConsumerAnchor ? siblingConsumerAnchor : headConsumer;
         desyncMMAv5Op(builder, mmaOp, *commChannel.producerBarrier, bufferIdx,
-                      phase, headConsumer, false, addCompletionBarrier,
+                      phase, completionConsumer, false, addCompletionBarrier,
                       waitConstraints);
       }
     }
@@ -4516,9 +4509,8 @@ void insertAsyncComm(
               .build(funcOp.getContext());
       optimizeTMALoads(builder, tmaLoads, *commChannel.producerBarrier,
                        commChannel.multicastReuseBarrier.value_or(Value()),
-                       commChannel.multicastReadyBarriers,
-                       bufferIdx, bufferIdx, phase, tmaHeadProducer,
-                       headConsumer, consumerWaitPoint,
+                       commChannel.multicastReadyBarriers, bufferIdx, bufferIdx,
+                       phase, tmaHeadProducer, headConsumer, consumerWaitPoint,
                        additionalConsumerTaskIds, waitConstraints);
     }
   }
@@ -5328,18 +5320,41 @@ static void lowerMultiTaskSubtiledRegions(triton::FuncOp funcOp) {
     ttng::lowerSubtiledRegion(op);
 }
 
+static LogicalResult validateCrossRegionChannels(
+    triton::FuncOp funcOp,
+    const SmallVector<std::unique_ptr<Channel>> &channels) {
+  for (const auto &channel : channels) {
+    Operation *producer = channel->getSrcOp();
+    Operation *consumer = channel->getDstOp();
+    if (!producer || !consumer) {
+      return funcOp.emitError()
+             << "warp specialization could not resolve channel #"
+             << channel->uniqID << " endpoints";
+    }
+    if (!isSupportedCrossRegionChannel(producer, consumer)) {
+      return funcOp.emitError()
+             << "warp specialization does not support cross-region channel #"
+             << channel->uniqID << " (" << to_string(channel->channelKind)
+             << ")";
+    }
+  }
+  return success();
+}
+
 } // namespace
 
-void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers) {
+LogicalResult doCodePartition(triton::FuncOp funcOp, unsigned numBuffers) {
   // Step 1: collect all communications between producers and consumers.
   SmallVector<std::unique_ptr<Channel>> channelsOrigin;
   collectAllocChannels(channelsOrigin, funcOp);
+  if (failed(validateCrossRegionChannels(funcOp, channelsOrigin)))
+    return failure();
   SmallVector<Channel *> channels;
   for (const auto &c : channelsOrigin) {
     channels.push_back(c.get());
   }
   if (channels.empty()) {
-    return;
+    return success();
   }
   SmallVector<Channel *> orderedChannels;
   orderedChannels = channels;
@@ -5771,6 +5786,7 @@ void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers) {
     LDBG("\n\nwith specializeRegion");
     funcOp.dump();
   });
+  return success();
 }
 
 #define GEN_PASS_DEF_NVGPUTESTWSCODEPARTITION
@@ -5805,7 +5821,10 @@ public:
         signalPassFailure();
         return;
       }
-      doCodePartition(funcOp, numBuffers);
+      if (failed(doCodePartition(funcOp, numBuffers))) {
+        signalPassFailure();
+        return;
+      }
     }
     // Set NameLoc("accum_cnt") on ForOp block arguments whose corresponding
     // yield operand already has an "accum_cnt" NameLoc. This must be done at

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Transforms/RegionUtils.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -191,11 +192,33 @@ Value getTMALoadBufferForStage(OpBuilderWithAsyncTaskIds &builder, Value buffer,
 
 } // namespace
 
+static void createMulticastRendezvous(OpBuilderWithAsyncTaskIds &builder,
+                                      Location loc, Value barrierAlloc,
+                                      Value bufferIdx, Value phase,
+                                      Operation *clusterOp) {
+  auto module = clusterOp->getParentOfType<ModuleOp>();
+  auto dims = ttg::TritonGPUDialect::getClusterDims(module);
+  unsigned clusterSize = product(dims);
+  assert(clusterSize > 1 && llvm::isPowerOf2_32(clusterSize));
+
+  Value barrier =
+      getBarrierForPipelineStage(builder, barrierAlloc, bufferIdx);
+  builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
+      loc, barrier, /*count=*/1, /*ctaMask=*/clusterSize - 1,
+      /*pred=*/Value());
+  if (!phase.getType().isInteger(32))
+    phase = builder.createWithAsyncTaskIds<arith::ExtUIOp>(
+        loc, builder.getI32Type(), phase);
+  builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(loc, barrier, phase);
+}
+
 Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             SmallVector<ttnvws::DescriptorLoadOp> &tmaLoads,
-                            Value barrierAlloc, Value bufferIdx,
-                            Value bufferIdxExtract, Value phase,
-                            Operation *headProducer, Operation *headConsumer,
+                            Value barrierAlloc, Value multicastReuseBarrier,
+                            const DenseMap<int, Value> &multicastReadyBarriers,
+                            Value bufferIdx, Value bufferIdxExtract,
+                            Value phase, Operation *headProducer,
+                            Operation *headConsumer,
                             Operation *headConsumerSameLevel,
                             ArrayRef<int> additionalConsumerTaskIds,
                             DictionaryAttr consumerWaitConstraints) {
@@ -217,6 +240,16 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   builder.createWithAsyncTaskIds<ttng::BarrierExpectOp>(loc, prodBarrier,
                                                         sizeInBytes, pred);
 
+  bool hasMulticast = llvm::any_of(
+      tmaLoads,
+      [](auto load) { return load->hasAttr(tt::kMulticastAxesAttrName); });
+  if (hasMulticast) {
+    assert(multicastReuseBarrier &&
+           "multicast producer requires a reuse rendezvous");
+    createMulticastRendezvous(builder, loc, multicastReuseBarrier, bufferIdx,
+                              phase, headProducer);
+  }
+
   // Convert all the producers to async_tma_copy_global_to_local
   Operation *copy = nullptr;
   for (auto tmaLoad : tmaLoads) {
@@ -228,6 +261,8 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     copy = builder.createWithAsyncTaskIds<ttng::AsyncTMACopyGlobalToLocalOp>(
         tmaLoad.getLoc(), tmaLoad.getDesc(), tmaLoad.getIndices(), prodBarrier,
         pipelineBuffer, pred);
+    if (Attribute axes = tmaLoad->getAttr(tt::kMulticastAxesAttrName))
+      copy->setAttr(tt::kMulticastAxesAttrName, axes);
   }
 
   // Create a wait_barrier before the first consumer.
@@ -253,11 +288,28 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, consBarrier, phase, waitPred, /*deps=*/ValueRange{},
       consumerWaitConstraints);
+  if (hasMulticast) {
+    for (int taskId : getAsyncTaskIds(headConsumer)) {
+      auto it = multicastReadyBarriers.find(taskId);
+      assert(it != multicastReadyBarriers.end() &&
+             "multicast consumer requires a ready rendezvous");
+      builder.setAsynTaskIdsFromArray({taskId});
+      createMulticastRendezvous(builder, loc, it->second, bufferIdxExtract,
+                                phase, headConsumer);
+    }
+  }
   for (int extraTaskId : additionalConsumerTaskIds) {
     builder.setAsynTaskIdsFromArray({extraTaskId});
     builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
         loc, consBarrier, phase, waitPred,
         /*deps=*/ValueRange{}, consumerWaitConstraints);
+    if (hasMulticast) {
+      auto it = multicastReadyBarriers.find(extraTaskId);
+      assert(it != multicastReadyBarriers.end() &&
+             "multicast consumer requires a ready rendezvous");
+      createMulticastRendezvous(builder, loc, it->second, bufferIdxExtract,
+                                phase, headConsumer);
+    }
   }
 
   for (auto tmaLoad : tmaLoads)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -88,6 +88,40 @@ static bool isValueNeededByTask(Value value, AsyncTaskId asyncTaskId,
           }
           continue;
         }
+        if (auto whileOp = dyn_cast<scf::WhileOp>(yield->getParentOp())) {
+          for (auto [index, operand] : llvm::enumerate(yield.getOperands())) {
+            if (operand != curr)
+              continue;
+            Value beforeArg = whileOp.getBeforeArguments()[index];
+            if (followBackedge && visited.insert(beforeArg).second)
+              worklist.push_back(beforeArg);
+          }
+          continue;
+        }
+      }
+      // A while condition can forward only a subset of the before-region
+      // arguments, and may reorder them. Follow the SSA forwarding relation to
+      // the matching after-region argument and result instead of treating the
+      // shared condition op itself as a use by every task.
+      if (auto condition = dyn_cast<scf::ConditionOp>(user)) {
+        auto whileOp = cast<scf::WhileOp>(condition->getParentOp());
+        if (curr == condition.getCondition() &&
+            hasAsyncTaskId(whileOp, asyncTaskId))
+          return true;
+        bool isForwarded = false;
+        for (auto [index, arg] : llvm::enumerate(condition.getArgs())) {
+          if (arg != curr)
+            continue;
+          isForwarded = true;
+          Value afterArg = whileOp.getAfterArguments()[index];
+          if (visited.insert(afterArg).second)
+            worklist.push_back(afterArg);
+          Value result = whileOp.getResult(index);
+          if (visited.insert(result).second)
+            worklist.push_back(result);
+        }
+        if (isForwarded)
+          continue;
       }
       // Follow an init only through its matching loop-carried value.
       if (auto forOp = dyn_cast<scf::ForOp>(user)) {
@@ -107,6 +141,19 @@ static bool isValueNeededByTask(Value value, AsyncTaskId asyncTaskId,
                              curr == forOp.getUpperBound() ||
                              curr == forOp.getStep();
         if (isInit && !isLoopControl)
+          continue;
+      }
+      if (auto whileOp = dyn_cast<scf::WhileOp>(user)) {
+        bool isInit = false;
+        for (auto [index, init] : llvm::enumerate(whileOp.getInits())) {
+          if (init != curr)
+            continue;
+          isInit = true;
+          Value beforeArg = whileOp.getBeforeArguments()[index];
+          if (visited.insert(beforeArg).second)
+            worklist.push_back(beforeArg);
+        }
+        if (isInit)
           continue;
       }
       if (hasAsyncTaskId(user, asyncTaskId))
@@ -325,6 +372,28 @@ SmallVector<unsigned> collectBlockArgsForTask(scf::ForOp forOp,
   return args;
 }
 
+struct WhileTaskSlots {
+  SmallVector<unsigned> before;
+  SmallVector<unsigned> results;
+};
+
+static WhileTaskSlots collectWhileSlotsForTask(scf::WhileOp whileOp,
+                                                AsyncTaskId asyncTaskId) {
+  WhileTaskSlots slots;
+  for (auto [index, arg] : llvm::enumerate(whileOp.getBeforeArguments())) {
+    if (isValueNeededByTask(arg, asyncTaskId, /*followBackedge=*/false))
+      slots.before.push_back(index);
+  }
+  for (unsigned index = 0; index < whileOp.getNumResults(); ++index) {
+    if (isValueNeededByTask(whileOp.getAfterArguments()[index], asyncTaskId,
+                            /*followBackedge=*/false) ||
+        isValueNeededByTask(whileOp.getResult(index), asyncTaskId,
+                            /*followBackedge=*/false))
+      slots.results.push_back(index);
+  }
+  return slots;
+}
+
 Operation *SpecializeIfOp(scf::IfOp ifOp, IRMapping &mapping,
                           OpBuilderWithAsyncTaskIds &builder,
                           AsyncTaskId asyncTaskId) {
@@ -503,13 +572,19 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
 Operation *SpecializeWhileOp(scf::WhileOp whileOp, IRMapping &mapping,
                              OpBuilderWithAsyncTaskIds &builder,
                              AsyncTaskId asyncTaskId) {
+  WhileTaskSlots slots = collectWhileSlotsForTask(whileOp, asyncTaskId);
+
   SmallVector<Value> newInits;
-  for (Value init : whileOp.getInits())
-    newInits.push_back(mapping.lookupOrDefault(init));
+  for (unsigned index : slots.before)
+    newInits.push_back(mapping.lookupOrDefault(whileOp.getInits()[index]));
+
+  SmallVector<Type> newResultTypes;
+  for (unsigned index : slots.results)
+    newResultTypes.push_back(whileOp.getResult(index).getType());
 
   builder.setLoopScheduleInfoFromOp(whileOp);
   auto newWhileOp = builder.createWithAsyncTaskIds<scf::WhileOp>(
-      whileOp.getLoc(), whileOp->getResultTypes(), newInits);
+      whileOp.getLoc(), newResultTypes, newInits);
   builder.clearLoopScheduleInfo();
   for (auto attr : whileOp->getAttrs()) {
     if (attr.getName() != "async_task_id")
@@ -519,7 +594,7 @@ Operation *SpecializeWhileOp(scf::WhileOp whileOp, IRMapping &mapping,
   SmallVector<Type> beforeTypes;
   for (Value init : newInits)
     beforeTypes.push_back(init.getType());
-  SmallVector<Type> afterTypes(whileOp->getResultTypes());
+  SmallVector<Type> afterTypes(newResultTypes);
   SmallVector<Location> beforeLocs(beforeTypes.size(), whileOp.getLoc());
   SmallVector<Location> afterLocs(afterTypes.size(), whileOp.getLoc());
   if (newWhileOp.getBefore().empty())
@@ -530,12 +605,21 @@ Operation *SpecializeWhileOp(scf::WhileOp whileOp, IRMapping &mapping,
   newWhileOp.getAfterBody()->addArguments(afterTypes, afterLocs);
 
   IRMapping localMapping = mapping;
-  for (auto [oldArg, newArg] :
-       llvm::zip(whileOp.getBeforeArguments(), newWhileOp.getBeforeArguments()))
-    localMapping.map(oldArg, newArg);
-  for (auto [oldArg, newArg] :
-       llvm::zip(whileOp.getAfterArguments(), newWhileOp.getAfterArguments()))
-    localMapping.map(oldArg, newArg);
+  for (auto [newIndex, oldIndex] : llvm::enumerate(slots.before))
+    localMapping.map(whileOp.getBeforeArguments()[oldIndex],
+                     newWhileOp.getBeforeArguments()[newIndex]);
+  for (auto [newIndex, oldIndex] : llvm::enumerate(slots.results))
+    localMapping.map(whileOp.getAfterArguments()[oldIndex],
+                     newWhileOp.getAfterArguments()[newIndex]);
+
+  auto mapRegionValue = [&](Value value, Region &region) {
+    if (region.isAncestor(value.getParentRegion())) {
+      Value mapped = localMapping.lookupOrNull(value);
+      assert(mapped && "retained while value was not cloned for this task");
+      return mapped;
+    }
+    return localMapping.lookupOrDefault(value);
+  };
 
   OpBuilderWithAsyncTaskIds whileBuilder(whileOp.getContext());
   whileBuilder.setAsynTaskIdsFromArray({asyncTaskId});
@@ -545,12 +629,13 @@ Operation *SpecializeWhileOp(scf::WhileOp whileOp, IRMapping &mapping,
     SpecializeOp(&op, localMapping, whileBuilder, asyncTaskId);
   auto condOp = whileOp.getConditionOp();
   SmallVector<Value> condArgs;
-  for (Value arg : condOp.getArgs())
-    condArgs.push_back(localMapping.lookupOrDefault(arg));
+  for (unsigned index : slots.results)
+    condArgs.push_back(mapRegionValue(condOp.getArgs()[index],
+                                      whileOp.getBefore()));
   whileBuilder.setLoopScheduleInfoFromOp(condOp);
   whileBuilder.createWithAsyncTaskIds<scf::ConditionOp>(
-      condOp.getLoc(), localMapping.lookupOrDefault(condOp.getCondition()),
-      condArgs);
+      condOp.getLoc(),
+      mapRegionValue(condOp.getCondition(), whileOp.getBefore()), condArgs);
   whileBuilder.clearLoopScheduleInfo();
 
   whileBuilder.setInsertionPointToStart(newWhileOp.getAfterBody());
@@ -558,16 +643,16 @@ Operation *SpecializeWhileOp(scf::WhileOp whileOp, IRMapping &mapping,
     SpecializeOp(&op, localMapping, whileBuilder, asyncTaskId);
   auto yieldOp = whileOp.getYieldOp();
   SmallVector<Value> yieldArgs;
-  for (Value arg : yieldOp.getOperands())
-    yieldArgs.push_back(localMapping.lookupOrDefault(arg));
+  for (unsigned index : slots.before)
+    yieldArgs.push_back(
+        mapRegionValue(yieldOp.getOperand(index), whileOp.getAfter()));
   whileBuilder.setLoopScheduleInfoFromOp(yieldOp);
   whileBuilder.createWithAsyncTaskIds<scf::YieldOp>(yieldOp.getLoc(),
                                                     yieldArgs);
   whileBuilder.clearLoopScheduleInfo();
 
-  for (auto [oldResult, newResult] :
-       llvm::zip(whileOp.getResults(), newWhileOp.getResults()))
-    mapping.map(oldResult, newResult);
+  for (auto [newIndex, oldIndex] : llvm::enumerate(slots.results))
+    mapping.map(whileOp.getResult(oldIndex), newWhileOp.getResult(newIndex));
 
   return newWhileOp;
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
@@ -27,7 +27,8 @@ LogicalResult doTaskIdPropagate(triton::FuncOp funcOp);
 // Cross-partition run-once atomic support. Returns failure() when an atomic
 // forces a graceful warp-specialization reject (kernel already de-specialized).
 LogicalResult doDynamicTileBroadcast(triton::FuncOp funcOp,
-                                     int tilePrefetchDepth);
+                                     int tilePrefetchDepth,
+                                     bool emitRejectionDiagnostics = false);
 
 // Test-only knobs for doMemoryPlanner. The production pipeline uses the
 // defaults; only the -nvgpu-test-ws-memory-planner pass varies them:

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WarpSpecializationPipeline.h
@@ -57,7 +57,7 @@ LogicalResult doBufferAllocation(triton::FuncOp funcOp);
 LogicalResult doConvertDescriptorLoadsToNVWS(triton::FuncOp funcOp);
 void doHoistLoopInvariantTMEMStore(triton::FuncOp funcOp);
 void removeRedundantTmemZeroStores(triton::FuncOp funcOp);
-void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers);
+LogicalResult doCodePartition(triton::FuncOp funcOp, unsigned numBuffers);
 void doTokenLowering(triton::FuncOp funcOp, unsigned numConsumerGroups);
 void doPingPongPrep(triton::FuncOp funcOp, unsigned numWarpGroups,
                     int capability, int defaultNumStages);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodePartition.md
@@ -65,6 +65,19 @@ Step 4:   separateLocalAllocWithSrc   — split local_alloc(src) → alloc + sto
 
 ## Channel Discovery
 
+## Compiler-Selected TMA Multicast
+
+The standard Triton multicast planner annotates eligible descriptor loads before
+warp-specialization lowering. Native warp specialization preserves the plan,
+groups loads by broadcast axes, and brackets each multicast transaction with
+full-cluster rendezvous.
+
+Meta AutoWS preserves the same plan through NVWS channels. Channel construction
+allocates cluster-wide reuse and consumer-ready barriers, and memory lowering
+executes those rendezvous in the participating task partitions before buffer
+reuse. If producers sharing a channel group have incompatible multicast axes,
+channel construction removes the plan and falls back to per-CTA TMA.
+
 ### `collectAsyncChannels`
 
 Walks the function to find all cross-partition data dependencies:

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -427,8 +427,9 @@ struct ArriveBarrierOpConversion
 
     if (isPerThread) {
       // Warp arrive: every thread arrives independently, no leader pattern.
-      // perThread arrives are warp-specialization (single CTA) and never
-      // broadcast across CTAs, so no lead-CTA redirection applies here.
+      // perThread arrives do not use ctaMask multicast or lead-CTA
+      // redirection, but the barrier itself may be mapped into remote shared
+      // memory.
       bool hasPred = !!op.getPred();
       std::stringstream ptxAsm;
       if (hasPred) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -40,8 +40,6 @@ using namespace mlir::triton;
 namespace ttg = mlir::triton::gpu;
 namespace ttng = mlir::triton::nvidia_gpu;
 
-namespace ttg = mlir::triton::gpu;
-
 void mlir::triton::NVIDIA::createFenceMBarrierInitReleaseCluster(
     OpBuilder &builder, Location loc, Value pred) {
   PTXBuilder ptxBuilder;
@@ -71,6 +69,12 @@ PhysicalClusterInfo getPhysicalClusterInfo(Operation *op) {
   if (explicitSize > 1)
     return {std::move(dims), explicitSize, numCTAs == 1};
   return {{numCTAs, 1, 1}, numCTAs, false};
+}
+
+static unsigned getBarrierNumCTAs(ttg::MemDescType barrierTy) {
+  auto cgaLayout = ttg::getCGALayout(barrierTy.getEncoding());
+  auto kBlock = StringAttr::get(barrierTy.getContext(), "block");
+  return cgaLayout.getLinearLayout().getInDimSize(kBlock);
 }
 
 Value getElectWarp0OrThread0(const NVIDIA::TargetInfo &targetInfo,
@@ -172,7 +176,7 @@ struct InitBarrierOpConversion
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
       pred = b.and_(pred, *leaderPred);
 
-    auto numCTAs = triton::gpu::lookupNumCTAs(op);
+    auto numCTAs = getBarrierNumCTAs(barrierTy);
     auto initCount = op.getCount();
     // The lead barrier accounts for all arrives from CTAs that broadcast into
     // the same barrier.
@@ -298,7 +302,7 @@ struct WaitBarrierOpConversion
     auto pred = adaptor.getPred();
     if (auto leaderPred =
             LLVM::NVIDIA::getLeaderCTAPredicate(loc, rewriter, barrierTy))
-      pred = b.and_(pred, *leaderPred);
+      pred = pred ? b.and_(pred, *leaderPred) : *leaderPred;
 
     bool predicated = pred && !matchPattern(pred, m_NonZero());
     int suspendNs = 0;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ClusterOpsToLLVM.cpp
@@ -116,6 +116,13 @@ static Value getClusterBarrierMbarPtr(Location loc, RewriterBase &rewriter,
                b.i32_val(offset));
 }
 
+static int getClusterSize(Operation *op) {
+  ModuleOp mod = op->getParentOfType<ModuleOp>();
+  auto dims = triton::gpu::TritonGPUDialect::getClusterDims(mod);
+  int physicalSize = dims[0] * dims[1] * dims[2];
+  return physicalSize > 1 ? physicalSize : triton::gpu::lookupNumCTAs(op);
+}
+
 template <typename EmitFn>
 void lowerClusterSyncForWarpCounts(Location loc, OpBuilder &rewriter,
                                    int defaultNumWarps, int totalNumWarps,
@@ -317,7 +324,7 @@ struct ClusterBarrierOpConversion
     Value barrierPtr = b.gep(ptrTy, barrierSlotTy, barrierPtr0, barrierIdx);
     Value threadId = getThreadId(rewriter, loc);
     Value pred = b.icmp_eq(threadId, b.i32_val(0));
-    int numCTAs = triton::gpu::lookupNumCTAs(op);
+    int numCTAs = getClusterSize(op);
     bool relaxed = op.getRelaxed() && targetInfo.getPtxVersion() >= 86;
     if (targetInfo.supportsMbarrierMulticast()) {
       Value ctaId = NVVM::ClusterId::create(rewriter, loc, i32_ty);
@@ -431,7 +438,7 @@ struct InitializeWSClusterBarriers
     int64_t count = countAttr.getInt();
     int64_t offset =
         shared - count * triton::nvidia_gpu::kClusterBarrierMbarAllocationSize;
-    int numCTAs = triton::gpu::lookupNumCTAs(kernel);
+    int numCTAs = getClusterSize(kernel);
     for (int64_t i = 0; i < count;
          ++i, offset += triton::nvidia_gpu::kClusterBarrierMbarAllocationSize) {
       Value barrierPtr0 =

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -15,6 +15,7 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/TMAMulticast.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -1376,6 +1377,11 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       pred = b.and_(pred, b.icmp_eq(ctaIdInGroup, b.i32_val(0)));
     }
 
+    if (op->hasAttr(tt::kMulticastAxesAttrName) &&
+        !op.getMulticastTargets())
+      return op.emitError(
+          "tt.multicast_axes must be materialized before LLVM lowering");
+
     uint32_t barrierMask =
         toLinearLayout(barrierTy).getFreeVariableMasks().lookup(kBlock);
     // Use a cross-CTA mbarrier pointer when the barrier mask is set.
@@ -1422,7 +1428,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
       // the cluster -- a cluster barrier (#9510), multicast, or a 2-CTA group;
       // otherwise it is CTA-local. The barrier component keys on the barrier
       // layout (not the SMEM layout), matching #9510.
-      auto multicastMask = op.getMulticastTargets();
+      if (Value explicitMask = op.getMulticastTargets())
+        multicastMask = explicitMask;
       // The current Hopper toolchain emits PTX < 8.6, where shared::cta TMA
       // loads are not accepted. Conservatively use cluster scope on Hopper;
       // keep CTA scope on Blackwell.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -151,7 +151,9 @@ Value createLeaderCTAPredicate(Location loc, OpBuilder &rewriter) {
 
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
                              uint16_t broadcastBits) {
-  int numCTAs = triton::gpu::lookupNumCTAs(rewriter);
+  auto module =
+      rewriter.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>();
+  int numCTAs = triton::gpu::lookupPhysicalNumCTAs(module);
   auto encoding =
       triton::nvidia_gpu::getTMAMulticastMaskEncoding(numCTAs, broadcastBits);
   auto b = TritonLLVMOpBuilder(loc, rewriter);

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -191,6 +191,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUTMemBarrierInsertionPass);
   ADD_PASS_WRAPPER_0("add_tma_lowering",
                      ttng::createTritonNvidiaGPUTMALoweringPass);
+  ADD_PASS_WRAPPER_0("add_tma_multicast",
+                     ttng::createTritonNvidiaGPUTMAMulticastPass);
   ADD_PASS_WRAPPER_1("add_promote_load_to_tma", createPromoteLoadToTMAWrapper,
                      bool);
   ADD_PASS_WRAPPER_0("add_tma_store_buffer_reuse",

--- a/unittest/Analysis/CMakeLists.txt
+++ b/unittest/Analysis/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_triton_ut(
   NAME TestTritonAnalysis
-  SRCS UtilityTest.cpp
+  SRCS UtilityTest.cpp TMAMulticastTest.cpp
   LIBS
     TritonAnalysis
     TritonIR

--- a/unittest/Analysis/TMAMulticastTest.cpp
+++ b/unittest/Analysis/TMAMulticastTest.cpp
@@ -1,0 +1,65 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAMulticast.h"
+
+#include "llvm/ADT/SmallBitVector.h"
+#include <gtest/gtest.h>
+
+using mlir::triton::nvidia_gpu::TMAClusterGeometry;
+
+namespace {
+
+llvm::SmallBitVector axes(std::initializer_list<unsigned> values) {
+  llvm::SmallBitVector result(3);
+  for (unsigned value : values)
+    result.set(value);
+  return result;
+}
+
+TEST(TMAMulticastGeometry, RankCoordinatesAreXMajor) {
+  TMAClusterGeometry geometry{{2, 4, 1}};
+  EXPECT_EQ(geometry.size(), 8u);
+  EXPECT_EQ(geometry.coordinates(0), (llvm::SmallVector<int, 3>{0, 0, 0}));
+  EXPECT_EQ(geometry.coordinates(3), (llvm::SmallVector<int, 3>{1, 1, 0}));
+  EXPECT_EQ(geometry.coordinates(7), (llvm::SmallVector<int, 3>{1, 3, 0}));
+}
+
+TEST(TMAMulticastGeometry, OneDimensionalGroups) {
+  for (int size : {2, 4, 8}) {
+    TMAClusterGeometry geometry{{size, 1, 1}};
+    uint16_t fullMask = uint16_t((1u << size) - 1);
+    for (unsigned rank = 0; rank < geometry.size(); ++rank) {
+      EXPECT_EQ(geometry.maskFor(rank, axes({0})), fullMask);
+      EXPECT_EQ(geometry.leaderFor(rank, axes({0})), 0u);
+    }
+  }
+}
+
+TEST(TMAMulticastGeometry, RectangularOperandGroups) {
+  TMAClusterGeometry geometry{{2, 4, 1}};
+  EXPECT_EQ(geometry.maskFor(0, axes({1})), 0x55);
+  EXPECT_EQ(geometry.maskFor(1, axes({1})), 0xaa);
+  EXPECT_EQ(geometry.leaderFor(7, axes({1})), 1u);
+  EXPECT_EQ(geometry.maskFor(0, axes({0})), 0x03);
+  EXPECT_EQ(geometry.maskFor(5, axes({0})), 0x30);
+  EXPECT_EQ(geometry.leaderFor(7, axes({0})), 6u);
+}
+
+TEST(TMAMulticastGeometry, ThreeDimensionalGroups) {
+  TMAClusterGeometry geometry{{2, 2, 2}};
+  EXPECT_EQ(geometry.coordinates(4), (llvm::SmallVector<int, 3>{0, 0, 1}));
+  EXPECT_EQ(geometry.coordinates(7), (llvm::SmallVector<int, 3>{1, 1, 1}));
+  EXPECT_EQ(geometry.maskFor(0, axes({2})), 0x11);
+  EXPECT_EQ(geometry.maskFor(3, axes({2})), 0x88);
+  EXPECT_EQ(geometry.leaderFor(7, axes({2})), 3u);
+  EXPECT_EQ(geometry.maskFor(0, axes({1, 2})), 0x55);
+  EXPECT_EQ(geometry.maskFor(1, axes({1, 2})), 0xaa);
+}
+
+TEST(TMAMulticastGeometry, SingletonWhenNoAxisBroadcasts) {
+  TMAClusterGeometry geometry{{4, 2, 1}};
+  for (unsigned rank = 0; rank < geometry.size(); ++rank) {
+    EXPECT_EQ(geometry.maskFor(rank, axes({})), uint16_t(1u << rank));
+    EXPECT_EQ(geometry.leaderFor(rank, axes({})), rank);
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Teach physical warp specialization to follow each `scf.while` init, condition-forwarded value, result, and backedge independently. Each task retains only the while slots it consumes, preventing epilogue-only state from being cloned into the load and MMA partitions.

Add a clustered multicast lit reproducer and a Tutorial 09 runtime test whose source `while` survives through TTIR and final TTGIR across multiple persistent iterations. The runtime test uses explicit per-load multicast, a 2x2 cluster, a guarded boundary epilogue, and verifies GEMM correctness.

Differential Revision: D116164614
