### PR TITLE
Clarify named barrier thread count semantics

### DIFF
--- a/.claude/skills/tlx-api-reference/SKILL.md
+++ b/.claude/skills/tlx-api-reference/SKILL.md
@@ -56,10 +56,13 @@ with tlx.async_tasks():
 
 | Function | Description | Arch |
 |---|---|---|
-| `tlx.named_barrier_wait(bar_id, num_threads)` | Wait until num_threads arrive at bar_id | NVIDIA |
-| `tlx.named_barrier_arrive(bar_id, num_threads)` | Signal arrival at bar_id | NVIDIA |
+| `tlx.named_barrier_wait(bar_id, num_threads)` | Wait until the total participant count reaches bar_id | NVIDIA |
+| `tlx.named_barrier_arrive(bar_id, num_threads)` | Signal arrival at bar_id using the total participant count | NVIDIA |
 
-`num_threads` must be a multiple of 32 (warp size). Typically `num_warp_groups * warps_per_group * 32`.
+`num_threads` is the total number of threads required to flip the barrier phase:
+`num_waiting_threads + num_arriving_threads`. Wait and Arrive calls for the same
+barrier phase must use the same value. The count must be a multiple of 32 (warp
+size); it is typically `num_warp_groups * warps_per_group * 32`.
 
 Used for PingPong scheduling to prevent tensor core contention between consumer warp groups.
 

--- a/README.md
+++ b/README.md
@@ -583,11 +583,15 @@ Binary wheels are available for CPython 3.10-3.14.
 
 - `tlx.named_barrier_wait(bar_id, num_threads)` **[Hopper+]**
 
-    Wait until `num_threads` threads have reached the specified named mbarrier phase.
+    Wait until `num_threads` total threads have reached the specified named mbarrier phase.
 
 - `tlx.named_barrier_arrive(bar_id, num_threads)` **[Hopper+]**
 
-    Signal arrival at a named mbarrier with the given thread count.
+    Signal arrival at a named mbarrier.
+
+    For both APIs, `num_threads` is the total number of threads required to flip
+    the barrier phase: `num_waiting_threads + num_arriving_threads`. Wait and
+    Arrive calls for the same barrier phase must use the same value.
 
 - `tlx.barrier_expect_bytes(bar, bytes)` **[Hopper+]**
 

--- a/third_party/tlx/doc/tlx_barriers.md
+++ b/third_party/tlx/doc/tlx_barriers.md
@@ -110,8 +110,11 @@ barriers.
 
 - Named barriers do not have to be allocated or initialized.
 
-- Wait and Arrive are called with the count of expected threads to
-  arrive at the barrier.
+- Wait and Arrive are called with the total number of threads required
+  to flip the barrier phase. This includes threads that execute Wait
+  and threads that execute Arrive: *num_waiting_threads +
+  num_arriving_threads*. Wait and Arrive calls for the same barrier
+  phase must use the same thread count.
 
 - All threads in the warp participate in the arrive operation, so the
   thread count should be *number of warps \* threads per warp*.
@@ -122,14 +125,17 @@ barriers.
 #### APIs
 
 - ***tlx.named_barrier_wait(bar_id, num_threads)***
-  Wait until num_threads threads have reached the phase of the *bar_id*
-  named barrier. num_threads has to be a multiple of warp size, i.e.,
-  a multiple of 32.
+  Wait until *num_threads* total threads have reached the phase of the
+  *bar_id* named barrier. The waiting threads contribute to this total,
+  so *num_threads* is the number of waiting threads plus the number of
+  arriving threads. It must match the count passed to Arrive and be a
+  multiple of warp size, i.e., a multiple of 32.
 
 - ***tlx.named_barrier_arrive(bar_id, num_threads)***
-  Signal arrival at *bar_id* named barrier with an arrival count of
-  *num_threads*. num_threads has to be a multiple of warp size, i.e.,
-  a multiple of 32.
+  Signal arrival at the *bar_id* named barrier. *num_threads* is the
+  total number of threads required to flip the barrier phase, including
+  both waiting and arriving threads. It must match the count passed to
+  Wait and be a multiple of warp size, i.e., a multiple of 32.
 
 | TLX | MLIR | PTX |
 |----|----|----|

--- a/third_party/tlx/language/tlx/barrier.py
+++ b/third_party/tlx/language/tlx/barrier.py
@@ -183,11 +183,13 @@ def named_barrier_wait(
     _semantic=None,
 ) -> None:
     """
-    Wait until `arrive_count` threads have reached the specified named barrier.
+    Wait until the total participant count reaches the specified named barrier.
 
     Arguments:
         bar (tl.constexpr): Identifier for the named barrier (e.g. from a buffer view).
-        arrive_count (tl.constexpr): Number of threads arriving at the barrier.
+        arrive_count (tl.constexpr): Total number of threads required to flip the
+            barrier phase, including threads executing both `named_barrier_wait`
+            and `named_barrier_arrive`. Both calls must use the same count.
     """
 
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
@@ -202,11 +204,13 @@ def named_barrier_arrive(
     _semantic=None,
 ) -> None:
     """
-    Signal arrival at a named mbarrier with the given thread count.
+    Signal arrival at a named mbarrier.
 
     Arguments:
         bar (tl.constexpr): Identifier for the named barrier (e.g. from a buffer view).
-        arrive_count (tl.constexpr): Number of threads arriving at the barrier.
+        arrive_count (tl.constexpr): Total number of threads required to flip the
+            barrier phase, including threads executing both `named_barrier_wait`
+            and `named_barrier_arrive`. Both calls must use the same count.
     """
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
     arrive_count_handle = _semantic._convert_elem_to_ir_value(arrive_count, require_i64=False)


### PR DESCRIPTION
Summary: Document that `num_threads` is the total number of threads that flip a named barrier phase: `num_waiting_threads + num_arriving_threads`. Clarify that matching Wait and Arrive calls must use the same value.

Reviewed By: htyu

Differential Revision: D116655700


