### PR TITLE
[TLX] Fix non-constexpr global VEC_SIZE in the MXFP8 GEMM tutorial

### DIFF
--- a/third_party/tlx/tutorials/blackwell_gemm_ws_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws_mxfp8.py
@@ -646,6 +646,10 @@ def _process_tile_producer_inner(
 
     REP_M: tl.constexpr = BLOCK_SIZE_M // 128
     REP_N: tl.constexpr = BLOCK_SIZE_N // 128
+    # Local shadow of the module-level VEC_SIZE: the frontend rejects reads of
+    # non-constexpr globals, and making that global tl.constexpr would disable
+    # this kernel's fast dispatch path.
+    VEC_SIZE: tl.constexpr = 32
     REP_K: tl.constexpr = BLOCK_SIZE_K // VEC_SIZE // 4
     BLOCK_N_PER_CTA: tl.constexpr = BLOCK_SIZE_N // NUM_CTAS
     A_BYTES: tl.constexpr = BLOCK_SIZE_M * BLOCK_SIZE_K
@@ -793,6 +797,10 @@ def _gemm_mxfp8_ws_kernel(  # noqa: TR001
 
     REP_M: tl.constexpr = BLOCK_SIZE_M // 128
     REP_N: tl.constexpr = BLOCK_SIZE_N // 128
+    # Local shadow of the module-level VEC_SIZE: the frontend rejects reads of
+    # non-constexpr globals, and making that global tl.constexpr would disable
+    # this kernel's fast dispatch path.
+    VEC_SIZE: tl.constexpr = 32
     REP_K: tl.constexpr = BLOCK_SIZE_K // VEC_SIZE // 4
     BLOCK_N_PER_CTA: tl.constexpr = BLOCK_SIZE_N // NUM_CTAS
 


### PR DESCRIPTION
`blackwell_gemm_ws_mxfp8.py` (introduced by #2803) hits error "Cannot access global variable VEC_SIZE from within @jit'ed function" because triton.jit functions reads a module level `VEC_SIZE` (only tl.constexpr globals being allowed) in kernel. 

Fixed by shadowing it with a local VEC_SIZE: tl.constexpr = 32 in each kernel

re why this error was landed, there was an OSS CI outage during that period https://github.com/facebookexperimental/triton/pull/2803/commits

## Test plan

Requiring the fix in #2984

`pytest third_party/tlx/tutorials/testing/test_correctness.py -k gemm_ws_mxfp8` — 13 failed → 13 passed