### PR TITLE
[Triton][TLX] Default masked tlx.async_load lanes to zero-fill (#2895)

### DIFF
--- a/python/test/unit/language/test_tlx_async_load_partial_mask.py
+++ b/python/test/unit/language/test_tlx_async_load_partial_mask.py
@@ -47,6 +47,10 @@ if has_tlx():
         offs = offs_m[:, None] * BLOCK_K + offs_k[None, :]
         smem = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(a_ptr), 1)
         if USE_MASK:
+            # Ensure masked lanes must be overwritten rather than relying on
+            # freshly allocated shared memory happening to contain zero.
+            poison = tl.full((BLOCK_M, BLOCK_K), 7.0, tlx.dtype_of(a_ptr))
+            tlx.local_store(tlx.local_view(smem, 0), poison)
             tok = tlx.async_load(a_ptr + offs, tlx.local_view(smem, 0), mask=offs_k[None, :] < VALID_K)
         else:
             tok = tlx.async_load(a_ptr + offs, tlx.local_view(smem, 0))
@@ -122,6 +126,7 @@ class TlxAsyncLoadPartialMaskTest(unittest.TestCase):
         )
         torch.cuda.synchronize()
         torch.testing.assert_close(out[:, :5], a[:, :5])
+        torch.testing.assert_close(out[:, 5:], torch.zeros_like(out[:, 5:]))
 
     def test_sync_load_partial_mask_fix_ok(self):
         # THE FIX: the same partial mask via a synchronous tl.load compiles and is correct.

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -857,6 +857,9 @@ def async_load(
     """
     Loads buffer from global to local memory asynchronously.
 
+    When ``mask`` is provided and ``other`` is omitted, masked destination
+    elements are filled with zero.
+
     When ``bulk=True``, emits a single ``cp.async.bulk`` instruction instead of
     per-thread ``cp.async`` copies. Requirements for bulk mode:
 
@@ -918,9 +921,11 @@ def async_load(
     assert bulk_size is None, "bulk_size requires bulk=True"
     assert barrier is None, "barrier requires bulk=True"
 
-    # Unwrap constexpr and convert to tensor (same as tl.load)
+    # Unwrap constexpr, apply the TLX zero-fill default, and convert to tensor.
     mask = tl._unwrap_if_constexpr(mask)
     other = tl._unwrap_if_constexpr(other)
+    if mask is not None and other is None:
+        other = 0.0
     if mask is not None:
         mask = _semantic.to_tensor(mask)
     if other is not None:


### PR DESCRIPTION
Summary:

Diff summary:

- mem_ops.py
  - Changed tlx.async_load so masked loads default other to 0.0 when omitted.
  - Documented that masked destination elements are zero-filled.
  - Bulk async-load behavior remains unchanged.

- test_tlx_async_load_partial_mask.py
  - Pre-fills shared memory with 7.0 before masked async loads.
  - Verifies valid lanes contain loaded input values.
  - Verifies masked lanes are overwritten with zero instead of retaining stale shared-memory data.

Reviewed By: htyu

Differential Revision: D116500886


