### PR TITLE
[triton][tlx][amd] cond_barrier / workgroup_barrier primitives + Membar sched-fence fix (#2900)

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -74,6 +74,10 @@ void registerTestScopeIdAllocationPass();
 } // namespace test
 } // namespace mlir
 
+namespace mlir::triton::AMD {
+void registerSchedulingBarrierExternalModel(mlir::DialectRegistry &registry);
+} // namespace mlir::triton::AMD
+
 inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerAllPasses();
   mlir::triton::registerTritonPasses();
@@ -199,4 +203,6 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
       mlir::triton::proton::ProtonDialect,
       mlir::triton::proton::gpu::ProtonGPUDialect, mlir::ROCDL::ROCDLDialect,
       mlir::triton::gluon::GluonDialect, mlir::triton::tlx::TLXDialect>();
+
+  mlir::triton::AMD::registerSchedulingBarrierExternalModel(registry);
 }

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOpInterfaces.td
@@ -77,4 +77,19 @@ def MBarrierOpInterface : OpInterface<"MBarrierOpInterface"> {
   ];
 }
 
+def SchedulingBarrierOpInterface : OpInterface<"SchedulingBarrierOpInterface"> {
+  let description = [{
+    Marker interface for scheduling-only fence operations that carry no
+    cross-wave memory semantics (e.g. the AMD rocdl.sched.barrier /
+    rocdl.sched.group.barrier that bracket the real ttg.barrier a
+    tlx.workgroup_barrier interposes). The Membar analysis looks THROUGH ops
+    carrying this interface when scanning forward for a sync point; treating one
+    as a stopping point would make it insert a redundant workgroup barrier.
+    Backends attach this to their ops via an external model, so the core
+    analysis stays free of any backend-dialect dependency.
+  }];
+
+  let cppNamespace = "::mlir::triton::gpu";
+}
+
 #endif // TRITONGPU_OP_INTERFACES

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -292,9 +292,18 @@ bool containsLocalBarrier(Operation *op) {
 }
 
 // Returns true if the same block has a later wait or local barrier before any
