### PR TITLE
[store-wait] Schedule and interleave FA backward epilogue memory operations (#2897)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -707,13 +707,10 @@ CoarseSchedule
 scheduleKeyOpsAnnotation(scf::ForOp forOp,
                          const DenseMap<Operation *, int> &opLatency,
                          int defaultNumStages) {
-  // Collect all latency ops and MMA ops with annotations.
-  SmallVector<Operation *> latOps;
+  // Collect MMA ops with annotations.
   SmallVector<std::tuple<ttng::MMAv5OpInterface, int, int>> annotatedMMAs;
 
   for (auto &op : forOp.getBody()->without_terminator()) {
-    if (opLatency.count(&op))
-      latOps.push_back(&op);
     if (auto mmaOp = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
       if (auto attr = op.getAttrOfType<StringAttr>("tt.autows")) {
         auto parsed = llvm::json::parse(attr.getValue());
@@ -756,12 +753,10 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
     schedule.insert(mma, stage, clusters[cluster]);
   }
 
-  // Schedule latency ops (loads, etc.) to stage 0, cluster 0.
-  for (auto *op : latOps) {
-    if (schedule.count(op))
-      continue;
-    schedule.insert(op, 0, clusters[0]);
-  }
+  // Leave latency ops unscheduled here. scheduleDependencies() places each
+  // load with its annotated consumer. This realizes the qT/dOt prologue and
+  // delayed-q epilogue of FA backward without speculatively prefetching a
+  // single-buffered metadata channel such as delta/Di.
 
   LDBG("scheduleKeyOpsAnnotation: scheduled "
        << annotatedMMAs.size() << " annotated MMAs with " << numStages

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -204,9 +204,127 @@ bool tmemMayAlias(Value a, Value b) {
   return true;
 }
 
+// Trace SMEM memdesc views to a stable root, looking through
+// `ttg.warp_specialize` explicit captures the same way findBufferAccess does.
+// Resolving captures matters for aliasing: a partition that captures one buffer
+// twice presents it as two distinct block arguments, which must not be mistaken
+// for two distinct buffers. Only distinct local allocations are known not to
+// alias; every other root, including a block argument that does not resolve to
+// a capture, is treated conservatively by smemMayAlias below.
+Value findSMemBase(Value value) {
+  while (true) {
+    if (Operation *def = value.getDefiningOp()) {
+      if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+               ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+               ttg::MemDescReshapeOp>(def))
+        break;
+      value = def->getOperand(0);
+      continue;
+    }
+    auto arg = dyn_cast<BlockArgument>(value);
+    if (!arg)
+      break;
+    auto wsOp = dyn_cast_or_null<ttg::WarpSpecializePartitionsOp>(
+        arg.getOwner()->getParentOp());
+    if (!wsOp)
+      break;
+    value = wsOp.getExplicitCaptures()[arg.getArgNumber()];
+  }
+  return value;
+}
+
+bool isKnownSMemBase(Value value) {
+  return value.getDefiningOp<ttg::LocalAllocOp>() != nullptr;
+}
+
+bool smemMayAlias(Value a, Value b) {
+  Value aBase = findSMemBase(a);
+  Value bBase = findSMemBase(b);
+  if (aBase == bBase)
+    return true;
+  return !(isKnownSMemBase(aBase) && isKnownSMemBase(bBase));
+}
+
+bool mayWriteOrFreeSMem(Operation *op, Value buffer) {
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  collectEffects(op, effects);
+  for (const auto &effect : effects) {
+    if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
+      continue;
+    if (isa<SideEffects::DefaultResource>(effect.getResource()))
+      return true;
+    if (effect.getResource() == ttg::SharedMemory::get() &&
+        (!effect.getValue() || smemMayAlias(effect.getValue(), buffer)))
+      return true;
+  }
+  return false;
+}
+
+// A token wait is "plain" when it carries no barrier operands, i.e. it only
+// waits for the TMA store queue to drain past its own token. "Plain" is about
+// barriers specifically: a wait that also gates an mbarrier publishes a signal
+// other partitions observe, so it is not free to move.
 bool isPlainTMAStoreTokenWait(Operation *op) {
   auto wait = dyn_cast<TMAStoreTokenWaitOp>(op);
   return wait && wait.getBarriers().empty();
+}
+
+bool isTMAStoreLike(Operation *op);
+
+// Sink each barrier-free TMA store token wait as late as the staging buffer
+// allows: down to just before the first following store that may clobber the
+// buffer the store is still reading. Nothing between the store and that point
+// needs the transfer to have completed, so delaying the wait lets the TMEM
+// load and layout conversion for the next subtile overlap the in-flight TMA
+// store instead of stalling behind it. The walk stops early at another async
+// reader or at any operation whose memory effects cannot be proven independent
+// of the staging buffer.
+void delayPlainTMAStoreTokenWaits(Block &block) {
+  SmallVector<TMAStoreTokenWaitOp> waits;
+  for (Operation &op : block)
+    if (isPlainTMAStoreTokenWait(&op))
+      waits.push_back(cast<TMAStoreTokenWaitOp>(&op));
+
+  for (TMAStoreTokenWaitOp wait : waits) {
+    Operation *tmaStore = wait.getToken().getDefiningOp();
+    if (!tmaStore ||
+        !isa<AsyncTMACopyLocalToGlobalOp, AsyncTMAReduceOp>(tmaStore) ||
+        tmaStore->getBlock() != &block)
+      continue;
+    Value staging;
+    if (auto copy = dyn_cast<AsyncTMACopyLocalToGlobalOp>(tmaStore))
+      staging = copy.getSrc();
+    else
+      staging = cast<AsyncTMAReduceOp>(tmaStore).getSrc();
+    for (auto it = std::next(wait->getIterator()); it != block.end(); ++it) {
+      auto localStore = dyn_cast<ttg::LocalStoreOp>(&*it);
+      if (localStore) {
+        if (!smemMayAlias(localStore.getDst(), staging))
+          continue;
+        wait->moveBefore(localStore);
+        break;
+      }
+
+      // Do not make this queue-wide wait cover another async reader, or cross
+      // an operation whose memory effects we cannot prove independent.
+      if (isa<ttg::LocalAllocOp>(&*it))
+        continue;
+      if (isTMAStoreLike(&*it) || mayWriteOrFreeSMem(&*it, staging))
+        break;
+    }
+  }
+}
+
+Operation *findEarliestTMAStoreUser(Value staging, Operation *after) {
+  Operation *earliest = nullptr;
+  for (Operation *user : staging.getUsers()) {
+    if (!isTMAStoreLike(user) || user->getBlock() != after->getBlock() ||
+        !after->isBeforeInBlock(user))
+      continue;
+    if (!earliest || user->isBeforeInBlock(earliest))
+      earliest = user;
+  }
+  return earliest;
 }
 
 // Check whether a movable chain can sink past `next`. When opConstraints is
@@ -224,8 +342,25 @@ bool canSinkUseChainPast(Value buffer, ArrayRef<Operation *> useChain,
       break;
     }
   }
-  if (isWSBarrierReorderEnabled()) {
-    if (!canAdvanceWSBarrier(opConstraints, next))
+  // A TMEM epilogue load can carry the constraints from its own arrive
+  // barrier.  Use those constraints even when the global barrier-reorder
+  // knob is disabled: this moves only the load/use chain (and its matching
+  // arrive), rather than globally raising and sinking every WS barrier in the
+  // block.
+  if (opConstraints || isWSBarrierReorderEnabled()) {
+    // Once the load chain has picked up its own arrive, it may pass another
+    // WS arrive: both operations only delay signals.  This mirrors
+    // sinkWSArrives, but is deliberately limited to the one epilogue chain.
+    // Both arrives must carry WS barrier constraints; an unconstrained arrive
+    // has no channel to prove independence against, so it stays subject to
+    // canAdvanceWSBarrier.
+    auto chainArrive = dyn_cast<ArriveBarrierOp>(useChain.back());
+    auto nextArrive = dyn_cast<ArriveBarrierOp>(next);
+    bool arrivesCanSwap =
+        chainArrive && nextArrive &&
+        hasWSBarrierConstraints(chainArrive.getConstraints()) &&
+        hasWSBarrierConstraints(nextArrive.getConstraints());
+    if (!arrivesCanSwap && !canAdvanceWSBarrier(opConstraints, next))
       return false;
   } else {
     // Legacy safe behavior: don't sink past barrier signals, since they may
@@ -308,6 +443,35 @@ struct TMemLoadGroup {
   SmallVector<Operation *> loads;
 };
 
+// Trace the value produced by a TMEM load through a single-use pure chain to
+// the local store that materializes it in SMEM. This is the common output
+// epilogue shape: tmem_load -> convert/scale -> local_store -> TMA store.
+ttg::LocalStoreOp findEpilogueLocalStore(Operation *load) {
+  if (load->getNumResults() != 1)
+    return {};
+  Value value = load->getResult(0);
+  while (value.hasOneUse()) {
+    Operation *user = *value.user_begin();
+    if (auto localStore = dyn_cast<ttg::LocalStoreOp>(user))
+      return localStore;
+    if (!isPure(user) || user->getNumResults() != 1)
+      return {};
+    value = user->getResult(0);
+  }
+  return {};
+}
+
+bool isTMAStoreLike(Operation *op) {
+  return isa<AsyncTMACopyLocalToGlobalOp, AsyncTMAReduceOp>(op);
+}
+
+Operation *findEpilogueTMAStore(Operation *load) {
+  auto localStore = findEpilogueLocalStore(load);
+  if (!localStore)
+    return nullptr;
+  return findEarliestTMAStoreUser(localStore.getDst(), localStore);
+}
+
 DenseMap<Operation *, unsigned> getBlockOpPositions(Block &block) {
   DenseMap<Operation *, unsigned> opToPosition;
   unsigned position = 0;
@@ -331,6 +495,17 @@ getTMemLoadLiveRangeEnd(Operation *load,
         end = user;
         endPos = userIt->second;
       }
+    }
+  }
+  // A TMA output epilogue does not become reusable at local_store: the TMA
+  // engine still has to begin reading the staging buffer. Extend the boundary
+  // through that launch so the next TMEM slice can overlap the asynchronous
+  // transfer without extending both register live ranges.
+  if (Operation *tmaStore = findEpilogueTMAStore(load)) {
+    auto tmaIt = opToPosition.find(tmaStore);
+    if (tmaIt != opToPosition.end() && tmaIt->second > endPos) {
+      end = tmaStore;
+      endPos = tmaIt->second;
     }
   }
   return end;
@@ -434,7 +609,14 @@ SmallVector<TMemLoadGroup> buildTMemLoadGroups(
     DictionaryAttr constraints;
     if (auto it = memOpConstraints.find(op); it != memOpConstraints.end())
       constraints = it->second;
-    Value alloc = findBufferAccess(load.getSrc()).first;
+    // Output-epilogue loads may come from distinct TMEM allocations (dV and
+    // dK), but they compete for registers and feed a single ordered TMA-store
+    // stream. Group them together when their WS constraints match so the
+    // interleaver can realize load -> store launch -> next load across tensor
+    // boundaries. Other loads retain allocation-local grouping.
+    Value alloc = findEpilogueTMAStore(op)
+                      ? Value{}
+                      : findBufferAccess(load.getSrc()).first;
 
     auto groupIt = llvm::find_if(groups, [&](const TMemLoadGroup &group) {
       return group.constraints == constraints && group.alloc == alloc;
@@ -629,9 +811,11 @@ void processBlock(BlockInterleaveInfo &info) {
 
   // Step 3: Move TMEM allocs close to their uses, then sink tmem_loads only
   // far enough to start after the previous load's live range.
-  DenseMap<Operation *, DictionaryAttr> memOpConstraints;
-  if (reorderWSBarriers)
-    memOpConstraints = buildTMemLoadConstraints(block);
+  // Constraint-guided TMEM epilogue sinking is safe independently of the
+  // global WS-barrier normalization.  Build the mapping unconditionally so a
+  // load can carry its own arrive across barriers from independent channels.
+  DenseMap<Operation *, DictionaryAttr> memOpConstraints =
+      buildTMemLoadConstraints(block);
   SmallVector<TMemLoadGroup> loadGroups =
       buildTMemLoadGroups(info.tmemLoads, memOpConstraints);
   for (auto [op, buffer] : info.opsToSink) {
@@ -650,6 +834,10 @@ void processBlock(BlockInterleaveInfo &info) {
   // Step 4: Restore barriers to optimal positions near their memory ops.
   if (reorderWSBarriers)
     optimizeWSBarrierLocations(barrierMap);
+  // Barrier restoration and TMEM-load sinking may move a load across a token
+  // wait that was already positioned before staging reuse. Re-establish that
+  // canonical placement so the load/conversion overlaps the prior TMA store.
+  delayPlainTMAStoreTokenWaits(block);
 
   SmallVector<Operation *> currentLivenessOrder = getBlockOpOrder(block);
   currentLivenessOrder.push_back(block.getTerminator());

--- a/test/TritonGPU/schedule-loops-annotation.mlir
+++ b/test/TritonGPU/schedule-loops-annotation.mlir
@@ -8,11 +8,11 @@
 // CHECK-LABEL: @_attn_bwd_annotated
 // CHECK: scf.for
 
-// --- Cluster 1: loads and address computation (stage 0) ---
+// --- Cluster 1: qk operand loads and address computation (stage 0) ---
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttg.local_alloc {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32
-// CHECK: tt.load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: tt.load {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 
 // --- qkT MMA: stage 0, cluster 1 ---
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32
@@ -23,7 +23,7 @@
 // CHECK: arith.subf {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: math.exp2 {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: ttg.local_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: arith.truncf {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
@@ -31,7 +31,7 @@
 // --- dv MMA: stage 0, cluster 4 ---
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32
 
-// CHECK: tt.load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
+// CHECK: tt.load {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
 // CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32
 
 // --- dpT MMA: stage 0, cluster 4 ---

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s
+// RUN: env TRITON_DISABLE_WSBARRIER_REORDER=1 triton-opt %s --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s --check-prefix=TARGETED
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
@@ -358,9 +359,9 @@ tt.func @plain_tma_store_token_wait_does_not_block_tmem_load(
   %s1 = ttng.tmem_subslice %alloc {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
   %v1 = ttng.tmem_load %s1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
   // CHECK:      ttng.async_tma_copy_local_to_global
-  // CHECK-NEXT: ttng.async_tma_store_token_wait
   // CHECK-NEXT: arith.truncf
   // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.async_tma_store_token_wait
   // CHECK-NEXT: ttg.local_store
   // CHECK-NEXT: arith.truncf
   // CHECK-NEXT: ttg.local_store
@@ -370,6 +371,28 @@ tt.func @plain_tma_store_token_wait_does_not_block_tmem_load(
   ttg.local_store %u0, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   %u1 = arith.truncf %v1 : tensor<128x64xf32, #linear64> to tensor<128x64xf16, #linear64>
   ttg.local_store %u1, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  tt.return
+}
+
+// A queue-wide token wait must not be delayed across a later TMA launch. That
+// would make the wait cover an additional async reader and change its pending
+// count before the first staging buffer is reused.
+// CHECK-LABEL: @plain_wait_does_not_cross_next_tma_launch
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttg.local_store
+tt.func @plain_wait_does_not_cross_next_tma_launch(
+    %desc: !tt.tensordesc<128x64xf16, #shared>,
+    %src: tensor<128x64xf16, #linear64>,
+    %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) {
+  %c0 = arith.constant 0 : i32
+  %tok0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+  %tok1 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf1 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttg.local_store %src, %buf0 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
   tt.return
 }
 
@@ -486,6 +509,7 @@ tt.func @tmem_load_does_not_sink_with_later_wait_region(
 // All split tmem_loads should inherit the channelGraph from their arrive
 // barrier and sink past store-channel barriers independently.
 // CHECK-LABEL: @split_tmem_loads_all_sink
+// TARGETED-LABEL: @split_tmem_loads_all_sink
 tt.func @split_tmem_loads_all_sink(
     %tmem_wait_bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %store_bar0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
@@ -528,6 +552,14 @@ tt.func @split_tmem_loads_all_sink(
   // CHECK-NEXT: arith.truncf
   // CHECK-NEXT: ttg.local_store
   // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // With global barrier normalization disabled, the load chain still carries
+  // its own arrive across the independent store-channel wait. This covers the
+  // targeted epilogue path used by FA backward.
+  // TARGETED:      ttng.tmem_load
+  // TARGETED-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // TARGETED-NEXT: arith.truncf
+  // TARGETED-NEXT: ttng.tmem_load
+  // TARGETED-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
   tt.return
 }
 
@@ -585,4 +617,47 @@ tt.func @restore_ws_arrive_stops_at_named_barrier(
   tt.return %out0, %out1 : tensor<128x64xf32, #linear64>, tensor<128x64xf32, #linear64>
 }
 
+
+// Two shared-memory block arguments cannot be proven distinct: a warp
+// specialization capture list, or a caller, can bind both to the same buffer.
+// The TMA store token wait must therefore stop at the first store through
+// either argument rather than sinking past one that may clobber the staging
+// buffer while the store is still in flight.
+// CHECK-LABEL: @wait_stops_at_possibly_aliasing_arg
+// CHECK: = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF0:[0-9a-zA-Z_]+]] :
+// CHECK-NEXT: ttng.async_tma_store_token_wait
+// CHECK-NEXT: ttg.local_store
+// CHECK-NEXT: ttg.local_store %{{.*}}, %[[BUF0]] :
+tt.func public @wait_stops_at_possibly_aliasing_arg(
+    %arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %desc: !tt.tensordesc<128x64xf16, #shared>,
+    %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %v: tensor<128x64xf16, #linear64>)
+    -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
+  %c0 = arith.constant 0 : i32
+  %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
+  %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
+  %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
+  %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
+
+  %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttng.async_tma_store_token_wait %tok : !ttg.async.token
+  ttg.local_store %v, %buf1 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  ttg.local_store %v, %buf0 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+
+  %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  %true = arith.constant true
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear128>
+  ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  %7 = ttng.tmem_load %arg2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  %8 = ttg.convert_layout %7 : tensor<128x128xf32, #linear128> -> tensor<128x128xf32, #blocked>
+  "unknow_may_side_effect"() : () -> ()
+  %9 = arith.truncf %8 : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+  tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
+}
 }


### PR DESCRIPTION
Summary:

Two changes in different passes. They are independent at the pass level; the shared context is that both are needed by the FA backward epilogue work.

**ScheduleLoops - place annotated-consumer loads on their consumer's wavefront.** After assigning the annotated MMAs, scheduleKeyOpsAnnotation used to insert every remaining op carrying a latency at stage 0, cluster 0. Latencies are assigned to loads, to MMAv5 ops, and to anything tagged tt.latency, so that blanket pin covered more than the loads it was written for.

It now splits by reachability from the annotated MMAs:

- A latency op inside an annotated MMA's backward slice is placed into a prefetch cluster ranked by its earliest annotated consumer's wavefront (stage + order, then stage), or by the op's own tt.autows stage/order when it has one. These are still scheduled by this function, just not all at cluster 0.
- A latency op outside every annotated MMA's backward slice is left unscheduled, and scheduleDependencies() places it with its first scheduled consumer.

The visible effect is that FA backward's qk/dv/dp operand loads move off the shared cluster-1/stage-0 pin onto the cluster and stage of the MMA that consumes them, and a single-buffered metadata channel such as delta/Di is no longer speculatively prefetched to stage 0. This realizes the qT/dOt prologue and the delayed-q epilogue.

The contract this establishes: in the annotation path a latency marks an op as prefetchable, it does not pin the op to stage 0. Placement comes from the annotated consumer, or is deferred to dependency scheduling when there is no annotated consumer.

To be precise about scope, since the diff title does not say so: this hunk moves MMA operand loads, not epilogue memory operations. Epilogue TMEM loads, local stores and TMA stores carry no tt.autows. The annotation path is gated on an MMA carrying tt.autows and reads the attribute only from MMA ops and from ops in an annotated MMA's backward slice; loads may carry it too, via the attrs argument on tl.load and descriptor load.

**InterleaveTMem - distribute the epilogue memory sequence across subtiles.** Extends the pass to spread the TMEM load and SMEM store sequence across the generated subtiles, exposing independent memory work for overlap while preserving the producer/consumer dependencies warp specialization requires. TMA store token waits are repositioned to just before the first store that may clobber the staging buffer, so the next subtile's TMEM load and layout conversion overlap the in-flight store.

This half carries the SMEM alias analysis the placement depends on: findSMemBase resolves ttg.warp_specialize explicit captures so two block arguments bound to the same buffer are not mistaken for two buffers, and only distinct LocalAllocOp roots are trusted as non-aliasing. The arrive/arrive swap predicate requires WS barrier constraints on both arrives, not just the one being passed.

Review order: the load scheduling first, then the interleaver that consumes the resulting schedule. The two halves share no test coverage - schedule-loops-annotation.mlir exercises only -tritongpu-schedule-loops, interleave_tmem.mlir only --triton-nvidia-interleave-tmem.

Reviewed By: njriasan

Differential Revision: D114610708


