### PR TITLE
[CI] Fix pre-commit and wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,9 +102,8 @@ jobs:
             export CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux_2_28_${{ matrix.config.arch }}:latest"
           fi
 
-          export CIBW_BUILD="cp3{10,11,12,13,13t,14,14t}-manylinux_${{ matrix.config.arch }}"
+          export CIBW_BUILD="cp3{10,11,12,13,14,14t}-manylinux_${{ matrix.config.arch }}"
           export CIBW_SKIP="cp{35,36,37,38,39}-*"
-          export CIBW_ENABLE=cpython-freethreading
           python3 -m cibuildwheel . --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v7

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -462,8 +462,7 @@ private:
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
                       /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
                       /*affineBlockOffset=*/Value(),
-                      /*maskSpanAffineBlock=*/0,
-                      rewriter, targetInfo);
+                      /*maskSpanAffineBlock=*/0, rewriter, targetInfo);
       emitBarrier();
       auto tileOutVals = lowerLdStShared(
           loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1066,10 +1066,9 @@ SmallVector<Value> lowerLdSt(
   bool blockIsBroadcast =
       !hasBlockInput ||
       cvt.sublayoutIsZero({kBlock}, to_vector(cvt.getOutDimNames()));
-  bool crossCTA =
-      hasBlockOutput &&
-      (maskSpanAffineBlock != 0 ||
-       (!blockIsBroadcast && !cvt.isIdentityOnOutDim(kBlock)));
+  bool crossCTA = hasBlockOutput &&
+                  (maskSpanAffineBlock != 0 ||
+                   (!blockIsBroadcast && !cvt.isIdentityOnOutDim(kBlock)));
 
   // Either we have multiple bases with a matching partition dimension,
   // or we have a single base.
@@ -1312,9 +1311,9 @@ SmallVector<Value> lowerLocalLdSt(
                                smemObj.getBases().end());
   return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
                          paddingShifts, affineOffset, maskSpanAffineOffset,
-                         affineBlockOffset, maskSpanAffineBlock,
-                         rewriter, targetInfo, maybeMaxVecElems, localLoadOp,
-                         ctaRank, barrierPtr, distributedCoordinates);
+                         affineBlockOffset, maskSpanAffineBlock, rewriter,
+                         targetInfo, maybeMaxVecElems, localLoadOp, ctaRank,
+                         barrierPtr, distributedCoordinates);
 }
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -875,12 +875,12 @@ private:
       MemType memType = materialized.memType;
       if (memType == MemType::SHARED_MEM) {
         if (effect.proxy == MemEffectsOpInfo::Effects::Proxy::Async) {
-          funcBuilder.createVerifyProxyAccessCall(
-              b, bufferMask, baseThread, effect.operandName, pred, op,
-              effectCTAs);
+          funcBuilder.createVerifyProxyAccessCall(b, bufferMask, baseThread,
+                                                  effect.operandName, pred, op,
+                                                  effectCTAs);
         } else {
-          funcBuilder.createSetProxyAccessCall(
-              b, bufferMask, baseThread, pred, op, effectCTAs);
+          funcBuilder.createSetProxyAccessCall(b, bufferMask, baseThread, pred,
+                                               op, effectCTAs);
         }
       }
       if (effect.rw == MemEffectsOpInfo::Effects::Read) {

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -3209,19 +3209,19 @@ public:
 
     TmemScratchManager scratch(twoCTAs);
     RewritePatternSet patterns(&getContext());
-    patterns
-        .add<BinaryFloatToIntPattern<arith::AddFOp, arith::AddIOp>,
-             BinaryFloatToIntPattern<arith::SubFOp, arith::SubIOp>,
-             BinaryFloatToIntPattern<arith::MulFOp, arith::MulIOp>,
-             BinaryFloatToIntPattern<arith::MinimumFOp, arith::MinSIOp>,
-             BinaryFloatToIntPattern<arith::MaximumFOp, arith::MaxSIOp>,
-             BinaryFloatToIntPattern<arith::MinNumFOp, arith::MinSIOp>,
-             BinaryFloatToIntPattern<arith::MaxNumFOp, arith::MaxSIOp>,
-             NegFOpPattern, DivFOpPattern, PreciseDivFOpPattern, RemFOpPattern,
-             ClampFOpPattern, FmaPattern, ExpOpPattern, Exp2OpPattern,
-             CosOpPattern, SinOpPattern, ExtFOpPattern, TruncFOpPattern,
-             FpToFpPattern, Fp4ToFpPattern, PackedArithPattern, DotPattern,
-             DotScaledPattern>(&getContext());
+    patterns.add<BinaryFloatToIntPattern<arith::AddFOp, arith::AddIOp>,
+                 BinaryFloatToIntPattern<arith::SubFOp, arith::SubIOp>,
+                 BinaryFloatToIntPattern<arith::MulFOp, arith::MulIOp>,
+                 BinaryFloatToIntPattern<arith::MinimumFOp, arith::MinSIOp>,
+                 BinaryFloatToIntPattern<arith::MaximumFOp, arith::MaxSIOp>,
+                 BinaryFloatToIntPattern<arith::MinNumFOp, arith::MinSIOp>,
+                 BinaryFloatToIntPattern<arith::MaxNumFOp, arith::MaxSIOp>,
+                 NegFOpPattern, DivFOpPattern, PreciseDivFOpPattern,
+                 RemFOpPattern, ClampFOpPattern, FmaPattern, ExpOpPattern,
+                 Exp2OpPattern, CosOpPattern, SinOpPattern, ExtFOpPattern,
+                 TruncFOpPattern, FpToFpPattern, Fp4ToFpPattern,
+                 PackedArithPattern, DotPattern, DotScaledPattern>(
+        &getContext());
     patterns.add<UnaryPattern<math::LogOp>>(&getContext(), UnaryOpId::Log);
     patterns.add<UnaryPattern<math::Log2Op>>(&getContext(), UnaryOpId::Log2);
     patterns.add<UnaryPattern<math::SqrtOp>>(&getContext(), UnaryOpId::Sqrt);

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -164,8 +164,8 @@ struct GluonLayouts {
         py::module_::import_("triton.experimental.gluon.language.amd._layouts");
     auto blackwellLayouts = py::module_::import_(
         "triton.experimental.gluon.language.nvidia.blackwell");
-    auto rubinLayouts = py::module_::import_(
-        "triton.experimental.gluon.language.nvidia.rubin");
+    auto rubinLayouts =
+        py::module_::import_("triton.experimental.gluon.language.nvidia.rubin");
     AutoLayout = py::object(layouts.attr("AutoLayout")).release();
     CoalescedLayout = py::object(layouts.attr("CoalescedLayout")).release();
     BlockedLayout = py::object(layouts.attr("BlockedLayout")).release();
@@ -1052,21 +1052,22 @@ void init_gluon_ir(py::module_ &m) {
              self.create<ttng::TCGen5CommitOp>(barrier, pred, descs);
            })
 
-      .def("create_async_tma_copy_global_to_local",
-           [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
-              Value barrier, Value result, Value pred, bool multicast,
-              std::optional<std::vector<Value>> offsets) {
-             multicast &= ttng::hasCGABroadcast(
-                 cast<ttg::MemDescType>(result.getType()));
-             ValueRange offsetsRange =
-                 offsets.has_value() ? ValueRange(*offsets) : ValueRange{};
-             self.create<ttng::AsyncTMACopyGlobalToLocalOp>(
-                 /*multicastTargets=*/Value(), descPtr, coord, offsetsRange,
-                 barrier, result, pred, multicast);
-           },
-           py::arg("descPtr"), py::arg("coord"), py::arg("barrier"),
-           py::arg("result"), py::arg("pred"), py::arg("multicast"),
-           py::arg("offsets").none())
+      .def(
+          "create_async_tma_copy_global_to_local",
+          [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
+             Value barrier, Value result, Value pred, bool multicast,
+             std::optional<std::vector<Value>> offsets) {
+            multicast &=
+                ttng::hasCGABroadcast(cast<ttg::MemDescType>(result.getType()));
+            ValueRange offsetsRange =
+                offsets.has_value() ? ValueRange(*offsets) : ValueRange{};
+            self.create<ttng::AsyncTMACopyGlobalToLocalOp>(
+                /*multicastTargets=*/Value(), descPtr, coord, offsetsRange,
+                barrier, result, pred, multicast);
+          },
+          py::arg("descPtr"), py::arg("coord"), py::arg("barrier"),
+          py::arg("result"), py::arg("pred"), py::arg("multicast"),
+          py::arg("offsets").none())
       .def("create_async_tma_copy_local_to_global",
            [](GluonOpBuilder &self, Value descPtr, std::vector<Value> &coord,
               Value src) {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1032,8 +1032,8 @@ void init_triton_ir(py::module_ &m) {
   // The builder binding is static so it persists throughout compilation,
   // letting DSL plugins (registerCustomOps) and third-party backends (TLX,
   // via getBuilderClass) register their ops on it separately.
-  static py::class_<TritonOpBuilder> TritonOpBuilderBinding(
-      m, "builder", py::dynamic_attr());
+  static py::class_<TritonOpBuilder> TritonOpBuilderBinding(m, "builder",
+                                                            py::dynamic_attr());
   builderClassPtr = &TritonOpBuilderBinding;
   TritonOpBuilderBinding.def(py::init<MLIRContext *>())
       .def("get_op_builder", &TritonOpBuilder::getBuilder, ret::reference)

--- a/python/test/unit/test_knobs.py
+++ b/python/test/unit/test_knobs.py
@@ -309,8 +309,7 @@ def test_nvidia_tool_probe_reports_reason(tmp_path):
     assert reason == "no such file"
 
     # The case that motivated this: present and executable, but killed at exec.
-    broken = _fake_tool(tmp_path / "broken",
-                        'sys.stderr.write("undefined symbol: unw_backtrace\\n"); sys.exit(127)')
+    broken = _fake_tool(tmp_path / "broken", 'sys.stderr.write("undefined symbol: unw_backtrace\\n"); sys.exit(127)')
     tool, reason = probe(str(broken))
     assert tool is None
     assert "exited with status 127" in reason

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -609,6 +609,7 @@ class nvidia_knobs(base_knobs):
 
     def get_tool_env(self) -> Optional[dict[str, str]]:
         return self.tool_env() if self.tool_env is not None else None
+
     # Number of buffers for the dynamic-persistent tile-id broadcast channel
     # (cross-partition run-once atomic support). 1 = single-stage.
     ws_tile_prefetch_depth: env_int = env_int("TRITON_WS_TILE_PREFETCH_DEPTH", 1)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -1024,9 +1024,7 @@ public:
     std::string constraints;
     constexpr unsigned warpSize = 64;
     bool hasLiveDependency = llvm::any_of(op.getInputs(), [](Value input) {
-      return !cast<RankedTensorType>(input.getType())
-                  .getElementType()
-                  .isF32();
+      return !cast<RankedTensorType>(input.getType()).getElementType().isF32();
     });
     for (auto [source, converted] :
          llvm::zip(op.getInputs(), adaptor.getInputs())) {

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1371,8 +1371,7 @@ class CUDABackend(BaseBackend):
                 fbin,
             ]
             try:
-                subprocess.run(ptxas_cmd, check=True, close_fds=False, stderr=flog,
-                               env=knobs.nvidia.get_tool_env())
+                subprocess.run(ptxas_cmd, check=True, close_fds=False, stderr=flog, env=knobs.nvidia.get_tool_env())
                 if knobs.nvidia.dump_ptxas_log:
                     with open(flog.name) as log_file:
                         print(log_file.read())

--- a/third_party/tlx/language/tlx/hw/resources.py
+++ b/third_party/tlx/language/tlx/hw/resources.py
@@ -49,7 +49,7 @@ class Sm90:
     #: class is pinned to one. Resolution walks ARCH_SPECS in order and takes
     #: the first match, so a pinned entry must precede the broader one it
     #: overlaps (Sm107 before Sm100).
-    cuda_majors: tuple[int, ...] = (9,)
+    cuda_majors: tuple[int, ...] = (9, )
     cuda_minor: int | None = None
     #: 228KB SMEM per SM; 227KB is the max opt-in per block.
     smem_bytes: int = 232448
@@ -111,7 +111,7 @@ class Sm107(Sm100):
     product = "Rubin"
     #: Pinned to (10, 7), so this must precede Sm100 in ARCH_SPECS -- major 10
     #: alone would otherwise match Blackwell first.
-    cuda_majors = (10,)
+    cuda_majors = (10, )
     cuda_minor = 7
 
 

--- a/third_party/tlx/language/tlx/hw/target.py
+++ b/third_party/tlx/language/tlx/hw/target.py
@@ -236,12 +236,10 @@ def current_target() -> Target:
             # Do NOT fall through to Blackwell. A consumer part (major 12) has
             # a far smaller SMEM budget, so claiming it is a B200 would hand
             # out configs that cannot launch.
-            raise ValueError(
-                f"unrecognized CUDA compute capability {capability}. torchTLX "
-                f"targets "
-                f"{sorted(k for k, s in ARCH_SPECS.items() if s.vendor == 'nvidia')}; "
-                f"add a class to ARCH_SPECS to support it"
-            )
+            raise ValueError(f"unrecognized CUDA compute capability {capability}. torchTLX "
+                             f"targets "
+                             f"{sorted(k for k, s in ARCH_SPECS.items() if s.vendor == 'nvidia')}; "
+                             f"add a class to ARCH_SPECS to support it")
 
     # Prefer what the driver reports; the table is the fallback. This is what
     # lets a part we have not tuned for yet report its own limits.

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -446,8 +446,8 @@ def async_dot(
         handles = [t.handle for t in mBarriers]
         is_async = force_async or len(handles) > 0
         use_acc_handle = _get_use_acc_handle(use_acc, _semantic.builder)
-        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred, bool(two_ctas),
-                                                     handles, bool(is_async))
+        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred,
+                                                     bool(two_ctas), handles, bool(is_async))
         return tl.tensor(output, tl.void)
     else:
         mma_layout = _semantic.builder.make_nv_mma_encoding_attr(A_handle, acc_handle, version, 0,

--- a/third_party/tlx/tutorials/amd_addmm_gfx950.py
+++ b/third_party/tlx/tutorials/amd_addmm_gfx950.py
@@ -16,15 +16,13 @@ from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kern
     _launch_register,
 )
 
-
 _PATH_AUTOTUNE_WARMUP = 25
 _PATH_AUTOTUNE_REP = 100
 _PATH_CACHE: dict[tuple[object, ...], str] = {}
 _TAIL_BLOCK_K = 2 * BLOCK_K
 _MAX_DEFERRED_EPILOGUE_ELEMENTS = 16 * 1024 * 1024
 _TAIL_CONFIGS = [
-    triton.Config({"BLOCK_M": block_m, "BLOCK_N": block_n}, num_warps=num_warps)
-    for block_m, block_n, num_warps in (
+    triton.Config({"BLOCK_M": block_m, "BLOCK_N": block_n}, num_warps=num_warps) for block_m, block_n, num_warps in (
         (64, 64, 4),
         (64, 128, 4),
         (128, 64, 4),
@@ -41,13 +39,8 @@ def _can_use_inter_wave_tail(a: torch.Tensor, b: torch.Tensor) -> bool:
     M, K = a.shape
     N = b.shape[1]
     output_elements = M * N
-    return (
-        K > 1536
-        and K % BLOCK_K != 0
-        and K * a.element_size() % 16 == 0
-        and a.element_size() == 2
-        and 2 * 1024 * 1024 < output_elements <= _MAX_DEFERRED_EPILOGUE_ELEMENTS
-    )
+    return (K > 1536 and K % BLOCK_K != 0 and K * a.element_size() % 16 == 0 and a.element_size() == 2
+            and 2 * 1024 * 1024 < output_elements <= _MAX_DEFERRED_EPILOGUE_ELEMENTS)
 
 
 def _path_key(
@@ -122,7 +115,7 @@ def _launch_inter_wave_with_tail(bias: torch.Tensor, a: torch.Tensor, b: torch.T
     _, N = b.shape
     k_main = K // _TAIL_BLOCK_K * _TAIL_BLOCK_K
     main, out = _launch(a, b, SPLIT_K=1, TILE=(256, 256), K_LIMIT=k_main, DEFER_EPILOGUE=True)
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),)
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]), )
     _addmm_tail_kernel[grid](
         a,
         b,
@@ -168,7 +161,8 @@ def _autotune_path(
         if torch.allclose(register_output, inter_wave_tail_output, rtol=1e-2, atol=1e-2):
             candidates["inter_wave_tail"] = inter_wave_tail
     timings = {
-        name: triton.testing.do_bench(
+        name:
+        triton.testing.do_bench(
             candidate,
             warmup=_PATH_AUTOTUNE_WARMUP,
             rep=_PATH_AUTOTUNE_REP,

--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/matmul_kernel_persistent.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/matmul_kernel_persistent.py
@@ -13,7 +13,6 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 
-
 TILE = tl.constexpr(32)
 BLOCK_K = tl.constexpr(64)
 K_BLOCKS = tl.constexpr(96)
@@ -42,9 +41,7 @@ _MT256X160_B_PUBLISH_PLAN = (
     ((4, 0, 3), (-1, 0, 0)),
     ((1, 0, 2), (4, 3, 2)),
 )
-_MT256X160_FINISH_MFMA_PLAN = (
-    7, 8, 9, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34
-)
+_MT256X160_FINISH_MFMA_PLAN = (7, 8, 9, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34)
 _MT256X160_PIPELINE_SPEC = (
     _M8_A1_READ_PLAN,
     4,
@@ -90,32 +87,24 @@ _SHAPE_DEFAULTS = {
 
 # Every complete group of four N32 fragments shares one N128 LDS image.  Any
 # remaining fragments use separate N32 images, avoiding power-of-two padding.
-_B_BASES = tl.constexpr(
-    [[1 << bit, 0] for bit in range(6)]
-    + [[0, 1 << bit] for bit in (4, 5, 6, 0, 1, 2, 3)]
-)
+_B_BASES = tl.constexpr([[1 << bit, 0] for bit in range(6)] + [[0, 1 << bit] for bit in (4, 5, 6, 0, 1, 2, 3)])
 
 # Four waves jointly own the first four N32 accumulator fragments as one 32x128
 # region.  Each lane gets sixteen contiguous N values, allowing four narrow
 # stores to become two 128-bit stores after one layout conversion.
 _C_STORE_32X128_LAYOUT = tlx.layout(
-    shape=((16, 4, 2, 2), (16,)),
-    stride=((128, 16, 2048, 64), (1,)),
+    shape=((16, 4, 2, 2), (16, )),
+    stride=((128, 16, 2048, 64), (1, )),
 )
+
 
 @triton.jit
 def _global_loads(source, kb, tile_spec: tl.constexpr):
     a_ptr, b_ptr, stride_ak, stride_bk, a_offsets, b_offsets = source
     a_ptr += kb * BLOCK_K * stride_ak
     b_ptr += kb * BLOCK_K * stride_bk
-    a = [
-        tlx.buffer_load(a_ptr, a_offsets[mi], contiguity=8)
-        for mi in range(tl.constexpr(tile_spec[0] // TILE))
-    ]
-    b = [
-        tlx.buffer_load(b_ptr, b_offsets[nj], contiguity=8)
-        for nj in range(tl.constexpr(tile_spec[1] // TILE))
-    ]
+    a = [tlx.buffer_load(a_ptr, a_offsets[mi], contiguity=8) for mi in range(tl.constexpr(tile_spec[0] // TILE))]
+    b = [tlx.buffer_load(b_ptr, b_offsets[nj], contiguity=8) for nj in range(tl.constexpr(tile_spec[1] // TILE))]
     return tl.tuple(a + b)
 
 
@@ -132,18 +121,12 @@ def _local_store_one(stage, value, index: tl.constexpr, tile_spec: tl.constexpr)
         nj: tl.constexpr = index - m_fragments
         view = tlx.local_slice(
             tlx.local_view(
-                b_buffers[
-                    nj // N_GROUP_FRAGMENTS
-                    if nj < n_main_fragments
-                    else n_main_groups + nj - n_main_fragments
-                ],
+                b_buffers[nj // N_GROUP_FRAGMENTS if nj < n_main_fragments else n_main_groups + nj - n_main_fragments],
                 0,
             ),
             [
                 0,
-                (nj % N_GROUP_FRAGMENTS) * TILE
-                if nj < n_main_fragments
-                else 0,
+                (nj % N_GROUP_FRAGMENTS) * TILE if nj < n_main_fragments else 0,
             ],
             [BLOCK_K, TILE],
         )
@@ -152,17 +135,13 @@ def _local_store_one(stage, value, index: tl.constexpr, tile_spec: tl.constexpr)
 
 @triton.jit
 def _local_store_all(stage, values, tile_spec: tl.constexpr):
-    load_groups: tl.constexpr = tl.constexpr(
-        tile_spec[0] // TILE + tile_spec[1] // TILE
-    )
+    load_groups: tl.constexpr = tl.constexpr(tile_spec[0] // TILE + tile_spec[1] // TILE)
     for index in tl.static_range(load_groups):
         _local_store_one(stage, values[index], index, tile_spec)
 
 
 @triton.jit
-def _local_load_a(
-    stage, kh: tl.constexpr, mi: tl.constexpr, dot_a: tl.constexpr
-):
+def _local_load_a(stage, kh: tl.constexpr, mi: tl.constexpr, dot_a: tl.constexpr):
     a_buffers = stage[0]
     view = tlx.local_slice(
         tlx.local_view(a_buffers[mi], 0),
@@ -186,18 +165,12 @@ def _local_load_b(
     n_main_fragments: tl.constexpr = n_main_groups * N_GROUP_FRAGMENTS
     view = tlx.local_slice(
         tlx.local_view(
-            b_buffers[
-                nj // N_GROUP_FRAGMENTS
-                if nj < n_main_fragments
-                else n_main_groups + nj - n_main_fragments
-            ],
+            b_buffers[nj // N_GROUP_FRAGMENTS if nj < n_main_fragments else n_main_groups + nj - n_main_fragments],
             0,
         ),
         [
             kh * TILE,
-            (nj % N_GROUP_FRAGMENTS) * TILE
-            if nj < n_main_fragments
-            else 0,
+            (nj % N_GROUP_FRAGMENTS) * TILE if nj < n_main_fragments else 0,
         ],
         [TILE, TILE],
     )
@@ -212,10 +185,8 @@ def _local_load_b_row(
     dot_b: tl.constexpr,
     tile_spec: tl.constexpr,
 ):
-    return tl.tuple([
-        _local_load_b(stage, kh, nj, dot_b, tile_spec)
-        for nj in range(tl.constexpr(tile_spec[1] // TILE))
-    ])
+    return tl.tuple(
+        [_local_load_b(stage, kh, nj, dot_b, tile_spec) for nj in range(tl.constexpr(tile_spec[1] // TILE))])
 
 
 @triton.jit
@@ -233,27 +204,17 @@ def _mfma_part(
     tile_spec: tl.constexpr,
 ):
     n_fragments: tl.constexpr = tl.constexpr(tile_spec[1] // TILE)
-    accumulators: tl.constexpr = tl.constexpr(
-        tile_spec[0] // TILE * tile_spec[1] // TILE
-    )
+    accumulators: tl.constexpr = tl.constexpr(tile_spec[0] // TILE * tile_spec[1] // TILE)
     return tl.tuple([
         tlx.amd_scheduled_mfma(
             tlx.require_layout(a_operand, dot_a, pin=False),
-            tlx.require_layout(
-                b_operands[index % n_fragments], dot_b, pin=False
-            ),
+            tlx.require_layout(b_operands[index % n_fragments], dot_b, pin=False),
             tlx.require_layout(acc[index], mma, pin=False),
             accumulator_role="persistent",
             resident_operand=None,
             initialize=initialize,
-        )
-        if (
-            index // n_fragments == mi
-            and index % n_fragments >= first_nj
-            and index % n_fragments < first_nj + count
-        )
-        else acc[index]
-        for index in range(accumulators)
+        ) if (index // n_fragments == mi and index % n_fragments >= first_nj and index % n_fragments < first_nj + count)
+        else acc[index] for index in range(accumulators)
     ])
 
 
@@ -270,16 +231,22 @@ def _mfma_row(
     tile_spec: tl.constexpr,
 ):
     return _mfma_part(
-        a_operand, b_operands, acc, mi, 0,
+        a_operand,
+        b_operands,
+        acc,
+        mi,
+        0,
         tl.constexpr(tile_spec[1] // TILE),
-        mma, dot_a, dot_b, initialize, tile_spec,
+        mma,
+        dot_a,
+        dot_b,
+        initialize,
+        tile_spec,
     )
 
 
 @triton.jit
-def _global_prefetch_one(
-    source, kb, index: tl.constexpr, tile_spec: tl.constexpr
-):
+def _global_prefetch_one(source, kb, index: tl.constexpr, tile_spec: tl.constexpr):
     a_ptr, b_ptr, stride_ak, stride_bk, a_offsets, b_offsets = source
     m_fragments: tl.constexpr = tl.constexpr(tile_spec[0] // TILE)
     if index < m_fragments:
@@ -330,9 +297,17 @@ def _publish_a_row(
 
     # K(t): compute columns [0, mfmas_before_prefetch) of accumulator row mi.
     acc = _mfma_part(
-        a_operand, b_operands, acc, mi, 0,
+        a_operand,
+        b_operands,
+        acc,
+        mi,
+        0,
         tl.constexpr(pipeline_spec[1]),
-        mma, dot_a, dot_b, initialize, tile_spec,
+        mma,
+        dot_a,
+        dot_b,
+        initialize,
+        tile_spec,
     )
 
     # K(t+2): issue this row's next global A[32, 64] load into VGPRs.
@@ -342,10 +317,17 @@ def _publish_a_row(
     # [mfmas_before_prefetch, n_fragments).  For N160 the split is 4 + 1;
     # for N192 it is 5 + 1.
     acc = _mfma_part(
-        a_operand, b_operands, acc, mi,
+        a_operand,
+        b_operands,
+        acc,
+        mi,
         tl.constexpr(pipeline_spec[1]),
         n_fragments - tl.constexpr(pipeline_spec[1]),
-        mma, dot_a, dot_b, initialize, tile_spec,
+        mma,
+        dot_a,
+        dot_b,
+        initialize,
+        tile_spec,
     )
     return acc, future
 
@@ -370,17 +352,24 @@ def _publish_b_fragment(
     index: tl.constexpr = m_fragments + nj
     _local_store_one(next_stage, prefetched[index], index, tile_spec)
     acc = _mfma_part(
-        a_operands[0], b_operands, acc,
-        0, nj, 1, mma, dot_a, dot_b, False, tile_spec,
+        a_operands[0],
+        b_operands,
+        acc,
+        0,
+        nj,
+        1,
+        mma,
+        dot_a,
+        dot_b,
+        False,
+        tile_spec,
     )
 
     future = _global_prefetch_one(source, future_kb, index, tile_spec)
 
     # Spread the MFMA rows across publish groups according to a tile-specific
     # compile-time plan, so the pipeline core itself is independent of 8x5.
-    for part in tl.static_range(
-        tl.constexpr(len(pipeline_spec[2][nj]))
-    ):
+    for part in tl.static_range(tl.constexpr(len(pipeline_spec[2][nj]))):
         if tl.constexpr(pipeline_spec[2][nj][part][2]) > 0:
             acc = _mfma_part(
                 a_operands[tl.constexpr(pipeline_spec[2][nj][part][0])],
@@ -417,9 +406,19 @@ def _publish_b_rows(
     future = tl.tuple([])
     for nj in tl.static_range(tl.constexpr(tile_spec[1] // TILE)):
         acc, value = _publish_b_fragment(
-            a_operands, b_operands, acc, prefetched,
-            next_stage, source, future_kb, nj, mma, dot_a, dot_b,
-            pipeline_spec, tile_spec,
+            a_operands,
+            b_operands,
+            acc,
+            prefetched,
+            next_stage,
+            source,
+            future_kb,
+            nj,
+            mma,
+            dot_a,
+            dot_b,
+            pipeline_spec,
+            tile_spec,
         )
         future += tl.tuple([value])
     return acc, future
@@ -445,9 +444,17 @@ def _finish_read(
         value = _local_load_a(next_stage, 0, read - n_fragments, dot_a)
     flat: tl.constexpr = tl.constexpr(pipeline_spec[3][read])
     acc = _mfma_part(
-        a_operands[flat // n_fragments], b_operands, acc,
-        flat // n_fragments, flat % n_fragments, 1,
-        mma, dot_a, dot_b, False, tile_spec,
+        a_operands[flat // n_fragments],
+        b_operands,
+        acc,
+        flat // n_fragments,
+        flat % n_fragments,
+        1,
+        mma,
+        dot_a,
+        dot_b,
+        False,
+        tile_spec,
     )
     return acc, value
 
@@ -473,16 +480,31 @@ def _finish_iteration(
     n_fragments: tl.constexpr = tl.constexpr(tile_spec[1] // TILE)
     for read in tl.static_range(m_fragments + n_fragments):
         acc, value = _finish_read(
-            next_stage, a_operands, b_operands,
-            acc, read, mma, dot_a, dot_b, pipeline_spec, tile_spec,
+            next_stage,
+            a_operands,
+            b_operands,
+            acc,
+            read,
+            mma,
+            dot_a,
+            dot_b,
+            pipeline_spec,
+            tile_spec,
         )
         if read < n_fragments:
             next_b += tl.tuple([value])
         else:
             next_a += tl.tuple([value])
     acc = _mfma_row(
-        a_operands[m_fragments - 1], b_operands, acc, m_fragments - 1,
-        mma, dot_a, dot_b, False, tile_spec,
+        a_operands[m_fragments - 1],
+        b_operands,
+        acc,
+        m_fragments - 1,
+        mma,
+        dot_a,
+        dot_b,
+        False,
+        tile_spec,
     )
     return acc, early_prefetched + late_prefetched, next_a, next_b
 
@@ -528,16 +550,25 @@ def _pipeline(
         # K(t).kh1: spread the smaller B operand window across the first
         # n_fragments loop iterations instead of issuing one late LDS burst.
         if mi < n_fragments:
-            b1 += tl.tuple([
-                _local_load_b(current_stage, 1, mi, dot_b, tile_spec)
-            ])
+            b1 += tl.tuple([_local_load_b(current_stage, 1, mi, dot_b, tile_spec)])
 
         # In one interleaved step: publish A(mi,K(t+1)) from VGPRs to the next
         # LDS stage, compute row mi of K(t).kh0, and prefetch A(mi,K(t+2)).
         acc, future = _publish_a_row(
-            current_a[mi], current_b, acc, prefetched[mi],
-            next_stage, source, future_kb,
-            mi, mma, dot_a, dot_b, initialize, pipeline_spec, tile_spec,
+            current_a[mi],
+            current_b,
+            acc,
+            prefetched[mi],
+            next_stage,
+            source,
+            future_kb,
+            mi,
+            mma,
+            dot_a,
+            dot_b,
+            initialize,
+            pipeline_spec,
+            tile_spec,
         )
         future_a += tl.tuple([future])
 
@@ -545,19 +576,27 @@ def _pipeline(
         # plan covers every A fragment exactly once while controlling lifetime.
         if tl.constexpr(pipeline_spec[0][mi][1]) > 0:
             a1 += tl.tuple([
-                _local_load_a(current_stage, 1, index, dot_a)
-                for index in range(
+                _local_load_a(current_stage, 1, index, dot_a) for index in range(
                     tl.constexpr(pipeline_spec[0][mi][0]),
-                    tl.constexpr(pipeline_spec[0][mi][0])
-                    + tl.constexpr(pipeline_spec[0][mi][1]),
+                    tl.constexpr(pipeline_spec[0][mi][0]) + tl.constexpr(pipeline_spec[0][mi][1]),
                 )
             ])
 
     # Publish B(K(t+1)) to next LDS and prefetch B(K(t+2)), while a1/b1
     # compute most of the current K(t).kh1 accumulator updates.
     acc, late_prefetched = _publish_b_rows(
-        a1, b1, acc, prefetched, next_stage,
-        source, future_kb, mma, dot_a, dot_b, pipeline_spec, tile_spec,
+        a1,
+        b1,
+        acc,
+        prefetched,
+        next_stage,
+        source,
+        future_kb,
+        mma,
+        dot_a,
+        dot_b,
+        pipeline_spec,
+        tile_spec,
     )
 
     # All A/B fragments of K(t+1) are now in next_stage.  Make them visible
@@ -565,8 +604,17 @@ def _pipeline(
     # K(t).kh1 MFMA updates in _finish_iteration.
     tl.debug_barrier()
     return _finish_iteration(
-        next_stage, a1, b1, acc, future_a, late_prefetched,
-        mma, dot_a, dot_b, pipeline_spec, tile_spec,
+        next_stage,
+        a1,
+        b1,
+        acc,
+        future_a,
+        late_prefetched,
+        mma,
+        dot_a,
+        dot_b,
+        pipeline_spec,
+        tile_spec,
     )
 
 
@@ -597,16 +645,38 @@ def _pipeline_pair(
     """
     # Consume K(kb), publish K(kb+1) into stage1, and prefetch K(kb+2).
     acc, prefetched, current_a, current_b = _pipeline(
-        source, kb + 2, stage0, stage1, current_a, current_b,
-        prefetched, acc, mma, dot_a, dot_b, initialize,
-        pipeline_spec, tile_spec,
+        source,
+        kb + 2,
+        stage0,
+        stage1,
+        current_a,
+        current_b,
+        prefetched,
+        acc,
+        mma,
+        dot_a,
+        dot_b,
+        initialize,
+        pipeline_spec,
+        tile_spec,
     )
     # Consume K(kb+1), publish K(kb+2) into stage0, and prefetch K(kb+3).
     # Accumulators were initialized by the first call, so initialize=False.
     return _pipeline(
-        source, kb + 3, stage1, stage0, current_a, current_b,
-        prefetched, acc, mma, dot_a, dot_b, False,
-        pipeline_spec, tile_spec,
+        source,
+        kb + 3,
+        stage1,
+        stage0,
+        current_a,
+        current_b,
+        prefetched,
+        acc,
+        mma,
+        dot_a,
+        dot_b,
+        False,
+        pipeline_spec,
+        tile_spec,
     )
 
 
@@ -633,13 +703,11 @@ def _make_global_tile_load_addresses(
     block_m_offset = pid_m * block_m
     block_n_offset = pid_n * block_n
     a_offsets = tl.tuple([
-        (block_m_offset + mi * TILE + tl.arange(0, TILE))[:, None] * stride_am
-        + rk[None, :] * stride_ak
+        (block_m_offset + mi * TILE + tl.arange(0, TILE))[:, None] * stride_am + rk[None, :] * stride_ak
         for mi in range(m_fragments)
     ])
     b_offsets = tl.tuple([
-        rk[:, None] * stride_bk
-        + (block_n_offset + nj * TILE + tl.arange(0, TILE))[None, :] * stride_bn
+        rk[:, None] * stride_bk + (block_n_offset + nj * TILE + tl.arange(0, TILE))[None, :] * stride_bn
         for nj in range(n_fragments)
     ])
     return tl.tuple([a_ptr, b_ptr, stride_ak, stride_bk, a_offsets, b_offsets])
@@ -647,15 +715,26 @@ def _make_global_tile_load_addresses(
 
 @triton.jit
 def _consume_k32(
-    stage, kh: tl.constexpr, acc,
-    mma: tl.constexpr, dot_a: tl.constexpr, dot_b: tl.constexpr,
+    stage,
+    kh: tl.constexpr,
+    acc,
+    mma: tl.constexpr,
+    dot_a: tl.constexpr,
+    dot_b: tl.constexpr,
     tile_spec: tl.constexpr,
 ):
     b_operands = _local_load_b_row(stage, kh, dot_b, tile_spec)
     for mi in tl.static_range(tl.constexpr(tile_spec[0] // TILE)):
         acc = _mfma_row(
-            _local_load_a(stage, kh, mi, dot_a), b_operands, acc,
-            mi, mma, dot_a, dot_b, False, tile_spec,
+            _local_load_a(stage, kh, mi, dot_a),
+            b_operands,
+            acc,
+            mi,
+            mma,
+            dot_a,
+            dot_b,
+            False,
+            tile_spec,
         )
     return acc
 
@@ -688,10 +767,7 @@ def _compute_full_tile(
     _local_store_all(stage0, preloaded_k0, tile_spec)
     tl.debug_barrier()
     current_b = _local_load_b_row(stage0, 0, dot_b, tile_spec)
-    current_a = tl.tuple([
-        _local_load_a(stage0, 0, mi, dot_a)
-        for mi in range(m_fragments)
-    ])
+    current_a = tl.tuple([_local_load_a(stage0, 0, mi, dot_a) for mi in range(m_fragments)])
     prefetched = _global_loads(source, 1, tile_spec)
 
     # Create one persistent FP32 accumulator for every logical C[32, 32]
@@ -699,9 +775,20 @@ def _compute_full_tile(
     zero = tlx.zeros((TILE, TILE), tl.float32, layout=mma)
     acc = tl.tuple([zero for _ in range(m_fragments * n_fragments)])
     acc, prefetched, current_a, current_b = _pipeline_pair(
-        0, source,
-        stage0, stage1, current_a, current_b, prefetched, acc,
-        mma, dot_a, dot_b, True, pipeline_spec, tile_spec,
+        0,
+        source,
+        stage0,
+        stage1,
+        current_a,
+        current_b,
+        prefetched,
+        acc,
+        mma,
+        dot_a,
+        dot_b,
+        True,
+        pipeline_spec,
+        tile_spec,
     )
 
     # Steady state: pair(kb) consumes K(kb)/K(kb+1) and prepares
@@ -709,9 +796,20 @@ def _compute_full_tile(
     # exits with K94 in stage0/current operands plus K95 in prefetch VGPRs.
     for kb in tl.range(2, K_BLOCKS - 2, 2, num_stages=1):
         acc, prefetched, current_a, current_b = _pipeline_pair(
-            kb, source,
-            stage0, stage1, current_a, current_b, prefetched, acc,
-            mma, dot_a, dot_b, False, pipeline_spec, tile_spec,
+            kb,
+            source,
+            stage0,
+            stage1,
+            current_a,
+            current_b,
+            prefetched,
+            acc,
+            mma,
+            dot_a,
+            dot_b,
+            False,
+            pipeline_spec,
+            tile_spec,
         )
 
     # Epilogue: publish K95 into stage1 while consuming the already-resident
@@ -720,15 +818,20 @@ def _compute_full_tile(
     _local_store_all(stage1, prefetched, tile_spec)
     for mi in tl.static_range(m_fragments):
         acc = _mfma_row(
-            current_a[mi], current_b, acc, mi,
-            mma, dot_a, dot_b, False, tile_spec,
+            current_a[mi],
+            current_b,
+            acc,
+            mi,
+            mma,
+            dot_a,
+            dot_b,
+            False,
+            tile_spec,
         )
     acc = _consume_k32(stage0, 1, acc, mma, dot_a, dot_b, tile_spec)
     tl.debug_barrier()
     for kh in tl.static_range(2):
-        acc = _consume_k32(
-            stage1, kh, acc, mma, dot_a, dot_b, tile_spec
-        )
+        acc = _consume_k32(stage1, kh, acc, mma, dot_a, dot_b, tile_spec)
     return acc
 
 
@@ -756,31 +859,16 @@ def _global_store_output(
     rn = pid_n * block_n + tl.arange(0, TILE)
     for mi in tl.static_range(m_fragments):
         for group in tl.static_range(n_main_groups):
-            rn_wide = (
-                pid_n * block_n
-                + group * N_GROUP_FRAGMENTS * TILE
-                + tl.arange(0, N_GROUP_FRAGMENTS * TILE)
-            )
-            offsets = (
-                c_ptr
-                + (rm + mi * TILE)[:, None] * stride_cm
-                + rn_wide[None, :] * stride_cn
-            )
+            rn_wide = (pid_n * block_n + group * N_GROUP_FRAGMENTS * TILE + tl.arange(0, N_GROUP_FRAGMENTS * TILE))
+            offsets = (c_ptr + (rm + mi * TILE)[:, None] * stride_cm + rn_wide[None, :] * stride_cn)
             lo = tl.cat(
                 tlx.require_layout(
-                    acc[
-                        mi * n_fragments
-                        + group * N_GROUP_FRAGMENTS
-                    ],
+                    acc[mi * n_fragments + group * N_GROUP_FRAGMENTS],
                     mma,
                     pin=False,
                 ),
                 tlx.require_layout(
-                    acc[
-                        mi * n_fragments
-                        + group * N_GROUP_FRAGMENTS
-                        + 1
-                    ],
+                    acc[mi * n_fragments + group * N_GROUP_FRAGMENTS + 1],
                     mma,
                     pin=False,
                 ),
@@ -788,39 +876,25 @@ def _global_store_output(
             )
             hi = tl.cat(
                 tlx.require_layout(
-                    acc[
-                        mi * n_fragments
-                        + group * N_GROUP_FRAGMENTS
-                        + 2
-                    ],
+                    acc[mi * n_fragments + group * N_GROUP_FRAGMENTS + 2],
                     mma,
                     pin=False,
                 ),
                 tlx.require_layout(
-                    acc[
-                        mi * n_fragments
-                        + group * N_GROUP_FRAGMENTS
-                        + 3
-                    ],
+                    acc[mi * n_fragments + group * N_GROUP_FRAGMENTS + 3],
                     mma,
                     pin=False,
                 ),
                 dim=1,
             )
             value = tl.cat(lo, hi, dim=1)
-            value = tlx.require_layout(
-                value.to(c_ptr.dtype.element_ty), _C_STORE_32X128_LAYOUT
-            )
+            value = tlx.require_layout(value.to(c_ptr.dtype.element_ty), _C_STORE_32X128_LAYOUT)
             tlx.assert_same_layout(value, _C_STORE_32X128_LAYOUT)
             tl.store(offsets, value)
         for tail in tl.static_range(n_tail_fragments):
             offsets = tlx.require_layout(
-                c_ptr
-                + (rm + mi * TILE)[:, None] * stride_cm
-                + (
-                    rn
-                    + (n_main_fragments + tail) * TILE
-                )[None, :] * stride_cn,
+                c_ptr + (rm + mi * TILE)[:, None] * stride_cm + (rn +
+                                                                 (n_main_fragments + tail) * TILE)[None, :] * stride_cn,
                 mma,
                 pin=False,
             )
@@ -834,13 +908,8 @@ def _global_store_output(
 
 @triton.jit
 def _commit_accumulators(acc, mma: tl.constexpr, tile_spec: tl.constexpr):
-    accumulators: tl.constexpr = tl.constexpr(
-        tile_spec[0] // TILE * tile_spec[1] // TILE
-    )
-    values = [
-        tlx.require_layout(acc[index], mma, pin=False)
-        for index in range(accumulators)
-    ]
+    accumulators: tl.constexpr = tl.constexpr(tile_spec[0] // TILE * tile_spec[1] // TILE)
+    values = [tlx.require_layout(acc[index], mma, pin=False) for index in range(accumulators)]
     return tlx.amd_mfma_commit(tl.tuple(values))
 
 
@@ -854,30 +923,16 @@ def _local_alloc_stage(
     m_fragments: tl.constexpr = tl.constexpr(tile_spec[0] // TILE)
     n_fragments: tl.constexpr = tl.constexpr(tile_spec[1] // TILE)
     n_main_groups: tl.constexpr = n_fragments // N_GROUP_FRAGMENTS
-    n_tail_fragments: tl.constexpr = (
-        n_fragments - n_main_groups * N_GROUP_FRAGMENTS
-    )
-    a_buffers = tl.tuple([
-        tlx.local_alloc((TILE, BLOCK_K), tl.float16, 1, layout=a_layout)
-        for _ in range(m_fragments)
-    ])
-    b_buffers = tl.tuple(
-        [
-            tlx.local_alloc(
-                (BLOCK_K, N_GROUP_FRAGMENTS * TILE),
-                tl.float16,
-                1,
-                layout=b_main_layout,
-            )
-            for _ in range(n_main_groups)
-        ]
-        + [
-            tlx.local_alloc(
-                (BLOCK_K, TILE), tl.float16, 1, layout=b_tail_layout
-            )
-            for _ in range(n_tail_fragments)
-        ]
-    )
+    n_tail_fragments: tl.constexpr = (n_fragments - n_main_groups * N_GROUP_FRAGMENTS)
+    a_buffers = tl.tuple([tlx.local_alloc((TILE, BLOCK_K), tl.float16, 1, layout=a_layout) for _ in range(m_fragments)])
+    b_buffers = tl.tuple([
+        tlx.local_alloc(
+            (BLOCK_K, N_GROUP_FRAGMENTS * TILE),
+            tl.float16,
+            1,
+            layout=b_main_layout,
+        ) for _ in range(n_main_groups)
+    ] + [tlx.local_alloc((BLOCK_K, TILE), tl.float16, 1, layout=b_tail_layout) for _ in range(n_tail_fragments)])
     return tl.tuple([a_buffers, b_buffers])
 
 
@@ -903,27 +958,13 @@ def _kernel(
     )
     dot_a: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
     dot_b: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
-    a_layout: tl.constexpr = (
-        tlx.padded_shared_layout_encoding.with_identity_for(
-            [(64, 16)], [TILE, BLOCK_K], order=[1, 0]
-        )
-    )
-    b_main_layout: tl.constexpr = (
-        tlx.padded_shared_layout_encoding.with_bases(
-            [(512, 16)], _B_BASES, [BLOCK_K, 128]
-        )
-    )
-    b_tail_layout: tl.constexpr = (
-        tlx.padded_shared_layout_encoding.with_identity_for(
-            [(256, 16)], [BLOCK_K, TILE], order=[0, 1]
-        )
-    )
-    stage0 = _local_alloc_stage(
-        a_layout, b_main_layout, b_tail_layout, TILE_SPEC
-    )
-    stage1 = _local_alloc_stage(
-        a_layout, b_main_layout, b_tail_layout, TILE_SPEC
-    )
+    a_layout: tl.constexpr = (tlx.padded_shared_layout_encoding.with_identity_for([(64, 16)], [TILE, BLOCK_K],
+                                                                                  order=[1, 0]))
+    b_main_layout: tl.constexpr = (tlx.padded_shared_layout_encoding.with_bases([(512, 16)], _B_BASES, [BLOCK_K, 128]))
+    b_tail_layout: tl.constexpr = (tlx.padded_shared_layout_encoding.with_identity_for([(256, 16)], [BLOCK_K, TILE],
+                                                                                       order=[0, 1]))
+    stage0 = _local_alloc_stage(a_layout, b_main_layout, b_tail_layout, TILE_SPEC)
+    stage1 = _local_alloc_stage(a_layout, b_main_layout, b_tail_layout, TILE_SPEC)
 
     # Persistently assign a compile-time group of adjacent N tiles to each
     # program.  For example, 128 N tiles with two tiles/program produce 64
@@ -936,22 +977,33 @@ def _kernel(
     programs_per_m = num_pid_n // tiles_per_program
     program_m = program // programs_per_m
     program_n = program % programs_per_m
-    first_tile = (
-        program_m * num_pid_n + program_n * tiles_per_program
-    )
+    first_tile = (program_m * num_pid_n + program_n * tiles_per_program)
 
     # Prime the persistent traversal with the first tile's complete K0 slice.
     tile_load_addresses = _make_global_tile_load_addresses(
-        a_ptr, b_ptr, stride_am, stride_ak,
-        stride_bk, stride_bn, first_tile, TILE_SPEC,
+        a_ptr,
+        b_ptr,
+        stride_am,
+        stride_ak,
+        stride_bk,
+        stride_bn,
+        first_tile,
+        TILE_SPEC,
     )
     prefetched_k0 = _global_loads(tile_load_addresses, 0, TILE_SPEC)
 
     for tile_offset in tl.static_range(tiles_per_program):
         tile_id = first_tile + tile_offset
         acc_tile = _compute_full_tile(
-            tile_load_addresses, prefetched_k0, stage0, stage1,
-            mma, dot_a, dot_b, PIPELINE_SPEC, TILE_SPEC,
+            tile_load_addresses,
+            prefetched_k0,
+            stage0,
+            stage1,
+            mma,
+            dot_a,
+            dot_b,
+            PIPELINE_SPEC,
+            TILE_SPEC,
         )
 
         # Before the current tile's epilogue, issue the next tile's K0 loads.
@@ -959,17 +1011,26 @@ def _kernel(
         # live together, independent of tiles_per_program.
         if tile_offset + 1 < tiles_per_program:
             next_tile_load_addresses = _make_global_tile_load_addresses(
-                a_ptr, b_ptr, stride_am, stride_ak,
-                stride_bk, stride_bn, tile_id + 1, TILE_SPEC,
+                a_ptr,
+                b_ptr,
+                stride_am,
+                stride_ak,
+                stride_bk,
+                stride_bn,
+                tile_id + 1,
+                TILE_SPEC,
             )
-            next_prefetched_k0 = _global_loads(
-                next_tile_load_addresses, 0, TILE_SPEC
-            )
+            next_prefetched_k0 = _global_loads(next_tile_load_addresses, 0, TILE_SPEC)
 
         acc_tile = _commit_accumulators(acc_tile, mma, TILE_SPEC)
         _global_store_output(
-            c_ptr, acc_tile, stride_cm, stride_cn,
-            tile_id, mma, TILE_SPEC,
+            c_ptr,
+            acc_tile,
+            stride_cm,
+            stride_cn,
+            tile_id,
+            mma,
+            TILE_SPEC,
         )
 
         if tile_offset + 1 < tiles_per_program:
@@ -981,9 +1042,7 @@ def _validate_specialization(m, n, tile_spec, pipeline_spec):
     block_m, block_n, num_pid_n, num_programs, tiles_per_program = tile_spec
     m_fragments = block_m // int(TILE)
     n_fragments = block_n // int(TILE)
-    a1_read_plan, mfmas_before_prefetch, b_publish_plan, finish_plan = (
-        pipeline_spec
-    )
+    a1_read_plan, mfmas_before_prefetch, b_publish_plan, finish_plan = (pipeline_spec)
     assert m % block_m == 0 and n % block_n == 0
     assert num_pid_n == n // block_n
     assert tiles_per_program > 0
@@ -1010,15 +1069,10 @@ def _validate_specialization(m, n, tile_spec, pipeline_spec):
             assert 0 <= mi < m_fragments
             assert 0 <= first_nj < n_fragments
             assert first_nj + count <= n_fragments
-            mfma_coverage.extend(
-                mi * n_fragments + nj
-                for nj in range(first_nj, first_nj + count)
-            )
+            mfma_coverage.extend(mi * n_fragments + nj for nj in range(first_nj, first_nj + count))
     assert all(0 <= flat < m_fragments * n_fragments for flat in finish_plan)
     mfma_coverage.extend(finish_plan)
-    mfma_coverage.extend(
-        range((m_fragments - 1) * n_fragments, m_fragments * n_fragments)
-    )
+    mfma_coverage.extend(range((m_fragments - 1) * n_fragments, m_fragments * n_fragments))
     assert sorted(mfma_coverage) == list(range(m_fragments * n_fragments))
 
 
@@ -1028,11 +1082,7 @@ def supports(a, b):
         return False
     m, k = a.shape
     _, n = b.shape
-    return (
-        a.dtype == torch.float16
-        and b.dtype == torch.float16
-        and (m, n, k) in _SHAPE_DEFAULTS
-    )
+    return (a.dtype == torch.float16 and b.dtype == torch.float16 and (m, n, k) in _SHAPE_DEFAULTS)
 
 
 def matmul(a, b, out=None, specialization=None):
@@ -1053,7 +1103,7 @@ def matmul(a, b, out=None, specialization=None):
     expected_shape, tile_spec, pipeline_spec = _SPECIALIZATIONS[specialization]
     assert (m, n, k) == expected_shape
     _validate_specialization(m, n, tile_spec, pipeline_spec)
-    _kernel[(tile_spec[3],)](
+    _kernel[(tile_spec[3], )](
         a,
         b,
         out,

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -43,44 +43,25 @@ def _prune_register_configs(configs, named_args, **_):
     k = named_args["K"]
     if 128 <= k < 256 and named_args["M"] >= 16384 and named_args["N"] <= 128:
         preferred = [
-            config
-            for config in configs
-            if config.kwargs["NUM_XCDS"] == 1
-            and config.kwargs["BLOCK_M"] == 128
-            and config.kwargs["BLOCK_N"] == 64
-            and config.kwargs["BLOCK_K"] == 64
-            and config.kwargs["GROUP_M"] == 4
-            and config.kwargs["waves_per_eu"] == 0
-            and config.num_warps == 4
-            and config.num_stages == 2
+            config for config in configs if config.kwargs["NUM_XCDS"] == 1 and config.kwargs["BLOCK_M"] == 128
+            and config.kwargs["BLOCK_N"] == 64 and config.kwargs["BLOCK_K"] == 64 and config.kwargs["GROUP_M"] == 4
+            and config.kwargs["waves_per_eu"] == 0 and config.num_warps == 4 and config.num_stages == 2
         ]
         if preferred:
             return preferred
     if k == 1536 and named_args["M"] == 3072 and named_args["N"] == 3072:
         preferred = [
-            config
-            for config in configs
-            if config.kwargs["NUM_XCDS"] == 8
-            and config.kwargs["BLOCK_M"] == 128
-            and config.kwargs["BLOCK_N"] == 128
-            and config.kwargs["BLOCK_K"] == 64
-            and config.kwargs["GROUP_M"] == 16
-            and config.kwargs["waves_per_eu"] == 0
-            and config.num_warps == 4
-            and config.num_stages == 2
+            config for config in configs if config.kwargs["NUM_XCDS"] == 8 and config.kwargs["BLOCK_M"] == 128
+            and config.kwargs["BLOCK_N"] == 128 and config.kwargs["BLOCK_K"] == 64 and config.kwargs["GROUP_M"] == 16
+            and config.kwargs["waves_per_eu"] == 0 and config.num_warps == 4 and config.num_stages == 2
         ]
         if preferred:
             return preferred
     if k == 256 and named_args["M"] <= 1024 and named_args["N"] >= 16384:
         preferred = [
-            config
-            for config in configs
-            if config.kwargs["BLOCK_M"] == 256
-            and config.kwargs["BLOCK_N"] == 128
-            and config.kwargs["BLOCK_K"] == 32
-            and config.kwargs["GROUP_M"] == 4
-            and config.kwargs["waves_per_eu"] == 2
-            and config.num_warps == 4
+            config for config in configs
+            if config.kwargs["BLOCK_M"] == 256 and config.kwargs["BLOCK_N"] == 128 and config.kwargs["BLOCK_K"] == 32
+            and config.kwargs["GROUP_M"] == 4 and config.kwargs["waves_per_eu"] == 2 and config.num_warps == 4
         ]
         if preferred:
             return preferred
@@ -103,8 +84,7 @@ _REGISTER_CONFIGS = [
         },
         num_warps=num_warps,
         num_stages=2,
-    )
-    for block_m, block_n, block_k, group_m, num_warps, waves_per_eu in (
+    ) for block_m, block_n, block_k, group_m, num_warps, waves_per_eu in (
         (16, 16, 256, 4, 4, 2),
         (32, 16, 256, 4, 4, 0),
         (32, 32, 16, 8, 4, 2),
@@ -158,8 +138,7 @@ _REGISTER_CONFIGS += [
         },
         num_warps=num_warps,
         num_stages=num_stages,
-    )
-    for block_m, block_n, block_k, group_m, num_warps, num_stages, waves_per_eu in (
+    ) for block_m, block_n, block_k, group_m, num_warps, num_stages, waves_per_eu in (
         (128, 64, 64, 4, 4, 2, 0),
         (128, 64, 64, 4, 4, 3, 0),
         (128, 64, 64, 16, 4, 3, 0),
@@ -190,8 +169,7 @@ _REGISTER_CONFIGS += [
         },
         num_warps=num_warps,
         num_stages=num_stages,
-    )
-    for block_m, block_n, block_k, group_m, num_warps, num_stages, waves_per_eu in (
+    ) for block_m, block_n, block_k, group_m, num_warps, num_stages, waves_per_eu in (
         (128, 64, 64, 4, 4, 2, 0),
         (128, 64, 64, 4, 4, 3, 0),
         (128, 128, 64, 8, 4, 2, 0),
@@ -349,11 +327,9 @@ def _launch_register(a, b, bias=None):
         if bias.device != a.device or bias.dtype != a.dtype:
             raise ValueError("Bias and matrix operands must have matching device and dtype")
     out = torch.empty((M, N), device=a.device, dtype=a.dtype)
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),)
-    disable_agpr = (K == 256 and N > 256) or (
-        K > 512 and (K % BLOCK_K != 0 or M * N <= 2 * 1024 * 1024)
-    )
-    launch_options = {"llvm_fn_attrs": (("amdgpu-agpr-alloc", "0,0"),)} if disable_agpr else {}
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]), )
+    disable_agpr = (K == 256 and N > 256) or (K > 512 and (K % BLOCK_K != 0 or M * N <= 2 * 1024 * 1024))
+    launch_options = {"llvm_fn_attrs": (("amdgpu-agpr-alloc", "0,0"), )} if disable_agpr else {}
     bias_ptr = bias if bias is not None else out
     _register_kernel[grid](
         a,


### PR DESCRIPTION
- Apply the formatting required by the all-files pre-commit workflow.
- Sync upstream commit 5900ea6b2 by dropping the unsupported CPython 3.13 free-threaded wheel and the removed cpython-freethreading enable group.
- Keep CPython 3.14 free-threaded wheels, which cibuildwheel 4 supports by default.

Testing:
- pre-commit run --all-files --verbose
- cibuildwheel 4.2.0 --print-build-identifiers