-// memory effect or nested control flow.
+// memory effect or nested control flow. Scheduling-only fences carrying
+// ttg::SchedulingBarrierOpInterface (e.g. the AMD rocdl.sched.barrier that
+// brackets the real ttg.barrier a tlx.workgroup_barrier interposes) have no
+// cross-wave memory semantics and are skipped: treating one as a stopping point
+// would make Membar insert a redundant barrier right after the async wait --
+// doubling the workgroup barrier and stalling a hand-written ping-pong
+// schedule.
 static bool hasSyncPointBeforeMemoryEffect(Operation *op) {
   for (Operation *next = op->getNextNode(); next; next = next->getNextNode()) {
+    if (isa<triton::gpu::SchedulingBarrierOpInterface>(next))
+      continue;
+
     if (containsLocalBarrier(next) ||
         next->hasTrait<mlir::OpTrait::MemWaitOpTrait>())
       return true;

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -295,6 +295,14 @@ bool containsLocalBarrier(Operation *op) {
 // memory effect or nested control flow.
 static bool hasSyncPointBeforeMemoryEffect(Operation *op) {
   for (Operation *next = op->getNextNode(); next; next = next->getNextNode()) {
+    // Skip scheduling-only fences (rocdl.sched.*) that tlx.workgroup_barrier /
+    // tlx.sched_barrier interpose before the real ttg.barrier. They carry no
+    // cross-wave memory semantics, so treating one as a stopping point makes
+    // Membar insert a redundant barrier right after the async wait -- doubling
+    // the workgroup barrier and stalling a hand-written ping-pong schedule.
+    if (next->getName().getStringRef().starts_with("rocdl.sched."))
+      continue;
+
     if (containsLocalBarrier(next) ||
         next->hasTrait<mlir::OpTrait::MemWaitOpTrait>())
       return true;

--- a/python/test/unit/language/test_tlx_barriers.py
+++ b/python/test/unit/language/test_tlx_barriers.py
@@ -467,3 +467,67 @@ def test_named_barrier_wait_1warp_async_deadlock_single_proc(device):
     result = output.cpu().tolist()
     assert result[0] == 5, f"Expected output[0]=5, got {result[0]}"
     assert result[1] == 99, f"Expected output[1]=99, got {result[1]}"
+
+
+# ---- AMD CDNA workgroup / cond barriers (tlx.workgroup_barrier, tlx.cond_barrier) ----
+
+
+@triton.jit
+def _workgroup_barrier_sum_kernel(x_ptr, out_ptr, BLOCK: tl.constexpr):
+    # One workgroup, BLOCK lanes across several warps. Each lane publishes its input
+    # into its own LDS slot, then every lane sums the WHOLE buffer -- so each lane
+    # must observe every other (cross-warp) lane's store. workgroup_barrier provides
+    # the LDS fence + rendezvous; without it the sum races and drops cross-warp
+    # stores.
+    off = tl.arange(0, BLOCK)
+    smem = tlx.local_alloc((BLOCK,), tl.int32, 1)
+    buf = tlx.local_view(smem, 0)
+    tlx.local_store(buf, tl.load(x_ptr + off))
+    tlx.workgroup_barrier()
+    total = tl.sum(tlx.local_load(buf))
+    tl.store(out_ptr + off, total + tl.zeros((BLOCK,), tl.int32))
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires AMD (HIP)")
+def test_amd_workgroup_barrier(device):
+    BLOCK = 256  # 4 warps x 64 lanes -> exercises cross-warp LDS visibility
+    x = torch.randint(-(2**20), 2**20, (BLOCK,), device=device, dtype=torch.int32)
+    out = torch.empty_like(x)
+    compiled = _workgroup_barrier_sum_kernel[(1,)](x, out, BLOCK=BLOCK, num_warps=4)
+    torch.cuda.synchronize()
+    expected = torch.full((BLOCK,), int(x.sum().item()), device=device, dtype=torch.int32)
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+    # Lowers to a fenced ttg.barrier bracketed by rocdl.sched.barrier fences.
+    ttgir = compiled.asm["ttgir"]
+    assert ttgir.count("ttg.barrier") >= 1, f"TTGIR {ttgir}"
+    assert ttgir.count("rocdl.sched.barrier") >= 2, f"TTGIR {ttgir}"
+
+
+@triton.jit
+def _cond_barrier_kernel(x_ptr, out_ptr, BLOCK: tl.constexpr):
+    # Exercise the cond_barrier phase-shift bracket (cond_barrier(wg != 0) ...
+    # cond_barrier(wg == 0), the split-M ping-pong pattern) around a
+    # workgroup_barrier. The payload is a per-lane copy -- independent of the
+    # (deliberately out-of-phase) barriers -- so the assertion checks what a unit
+    # test can: the paired bracket compiles and RECONVERGES without deadlock (a
+    # broken barrier-count contract would hang or drop the stores). cond_barrier's
+    # cross-warp phase-shift correctness is covered by the grouped-gemm integration.
+    off = tl.arange(0, BLOCK)
+    wg = tlx.thread_id(0) // 256
+    tlx.cond_barrier(wg != 0)
+    tlx.workgroup_barrier()
+    tlx.cond_barrier(wg == 0)
+    tl.store(out_ptr + off, tl.load(x_ptr + off))
+
+
+@pytest.mark.skipif(not is_hip(), reason="Requires AMD (HIP)")
+def test_amd_cond_barrier(device):
+    BLOCK = 512  # 8 warps -> two 256-lane warp-groups for the cond_barrier phase shift
+    x = torch.randint(-(2**20), 2**20, (BLOCK,), device=device, dtype=torch.int32)
+    out = torch.empty_like(x)
+    compiled = _cond_barrier_kernel[(1,)](x, out, BLOCK=BLOCK, num_warps=8)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, x, atol=0, rtol=0)
+    # The paired bracket lowers to two amdg.cond_barrier ops.
+    ttgir = compiled.asm["ttgir"]
+    assert ttgir.count("amdg.cond_barrier") == 2, f"TTGIR {ttgir}"

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -330,4 +330,57 @@ tt.func @missing_barrier_reused_allocation(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   tt.return
 }
 
+// tlx.workgroup_barrier lowers to `rocdl.sched.barrier none; ttg.barrier local;
+// rocdl.sched.barrier none`. When Membar scans forward from an async wait for a
+// sync point it must look THROUGH the scheduling-only sched fences to reach the
+// real ttg.barrier; otherwise it treats the first sched fence as a stopping
+// point and inserts a redundant barrier right after the wait, doubling the
+// workgroup barrier in a hand-rolled ping-pong. Here the wait is immediately
+// followed by the sched/barrier bracket, so the forward scan actually reaches
+// the sched fences (this fails without the look-through: an extra
+// `ttg.barrier local` appears between the async_wait and the first sched fence).
+// CHECK-LABEL: workgroup_barrier_after_async_wait_needs_no_barrier
+tt.func @workgroup_barrier_after_async_wait_needs_no_barrier(%A: !tt.ptr<f16>) {
+  %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
+  %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %async1 = amdg.buffer_load_to_local %A[%offset] into %alloc : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %token1 = ttg.async_commit_group tokens %async1
+  %wait1 = amdg.async_wait %token1 {num_inst = 0 : i32}
+  // No barrier is inserted between the async wait and the workgroup barrier; the
+  // wait's deferred barrier is satisfied by the real ttg.barrier below.
+  // CHECK: amdg.async_wait
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: rocdl.sched.barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: rocdl.sched.barrier
+  // CHECK-NOT: ttg.barrier local
+  rocdl.sched.barrier none
+  ttg.barrier local
+  rocdl.sched.barrier none
+  %read = ttg.local_load %alloc token %wait1 {ttg.amdg.syncedViaAsyncWait = true} : !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<128x32xf16, #AL>
+  tt.return
+}
+
+// A lone scheduling fence is NOT a sync point. After looking through the sched
+// fence the forward scan reaches the local_load's memory effect with no real
+// ttg.barrier in between, so Membar must still insert a barrier after the wait.
+// This guards the look-through against over-suppressing genuinely needed
+// barriers.
+// CHECK-LABEL: lone_sched_fence_still_needs_barrier
+tt.func @lone_sched_fence_still_needs_barrier(%A: !tt.ptr<f16>) {
+  %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
+  %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %async1 = amdg.buffer_load_to_local %A[%offset] into %alloc : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %token1 = ttg.async_commit_group tokens %async1
+  %wait1 = amdg.async_wait %token1 {num_inst = 0 : i32}
+  // The wait's deferred barrier is inserted before the lone sched fence.
+  // CHECK: amdg.async_wait
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: rocdl.sched.barrier
+  // CHECK-NEXT: ttg.local_load
+  rocdl.sched.barrier none
+  %read = ttg.local_load %alloc token %wait1 {ttg.amdg.syncedViaAsyncWait = true} : !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<128x32xf16, #AL>
+  tt.return
+}
+
 }

--- a/test/Conversion/amd/amdgpu_membar.mlir
+++ b/test/Conversion/amd/amdgpu_membar.mlir
@@ -330,4 +330,38 @@ tt.func @missing_barrier_reused_allocation(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
   tt.return
 }
 
+// tlx.workgroup_barrier lowers to `rocdl.sched.barrier 0; ttg.barrier local;
+// rocdl.sched.barrier 0`. When Membar scans forward for a sync point before a
+// memory effect it must look THROUGH the scheduling-only sched fences to the real
+// ttg.barrier; otherwise it treats the sched fence as a stopping point and inserts
+// a redundant barrier right after the async wait, doubling the workgroup barrier in
+// a hand-rolled ping-pong.
+// CHECK-LABEL: sched_barrier_is_not_a_sync_point
+tt.func @sched_barrier_is_not_a_sync_point(%A: !tt.ptr<f16>, %B: !tt.ptr<f16>) {
+  %offset = arith.constant dense<0> : tensor<128x32xi32, #AL>
+  %alloc = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Load + wait + read the buffer.
+  %async1 = amdg.buffer_load_to_local %A[%offset] into %alloc : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %token1 = ttg.async_commit_group tokens %async1
+  %wait1 = amdg.async_wait %token1 {num_inst = 0 : i32}
+  %read = ttg.local_load %alloc token %wait1 {ttg.amdg.syncedViaAsyncWait = true} : !ttg.memdesc<128x32xf16, #A_SHARED, #ttg.shared_memory, mutable> -> tensor<128x32xf16, #AL>
+  // workgroup_barrier: sched fence, real barrier, sched fence.
+  rocdl.sched.barrier 0
+  ttg.barrier local
+  rocdl.sched.barrier 0
+  // WAR: rewrite the same buffer. The ttg.barrier above already synchronizes the
+  // prior read, so Membar must NOT add another barrier after the wait/read.
+  // CHECK: ttg.local_load
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: rocdl.sched.barrier
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: rocdl.sched.barrier
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: amdg.buffer_load_to_local
+  %async2 = amdg.buffer_load_to_local %B[%offset] into %alloc : <f16>[tensor<128x32xi32, #AL>] -> <128x32xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  %token2 = ttg.async_commit_group tokens %async2
+  %wait2 = amdg.async_wait %token2 {num_inst = 0 : i32}
+  tt.return
+}
+
 }

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -4,6 +4,10 @@
 #include "mlir/IR/Operation.h"
 #include "triton/Analysis/Allocation.h"
 
+namespace mlir {
+class DialectRegistry;
+}
+
 namespace mlir::triton::AMD {
 
 // Filter function used in the AMDGPU backend to remove dependencies that do
@@ -15,6 +19,15 @@ namespace mlir::triton::AMD {
 // proven independent by the generic Membar allocation-slice analysis.
 bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
                   bool op2IsRead, Allocation *allocation);
+
+// Registers an external interface model marking the AMD scheduling-only fences
+// rocdl.sched.barrier / rocdl.sched.group.barrier with
+// ttg::SchedulingBarrierOpInterface. Membar's forward scan for a sync point
+// looks THROUGH ops carrying that interface (they have no cross-wave memory
+// semantics), so it does not insert a redundant barrier around the real
+// ttg.barrier that a tlx.workgroup_barrier interposes. Attaching via a dialect
+// extension keeps the core Membar analysis free of any ROCDL dependency.
+void registerSchedulingBarrierExternalModel(DialectRegistry &registry);
 } // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -2,6 +2,8 @@
 #include "AsyncUtility.h"
 #include "Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -72,5 +74,23 @@ bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
   return (filterAsyncLocalLoadsDependencies(op1, op2, op1IsRead, op2IsRead,
                                             allocation) ||
           filterLDSMemoryBarriersDependencies(op1, op2));
+}
+
+namespace {
+// External model that stamps the marker interface onto an upstream ROCDL op we
+// do not own. The interface has no methods, so the model body is empty.
+template <typename OpT>
+struct SchedulingBarrierModel
+    : public ::mlir::triton::gpu::SchedulingBarrierOpInterface::ExternalModel<
+          SchedulingBarrierModel<OpT>, OpT> {};
+} // namespace
+
+void registerSchedulingBarrierExternalModel(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, ROCDL::ROCDLDialect *) {
+    ROCDL::SchedBarrier::attachInterface<
+        SchedulingBarrierModel<ROCDL::SchedBarrier>>(*ctx);
+    ROCDL::SchedGroupBarrier::attachInterface<
+        SchedulingBarrierModel<ROCDL::SchedGroupBarrier>>(*ctx);
+  });
 }
 } // namespace mlir::triton::AMD

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -1,4 +1,5 @@
 #include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "TritonAMDGPUToLLVM/MembarUtility.h"
 #include "TritonAMDGPUToLLVM/Passes.h"
 #include "TritonAMDGPUTransforms/Passes.h"
 #include "amd/include/hipblas_instance.h"
