### PR TITLE
[TLX] Erase identity conversions after TLX layout finalization (#2989)

### DIFF
--- a/test/TLX/pinned-helper-offset-layout.mlir
+++ b/test/TLX/pinned-helper-offset-layout.mlir
@@ -12,6 +12,8 @@
 // passes is disabled because the current bug makes the call invalid again by
 // releasing only its operand.
 //
+// CHECK-DAG: #[[$TRANSPOSE_SRC_LINEAR:.*]] = #ttg.linear<{{.*}}register = {{\[\[0, 1\], \[8, 0\], \[0, 8\], \[0, 16\], \[0, 32\]\]}}
+// CHECK-DAG: #[[$TRANSPOSE_SRC_USER:.*]] = #tlx.user_layout<#[[$TRANSPOSE_SRC_LINEAR]]>
 // The helper restructures only the loaded value. The pinned offset flows into
 // amdg.buffer_load, which is an ownership boundary for argument dataflow.
 //
@@ -34,6 +36,11 @@
 // CHECK: %[[EXPLICIT_PIN:.*]] = tlx.require_layout
 // CHECK: %[[UNPINNED:.*]] = tt.call @explicit_release(%[[EXPLICIT_PIN]])
 // CHECK-SAME: -> tensor<4x256xi32>
+// CHECK: tt.return
+// CHECK-LABEL: tt.func public @transpose_result_pin
+// CHECK: %[[TRANSPOSE_VALUE:.*]] = arith.constant
+// CHECK-SAME: tensor<128x64xf32, #tlx.no_verify_layout<#[[$TRANSPOSE_SRC_USER]]>>
+// CHECK: tt.trans %[[TRANSPOSE_VALUE]]
 // CHECK: tt.return
 //
 // Full post-fixup snapshots follow. The current module uses generic syntax
@@ -107,6 +114,14 @@
   block = []
 }>
 #pin = #tlx.no_verify_layout<#tlx.user_layout<#tlx.no_verify_layout<#physical>>>
