### PR TITLE
[TLX][AMD] Add gfx950 GDPA forward kernel

### DIFF
--- a/third_party/tlx/tutorials/gfx950_gdpa.py
+++ b/third_party/tlx/tutorials/gfx950_gdpa.py
@@ -1,0 +1,652 @@
+"""GDPA (Generalized Dot-Product Attention) forward for AMD gfx950 / MI350 (CDNA4).
+
+GDPA is flash attention with the online softmax replaced by a pointwise
+activation:
+
+    qk  = q @ k.T * qk_scale
+    p   = gelu(qk)              # no row-max, no running sum, no acc rescale
+    out = p @ v
+
+Because there is no softmax there are no cross-lane reductions and no
+accumulator correction between the two dots, so the inner loop is strictly
+simpler than FA's.
+
+v1 scope (the OmniFM V3 pFFN production path):
+  * jagged Q   -- variable sequence length per batch, `q_offsets[B + 1]`
+  * dense KV   -- every batch has exactly `dff` key/value rows
+  * fast gelu, non-causal, no bias, no window, no GQA, no fused QKV
+Everything else in the Blackwell kernel's constexpr surface (FUSED_QKV,
+BROADCAST_Q, WINDOW_SIZE, STAGE, is_predict, ...) is out of scope here.
+
+Tensor layouts (all bf16, `d = D // H`):
+    q    [total_q, H, d]     jagged, row i of batch b at q_offsets[b] + i
+    k    [B * dff, H, d]     dense, batch b occupies rows b*dff .. (b+1)*dff
+    v    [B * dff, H, d]     dense, same as k
+    out  [total_q, H, d]     jagged, same layout as q
+
+These kernels are gfx950/MI350 (CDNA4)-specific.
+"""
+
+import math
+from typing import Any, Optional
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+try:
+    from triton.language.extra.libdevice import (
+        fast_dividef,
+        fast_expf,
+    )  # @manual=//triton:triton
+except ImportError:
+    try:
+        # @manual=//triton:triton
+        from triton.language.extra.hip.libdevice import fast_dividef, fast_expf
+    except ImportError:
+        # pyre-ignore[21]
+        from triton.language.math import (
+            fast_dividef,
+            fast_expf,
+        )  # @manual=//triton:triton
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# The production shape this kernel targets: OmniFM V3 pFFN.
+#   batch=2048 max_seq_len=500 dim=256 head=4 head_dim=64 kv_len(dff)=256 sp=0.68
+# Reference points on this shape (bf16, forward), MI350X, stock Triton GDPA:
+#   tuned (all AMD opts)  0.5927 ms / 144.9 TFLOPS   <- the number to beat
+#   baseline              1.4714 ms /  58.4 TFLOPS
+# Those numbers correspond to total_q = 327,680 (= B * 160), which the
+# "uniform" seq-len mode reproduces exactly; see SEQ_LEN_MODES.
+PROD_CONFIG: dict[str, Any] = {
+    "B": 2048,
+    "max_M": 500,
+    "D": 256,
+    "H": 4,
+    "dff": 256,
+    "sparsity": 0.68,
+    "dtype": torch.bfloat16,
+    "seq_len_mode": "uniform",
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Activation
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# The kernel reproduces the production `fast_gelu` (activation_enum_int == 3)
+# from fbcode/ads_mkl/ops/triton/math.py, AMD branch:
+#
+#     k = 2 * 0.7978845608
+#     fast_gelu(x) = x * sigmoid_approx(k * x * (1 + 0.044715 * x^2))
+#     sigmoid_approx(u) = fast_dividef(1, 1 + fast_expf(-u))
+#
+# This is the *tanh* approximation of gelu, rewritten through the identity
+#   0.5 * (1 + tanh(u)) == sigmoid(2u)
+# so it computes with HIP's fast_dividef/fast_expf instead of a tanh. It is
+# therefore numerically equivalent to torch.nn.GELU(approximate="tanh") --
+# which is exactly what ads_mkl's get_pytorch_activation maps FastGeLU to --
+# and NOT the cruder x * sigmoid(1.702x) form.
+#
+# The sigmoid rewrite is what makes this cheap on gfx950: the Blackwell path
+# uses `tanh_approx_fp32`, which is CUDA inline PTX (`tanh.approx.f32`) with no
+# gfx950 equivalent. This substitution is the +47.7% step in the MI350X GDPA
+# tuning ladder.
+#
+# The correctness reference below uses *exact* erf gelu, so the accuracy gate
+# absorbs the approximation error on purpose. `gelu_approx_error()` reports the
+# approximation's own contribution separately, so a failing test can be
+# attributed to either the kernel or the approximation rather than guessed at.
+
+# k = 2 * sqrt(2/pi), matching ads_mkl.
+GELU_TANH_K = 2.0 * 0.7978845608
+GELU_TANH_C = 0.044715
+
+
+def gelu_exact(x: torch.Tensor) -> torch.Tensor:
+    """Exact gelu: x * 0.5 * (1 + erf(x / sqrt(2))). Computed in fp32."""
+    x = x.float()
+    return x * 0.5 * (1.0 + torch.erf(x * (1.0 / math.sqrt(2.0))))
+
+
+def fast_gelu_ref(x: torch.Tensor) -> torch.Tensor:
+    """Torch mirror of the kernel's fast_gelu -- the ads_mkl AMD formula."""
+    x = x.float()
+    return x * torch.sigmoid(GELU_TANH_K * x * (1.0 + GELU_TANH_C * x * x))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Data generation
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Two incompatible readings of "sparsity" are in play, and they differ by 2.1x
+# in total work on the production shape. Both are supported explicitly rather
+# than silently picking one:
+#
+#   "uniform" -- every sequence is exactly round((1 - sparsity) * max_M).
+#       At B=2048, max_M=500, sparsity=0.68 this gives seq=160 and
+#       total_q = 2048 * 160 = 327,680, which reproduces the total_q behind the
+#       144.9 TFLOPS MI350X reference number exactly. Use this when comparing
+#       against that baseline.
+#
+#   "random"  -- the Blackwell GDPA generator: randint over
+#       [(2*sparsity - 1) * max_M, max_M). At the same settings this gives an
+#       average sequence of ~337 and total_q ~690k. Genuinely jagged, so it is
+#       the better stress test for the tile scheduler, but its latency is not
+#       comparable to the reference number.
+SEQ_LEN_MODES = ("uniform", "random")
+
+
+def generate_sparse_seq_len(
+    B: int,
+    max_seq_len: int,
+    sparsity: float,
+    device: torch.device | str,
+    mode: str = "uniform",
+    generator: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    """Per-batch Q lengths. See SEQ_LEN_MODES for the two conventions."""
+    assert mode in SEQ_LEN_MODES, f"mode must be one of {SEQ_LEN_MODES}, got {mode!r}"
+
+    if sparsity == 1.0:
+        return torch.full((B, ), max_seq_len, device=device, dtype=torch.int32)
+
+    if mode == "uniform":
+        seq = max(int(round((1.0 - sparsity) * max_seq_len)), 1)
+        return torch.full((B, ), seq, device=device, dtype=torch.int32)
+
+    if sparsity >= 0.5:
+        low = max(int((2 * sparsity - 1.0) * max_seq_len), 1)
+        high = max_seq_len
+    else:
+        low = 1
+        high = max(int(2 * sparsity * max_seq_len), 2)
+    return torch.randint(low=low, high=high, size=(B, ), device=device, dtype=torch.int32, generator=generator)
+
+
+def generate_gdpa_data(
+    B: int,
+    max_M: int,
+    D: int,
+    H: int,
+    dff: int,
+    sparsity: float = 0.68,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | str | None = None,
+    seed: int = 42,
+    seq_len_mode: str = "uniform",
+) -> dict[str, Any]:
+    """Jagged-Q / dense-KV GDPA inputs.
+
+    Returns q/k/v plus `q_offsets` and the derived sizes. `D` is the *model*
+    dimension; per-head width is `d = D // H`.
+
+    `seq_len_mode` picks the sparsity convention -- see SEQ_LEN_MODES. It
+    changes total work by ~2x on the production shape, so it must be reported
+    alongside any measurement.
+
+    Values are drawn from a unit normal so the qk products land in the range
+    where the gelu approximation is least accurate -- this is deliberately the
+    hard case for the accuracy gate.
+    """
+    if device is None:
+        device = DEVICE
+    assert D % H == 0, f"D={D} must be divisible by H={H}"
+    d = D // H
+
+    gen = torch.Generator(device=device).manual_seed(seed)
+
+    seq_lens = generate_sparse_seq_len(B, max_M, sparsity, device, mode=seq_len_mode, generator=gen)
+    q_offsets = torch.cat(
+        [torch.zeros(1, device=device, dtype=torch.int32),
+         seq_lens.cumsum(dim=0).to(torch.int32)],
+        dim=0,
+    )
+    total_q = int(q_offsets[-1].item())
+
+    q = torch.randn(total_q, H, d, device=device, dtype=dtype, generator=gen)
+    k = torch.randn(B * dff, H, d, device=device, dtype=dtype, generator=gen)
+    v = torch.randn(B * dff, H, d, device=device, dtype=dtype, generator=gen)
+
+    return {
+        "q": q.contiguous(),
+        "k": k.contiguous(),
+        "v": v.contiguous(),
+        "q_offsets": q_offsets,
+        "seq_lens": seq_lens,
+        "B": B,
+        "H": H,
+        "D": D,
+        "d": d,
+        "dff": dff,
+        "max_M": max_M,
+        "total_q": total_q,
+        "sparsity": sparsity,
+        "seq_len_mode": seq_len_mode,
+        "dtype": dtype,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Reference
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def gdpa_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_offsets: torch.Tensor,
+    dff: int,
+    qk_scale: float = 1.0,
+    activation=gelu_exact,
+) -> torch.Tensor:
+    """Torch reference: per (batch, head), out = activation(q @ k.T * s) @ v.
+
+    Accumulates in fp32 and casts back to q's dtype at the end, matching what
+    the kernel does (fp32 MFMA accumulators, bf16 store).
+
+    Deliberately a plain loop over batches -- this is a correctness oracle, not
+    a performance baseline, and the jagged Q makes a batched form awkward
+    without padding (which would change the numerics).
+    """
+    B = q_offsets.numel() - 1
+    out = torch.empty_like(q)
+    offsets = q_offsets.tolist()
+
+    for b in range(B):
+        lo, hi = offsets[b], offsets[b + 1]
+        if hi == lo:
+            continue
+        # [Mb, H, d] -> [H, Mb, d]
+        q_b = q[lo:hi].transpose(0, 1).float()
+        k_b = k[b * dff:(b + 1) * dff].transpose(0, 1).float()
+        v_b = v[b * dff:(b + 1) * dff].transpose(0, 1).float()
+
+        s = torch.bmm(q_b, k_b.transpose(1, 2)) * qk_scale  # [H, Mb, dff]
+        p = activation(s)
+        o = torch.bmm(p, v_b)  # [H, Mb, d]
+        out[lo:hi] = o.transpose(0, 1).to(out.dtype)
+
+    return out
+
+
+def gelu_approx_error(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_offsets: torch.Tensor,
+    dff: int,
+    qk_scale: float = 1.0,
+) -> dict[str, float]:
+    """How much of the kernel-vs-reference gap is the gelu approximation alone.
+
+    Runs the reference twice -- once with exact gelu, once with the sigmoid
+    form the kernel uses -- and reports the delta. Any kernel error below this
+    floor is not distinguishable from the approximation.
+    """
+    ref_exact = gdpa_ref(q, k, v, q_offsets, dff, qk_scale, activation=gelu_exact).float()
+    ref_fast = gdpa_ref(q, k, v, q_offsets, dff, qk_scale, activation=fast_gelu_ref).float()
+    diff = (ref_exact - ref_fast).abs()
+    denom = ref_exact.abs().clamp_min(1e-6)
+    return {
+        "max_abs": diff.max().item(),
+        "mean_abs": diff.mean().item(),
+        "max_rel": (diff / denom).max().item(),
+        "rel_l2": (diff.norm() / ref_exact.norm().clamp_min(1e-6)).item(),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TFLOPS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def gdpa_flops(total_q: int, H: int, d: int, dff: int) -> int:
+    """Forward FLOPs: two GEMMs per (row, head).
+
+    qk  : [total_q, d] @ [d, dff]  -> 2 * total_q * d * dff
+    pv  : [total_q, dff] @ [dff, d] -> 2 * total_q * dff * d
+    Times H heads. Matches the formula used in the MI350X GDPA tuning report
+    (`fwd_flops = 4 * H * d * total_Q * kv_len`), so numbers are directly
+    comparable to the 144.9 TFLOPS baseline.
+    """
+    return 4 * H * d * total_q * dff
+
+
+def gdpa_tflops(ms: float, total_q: int, H: int, d: int, dff: int) -> float:
+    return gdpa_flops(total_q, H, d, dff) * 1e-12 / (ms * 1e-3)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Kernels
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@triton.jit
+def _fast_gelu(x):
+    """ads_mkl's AMD `fast_gelu`, verbatim: x * sigmoid(k*x*(1 + c*x^2)).
+
+    Written as the sigmoid of the tanh argument (see the module header) so it
+    lowers to fast_expf/fast_dividef; gfx950 has no tanh.approx.f32.
+    """
+    u = x * (GELU_TANH_K + GELU_TANH_K * GELU_TANH_C * x * x)
+    return x * fast_dividef(1.0, 1.0 + fast_expf(-u))
+
+
+@triton.jit
+def _remap_xcd(pid, grid_size, NUM_XCDS: tl.constexpr):
+    """Round-robin pid -> XCD so consecutive tiles of one (batch, head) land on
+    the same chiplet and share its L2 slice for K/V."""
+    pids_per_xcd = (grid_size + NUM_XCDS - 1) // NUM_XCDS
+    tall_xcds = grid_size % NUM_XCDS
+    tall_xcds = NUM_XCDS if tall_xcds == 0 else tall_xcds
+    xcd = pid % NUM_XCDS
+    local_pid = pid // NUM_XCDS
+    if xcd < tall_xcds:
+        pid = xcd * pids_per_xcd + local_pid
+    else:
+        pid = tall_xcds * pids_per_xcd + (xcd - tall_xcds) * (pids_per_xcd - 1) + local_pid
+    return pid
+
+
+@triton.jit
+def _gdpa_pid_decode(H, MAX_M, BLOCK_M: tl.constexpr, NUM_XCDS: tl.constexpr):
+    """Flat pid -> (batch, head, m-tile). Grid is sized on MAX_M, so tiles past a
+    sequence's end are launched and exit immediately."""
+    num_m_blocks = tl.cdiv(MAX_M, BLOCK_M)
+    tpid = _remap_xcd(tl.program_id(0), tl.num_programs(0), NUM_XCDS)
+    off_h = tpid % H
+    off_nz = tpid // H
+    pid_m = off_nz % num_m_blocks
+    off_z = off_nz // num_m_blocks
+    return off_z, off_h, pid_m
+
+
+@triton.jit
+def _gdpa_assume_strides(stride_qm, stride_qh, stride_kn, stride_kh, stride_vn, stride_vh, stride_om, stride_oh):
+    tl.assume(stride_qm > 0)
+    tl.assume(stride_qh > 0)
+    tl.assume(stride_kn > 0)
+    tl.assume(stride_kh > 0)
+    tl.assume(stride_vn > 0)
+    tl.assume(stride_vh > 0)
+    tl.assume(stride_om > 0)
+    tl.assume(stride_oh > 0)
+
+
+@triton.jit
+def _gdpa_fwd_pipelined(
+    Q,
+    K,
+    V,
+    Out,
+    q_offsets,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_om,
+    stride_oh,
+    H,
+    MAX_M,
+    QK_SCALE: tl.constexpr,
+    DFF: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    NUM_BUFFERS: tl.constexpr,
+):
+    """Modulo-scheduled GDPA forward.
+
+    Prologue loads KV block 0; the steady-state loop consumes block i out of one
+    LDS slot while `buffer_load_to_lds` fills block i+1 into the other; the last
+    block is peeled so the hot loop never carries a mask. K is transposed at the
+    memdesc level (`local_trans`), which is metadata-only -- it lands `local_load`
+    directly in dot-operand layout and skips the ds_write/barrier/ds_read shuffle
+    that `tl.dot(q, k.T)` would emit every iteration.
+
+    Unlike flash attention there is no online softmax: `_fast_gelu` is pointwise,
+    so no row reduction and no accumulator rescale sit between the two dots.
+    """
+    _gdpa_assume_strides(stride_qm, stride_qh, stride_kn, stride_kh, stride_vn, stride_vh, stride_om, stride_oh)
+    off_z, off_h, pid_m = _gdpa_pid_decode(H, MAX_M, BLOCK_M, NUM_XCDS)
+
+    seq_start = tl.load(q_offsets + off_z).to(tl.int64)
+    seq_len = (tl.load(q_offsets + off_z + 1).to(tl.int64) - seq_start).to(tl.int32)
+    start_m = pid_m * BLOCK_M
+
+    if start_m < seq_len:
+        offs_m = start_m + tl.arange(0, BLOCK_M)
+        offs_n = tl.arange(0, BLOCK_N)
+        offs_d = tl.arange(0, BLOCK_D)
+        offs_dv = tl.arange(0, BLOCK_D_V)
+        mask_m = offs_m < seq_len
+
+        q_base = Q + off_h.to(tl.int64) * stride_qh + seq_start * stride_qm
+        q = tl.load(q_base + offs_m[:, None] * stride_qm + offs_d[None, :], mask=mask_m[:, None], other=0.0)
+
+        kv_start = off_z.to(tl.int64) * DFF
+        k_ptrs = (K + off_h.to(tl.int64) * stride_kh + kv_start * stride_kn + offs_n[:, None] * stride_kn +
+                  offs_d[None, :])
+        v_ptrs = (V + off_h.to(tl.int64) * stride_vh + kv_start * stride_vn + offs_n[:, None] * stride_vn +
+                  offs_dv[None, :])
+
+        k_buf = tlx.local_alloc((BLOCK_N, BLOCK_D), K.dtype.element_ty, NUM_BUFFERS)
+        v_buf = tlx.local_alloc((BLOCK_N, BLOCK_D_V), V.dtype.element_ty, NUM_BUFFERS)
+
+        acc = tl.zeros([BLOCK_M, BLOCK_D_V], dtype=tl.float32)
+
+        # KV is dense -- every batch has exactly DFF rows -- so the block count
+        # is a compile-time constant and only the final block can be ragged.
+        N_BLOCKS: tl.constexpr = (DFF + BLOCK_N - 1) // BLOCK_N
+        N_MAIN: tl.constexpr = N_BLOCKS - 1
+        EVEN_N: tl.constexpr = DFF % BLOCK_N == 0
+
+        # Prologue: fetch block 0.
+        if EVEN_N:
+            tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0))
+            tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0))
+        else:
+            mask0 = offs_n[:, None] < DFF
+            tok_k0 = tlx.async_load(k_ptrs, tlx.local_view(k_buf, 0), mask=mask0)
+            tok_v0 = tlx.async_load(v_ptrs, tlx.local_view(v_buf, 0), mask=mask0)
+        tlx.async_load_commit_group([tok_k0, tok_v0])
+
+        # Steady state: consume block i, prefetch block i+1 into the other slot.
+        for block_id in tl.range(0, N_MAIN * BLOCK_N, BLOCK_N, num_stages=1):
+            i = block_id // BLOCK_N
+            slot_cur = i % NUM_BUFFERS
+            slot_nxt = (i + 1) % NUM_BUFFERS
+            next_off = block_id + BLOCK_N
+
+            wait_tok = tlx.async_load_wait_group(0)
+            kt_cur = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, slot_cur)), token=wait_tok)
+            v_cur = tlx.local_load(tlx.local_view(v_buf, slot_cur), token=wait_tok)
+
+            if EVEN_N:
+                tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt))
+                tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt))
+            else:
+                next_mask = (next_off + offs_n[:, None]) < DFF
+                tok_k = tlx.async_load(k_ptrs + next_off * stride_kn, tlx.local_view(k_buf, slot_nxt), mask=next_mask)
+                tok_v = tlx.async_load(v_ptrs + next_off * stride_vn, tlx.local_view(v_buf, slot_nxt), mask=next_mask)
+            tlx.async_load_commit_group([tok_k, tok_v])
+
+            qk = tl.dot(q, kt_cur, allow_tf32=True) * QK_SCALE
+            p = _fast_gelu(qk)
+            acc = tl.dot(p.to(v_cur.dtype), v_cur, acc, allow_tf32=True)
+
+        # Peeled last block -- the only one that can need a boundary mask.
+        SLOT_LAST: tl.constexpr = N_MAIN % NUM_BUFFERS
+        wait_tok = tlx.async_load_wait_group(0)
+        kt_cur = tlx.local_load(tlx.local_trans(tlx.local_view(k_buf, SLOT_LAST)), token=wait_tok)
+        v_cur = tlx.local_load(tlx.local_view(v_buf, SLOT_LAST), token=wait_tok)
+
+        qk = tl.dot(q, kt_cur, allow_tf32=True) * QK_SCALE
+        p = _fast_gelu(qk)
+        if not EVEN_N:
+            kn_last = N_MAIN * BLOCK_N + offs_n
+            p = tl.where(kn_last[None, :] < DFF, p, 0.0)
+        acc = tl.dot(p.to(v_cur.dtype), v_cur, acc, allow_tf32=True)
+
+        o_base = Out + off_h.to(tl.int64) * stride_oh + seq_start * stride_om
+        tl.store(o_base + offs_m[:, None] * stride_om + offs_dv[None, :], acc.to(Out.dtype.element_ty),
+                 mask=mask_m[:, None])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Launcher
+# ═══════════════════════════════════════════════════════════════════════════
+
+# `matrix_instr_nonkdim` and `waves_per_eu` are the two knobs that actually paid
+# off in the MI350X stock-Triton GDPA tuning ladder (+29.8% for waves_per_eu on
+# top of everything else), so they stay in the search space rather than pinned.
+FULL_TUNING = False
+
+# (BLOCK_M, BLOCK_N, num_warps, NUM_BUFFERS). BLOCK_M dominates: a longer m-tile
+# amortises the K/V stream over more query rows, at the cost of more wasted rows
+# in each sequence's ragged tail. NUM_BUFFERS is cheap to deepen here -- CDNA4
+# has 160 KB of LDS and the widest entry below only needs 2 x (16 + 16) KB.
+_FWD_TILES = (
+    (128, 64, 4, 2),
+    (128, 64, 4, 3),
+    (256, 64, 8, 2),
+    (256, 64, 8, 3),
+    (256, 128, 8, 2),
+)
+_FWD_WAVES_PER_EU = (0, 2, 4)
+
+
+def _get_fwd_configs() -> list[triton.Config]:
+    if FULL_TUNING:
+        tiles = [(bm, bn, nw, nb)
+                 for bm in (64, 128, 256)
+                 for bn in (32, 64, 128)
+                 for nw in (4, 8)
+                 for nb in (2, 3, 4)]
+        waves = (0, 1, 2, 4)
+        nonkdims = (16, 32)
+    else:
+        tiles = list(_FWD_TILES)
+        waves = _FWD_WAVES_PER_EU
+        nonkdims = (16, )
+
+    return [
+        triton.Config(
+            {
+                "BLOCK_M": bm,
+                "BLOCK_N": bn,
+                "NUM_BUFFERS": nb,
+                "matrix_instr_nonkdim": nk,
+                "waves_per_eu": we,
+            },
+            num_stages=1,
+            num_warps=nw,
+        ) for bm, bn, nw, nb in tiles for we in waves for nk in nonkdims
+    ]
+
+
+_AUTOTUNE_KEY = ["H", "MAX_M", "DFF", "QK_SCALE"]
+
+_gdpa_fwd_pipelined_tuned = triton.autotune(configs=_get_fwd_configs(), key=_AUTOTUNE_KEY)(_gdpa_fwd_pipelined)
+
+
+def _check_and_prepare(q, k, v, q_offsets, dff):
+    assert q.dim() == 3 and k.dim() == 3 and v.dim() == 3, "q/k/v must be [rows, H, d]"
+    total_q, H, d = q.shape
+    B = q_offsets.numel() - 1
+    assert k.shape == (B * dff, H, d), f"k must be [B*dff, H, d] = {(B * dff, H, d)}, got {tuple(k.shape)}"
+    assert v.shape == k.shape, "v must have k's shape"
+    assert d & (d - 1) == 0, f"head_dim must be a power of two, got {d}"
+    assert q.stride(2) == 1 and k.stride(2) == 1 and v.stride(2) == 1, "q/k/v must be contiguous in d"
+    return total_q, H, d, B
+
+
+def _launch(kernel, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw):
+    total_q, H, d, B = _check_and_prepare(q, k, v, q_offsets, dff)
+    out = torch.empty_like(q)
+    if total_q == 0:
+        return out
+
+    if max_M is None:
+        # One host sync. Pass `max_M` explicitly on any timed path.
+        max_M = int((q_offsets[1:] - q_offsets[:-1]).max().item())
+    if max_M == 0:
+        return out
+
+    grid = lambda meta: (triton.cdiv(max_M, meta["BLOCK_M"]) * B * H, )  # noqa: E731
+    kernel[grid](
+        q,
+        k,
+        v,
+        out,
+        q_offsets,
+        q.stride(0),
+        q.stride(1),
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        out.stride(0),
+        out.stride(1),
+        H,
+        max_M,
+        QK_SCALE=qk_scale,
+        DFF=dff,
+        BLOCK_D=d,
+        BLOCK_D_V=d,
+        NUM_XCDS=num_xcds,
+        **kw,
+    )
+    return out
+
+
+def gdpa_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_offsets: torch.Tensor,
+    dff: int,
+    qk_scale: float = 1.0,
+    max_M: Optional[int] = None,
+    num_xcds: int = 8,
+    **kw,
+) -> torch.Tensor:
+    """GDPA forward, jagged Q x dense KV.
+
+    Args:
+        q:         [total_q, H, d] bf16, jagged rows
+        k, v:      [B * dff, H, d] bf16, dense per batch
+        q_offsets: [B + 1] int32, prefix sum of per-batch Q lengths
+        dff:       KV rows per batch
+        qk_scale:  scale applied to q @ k.T before the activation
+        max_M:     longest sequence, used to size the grid. Derived from
+                   `q_offsets` when omitted, which costs a host sync -- pass it
+                   explicitly from any benchmarked path.
+
+    Returns:
+        [total_q, H, d], same dtype/layout as q.
+    """
+    return _launch(_gdpa_fwd_pipelined_tuned, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw)
+
+
+KERNEL_REGISTRY = {
+    "pipelined": gdpa_forward,
+}
+
+
+def get_kernel(name):
+    if name not in KERNEL_REGISTRY:
+        raise ValueError(f"Unknown kernel: {name!r}. Available: {list(KERNEL_REGISTRY.keys())}")
+    return KERNEL_REGISTRY[name]
+
+
+# Default launcher for the suite.
+gdpa = gdpa_forward

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -94,6 +94,12 @@ from triton.language.extra.tlx.tutorials.amd_addmm_glu import (
     M as _amd_addmm_glu_M,
     N as _amd_addmm_glu_N,
 )
