### PR TITLE
[Triton][LinearLayout] Propagate modular solve failures

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -10,12 +11,15 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ValueRange.h"
+#include "triton/Tools/ModularArithmetic.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 
 namespace mlir::triton {
+
+struct LinearLayoutSolveResult;
 
 // # High-level overview of linear layouts
 //
@@ -834,14 +838,21 @@ public:
   // One requirement we *don't* have is that S is injective; we allow two shmem
   // offsets to hold the same 2D index.  If S is not injective,
   // the algorithm chooses the smallest offset for a given (lane, warp).
+  // Requires a supported solution; use tryInvertAndCompose otherwise.
   [[nodiscard]] LinearLayout invertAndCompose(const LinearLayout &outer) const;
+
+  // Recoverable form for callers admitting modular layouts.
+  [[nodiscard]] LinearLayoutSolveResult
+  tryInvertAndCompose(const LinearLayout &outer) const;
 
   // Get the layout that is the inverse of this layout.
   [[nodiscard]] LinearLayout invert() const;
   // Compute and return a psueodinverse of this layout. This is a layout such
   // that `B = A.psuedoinvert()` implies that `A(B(x)) = I`. If `A` is
   // invertible, then this returns `A^-1`.
+  // Requires a supported solution; use tryPseudoinvert otherwise.
   [[nodiscard]] LinearLayout pseudoinvert() const;
+  [[nodiscard]] LinearLayoutSolveResult tryPseudoinvert() const;
 
   // For each in-dim, returns a bitmask of the "free variables" in the layout
   // function.
@@ -903,11 +914,19 @@ private:
                                                     const LinearLayout &B);
 
   // Modular lstsq: solve AX = B over Z/nZ using CRT factorization.
-  static LinearLayout lstsqModular(const LinearLayout &A,
-                                   const LinearLayout &B);
+  static LinearLayoutSolveResult lstsqModular(const LinearLayout &A,
+                                              const LinearLayout &B);
 
   // Solve AX = B (least-squares over GF(2) or modular).
-  static LinearLayout lstsq(const LinearLayout &A, const LinearLayout &B);
+  static LinearLayoutSolveResult lstsq(const LinearLayout &A,
+                                       const LinearLayout &B);
+};
+
+struct LinearLayoutSolveResult {
+  ModularSolveStatus status;
+  std::optional<LinearLayout> layout;
+
+  bool succeeded() const { return status == ModularSolveStatus::Success; }
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/include/triton/Tools/ModularArithmetic.h
+++ b/include/triton/Tools/ModularArithmetic.h
@@ -51,6 +51,17 @@ struct ModMatrix {
   void normalize();
 };
 
+// NoSolution is proved within a supported family. Unsupported includes inputs
+// outside that family and incomplete algorithms such as singular lifting.
+enum class ModularSolveStatus { Success, NoSolution, Unsupported };
+
+struct ModularSolveResult {
+  ModularSolveStatus status;
+  std::vector<int64_t> solution;
+
+  bool succeeded() const { return status == ModularSolveStatus::Success; }
+};
+
 // Gaussian elimination to RREF in Z/nZ. Modifies matrix in-place, returns rank.
 int modRREF(ModMatrix &mat);
 
@@ -60,17 +71,29 @@ std::vector<int64_t> modSolveLinear(const ModMatrix &A,
                                     const std::vector<int64_t> &b,
                                     int64_t modulus);
 
+ModularSolveResult tryModSolveLinear(const ModMatrix &A,
+                                     const std::vector<int64_t> &b,
+                                     int64_t modulus);
+
 // Solve Ax = b (mod p^e) using Hensel lifting. Solvable singular systems such
 // as 2x = 2 (mod 4) currently return {}.
 std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
                                           const std::vector<int64_t> &b,
                                           int64_t prime, int exponent);
 
+ModularSolveResult tryModSolveLinearHensel(const ModMatrix &A,
+                                           const std::vector<int64_t> &b,
+                                           int64_t prime, int exponent);
+
 // Solve Ax = b (mod N) using CRT: factor N, solve subsystems, combine
 // solutions. Precondition: modulus > 0. Returns {} on precondition violation.
 std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
                                        const std::vector<int64_t> &b,
                                        int64_t modulus);