+#transpose_physical = #ttg.linear<{
+  register = [[1, 0], [0, 8], [8, 0], [16, 0], [32, 0]],
+  lane = [[2, 0], [4, 0], [0, 1], [0, 2], [0, 4]],
+  warp = [[0, 32], [0, 64], [0, 16]],
+  block = []
+}>
+#transpose_pin = #tlx.no_verify_layout<#tlx.user_layout<#transpose_physical>>
+#transpose_wrong_src_pin = #tlx.no_verify_layout<#tlx.user_layout<#transpose_physical>>
 
 module {
   tt.func private @load_then_restructure(
@@ -141,6 +156,14 @@ module {
         : tensor<4x256xi32> -> tensor<4x256xi32, #pin>
     %released = tt.call @explicit_release(%pinned)
         : (tensor<4x256xi32, #pin>) -> tensor<4x256xi32>
+    tt.return
+  }
+
+  tt.func public @transpose_result_pin() {
+    %value = arith.constant dense<0.0> : tensor<128x64xf32, #transpose_wrong_src_pin>
+    %transposed = tt.trans %value {order = array<i32: 1, 0>}
+        : tensor<128x64xf32, #transpose_wrong_src_pin>
+          -> tensor<64x128xf32, #transpose_pin>
     tt.return
   }
 }

--- a/test/TLX/user-layout.mlir
+++ b/test/TLX/user-layout.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt -split-input-file --tlx-propagate-layout %s | FileCheck %s
+// RUN: triton-opt -split-input-file --tlx-propagate-layout --tlx-finalize-user-layouts %s | FileCheck %s
 
 // A user-pinned layout (#tlx.user_layout<...>) is honored by layout propagation:
 // the value is never retagged, and the wrapper is unwrapped back to the concrete
@@ -47,6 +47,24 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32,
     %buf = ttg.local_alloc %src : (tensor<64x32xf16, #blocked>) -> !ttg.memdesc<64x32xf16, #user, #smem, mutable>
     %a = ttg.local_load %buf : !ttg.memdesc<64x32xf16, #user, #smem, mutable> -> tensor<64x32xf16, #dot0>
     tt.return %a : tensor<64x32xf16, #dot0>
+  }
+}
+
+// -----
+
+// Unwrapping a user layout can turn a previously meaningful conversion into
+// an identity. Finalization must erase it from the emitted TTGIR.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#user = #tlx.user_layout<#tlx.no_verify_layout<#blocked>>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
+  // CHECK-LABEL: @erase_unwrapped_identity_conversion
+  tt.func @erase_unwrapped_identity_conversion(%arg0: tensor<128x64xf16, #user>) -> tensor<128x64xf16, #blocked> {
+    // CHECK-NOT: ttg.convert_layout
+    // CHECK: tt.return %{{.*}} : tensor<128x64xf16, #blocked>
+    %0 = ttg.convert_layout %arg0 : tensor<128x64xf16, #user> -> tensor<128x64xf16, #blocked>
+    tt.return %0 : tensor<128x64xf16, #blocked>
   }
 }
 

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -26,6 +26,13 @@ namespace mlir::triton::tlx {
 #define GEN_PASS_DEF_TRITONTLXFIXUP
 #include "tlx/dialect/include/Transforms/Passes.h.inc"
 
+static SmallVector<int32_t> invertPermutation(ArrayRef<int32_t> order) {
+  SmallVector<int32_t> inverse(order.size());
+  for (auto [i, dim] : llvm::enumerate(order))
+    inverse[dim] = i;
+  return inverse;
+}
+
 // ---------------------------------------------------------------------------
 // Placeholder (no_verify) layout propagation across encoding-uniform ops.
 //
@@ -660,6 +667,24 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
             bridgeOrRetype(elseY.getOperand(i), enc, elseY, i);
         }
         return;
+      }
+      // A result-side user pin on transpose must be reflected through the
+      // inverse permutation before normal forward type inference runs.
+      if (auto trans = dyn_cast<::mlir::triton::TransOp>(op)) {
+        auto resultType = cast<RankedTensorType>(trans.getType());
+        Attribute resultEnc = resultType.getEncoding();
+        if (isPlaceholderEncoding(resultEnc)) {
+          auto inverseOrder = invertPermutation(trans.getOrder());
+          Attribute srcEnc;
+          auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
+              &resultEnc.getDialect());
+          if (succeeded(layout->inferTransOpEncoding(
+                  resultEnc, resultType.getShape(), inverseOrder, srcEnc,
+                  trans.getLoc()))) {
+            changed |= retypeWithEncoding(trans.getSrc(), srcEnc);
+            return;
+          }
+        }
       }
       // Re-infer any op whose operands acquired a placeholder after frontend
       // construction. This covers trans/split/reduce/expand-dims and future ops

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -433,6 +433,16 @@ static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
       cst.setValueAttr(dense.reshape(resultType));
   });
 
+  SmallVector<ttg::ConvertLayoutOp> identityConversions;
+  moduleOp.walk([&](ttg::ConvertLayoutOp convert) {
+    if (convert.getSrc().getType() == convert.getType())
+      identityConversions.push_back(convert);
+  });
+  for (ttg::ConvertLayoutOp convert : identityConversions) {
+    convert.getResult().replaceAllUsesWith(convert.getSrc());
+    convert.erase();
+  }
+
   bool residual = false;
   moduleOp.walk([&](Operation *op) {
     for (Type type : op->getResultTypes())


### PR DESCRIPTION
Summary:

Remove exact identity `ttg.convert_layout` operations after `#tlx.user_layout` wrappers are finalized. This prevents wrapper-only conversions from surviving into emitted TTGIR.

Add a focused regression case covering a conversion that becomes an identity after finalization.

Differential Revision: D116873813