@@ -369,6 +370,7 @@ void init_triton_amd(py::module_ &m) {
     registry.insert<mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect>();
     // registry.insert<mlir::ROCDL::ROCDLDialect>();
     mlir::registerROCDLDialectTranslation(registry);
+    mlir::triton::AMD::registerSchedulingBarrierExternalModel(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -1323,6 +1323,23 @@ void init_triton_tlx_ir(py::module_ &m) {
                  self.getBuilder().getI32Type(), threadId);
              return threadId;
            })
+      .def("create_cond_barrier",
+           [](TritonOpBuilder &self, Value pred) -> void {
+             // Conditional s_barrier: only lanes with pred==true participate.
+             // Deliberately diverges the two warp-halves to phase-shift a
+             // hand-rolled ping-pong; caller must pair cond_barrier(pred) with
+             // cond_barrier(~pred) so all threads cross the same barrier count.
+             self.create<amdgpu::CondBarrierOp>(pred);
+           })
+      .def("create_workgroup_barrier",
+           [](TritonOpBuilder &self) -> void {
+             // Fenced full-workgroup barrier: a local (LDS-fenced) ttg.barrier
+             // bracketed by SchedBarrier(0) guards so the scheduler cannot hoist
+             // ops across the ping-pong cluster border.
+             self.create<ROCDL::SchedBarrier>(0);
+             self.create<ttg::BarrierOp>(ttg::AddrSpace::Local);
+             self.create<ROCDL::SchedBarrier>(0);
+           })
       .def("create_cvt_rs",
            [](TritonOpBuilder &self, Value &src, Type &dstType,
               Value rbits) -> Value {

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -1440,6 +1440,23 @@ void init_triton_tlx_ir(py::module_ &m) {
                  self.getBuilder().getI32Type(), threadId);
              return threadId;
            })
