### PR TITLE
[triton][PR] [triton][mslk][AMD] Autotune async copy for rowwise FP8 GEMM

### DIFF
--- a/.github/workflows/torchtlx.yml
+++ b/.github/workflows/torchtlx.yml
@@ -52,6 +52,7 @@ jobs:
           # Install the fork Triton on top of nightly torch's pinned pytorch-triton.
           install_triton $PWD
           uv pip install pytest expecttest
+          python scripts/_torchtlx_torch_shim.py
       - name: Run TorchTLX template + fusion tests
         id: run_torchtlx_tests
         timeout-minutes: 40
@@ -142,6 +143,7 @@ jobs:
     needs: b200-torchtlx-test
     if: always() && github.event_name == 'schedule' && needs.b200-torchtlx-test.outputs.failures != '' && needs.b200-torchtlx-test.outputs.failures != '[]'
     permissions:
+      actions: read
       contents: read
       issues: write
     strategy:
@@ -167,6 +169,7 @@ jobs:
     needs: mi350-torchtlx-test
     if: always() && github.event_name == 'schedule' && needs.mi350-torchtlx-test.outputs.failures != '' && needs.mi350-torchtlx-test.outputs.failures != '[]'
     permissions:
+      actions: read
       contents: read
       issues: write
     strategy:

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -117,6 +117,23 @@ def test_amd_sched_group_barrier_options_are_cache_keyed_and_validated():
         amd_compiler.HIPOptions(arch="gfx950", sched_group_barrier_required_region_count=-1)
 
 
+def test_amd_async_copy_config_override(monkeypatch):
+    monkeypatch.setattr(knobs.amd, "use_async_copy", None)
+    assert amd_compiler.is_async_copy_enabled("gfx950")
+    assert not amd_compiler.is_async_copy_enabled("gfx942")
+    assert not amd_compiler._resolve_async_copy_enabled("gfx950", False)
+    assert amd_compiler._resolve_async_copy_enabled("gfx942", True)
+
+    # The process-wide knob remains an authoritative debugging override.
+    monkeypatch.setattr(knobs.amd, "use_async_copy", True)
+    assert amd_compiler._resolve_async_copy_enabled("gfx950", False)
+    monkeypatch.setattr(knobs.amd, "use_async_copy", False)
+    assert not amd_compiler._resolve_async_copy_enabled("gfx942", True)
+
+    assert amd_compiler.HIPOptions(arch="gfx950",
+                                   use_async_copy=False).hash() != amd_compiler.HIPOptions(arch="gfx950").hash()
+
+
 def compile_for_target(fn, signature, constexprs, target):
     src = ASTSource(fn=fn, signature=signature, constexprs=constexprs)
     return triton_compile(src, target=target)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -35,6 +35,12 @@ def is_async_copy_enabled(arch):
     return ((arch in ["gfx950", "gfx1250"]) if knobs.amd.use_async_copy is None else knobs.amd.use_async_copy)
 
 
+def _resolve_async_copy_enabled(arch, config_use_async_copy=None):
+    if knobs.amd.use_async_copy is None and config_use_async_copy is not None:
+        return config_use_async_copy
+    return is_async_copy_enabled(arch)
+
+
 def is_coexec_scheduler_supported(arch):
     return arch in ["gfx1250"]
 
@@ -107,6 +113,7 @@ class HIPOptions:
     launch_cluster: bool = False  # No-op placeholder
     multicast: bool = False  # No-op placeholder (TMA multicast is NVIDIA-only)
     enable_tree_reduction: bool = False
+    use_async_copy: bool | None = None
     matrix_instr_nonkdim: int = 0
     kpack: int = 1
     allow_flush_denorm: bool = False
@@ -359,7 +366,7 @@ class HIPBackend(BaseBackend):
         passes.ttir.add_triton_licm(pm)
         passes.common.add_canonicalizer(pm)
 
-        use_async_copy = is_async_copy_enabled(options.arch)
+        use_async_copy = _resolve_async_copy_enabled(options.arch, options.use_async_copy)
         use_block_pingpong = is_pingpong_schedule_enabled(options.arch, use_async_copy)
         amd.passes.ttgpuir.add_optimize_descriptor_encoding(pm)
 