+
+ModularSolveResult tryModSolveLinearCRT(const ModMatrix &A,
+                                        const std::vector<int64_t> &b,
+                                        int64_t modulus);
 
 // Prime factorization: N = p1^e1 * p2^e2 * ... * pk^ek
 struct PrimeFactorization {

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1245,8 +1245,8 @@ LinearLayout::concatMatrices(const LinearLayout &A, const LinearLayout &B) {
 }
 
 // Modular lstsq implementation delegating to modSolveLinearCRT
-LinearLayout LinearLayout::lstsqModular(const LinearLayout &A,
-                                        const LinearLayout &B) {
+LinearLayoutSolveResult LinearLayout::lstsqModular(const LinearLayout &A,
+                                                   const LinearLayout &B) {
   assertDimsEqualIgnoringOrder(A.getOutDimNames(), B.getOutDimNames());
 
   int numRowsA = A.getTotalInDimSizeLog2();
@@ -1276,10 +1276,10 @@ LinearLayout LinearLayout::lstsqModular(const LinearLayout &A,
     for (int outIdx = 0; outIdx < numOutDims; outIdx++)
       rhs[outIdx] = matB_data[bCol * numOutDims + outIdx];
 
-    resultCols[bCol] = modSolveLinearCRT(matA_mod, rhs, workingModulus);
-    assert(!resultCols[bCol].empty() &&
-           "Precondition broken in lstsqModular: modSolveLinearCRT failed. "
-           "Im(B) not contained in Im(A)?");
+    auto result = tryModSolveLinearCRT(matA_mod, rhs, workingModulus);
+    if (!result.succeeded())
+      return {result.status, std::nullopt};
+    resultCols[bCol] = std::move(result.solution);
   }
 
   // Build result layout from solution
@@ -1317,10 +1317,12 @@ LinearLayout LinearLayout::lstsqModular(const LinearLayout &A,
   for (StringAttr dim : A.getInDimNames()) {
     retOutDims.push_back({dim, A.getInDimSize(dim)});
   }
-  return retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims);
+  return {ModularSolveStatus::Success,
+          retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims)};
 }
 
-LinearLayout LinearLayout::lstsq(const LinearLayout &A, const LinearLayout &B) {
+LinearLayoutSolveResult LinearLayout::lstsq(const LinearLayout &A,
+                                            const LinearLayout &B) {
   // Dispatch to modular solver if needed.
   // Only use the modular solver when A (the layout being inverted) is modular.
   // When only B is modular (e.g., NPOT output dim from msgToPackedOffset) but A
@@ -1348,12 +1350,17 @@ LinearLayout LinearLayout::lstsq(const LinearLayout &A, const LinearLayout &B) {
 
       auto C_pow2 = lstsq(A.sublayout(inDimNames, pow2OutDims),
                           B.sublayout(bInDimNames, pow2OutDims));
+      if (!C_pow2.succeeded())
+        return C_pow2;
+
       auto C_npot = lstsqModular(A.sublayout(inDimNames, npotOutDims),
                                  B.sublayout(bInDimNames, npotOutDims));
+      if (!C_npot.succeeded())
+        return C_npot;
 
       // Combine: OR the per-basis coefficients (disjoint by S=0 decoupling).
-      auto C_pow2_flat = C_pow2.flattenIns().flattenOuts();
-      auto C_npot_flat = C_npot.flattenIns().flattenOuts();
+      auto C_pow2_flat = C_pow2.layout->flattenIns().flattenOuts();
+      auto C_npot_flat = C_npot.layout->flattenIns().flattenOuts();
       StringAttr flatIn = *C_pow2_flat.getInDimNames().begin();
       StringAttr flatOut = *C_pow2_flat.getOutDimNames().begin();
 
@@ -1383,7 +1390,8 @@ LinearLayout LinearLayout::lstsq(const LinearLayout &A, const LinearLayout &B) {
         retInDims.push_back({dim, B.getInDimSize(dim)});
       for (StringAttr dim : inDimNames)
         retOutDims.push_back({dim, A.getInDimSize(dim)});
-      return ret.reshapeIns(retInDims).reshapeOuts(retOutDims);
+      return {ModularSolveStatus::Success,
+              ret.reshapeIns(retInDims).reshapeOuts(retOutDims)};
     }
 
     return lstsqModular(A, B);
@@ -1459,10 +1467,20 @@ LinearLayout LinearLayout::lstsq(const LinearLayout &A, const LinearLayout &B) {
   for (StringAttr dim : A.getInDimNames()) {
     retOutDims.push_back({dim, A.getInDimSize(dim)});
   }
-  return retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims);
+  return {ModularSolveStatus::Success,
+          retFlattened.reshapeIns(retInDims).reshapeOuts(retOutDims)};
 }
 
 LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
+  auto result = tryInvertAndCompose(outer);
+  if (!result.succeeded())
+    llvm::report_fatal_error(
+        "invertAndCompose failed; use tryInvertAndCompose for recovery");
+  return std::move(*result.layout);
+}
+
+LinearLayoutSolveResult
+LinearLayout::tryInvertAndCompose(const LinearLayout &outer) const {
   // TODO(Lezcano) Make friend and perhaps rename to `convertFrom` or `lstsq`
   // For this, we need to implement our LLVM lowerings by inverting the "outer"
   // layout, and then iterating over the elements from the "this" layout and
@@ -1527,7 +1545,13 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
   assert((ANonIdentityInDims.empty()) == (BNonIdentityInDims.empty()));
   bool isEmpty = ANonIdentityInDims.empty();
 
-  auto ret = isEmpty ? LinearLayout::empty() : lstsq(AReduced, BReduced);
+  LinearLayoutSolveResult solve =
+      isEmpty ? LinearLayoutSolveResult{ModularSolveStatus::Success,
+                                        LinearLayout::empty()}
+              : lstsq(AReduced, BReduced);
+  if (!solve.succeeded())
+    return solve;
+  LinearLayout ret = std::move(*solve.layout);
 
   // --- NPOT kernel equivalence fix ---
   //
@@ -1604,8 +1628,9 @@ LinearLayout LinearLayout::invertAndCompose(const LinearLayout &outer) const {
 
   // Reorder the dimensions in the result to match the order expected by the
   // current and outer layouts.
-  return ret.transposeIns(llvm::to_vector(B.getInDimNames()))
-      .transposeOuts(llvm::to_vector(A.getInDimNames()));
+  return {ModularSolveStatus::Success,
+          ret.transposeIns(llvm::to_vector(B.getInDimNames()))
+              .transposeOuts(llvm::to_vector(A.getInDimNames()))};
 }
 
 LinearLayout LinearLayout::invert() const {
@@ -1615,6 +1640,14 @@ LinearLayout LinearLayout::invert() const {
 }
 
 LinearLayout LinearLayout::pseudoinvert() const {
+  auto result = tryPseudoinvert();
+  if (!result.succeeded())
+    llvm::report_fatal_error(
+        "pseudoinvert failed; use tryPseudoinvert for recovery");
+  return std::move(*result.layout);
+}
+
+LinearLayoutSolveResult LinearLayout::tryPseudoinvert() const {
   LinearLayout identity = LinearLayout::empty();
   for (auto outDim : getOutDimNames()) {
     auto size = getOutDimSize(outDim);
@@ -1624,7 +1657,7 @@ LinearLayout LinearLayout::pseudoinvert() const {
       identity *= LinearLayout::modularIdentity1D(size, outDim, outDim);
     }
   }
-  return identity.invertAndCompose(*this);
+  return identity.tryInvertAndCompose(*this);
 }
 
 LinearLayout LinearLayout::squeezeIns(StringAttr dim) const {

--- a/lib/Tools/ModularArithmetic.cpp
+++ b/lib/Tools/ModularArithmetic.cpp
@@ -108,6 +108,23 @@ bool isPrime(int64_t modulus) {
          factors.factors[0].second == 1;
 }
 
+std::optional<int64_t> getSupportedPrimePower(int64_t prime, int exponent) {
+  constexpr int64_t limit = int64_t{1} << 31;
+  int64_t result = 1;
+  for (int i = 0; i < exponent; ++i) {
+    if (result > limit / prime)
+      return std::nullopt;
+    result *= prime;
+  }
+  return result;
+}
+
+bool zeroVariableSystemHasSolution(const std::vector<int64_t> &b,
+                                   int64_t modulus) {
+  return std::all_of(b.begin(), b.end(),
+                     [modulus](int64_t value) { return value % modulus == 0; });
+}
+
 int64_t normalizeMod(__int128 value, int64_t modulus) {
   int64_t normalized = value % modulus;
   return normalized < 0 ? normalized + modulus : normalized;
@@ -280,9 +297,9 @@ int modRREF(ModMatrix &mat) {
 // NB: The `modulus` parameter is the modulus used for the solve, which may
 // differ from A.modulus (the modulus A was originally constructed with).
 // Callers (e.g. modSolveLinearCRT) re-reduce A's entries mod the new modulus.
-std::vector<int64_t> modSolveLinear(const ModMatrix &A,
-                                    const std::vector<int64_t> &b,
-                                    int64_t modulus) {
+static std::vector<int64_t>
+solveLinear(const ModMatrix &A, const std::vector<int64_t> &b,
+            int64_t modulus) {
   int n = A.rows;
   int m = A.cols;
 
@@ -346,7 +363,34 @@ std::vector<int64_t> modSolveLinear(const ModMatrix &A,
     }
   }
 
-  return isSolution(A, b, x, modulus) ? x : std::vector<int64_t>{};
+  return x;
+}
+
+std::vector<int64_t> modSolveLinear(const ModMatrix &A,
+                                    const std::vector<int64_t> &b,
+                                    int64_t modulus) {
+  auto solution = solveLinear(A, b, modulus);
+  return isSolution(A, b, solution, modulus) ? solution
+                                              : std::vector<int64_t>{};
+}
+
+ModularSolveResult tryModSolveLinear(const ModMatrix &A,
+                                     const std::vector<int64_t> &b,
+                                     int64_t modulus) {
+  if (!isPrime(modulus) || static_cast<int>(b.size()) != A.rows)
+    return {ModularSolveStatus::Unsupported, {}};
+  if (A.cols == 0)
+    return {zeroVariableSystemHasSolution(b, modulus)
+                ? ModularSolveStatus::Success
+                : ModularSolveStatus::NoSolution,
+            {}};
+
+  auto solution = solveLinear(A, b, modulus);
+  if (solution.empty())
+    return {ModularSolveStatus::NoSolution, {}};
+  if (!isSolution(A, b, solution, modulus))
+    return {ModularSolveStatus::Unsupported, {}};
+  return {ModularSolveStatus::Success, std::move(solution)};
 }
 
 // Solve Ax = b (mod p^e) by solving mod p then lifting each power via
@@ -437,6 +481,32 @@ std::vector<int64_t> modSolveLinearHensel(const ModMatrix &A,
   return isSolution(A, b, x_k, p_e) ? x_k : std::vector<int64_t>{};
 }
 
+ModularSolveResult tryModSolveLinearHensel(const ModMatrix &A,
+                                           const std::vector<int64_t> &b,
+                                           int64_t prime, int exponent) {
+  if (!isPrime(prime) || exponent < 1 ||
+      static_cast<int>(b.size()) != A.rows)
+    return {ModularSolveStatus::Unsupported, {}};
+
+  auto modulus = getSupportedPrimePower(prime, exponent);
+  if (!modulus)
+    return {ModularSolveStatus::Unsupported, {}};
+  if (A.cols == 0)
+    return {zeroVariableSystemHasSolution(b, *modulus)
+                ? ModularSolveStatus::Success
+                : ModularSolveStatus::NoSolution,
+            {}};
+
+  auto solution = modSolveLinearHensel(A, b, prime, exponent);
+  if (!solution.empty())
+    return {ModularSolveStatus::Success, std::move(solution)};
+
+  auto base = tryModSolveLinear(A, b, prime);
+  if (base.status == ModularSolveStatus::NoSolution)
+    return {ModularSolveStatus::NoSolution, {}};
+  return {ModularSolveStatus::Unsupported, {}};
+}
+
 std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
                                        const std::vector<int64_t> &b,
                                        int64_t modulus) {
@@ -509,6 +579,51 @@ std::vector<int64_t> modSolveLinearCRT(const ModMatrix &A,
   }
 
   return isSolution(A, b, x, modulus) ? x : std::vector<int64_t>{};
+}
+
+ModularSolveResult tryModSolveLinearCRT(const ModMatrix &A,
+                                        const std::vector<int64_t> &b,
+                                        int64_t modulus) {
+  if (modulus <= 0 || static_cast<int>(b.size()) != A.rows)
+    return {ModularSolveStatus::Unsupported, {}};
+
+  PrimeFactorization factors = factorize(modulus);
+  if (modulus > 1 && factors.factors.empty())
+    return {ModularSolveStatus::Unsupported, {}};
+  for (const auto &[prime, exponent] : factors.factors)
+    if (exponent > 1 && !getSupportedPrimePower(prime, exponent))
+      return {ModularSolveStatus::Unsupported, {}};
+  if (A.cols == 0)
+    return {zeroVariableSystemHasSolution(b, modulus)
+                ? ModularSolveStatus::Success
+                : ModularSolveStatus::NoSolution,
+            {}};
+
+  auto solution = modSolveLinearCRT(A, b, modulus);
+  if (!solution.empty())
+    return {ModularSolveStatus::Success, std::move(solution)};
+
+  for (const auto &[prime, exponent] : factors.factors) {
+    // Match the factor-reduced system used by modSolveLinearCRT.
+    int64_t factorModulus = intPow(prime, exponent);
+    ModMatrix factorA(A.rows, A.cols, factorModulus);
+    std::vector<int64_t> factorB(A.rows);
+    for (int row = 0; row < A.rows; ++row) {
+      for (int col = 0; col < A.cols; ++col)
+        factorA.at(row, col) = normalizeMod(A.at(row, col), factorModulus);
+      factorB[row] = normalizeMod(b[row], factorModulus);
+    }
+
+    ModularSolveResult factorResult =
+        exponent == 1
+            ? tryModSolveLinear(factorA, factorB, prime)
+            : tryModSolveLinearHensel(factorA, factorB, prime, exponent);
+    if (factorResult.status == ModularSolveStatus::NoSolution)
+      return {ModularSolveStatus::NoSolution, {}};
+    if (!factorResult.succeeded())
+      return {ModularSolveStatus::Unsupported, {}};
+  }
+  return {ModularSolveStatus::Unsupported, {}};
 }
 
 int64_t PrimeFactorization::product() const {

--- a/unittest/Tools/LinearLayoutTest.cpp
+++ b/unittest/Tools/LinearLayoutTest.cpp
@@ -1454,6 +1454,33 @@ TEST_F(LinearLayoutTest, InvertAndCompose_Modular_MultiDim_LCM) {
   }
 }
 
+TEST_F(LinearLayoutTest, TryInvertAndCompose_ModularStatus) {
+  auto makeLayout = [&](StringRef inDim, int32_t basis, int32_t size) {
+    BasesT bases;
+    bases[S(inDim)].push_back({basis});
+    return LinearLayout(std::move(bases), {{S("dim0"), size}}, false);
+  };
+
+  auto requested = makeLayout("register", 1, 6);
+  auto unavailable = makeLayout("offset", 2, 6);
+  auto noSolution = requested.tryInvertAndCompose(unavailable);
+  EXPECT_EQ(noSolution.status, ModularSolveStatus::NoSolution);
+  EXPECT_FALSE(noSolution.layout.has_value());
+  EXPECT_DEATH((void)requested.invertAndCompose(unavailable),
+               "invertAndCompose failed");
+  EXPECT_DEATH((void)unavailable.pseudoinvert(), "pseudoinvert failed");
+
+  auto available = LinearLayout::modularIdentity1D(6, S("offset"), S("dim0"));
+  auto success = requested.tryInvertAndCompose(available);
+  ASSERT_TRUE(success.succeeded());
+  EXPECT_TRUE(success.layout.has_value());
+
+  auto singularSource = makeLayout("register", 3, 9);
+  auto singularTarget = makeLayout("offset", 3, 9);
+  auto singular = singularSource.tryInvertAndCompose(singularTarget);
+  EXPECT_NE(singular.status, ModularSolveStatus::NoSolution);
+}
+
 // Test multi-dimensional NPOT layouts
 TEST_F(LinearLayoutTest, IsModularSurjectiveMultiDim) {
   // Create a 2D layout with NPOT dimensions: 3x6

--- a/unittest/Tools/ModularArithmeticTest.cpp
+++ b/unittest/Tools/ModularArithmeticTest.cpp
@@ -323,6 +323,43 @@ TEST_F(ModularArithmeticTest, ModSolveLinear_ExhaustivePrimeField) {
   }
 }
 
+TEST_F(ModularArithmeticTest, TypedSolveStatus) {
+  ModMatrix identity(1, 1, 3);
+  identity.at(0, 0) = 1;
+  EXPECT_EQ(tryModSolveLinear(identity, {2}, 3).status,
+            ModularSolveStatus::Success);
+
+  ModMatrix zero(1, 1, 3);
+  zero.at(0, 0) = 0;
+  EXPECT_EQ(tryModSolveLinear(zero, {1}, 3).status,
+            ModularSolveStatus::NoSolution);
+
+  ModMatrix noVariables(1, 0, 3);
+  EXPECT_EQ(tryModSolveLinear(noVariables, {0}, 3).status,
+            ModularSolveStatus::Success);
+  EXPECT_EQ(tryModSolveLinear(noVariables, {1}, 3).status,
+            ModularSolveStatus::NoSolution);
+
+  ModMatrix composite(1, 1, 4);
+  composite.at(0, 0) = 2;
+  EXPECT_EQ(tryModSolveLinear(composite, {1}, 4).status,
+            ModularSolveStatus::Unsupported);
+
+  auto singularLift = tryModSolveLinearHensel(composite, {2}, 2, 2);
+  EXPECT_NE(singularLift.status, ModularSolveStatus::NoSolution);
+  EXPECT_TRUE(singularLift.status == ModularSolveStatus::Success ||
+              singularLift.status == ModularSolveStatus::Unsupported);
+}
+
+TEST_F(ModularArithmeticTest, TypedSolveStatus_CRTFactorReduction) {
+  ModMatrix A(1, 1, 135);
+  // The large representative is solvable mod 27 and inconsistent mod 5.
+  A.at(0, 0) = std::numeric_limits<int64_t>::max() - 132;
+
+  EXPECT_EQ(tryModSolveLinearCRT(A, {86}, 135).status,
+            ModularSolveStatus::NoSolution);
+}
+
 TEST_F(ModularArithmeticTest, ModSolveLinearHensel_Mod9) {
   // modulus = 9 = 3^2
   ModMatrix A(2, 2, 9);


### PR DESCRIPTION
Summary:
Add typed modular solve outcomes that distinguish success, a proved no-solution result, and unsupported or incomplete solving. Add recoverable tryInvertAndCompose and tryPseudoinvert entry points. Modular lstsq now propagates solver failure before reading an empty solution column, removing the NDEBUG out-of-bounds path.

Audit the legacy value-returning surface: 56 production callers remain (40 invertAndCompose and 16 pseudoinvert). Migrating them belongs to T284919381, so these wrappers now fail loudly in release builds instead of propagating an empty layout. Mixed-radix callers use the recoverable try APIs.

Build on the landed D116320157 validation. The typed prime-field path validates the raw solver candidate before the vector compatibility API can erase its failure reason. A candidate that fails A*x = b is Unsupported, while an empty result from complete prime-field elimination is NoSolution. The landed compatibility APIs retain fail-closed validation for the legacy, Hensel, and CRT vector APIs.

CRT status disambiguation retries each prime-power factor with reduced matrix and RHS values, matching the main CRT solve and preserving Hensel's bounded-input invariant. Mixed pow2/NPOT least-squares solving short-circuits before the modular solve when the pow2 solve fails.

Differential Revision: D116503268