+      .def("create_cond_barrier",
+           [](TritonOpBuilder &self, Value pred) -> void {
+             // Conditional s_barrier: only lanes with pred==true participate.
+             // Deliberately diverges the two warp-halves to phase-shift a
+             // hand-rolled ping-pong; caller must pair cond_barrier(pred) with
+             // cond_barrier(~pred) so all threads cross the same barrier count.
+             self.create<amdgpu::CondBarrierOp>(pred);
+           })
+      .def("create_workgroup_barrier",
+           [](TritonOpBuilder &self) -> void {
+             // Fenced full-workgroup barrier: a local (LDS-fenced) ttg.barrier
+             // bracketed by SchedBarrier(0) guards so the scheduler cannot hoist
+             // ops across the ping-pong cluster border.
+             self.create<ROCDL::SchedBarrier>(ROCDL::SchedGroupMask::none);
+             self.create<ttg::BarrierOp>(ttg::AddrSpace::Local);
+             self.create<ROCDL::SchedBarrier>(ROCDL::SchedGroupMask::none);
+           })
       .def("create_cvt_rs",
            [](TritonOpBuilder &self, Value &src, Type &dstType,
               Value rbits) -> Value {

--- a/third_party/tlx/doc/tlx_barriers.md
+++ b/third_party/tlx/doc/tlx_barriers.md
@@ -97,8 +97,8 @@ Barrier operations can be classified into three categories: a)
 
 ## TLX Barriers
 
-TLX provides two categories of barriers: a) named barriers and b) memory
-barriers.
+TLX provides three categories of barriers: a) named barriers, b) memory
+barriers, and c) workgroup barriers (AMD).
 
 ### Named Barriers
 
