### PR TITLE
[triton][tlx] Emit scf.yield and loop back-edge updates as parallel copies (#2903)

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1971,13 +1971,25 @@ void printBlock(Block &block, llvm::raw_ostream &os,
     // targets, otherwise skip entirely
     if (op.getName().getStringRef() == "scf.yield") {
       if (!yieldTargets.empty()) {
-        // Print assignments: yieldTarget = yieldOperand
-        for (unsigned i = 0; i < op.getNumOperands() && i < yieldTargets.size();
-             ++i) {
+        // Emit the iter-arg updates as a single tuple assignment: scf.yield has
+        // parallel-copy semantics, so sequential `t = v` statements would let a
+        // later target read an already-updated one, desyncing barrier phases and
+        // deadlocking warp-specialized kernels.
+        unsigned n = std::min((size_t)op.getNumOperands(), yieldTargets.size());
+        SmallVector<std::string> lhs, rhs;
+        for (unsigned i = 0; i < n; ++i) {
+          lhs.push_back(getValueName(yieldTargets[i], argSubstitutionMap));
+          rhs.push_back(getValueName(op.getOperand(i), argSubstitutionMap));
+        }
+        if (!lhs.empty()) {
           for (unsigned j = 0; j < indent; ++j)
             os << "  ";
-          os << getValueName(yieldTargets[i], argSubstitutionMap) << " = "
-             << getValueName(op.getOperand(i), argSubstitutionMap) << "\n";
+          for (unsigned i = 0; i < lhs.size(); ++i)
+            os << (i ? ", " : "") << lhs[i];
+          os << " = ";
+          for (unsigned i = 0; i < rhs.size(); ++i)
+            os << (i ? ", " : "") << rhs[i];
+          os << "\n";
         }
       }
       // Skip yield in TLX output (either handled above or just skip)
@@ -2253,6 +2265,12 @@ void printBlockArgAssignments(Block *dest, OperandRange operands,
                               llvm::raw_ostream &os, unsigned indent,
                               DenseMap<Value, Value> *argSubstitutionMap,
                               int skipArgIdx = -1) {
+  // Emit block-argument updates as a single tuple assignment so a back-edge to
+  // a loop header follows parallel-copy semantics (all sources read before any
+  // target is updated). Sequential `dest = src` statements would let a later
+  // assignment read an already-updated earlier target; see the scf.yield
+  // handler for the same reasoning.
+  SmallVector<std::string> lhs, rhs;
   for (unsigned i = 0; i < dest->getNumArguments() && i < operands.size();
        ++i) {
     if ((int)i == skipArgIdx)
@@ -2261,11 +2279,20 @@ void printBlockArgAssignments(Block *dest, OperandRange operands,
         getValueName(dest->getArgument(i), argSubstitutionMap);
     std::string srcName = getValueName(operands[i], argSubstitutionMap);
     if (destName != srcName) {
-      for (unsigned j = 0; j < indent; ++j)
-        os << "  ";
-      os << destName << " = " << srcName << "\n";
+      lhs.push_back(destName);
+      rhs.push_back(srcName);
     }
   }
+  if (lhs.empty())
+    return;
+  for (unsigned j = 0; j < indent; ++j)
+    os << "  ";
+  for (unsigned i = 0; i < lhs.size(); ++i)
+    os << (i ? ", " : "") << lhs[i];
+  os << " = ";
+  for (unsigned i = 0; i < rhs.size(); ++i)
+    os << (i ? ", " : "") << rhs[i];
+  os << "\n";
 }
 
 // Detect if a header block represents a for-loop: iter starts at init,


### PR DESCRIPTION
Summary:

The pass lowered each loop-carried value update (an `scf.yield`, or a CF back-edge to a loop header) as a sequence of individual `target = source` statements. That violates the parallel-copy semantics of these updates: all sources are read in the pre-update state, then every iter-arg updates simultaneously. Sequential statements let a later assignment read an already-updated earlier target -- e.g. when a software pipeline carries a buffer index and a phase/parity that is derived from another carried value, the second assignment reads the first's next-iteration value, desyncing the pipeline and deadlocking the kernel.

Emit each `scf.yield` and each `printBlockArgAssignments` back-edge as a single tuple assignment (`t0, t1, ... = v0, v1, ...`), which matches Python's simultaneous tuple-unpack semantics.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D113598222