--- a/third_party/tlx/tutorials/accuracy_bench_bwd_autows_vs_tlx.py
+++ b/third_party/tlx/tutorials/accuracy_bench_bwd_autows_vs_tlx.py
@@ -33,7 +33,6 @@ DTYPE = torch.float16
 RUNS = int(os.environ.get("BENCH_RUNS", 5))
 SEED = int(os.environ.get("BENCH_SEED", 20))
 
-
 # baseVariant: "ws_persistent" (failing) or "ws" (passing). Default to the
 # failing persistent path under investigation.
 AWS_VARIANT = os.environ.get("BENCH_VARIANT", "ws_persistent")
@@ -50,10 +49,11 @@ def pin_tlx_config():
     aws_cfg = aws.configs_bwd_persist[BWD_IDX]
     num_ctas = aws_cfg.kwargs.get("NUM_CTAS", 1)
     block_m = aws_cfg.kwargs["BLOCK_M1"]
-    cfgs = [c for c in tlx.configs_bwd_tlx
-            if c.kwargs.get("NUM_CTAS", 1) == num_ctas
-            and c.kwargs.get("USE_WARP_BARRIER") is False
-            and (num_ctas > 1 or c.kwargs.get("BLOCK_M1") == block_m)]
+    cfgs = [
+        c for c in tlx.configs_bwd_tlx
+        if c.kwargs.get("NUM_CTAS", 1) == num_ctas and c.kwargs.get("USE_WARP_BARRIER") is False and (
+            num_ctas > 1 or c.kwargs.get("BLOCK_M1") == block_m)
+    ]
     assert len(cfgs) == 1, f"expected 1 matching TLX config, got {len(cfgs)}"
     tlx._attn_bwd_ws.configs = cfgs
     tlx._attn_bwd_ws.cache = {}

--- a/third_party/tlx/tutorials/gfx950_gdpa.py
+++ b/third_party/tlx/tutorials/gfx950_gdpa.py
@@ -526,11 +526,7 @@ _FWD_WAVES_PER_EU = (0, 2, 4)
 
 def _get_fwd_configs() -> list[triton.Config]:
     if FULL_TUNING:
-        tiles = [(bm, bn, nw, nb)
-                 for bm in (64, 128, 256)
-                 for bn in (32, 64, 128)
-                 for nw in (4, 8)
-                 for nb in (2, 3, 4)]
+        tiles = [(bm, bn, nw, nb) for bm in (64, 128, 256) for bn in (32, 64, 128) for nw in (4, 8) for nb in (2, 3, 4)]
         waves = (0, 1, 2, 4)
         nonkdims = (16, 32)
     else:


### PR DESCRIPTION
Summary:
Triton 3.8 enables async copy by default on gfx950. For the existing rowwise FP8 GEMM config, this raises LDS use from `49,152` to `101,312` bytes and regresses `(128, 1280, 8192)`.

This change:

- adds a cache-keyed `use_async_copy` AMD backend option while keeping the process-wide environment override authoritative;
- lets MSLK autotune the existing async-off schedule against a new async-on schedule: `BM32 BN32 BK256 G1 W4 S3 waves4 nonkdim16 kpack1`;
- keeps the existing MSLK config list for Triton builds without the new backend option;
- includes the formatting and workflow-permission cleanup required by the exported Triton PR.

## Results

| Config | Autotune time | LDS | VGPRs | Scratch |
| --- | ---: | ---: | ---: | ---: |
| New async-on | `0.01472 ms` | `50,624 B` | `50` | `0 B` |
| Existing async-off fallback | `0.01644 ms` | `49,152 B` | `100` | `0 B` |
| Existing async-on | `0.01716 ms` | `101,312 B` | `144` | `0 B` |

Across three independent clean-cache runs, the new config was 27.1% faster than the existing async-on config, with unchanged relative L2 error (`2.2166e-4`). The generated kernels use no private or scratch allocation, so the regression is LDS occupancy pressure rather than local-memory spilling.

Differential Revision: D115712909