+from triton.language.extra.tlx.tutorials.gfx950_gdpa import (
+    gdpa as _gfx950_gdpa,
+    gdpa_ref as _gfx950_gdpa_ref,
+    generate_gdpa_data as _gfx950_gdpa_gen,
+    gelu_approx_error as _gfx950_gdpa_approx_error,
+)
 from triton.language.extra.tlx.tutorials.amd_addmm_gfx950 import addmm as _amd_addmm
 from triton.language.extra.tlx.tutorials import amd_hstu_attn as _hstu
 from triton.tools.mxfp import MXScaleTensor
@@ -1809,6 +1815,58 @@ def test_amd_addmm_glu(kernel_name, K):
     ref = _amd_addmm_glu_baseline(bias, a, b, y)
     out = _amd_addmm_glu_registry[kernel_name](a, b, bias, y)
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+# =============================================================================
+# gfx950 GDPA (Generalized Dot-Product Attention) Tests
+# =============================================================================
+#
+# The kernel computes gelu via ads_mkl's AMD `fast_gelu`, which is the tanh
+# approximation rewritten as x * sigmoid(k*x*(1 + c*x^2)) so it lowers to
+# fast_expf/fast_dividef; gfx950 has no tanh.approx.f32. The reference uses exact
+# erf gelu, so the tolerance has to absorb the approximation error and is looser
+# than the other AMD attention tests. `gelu_approx_error` reports the
+# approximation's own contribution -- if a failure is at or near that floor it
+# is the approximation, not the kernel.
+
+# Threshold: the measured gelu-approximation floor is rel_l2 ~2.3e-3 across all
+# cases below, and bf16 output rounding adds ~2e-3. 1e-2 leaves ~3x headroom
+# over that combined floor while still catching a real kernel bug. Compared via
+# relative L2 rather than elementwise max-rel: the reference has near-zero
+# elements (max_rel reaches 5e3 on them) which make elementwise ratios useless.
+
+
+@pytest.mark.parametrize(
+    "B,max_M,H,dff,sparsity,seq_len_mode",
+    [(8, 500, 4, 256, 0.68, "uniform"),  # prod geometry, small batch
+     (8, 500, 4, 256, 0.68, "random"),  # genuinely ragged sequence lengths
+     (8, 500, 4, 256, 1.0, "uniform"),  # dense Q
+     (4, 137, 4, 256, 0.68, "random"),  # ragged max_M (not a multiple of BLOCK_M)
+     (4, 500, 4, 192, 0.68, "random"),  # dff not a power of two
+     (1, 64, 2, 256, 1.0, "uniform"),  # single batch, short Q
+     ],
+    ids=["uniform", "jagged", "dense", "ragged_m", "npot_dff", "single"],
+)
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
+def test_amd_gfx950_gdpa(B, max_M, H, dff, sparsity, seq_len_mode):
+    """GDPA forward: jagged Q x dense KV, out = gelu(q @ k.T) @ v per sequence."""
+    D = H * 64  # head_dim = 64, matching the production shape
+    data = _gfx950_gdpa_gen(B, max_M, D, H, dff, sparsity=sparsity, dtype=torch.bfloat16, device=DEVICE, seed=42,
+                            seq_len_mode=seq_len_mode)
+    q, k, v, q_offsets = data["q"], data["k"], data["v"], data["q_offsets"]
+
+    ref = _gfx950_gdpa_ref(q, k, v, q_offsets, dff, qk_scale=1.0)
+    out = _gfx950_gdpa(q, k, v, q_offsets, dff, qk_scale=1.0)
+
+    assert out.shape == q.shape and out.dtype == q.dtype
+    diff = (out.float() - ref.float()).abs()
+    rel_l2 = (diff.norm() / ref.float().norm().clamp_min(1e-6)).item()
+    if rel_l2 >= 1e-2:
+        floor = _gfx950_gdpa_approx_error(q, k, v, q_offsets, dff, qk_scale=1.0)
+        pytest.fail(f"GDPA rel_l2={rel_l2:.4e} exceeds 1e-2; "
+                    f"gelu-approximation floor is rel_l2={floor['rel_l2']:.4e} "
+                    f"(max_abs={floor['max_abs']:.4e}) -- a result near the floor "
+                    f"means the approximation, not the kernel")
 
 
 # =============================================================================