@@ -292,6 +292,36 @@ while !done:
   | tlx.barrier_expect_bytes | ttng::BarrierExpectOp | [<u>mbarrier.expect_tx</u>](http://mbarrier.expect_tx) |
   | tlx.barrier_wait | ttng::WaitBarrierOp | [<u>mbarrier.try_wait</u>](http://mbarrier.try_wait) |
   | tlx.barrier_arrive | ttng::ArriveBarrierOp | [<u>mbarrier.arrive</u>](http://mbarrier.arrive) |
+
+### Workgroup Barriers (AMD)
+
+- **Note:** Workgroup barriers are only supported on AMD (CDNA).
+
+- Unlike the NVIDIA named/memory barriers above, these are the plain CDNA
+  workgroup rendezvous used at hand-rolled ping-pong cluster borders. They are
+  synchronous and take no phase or arrival count.
+
+#### APIs
+
+- ***tlx.workgroup_barrier()***
+  Full-workgroup barrier with an LDS (shared-memory) memory fence. Lowers to a
+  local `s_barrier` bracketed by scheduler barriers so instructions cannot be
+  hoisted across it. This is the barrier used at hand-rolled ping-pong cluster
+  borders (pairs with *tlx.cond_barrier* for the phase shift).
+
+- ***tlx.cond_barrier(pred)***
+  Conditionally execute a workgroup barrier. Threads for which *pred* is true
+  participate in an `s_barrier`; the rest fall through without waiting. This
+  deliberately diverges the two halves of a workgroup to phase-shift warp groups
+  for hand-rolled block ping-pong, and sets no memory fence. The caller MUST
+  guarantee reconvergence: pair a *cond_barrier(pred)* before a loop with a
+  *cond_barrier(~pred)* after it so every thread crosses the same total number of
+  barriers.
+
+  | TLX [<u>barriers</u>](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/language/tlx/barrier.py) | MLIR | AMDGPU |
+  |----|----|----|
+  | tlx.workgroup_barrier | rocdl::SchedBarrier + ttg::BarrierOp (local) + rocdl::SchedBarrier | s_barrier |
+  | tlx.cond_barrier | amdgpu::CondBarrierOp | s_barrier (conditional) |
 
 ### Examples
 

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -7,10 +7,12 @@ from .barrier import (
     barrier_expect_bytes,
     barrier_wait,
     cluster_barrier,
+    cond_barrier,
     fence_mbarrier_init_cluster,
     named_barrier_arrive,
     named_barrier_wait,
     amd_sched_barrier,
+    workgroup_barrier,
 )
 from .dynamic_launch import (
     _alloc_clc_responses,
@@ -211,6 +213,8 @@ __all__ = [
     "prefetch",
     # barriers
     "cluster_barrier",
+    "cond_barrier",
+    "workgroup_barrier",
     "alloc_barriers",
     "alloc_warp_barrier",
     "barrier_expect_bytes",

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -7,10 +7,12 @@ from .barrier import (
     barrier_expect_bytes,
     barrier_wait,
     cluster_barrier,
+    cond_barrier,
     fence_mbarrier_init_cluster,
     named_barrier_arrive,
     named_barrier_wait,
     amd_sched_barrier,
+    workgroup_barrier,
 )
 from .dynamic_launch import (
     _alloc_clc_responses,
@@ -219,6 +221,8 @@ __all__ = [
     "prefetch",
     # barriers
     "cluster_barrier",
+    "cond_barrier",
+    "workgroup_barrier",
     "alloc_barriers",
     "alloc_warp_barrier",
     "barrier_expect_bytes",

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -24,6 +24,37 @@ def cluster_barrier(_semantic=None):
 
 
 @tl.builtin
+def cond_barrier(pred: tl.tensor, _semantic=None):
+    """
+    Conditionally execute a workgroup barrier (AMD only).
+
+    Threads for which `pred` is true participate in an `s_barrier`; the rest fall
+    through without waiting. This deliberately diverges the two halves of a
+    workgroup and is the primitive used to phase-shift warp groups for
+    hand-rolled block ping-pong.
+
+    The caller MUST guarantee all threads reconverge: pair a `cond_barrier(pred)`
+    before a loop with a `cond_barrier(~pred)` after it so every thread crosses
+    the same total number of barriers. This op sets no memory fence.
+    """
+    _semantic.builder.create_cond_barrier(pred.handle)
+
+
+@tl.builtin
+def workgroup_barrier(_semantic=None):
+    """
+    Full-workgroup barrier with an LDS memory fence (AMD).
+
+    Lowers to a local (shared-memory-fenced) `s_barrier` bracketed by scheduler
+    barriers so instructions cannot be hoisted across it. Unlike
+    `cluster_barrier` (NVIDIA cluster arrive/wait), this is the plain CDNA
+    workgroup rendezvous and is the barrier used at hand-rolled ping-pong cluster
+    borders (pairs with `cond_barrier` for the phase shift).
+    """
+    _semantic.builder.create_workgroup_barrier()
+
+
+@tl.builtin
 def fence_mbarrier_init_cluster(_semantic=None):
     """
     Emit a cluster fence instruction for mbarrier init.


### PR DESCRIPTION
Summary:

Adds two AMD tlx barrier builtins used by the split-M ping-pong grouped-GEMM
kernel: tlx.cond_barrier (a conditional s_barrier that phase-shifts the two warp
groups) and tlx.workgroup_barrier (an LDS-fenced workgroup barrier bracketed by
scheduler fences), each with its builder method and Python wrapper.

Also fixes the AMD Membar analysis to look through rocdl.sched.* scheduling-only
fences when scanning for a sync point, so it no longer inserts a redundant
barrier right after an async wait (which doubled the workgroup barrier and
stalled the hand-rolled ping-pong).

Authored with Claude (Devmate).

Reviewed By: htyu

Differential Revision: D116046095