--- a/third_party/tlx/tutorials/testing/test_gfx950_gdpa_perf.py
+++ b/third_party/tlx/tutorials/testing/test_gfx950_gdpa_perf.py
@@ -1,0 +1,157 @@
+"""Perf harness for the TLX AMD GDPA forward kernel (gfx950 / MI350, CDNA4).
+
+Run:
+    python third_party/tlx/tutorials/testing/test_gfx950_gdpa_perf.py
+    python third_party/tlx/tutorials/testing/test_gfx950_gdpa_perf.py --version tlx --shape prod
+
+Reference points on the production shape (OmniFM V3 pFFN:
+B=2048, max_M=500, D=256, H=4, head_dim=64, dff=256, sparsity=0.68, bf16),
+measured on MI350X with the stock Triton GDPA kernel:
+
+    forward, no AMD optimizations       1.4714 ms /  58.4 TFLOPS
+    + gelu fast math (sigmoid)          0.7694 ms / 111.7 TFLOPS
+    + PID swizzle (size=8)              0.8015 ms / 107.2 TFLOPS
+    + matrix_instr_nonkdim=16           0.8441 ms / 101.8 TFLOPS
+    + waves_per_eu (all opts)           0.5927 ms / 144.9 TFLOPS   <- target
+
+TFLOPS here uses the same formula as that report
+(`fwd_flops = 4 * H * d * total_Q * kv_len`); at total_Q = 327,680 and
+0.5927 ms it reproduces 144.9 TFLOPS exactly, so the numbers are directly
+comparable.
+
+That total_Q corresponds to a *uniform* sequence length of 160
+(= (1 - 0.68) * 500) across all 2048 batches, which is the default
+`seq_len_mode="uniform"` here. The Blackwell GDPA generator reads sparsity
+differently -- randint over [(2*sp - 1)*max_M, max_M), average ~337 -- which is
+2.1x the work. That mode is available as `--seq-len-mode random` and is the
+harder scheduling case, but its latency is *not* comparable to the numbers
+above. total_Q is always measured from the generated offsets, never assumed.
+"""
+
+import argparse
+
+import torch
+
+import triton
+
+from triton.language.extra.tlx.tutorials.gfx950_gdpa import (
+    SEQ_LEN_MODES,
+    generate_gdpa_data,
+    gdpa_ref,
+    gdpa_tflops,
+    fast_gelu_ref,
+    get_kernel,
+)
+
+from triton._internal_testing import is_hip
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+# name -> (B, max_M, D, H, dff, sparsity)
+SHAPES = {
+    # The production target.
+    "prod": (2048, 500, 256, 4, 256, 0.68),
+    # Same geometry, fully dense Q -- isolates the jagged scheduling cost.
+    "prod_dense": (2048, 500, 256, 4, 256, 1.0),
+    # Smaller batch, same per-sequence work -- occupancy / tail behaviour.
+    "small_batch": (256, 500, 256, 4, 256, 0.68),
+    # Wider KV -- shifts the balance toward the second GEMM.
+    "wide_kv": (2048, 500, 256, 4, 512, 0.68),
+}
+DEFAULT_SHAPES = ["prod"]
+
+PROVIDERS = ["tlx", "torch"]
+DEFAULT_PROVIDERS = ["tlx"]
+
+
+def _torch_eager(data):
+    """Eager torch baseline: the same math via the reference path.
+
+    This is a sanity floor, not a competitive baseline -- `gdpa_ref` loops over
+    batches in Python, so at B=2048 it is dominated by launch overhead. The
+    meaningful comparison is against the 144.9 TFLOPS Triton number recorded in
+    the module docstring.
+    """
+    return lambda: gdpa_ref(
+        data["q"],
+        data["k"],
+        data["v"],
+        data["q_offsets"],
+        data["dff"],
+        qk_scale=1.0,
+        activation=fast_gelu_ref,
+    )
+
+
+def create_benchmark(shapes, providers, kernel_name="pipelined", seq_len_mode="uniform"):
+    x_vals = [SHAPES[s] for s in shapes]
+    x_ids = list(shapes)
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["B", "max_M", "D", "H", "dff", "sparsity"],
+            x_vals=x_vals,
+            line_arg="provider",
+            line_vals=providers,
+            line_names=providers,
+            ylabel="TFLOPS",
+            plot_name=f"gfx950-gdpa-forward-bf16-{seq_len_mode}",
+            args={"kernel_name": kernel_name, "seq_len_mode": seq_len_mode},
+        ))
+    def benchmark(B, max_M, D, H, dff, sparsity, provider, kernel_name, seq_len_mode):
+        data = generate_gdpa_data(B, max_M, D, H, dff, sparsity=sparsity, dtype=torch.bfloat16, device=DEVICE,
+                                  seq_len_mode=seq_len_mode)
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider == "torch":
+            fn = _torch_eager(data)
+        elif provider == "tlx":
+            gdpa = get_kernel(kernel_name)
+            fn = lambda: gdpa(data["q"], data["k"], data["v"], data["q_offsets"], data["dff"], qk_scale=1.0)
+        else:
+            raise ValueError(f"unknown provider {provider!r}")
+
+        ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles, warmup=100, rep=200)
+
+        perf = lambda t: gdpa_tflops(t, data["total_q"], H, data["d"], dff)
+        return perf(ms), perf(max_ms), perf(min_ms)
+
+    return benchmark, x_ids
+
+
+def _print_shape_summary(shapes, seq_len_mode):
+    print(f"Shapes under test (seq_len_mode={seq_len_mode}, total_q measured from generated offsets):")
+    for name in shapes:
+        B, max_M, D, H, dff, sparsity = SHAPES[name]
+        data = generate_gdpa_data(B, max_M, D, H, dff, sparsity=sparsity, dtype=torch.bfloat16, device=DEVICE,
+                                  seq_len_mode=seq_len_mode)
+        note = ""
+        if name == "prod" and data["total_q"] == 327680:
+            note = "  <- matches the 144.9 TFLOPS reference total_q"
+        print(f"  {name:<12} B={B} max_M={max_M} D={D} H={H} d={data['d']} dff={dff} "
+              f"sp={sparsity} total_q={data['total_q']} (avg seq {data['total_q'] / B:.1f}){note}")
+    print()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark the TLX AMD GDPA forward kernel")
+    parser.add_argument("--shape", type=str, nargs="+", choices=list(SHAPES), default=None,
+                        help=f"Shapes to run. Choices: {list(SHAPES)}")
+    parser.add_argument("--version", type=str, nargs="+", choices=PROVIDERS, default=None,
+                        help=f"Providers to run. Choices: {PROVIDERS}")
+    parser.add_argument("--kernel", type=str, default="pipelined", help="Kernel variant from KERNEL_REGISTRY")
+    parser.add_argument("--seq-len-mode", type=str, choices=list(SEQ_LEN_MODES), default="uniform",
+                        help="Sparsity convention; 'uniform' reproduces the reference total_q")
+    args = parser.parse_args()
+
+    if not is_hip():
+        print("Skipping benchmarks, no AMD GPU found.")
+        raise SystemExit(0)
+
+    shapes = args.shape if args.shape else DEFAULT_SHAPES
+    providers = args.version if args.version else DEFAULT_PROVIDERS
+    print(f"Running GDPA benchmarks: shapes={shapes} providers={providers} "
+          f"kernel={args.kernel} seq_len_mode={args.seq_len_mode}")
+    _print_shape_summary(shapes, args.seq_len_mode)
+    benchmark, _ = create_benchmark(shapes, providers, kernel_name=args.kernel, seq_len_mode=args.seq_len_mode)
+    benchmark.run(print_data=True)


### PR DESCRIPTION
Summary:
TLX GDPA forward for gfx950/MI350 -- `gelu(Q @ K.T) @ V` over jagged Q and dense per-batch KV (the OmniFM V3 pFFN term). ~1.2x over stock Triton GDPA on that shape, 0.752 -> 0.630 ms, and accuracy-checked against it in the same run.
- **shape**: HSTU-style jagged frontend -- `q_offsets` gives per-batch Q rows, KV is a dense `dff` block per batch. Structurally non-causal FA with `N_CTX_K = dff`.
- **pipeline**: prologue fetches KV block 0; the loop computes block i out of one LDS slot while `tlx.async_load` (`buffer_load_to_lds`) fills i+1 into the next. Last block is peeled so the hot loop carries no mask.
- **K.T**: `tlx.local_trans` on the memdesc -- metadata-only, so `local_load` lands directly in dot-operand layout and skips the ds_write/barrier/ds_read shuffle `tl.dot(q, k.T)` emits every iteration.
- **activation**: ads_mkl's AMD `fast_gelu`, `x * sigmoid(k*x*(1 + c*x^2))` via `fast_expf`/`fast_dividef` (gfx950 has no `tanh.approx.f32`). Pointwise, so no cross-lane reduction and no accumulator rescale between the two dots.
- **scheduling**: XCD-pinned pid remap for K/V L2 locality; autotune over `BLOCK_M`/`BLOCK_N`/`NUM_BUFFERS` crossed with `waves_per_eu` and `matrix_instr_nonkdim`.
- **layering**: kernel body stays OSS in the triton-beta tree (`third_party/tlx/tutorials/gfx950_gdpa.py`), covered by the TLX tutorial correctness suite; `ads_mkl/ops/tlx/tlx_gdpa_gfx950.py` is a thin adapter presenting the ads_mkl GDPA signature, and the `tlx_gdpa_gfx950` tritonbench provider calls through it, gated on `is_hip_mi350()`.

Differential Revision: D116576196


