### PR TITLE
[TLX][FA] Introduce the forward execution plan

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -74,7 +74,7 @@ configs = [
         pre_hook=_host_descriptor_pre_hook,
         ctas_per_cga=(2, 1, 1),
     )
-    for kv in [4, 5, 6, 7, 8, 9]
+    for kv in [3, 6]
     for grp_n in [1]
     for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
 ]
@@ -93,7 +93,7 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
         if grp_n != target_group_size_n:
             continue
         if is_2cta:
-            if kv not in (4, 5, 6, 7):
+            if kv != target_kv_buffers:
                 continue
         else:
             if kv != target_kv_buffers:
@@ -503,7 +503,7 @@ def _fwd_control_tile(
 
 
 @triton.jit
-def _fwd_load_1cta(
+def _fwd_load_tile(
     tile_count,
     accum_cnt_kv,
     lo,
@@ -527,8 +527,53 @@ def _fwd_load_1cta(
     HEAD_DIM: tl.constexpr,
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
+    cluster_cta_rank=0,
+    v_tiles=None,
+    v_fulls=None,
+    v_empties=None,
+    NUM_GROUPS_PER_CTA: tl.constexpr = 2,
+    NUM_CTAS: tl.constexpr = 1,
 ):
+    USE_2CTA: tl.constexpr = NUM_CTAS == 2
     # load q0
+    if USE_2CTA:
+        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+        for group_id in tl.static_range(0, NUM_GROUPS_PER_CTA):
+            q_id = q_bufIdx + group_id * NUM_BUFFERS_Q
+            tlx.barrier_wait(q_empties[q_id], q_phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(q_fulls[q_id], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+            tlx.async_descriptor_load(
+                desc_q,
+                q_tiles[q_id],
+                [qo_offset_y + (group_id * NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
+                q_fulls[q_id],
+                two_ctas=True,
+            )
+        for _ in tl.range(lo, hi, BLOCK_N):
+            buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+            tlx.barrier_wait(kv_empties[buf], phase ^ 1)
+            tlx.barrier_wait(v_empties[buf], phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(kv_fulls[buf], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                tlx.barrier_expect_bytes(v_fulls[buf], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+            tlx.async_descriptor_load(
+                desc_k,
+                kv_tiles[buf],
+                [kv_offset_y + cluster_cta_rank * (BLOCK_N // NUM_CTAS), 0],
+                kv_fulls[buf],
+                two_ctas=True,
+            )
+            tlx.async_descriptor_load(
+                desc_v,
+                v_tiles[buf],
+                [kv_offset_y, cluster_cta_rank * (HEAD_DIM // NUM_CTAS)],
+                v_fulls[buf],
+                two_ctas=True,
+            )
+            kv_offset_y += BLOCK_N
+            accum_cnt_kv += 1
+        return accum_cnt_kv
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
     tlx.barrier_expect_bytes(q_fulls[q_bufIdx], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
@@ -878,7 +923,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         # V loaded as (N, D/2).
         k_tiles = tlx.local_alloc((BLOCK_N_KV, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM_KV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
-        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA, reuse=q_tiles)
+        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA)
     else:
         kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
@@ -1214,89 +1259,81 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1
 
-        # load
+        # Q/K/V loader role; output publication remains in the epilog task.
         with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
+                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_id // NUM_CTAS,
+                    H,
+                    num_pid_n,
+                    num_pid_in_group,
+                    N_CTX,
+                    EFFECTIVE_BLOCK_M,
+                    STAGE,
+                    GROUP_SIZE_N,
+                )
                 if USE_2CTA:
-                    _, off_hz2, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n,
-                                                                      num_pid_in_group, N_CTX, EFFECTIVE_BLOCK_M, STAGE,
-                                                                      GROUP_SIZE_N)
-
-                    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-                    # Q and O share SMEM (o_tiles reuses q_tiles). Wait for the
-                    # epilog to finish storing the previous tile's O before
-                    # overwriting the buffer with new Q data.
-                    _, o_phase = get_bufidx_phase(tile_count, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        tlx.barrier_wait(o_empties[cid], o_phase ^ 1)
-                    # load Q0
-                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx],
-                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo2 + cluster_cta_rank * BLOCK_M_SPLIT, 0],
-                                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
-                    # load Q1
-                    q_bufIdx1 = q_bufIdx + NUM_BUFFERS_Q
-                    tlx.barrier_wait(q_empties[q_bufIdx1], q_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx1],
-                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx1],
-                                              [qo2 + (NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
-                                              q_fulls[q_bufIdx1], two_ctas=tl.constexpr(True))
-
-                    kv_offset_y = kv2
-
-                    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
-                                              [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
-                                              two_ctas=tl.constexpr(True))
-
-                    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-                    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-                    kv_offset_y += BLOCK_N
-                    accum_cnt_kv += 1
-
-                    for _ in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
-                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-                        if is_leader:
-                            tlx.barrier_expect_bytes(k_fulls[k_bufIdx],
-                                                     K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
-                        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
-                                                  [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
-                                                  two_ctas=tl.constexpr(True))
-
-                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-                        if is_leader:
-                            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-                        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx],
-                                                  [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV], v_fulls[v_bufIdx],
-                                                  two_ctas=tl.constexpr(True))
-
-                        kv_offset_y += BLOCK_N
-                        accum_cnt_kv += 1
+                    accum_cnt_kv = _fwd_load_tile(
+                        tile_count,
+                        accum_cnt_kv,
+                        lo,
+                        hi,
+                        qo_offset_y,
+                        kv_offset_y,
+                        desc_q,
+                        desc_k,
+                        desc_v,
+                        q_tiles,
+                        k_tiles,
+                        q_fulls,
+                        q_empties,
+                        k_fulls,
+                        k_empties,
+                        Q_BYTES_PER_ELEM,
+                        K_BYTES_PER_ELEM,
+                        V_BYTES_PER_ELEM,
+                        BLOCK_M_SPLIT,
+                        BLOCK_N,
+                        HEAD_DIM,
+                        NUM_BUFFERS_Q,
+                        NUM_BUFFERS_KV,
+                        cluster_cta_rank,
+                        v_tiles,
+                        v_fulls,
+                        v_empties,
+                        NUM_GROUPS_PER_CTA,
+                        NUM_CTAS,
+                    )
                 else:
-                    _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group,
-                                                                              N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv = _fwd_load_1cta(tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y, desc_q,
-                                                  desc_k, desc_v, q_tiles, kv_tiles, q_fulls, q_empties, kv_fulls,
-                                                  kv_empties, Q_BYTES_PER_ELEM, K_BYTES_PER_ELEM, V_BYTES_PER_ELEM,
-                                                  BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM, NUM_BUFFERS_Q, NUM_BUFFERS_KV)
+                    accum_cnt_kv = _fwd_load_tile(
+                        tile_count,
+                        accum_cnt_kv,
+                        lo,
+                        hi,
+                        qo_offset_y,
+                        kv_offset_y,
+                        desc_q,
+                        desc_k,
+                        desc_v,
+                        q_tiles,
+                        kv_tiles,
+                        q_fulls,
+                        q_empties,
+                        kv_fulls,
+                        kv_empties,
+                        Q_BYTES_PER_ELEM,
+                        K_BYTES_PER_ELEM,
+                        V_BYTES_PER_ELEM,
+                        BLOCK_M_SPLIT,
+                        BLOCK_N,
+                        HEAD_DIM,
+                        NUM_BUFFERS_Q,
+                        NUM_BUFFERS_KV,
+                    )
 
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1,3 +1,5 @@
+from enum import IntEnum
+from typing import NamedTuple
 import torch
 import triton
 import triton.language as tl
@@ -8,6 +10,25 @@ from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _s
 from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+
+class Policy(IntEnum):
+    DENSE = 0
+    CAUSAL_64K = 1
+    CAUSAL_128K = 2
+    CAUSAL_256K = 3
+    CAUSAL_512K = 4
+
+
+class ForwardPlan(NamedTuple):
+    stage: int
+    pipelined: bool
+    policy: int
+    dense_regs: int
+
+
+POLICY_DENSE = tl.constexpr(int(Policy.DENSE))
+CAUSAL_POLICY_BIT_OFFSET = 16
+FWD_BLOCK_M = tl.constexpr(256)
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
@@ -258,7 +279,7 @@ def _apply_causal_mask(qk, col_limit, BLOCK: tl.constexpr, keep_ge: tl.constexpr
 
 
 @triton.jit
-def _softmax_inner_loop(
+def _fwd_softmax_tile(
     qk_fulls,
     qk_tiles,
     p_fulls,
@@ -843,46 +864,68 @@ def _fwd_mma_tile(
     prune_configs_by={"early_config_prune": prune_configs_by_hdim},
 )
 @triton.jit
-def _attn_fwd_ws(sm_scale, M,  #
-                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                 HEAD_DIM: tl.constexpr,  #
-                 BLOCK_M: tl.constexpr,  #
-                 BLOCK_N: tl.constexpr,  #
-                 STAGE: tl.constexpr,  #
-                 NUM_BUFFERS_Q: tl.constexpr,  #
-                 NUM_BUFFERS_KV: tl.constexpr,  #
-                 NUM_BUFFERS_QK: tl.constexpr,  #
-                 NUM_MMA_GROUPS: tl.constexpr,  #
-                 NUM_MMA_SLICES: tl.constexpr,  #
-                 GROUP_SIZE_N: tl.constexpr,  #
-                 RESCALE_OPT: tl.constexpr,  #
-                 USE_WHERE: tl.constexpr,  #
-                 USE_WARP_BARRIER: tl.constexpr,  #
-                 NUM_CTAS: tl.constexpr = 1,  #
-                 ):
+def _attn_fwd_ws(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    NUM_BUFFERS_Q: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+    NUM_MMA_SLICES: tl.constexpr,  #
+    GROUP_SIZE_N: tl.constexpr,  #
+    RESCALE_OPT: tl.constexpr,  #
+    USE_WHERE: tl.constexpr,  #
+    USE_WARP_BARRIER: tl.constexpr,  #
+    NUM_CTAS: tl.constexpr = 1,  #
+    PIPELINED: tl.constexpr = False,
+    POLICY: tl.constexpr = POLICY_DENSE,
+    DENSE_REGS: tl.constexpr = 200,
+):
     _attn_fwd_ws_kernel(sm_scale, M, Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX, HEAD_DIM, BLOCK_M, BLOCK_N, STAGE,
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_BUFFERS_QK, NUM_MMA_GROUPS, NUM_MMA_SLICES, GROUP_SIZE_N,
-                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS)
+                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS)
 
 
 @triton.jit
-def _attn_fwd_ws_kernel(sm_scale, M,  #
-                        Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
-                        HEAD_DIM: tl.constexpr,  #
-                        BLOCK_M: tl.constexpr,  #
-                        BLOCK_N: tl.constexpr,  #
-                        STAGE: tl.constexpr,  #
-                        NUM_BUFFERS_Q: tl.constexpr,  #
-                        NUM_BUFFERS_KV: tl.constexpr,  #
-                        NUM_BUFFERS_QK: tl.constexpr,  #
-                        NUM_MMA_GROUPS: tl.constexpr,  #
-                        NUM_MMA_SLICES: tl.constexpr,  #
-                        GROUP_SIZE_N: tl.constexpr,  #
-                        RESCALE_OPT: tl.constexpr,  #
-                        USE_WHERE: tl.constexpr,  #
-                        USE_WARP_BARRIER: tl.constexpr,  #
-                        NUM_CTAS: tl.constexpr = 1,  #
-                        ):
+def _attn_fwd_ws_kernel(
+    sm_scale,
+    M,  #
+    Z,
+    H,
+    desc_q,
+    desc_k,
+    desc_v,
+    desc_o,
+    N_CTX,  #
+    HEAD_DIM: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+    NUM_BUFFERS_Q: tl.constexpr,  #
+    NUM_BUFFERS_KV: tl.constexpr,  #
+    NUM_BUFFERS_QK: tl.constexpr,  #
+    NUM_MMA_GROUPS: tl.constexpr,  #
+    NUM_MMA_SLICES: tl.constexpr,  #
+    GROUP_SIZE_N: tl.constexpr,  #
+    RESCALE_OPT: tl.constexpr,  #
+    USE_WHERE: tl.constexpr,  #
+    USE_WARP_BARRIER: tl.constexpr,  #
+    NUM_CTAS: tl.constexpr = 1,  #
+    PIPELINED: tl.constexpr = False,
+    POLICY: tl.constexpr = POLICY_DENSE,
+    DENSE_REGS: tl.constexpr = 200,
+):
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
     tl.static_assert(NUM_BUFFERS_Q == 1)
@@ -1118,7 +1161,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     group_id = cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
-                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1144,7 +1187,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         USE_2CTA=USE_2CTA,
                     )
                 if STAGE & 2:
-                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1254,6 +1297,10 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         NUM_BUFFERS_Q,
                         NUM_BUFFERS_KV,
                         NUM_MMA_SLICES,
+                        None,
+                        None,
+                        None,
+                        False,
                     )
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
@@ -3404,6 +3451,15 @@ def _attn_bwd_ws(
         #     pass
 
 
+def _select_forward_plan(causal):
+    return ForwardPlan(
+        stage=3 if causal else 1,
+        pipelined=False,
+        policy=int(Policy.DENSE),
+        dense_regs=200,
+    )
+
+
 class _attention(torch.autograd.Function):
 
     @staticmethod
@@ -3413,7 +3469,7 @@ class _attention(torch.autograd.Function):
         assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
         assert HEAD_DIM_K in {16, 32, 64, 128, 256}
 
-        stage = 3 if causal else 1
+        plan = _select_forward_plan(causal)
 
         o = torch.empty_like(q)
         extra_kern_args = {}
@@ -3422,7 +3478,7 @@ class _attention(torch.autograd.Function):
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
-        dummy_block = [1, 1]
+        dummy_block = [128, HEAD_DIM_K] if plan.pipelined else [1, 1]
         desc_q = TensorDescriptor(
             q,
             shape=[y_dim, HEAD_DIM_K],
@@ -3453,27 +3509,64 @@ class _attention(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
 
-        def grid(META):
-            num_ctas = META.get("NUM_CTAS") or 1
-            n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
-            n_ctas = triton.cdiv(n_ctas, num_ctas) * num_ctas
-            return (n_ctas, )
+        if plan.pipelined:
+            grid = (triton.cdiv(q.shape[2], FWD_BLOCK_M.value) * q.shape[0] * q.shape[1], )
+            _attn_fwd_ws.fn[grid](
+                sm_scale,
+                M,  #
+                q.shape[0],
+                q.shape[1],  #
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,  #
+                N_CTX=q.shape[2],  #
+                HEAD_DIM=HEAD_DIM_K,  #
+                BLOCK_M=256,
+                BLOCK_N=128,
+                STAGE=plan.stage,  #
+                NUM_BUFFERS_Q=1,
+                NUM_BUFFERS_KV=3 if HEAD_DIM_K == 128 else 6,
+                NUM_BUFFERS_QK=1,
+                NUM_MMA_GROUPS=2,
+                NUM_MMA_SLICES=(2 if HEAD_DIM_K == 128 or (q.dtype != torch.float16 and plan.policy in (1, 2)) else 4),
+                GROUP_SIZE_N=4 if plan.policy == 1 else 1,
+                RESCALE_OPT=False,
+                USE_WHERE=False,
+                USE_WARP_BARRIER=True,
+                NUM_CTAS=1,
+                PIPELINED=True,
+                POLICY=plan.policy,
+                DENSE_REGS=plan.dense_regs,
+                num_stages=1,
+                num_warps=4,
+                **extra_kern_args,
+            )
+        else:
 
+            def grid(META):
+                num_ctas = META.get("NUM_CTAS") or 1
+                n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+                return (triton.cdiv(n_ctas, num_ctas) * num_ctas, )
+
+            _attn_fwd_ws[grid](
+                sm_scale,
+                M,
+                q.shape[0],
+                q.shape[1],
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                N_CTX=q.shape[2],
+                HEAD_DIM=HEAD_DIM_K,
+                STAGE=plan.stage,
+                PIPELINED=False,
+                POLICY=plan.policy,
+                DENSE_REGS=plan.dense_regs,
+                **extra_kern_args,
+            )
         ctx.grid = grid
-        _attn_fwd_ws[grid](
-            sm_scale,
-            M,  #
-            q.shape[0],
-            q.shape[1],  #
-            desc_q,
-            desc_k,
-            desc_v,
-            desc_o,  #
-            N_CTX=q.shape[2],  #
-            HEAD_DIM=HEAD_DIM_K,  #
-            STAGE=stage,  #
-            **extra_kern_args,
-        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -2,6 +2,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
+from triton.language import core
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _sub_f32x2
 from triton.language.extra.subtile_ops import _split_n_2D
@@ -99,6 +100,42 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
                 continue
         pruned.append(conf)
     return pruned
+
+
+@core.builtin
+def _s2_exp2_bf16(x, a2, b2m, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
+            mov.b64 ra, { $1, $2 };
+            mov.b64 rb, { $3, $4 };
+            mov.b64 rc, { $5, $6 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { v0, v1 }, rd;
+            prmt.b32 pk, v0, v1, 0x5410;
+            mov.b32 zz, 0;
+            mov.b32 mk, 0x00400040;
+            add.s16x2 uu, pk, mk;
+            mov.b32 c0, 0x3f3b3f3b;
+            fma.rn.bf16x2 pk, uu, c0, pk;
+            max.bf16x2 pk, pk, zz;
+            mov.b32 $0, pk;
+        }
+        """,
+        "=r,r,r,r,r,r,r",
+        [x, a2, b2m],
+        dtype=core.bfloat16,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@triton.jit
+def _reduce_bf16(a, b):
+    return (a + b).to(tl.bfloat16)
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -360,6 +360,149 @@ def _softmax_inner_loop(
 
 
 @triton.jit
+def _fwd_control_tile(
+    tile_id,
+    tile_count,
+    accum_cnt,
+    sm_scale,
+    M,
+    H,
+    num_pid_n,
+    num_pid_in_group,
+    N_CTX,
+    desc_o,
+    alpha_empties,
+    alpha_fulls,
+    alpha_tiles,
+    acc_empties,
+    acc_fulls,
+    acc_tiles,
+    l_fulls,
+    l_tiles,
+    m_tiles,
+    qk_empties,
+    o_empties,
+    o_fulls,
+    o_tiles,
+    cluster_cta_rank,
+    BLOCK_M_SPLIT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    EFFECTIVE_BLOCK_M: tl.constexpr,
+    GROUP_SIZE_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_CTAS: tl.constexpr,
+    NUM_GROUPS_PER_CTA: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
+    SCALAR_N: tl.constexpr,
+    STAGE: tl.constexpr,
+    USE_2CTA: tl.constexpr,
+    USE_WHERE: tl.constexpr,
+):
+    start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+        tile_id // NUM_CTAS,
+        H,
+        num_pid_n,
+        num_pid_in_group,
+        N_CTX,
+        EFFECTIVE_BLOCK_M,
+        STAGE,
+        GROUP_SIZE_N,
+    )
+    # Rescale the live output accumulator when the online-softmax gauge changes.
+    for _ in tl.range(lo, hi, BLOCK_N):
+        _, phase = get_bufidx_phase(accum_cnt, 1)
+        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+            tlx.barrier_wait(alpha_fulls[cid], phase)
+            alpha_loaded = tlx.local_load(alpha_tiles[cid])
+            alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
+            tlx.barrier_arrive(alpha_empties[cid])
+            if RESCALE_OPT:
+                # One warp vote skips the whole accumulator update when no lane
+                # changed its online-softmax gauge.
+                pred = alpha_1 < 1.0
+                ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
+                should_rescale = ballot_result != 0
+
+            if USE_WHERE:
+                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                    subslice = tlx.subslice(
+                        acc_tiles[cid],
+                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                        HEAD_DIM // NUM_MMA_SLICES,
+                    )
+                    acc = tlx.local_load(subslice)
+                    if RESCALE_OPT:
+                        scaled_acc = _mul_f32x2(acc, alpha_1)
+                        acc = tl.where(should_rescale, scaled_acc, acc)
+                    else:
+                        acc = _mul_f32x2(acc, alpha_1)
+                    tlx.local_store(subslice, acc)
+            else:
+                if RESCALE_OPT:
+                    should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
+                    should_rescale_scalar = tl.reshape(should_rescale_red, ())
+                if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        subslice = tlx.subslice(
+                            acc_tiles[cid],
+                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                            HEAD_DIM // NUM_MMA_SLICES,
+                        )
+                        acc = tlx.local_load(subslice)
+                        acc = _mul_f32x2(acc, alpha_1)
+                        tlx.local_store(subslice, acc)
+            if USE_2CTA:
+                tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
+            else:
+                tlx.barrier_arrive(acc_fulls[cid])
+        accum_cnt += 1
+
+    _, phase = get_bufidx_phase(tile_count, 1)
+    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+        group_id = cid * NUM_CTAS + cluster_cta_rank
+        # l and m share a synchronization group, so release QK only after both loads.
+        tlx.barrier_wait(l_fulls[cid], phase)
+        l_loaded = tlx.local_load(l_tiles[cid])
+        m_loaded = tlx.local_load(m_tiles[cid])
+        l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
+        m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
+        if USE_2CTA:
+            tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
+        else:
+            tlx.barrier_arrive(qk_empties[cid])
+        if RESCALE_OPT:
+            m = m * sm_scale * 1.44269504
+        m += tl.math.log2(l)
+        offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+        m_ptrs = M + off_hz * N_CTX + offs_m
+        tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
+
+        # Normalize the completed accumulator into the output staging tile;
+        # the epilog task owns publication to global memory.
+        tlx.barrier_wait(acc_empties[cid], phase)
+        tlx.barrier_wait(o_empties[cid], phase ^ 1)
+        scale = 1 / l
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            subslice = tlx.subslice(
+                acc_tiles[cid],
+                HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                HEAD_DIM // NUM_MMA_SLICES,
+            )
+            acc = tlx.local_load(subslice)
+            acc = _mul_f32x2(acc, scale)
+            acc = acc.to(tlx.dtype_of(desc_o))
+            subslice_o = tlx.local_slice(
+                o_tiles[cid],
+                [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
+                [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
+            )
+            tlx.local_store(subslice_o, acc)
+        tlx.barrier_arrive(o_fulls[cid])
+    return accum_cnt
+
+
+@triton.jit
 def _fwd_load_1cta(
     tile_count,
     accum_cnt_kv,
@@ -829,127 +972,53 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         # correction group
         with tlx.async_task("default"):
             accum_cnt = 0
-            phase = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_producer = 1
             clc_phase_consumer = 0
             while tile_id != -1:
-                # CLC producer: announce work to all consumer tasks
+                # Publish this persistent tile, then finalize its M and O outputs.
                 tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=USE_2CTA)
                 clc_phase_producer ^= 1
-
-                # initialize offsets
-                start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id // NUM_CTAS,
+                accum_cnt = _fwd_control_tile(
+                    tile_id,
+                    tile_count,
+                    accum_cnt,
+                    sm_scale,
+                    M,
                     H,
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
+                    desc_o,
+                    alpha_empties,
+                    alpha_fulls,
+                    alpha_tiles,
+                    acc_empties,
+                    acc_fulls,
+                    acc_tiles,
+                    l_fulls,
+                    l_tiles,
+                    m_tiles,
+                    qk_empties,
+                    o_empties,
+                    o_fulls,
+                    o_tiles,
+                    cluster_cta_rank,
+                    BLOCK_M_SPLIT,
+                    BLOCK_N,
                     EFFECTIVE_BLOCK_M,
-                    STAGE,
                     GROUP_SIZE_N,
+                    HEAD_DIM,
+                    NUM_CTAS,
+                    NUM_GROUPS_PER_CTA,
+                    NUM_MMA_SLICES,
+                    RESCALE_OPT,
+                    SCALAR_N,
+                    STAGE,
+                    USE_2CTA,
+                    USE_WHERE,
                 )
-                for _ in tl.range(lo, hi, BLOCK_N):
-                    _, phase = get_bufidx_phase(accum_cnt, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        # -- update output accumulator --
-                        tlx.barrier_wait(alpha_fulls[cid], phase)
-                        alpha_loaded = tlx.local_load(alpha_tiles[cid])
-                        alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
-                        tlx.barrier_arrive(alpha_empties[cid])
-                        # Perform warp-level ballot vote to check if any thread needs rescaling
-                        # 0xFFFFFFFF means all 32 threads in the warp participate
-                        if RESCALE_OPT:
-                            pred = alpha_1 < 1.0
-                            # ballot_result is a tensor with the same shape as pred
-                            # All elements contain the same warp-level ballot value
-                            # Non-zero means at least one thread has alpha_1 < 1.0
-                            ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
-                            should_rescale = ballot_result != 0
-
-                        if USE_WHERE:
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                subslice = tlx.subslice(
-                                    acc_tiles[cid],
-                                    HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                                    HEAD_DIM // NUM_MMA_SLICES,
-                                )
-                                acc = tlx.local_load(subslice)
-                                # Use tl.where to conditionally apply rescaling
-                                # acc = acc * alpha_1 where should_rescale, else acc unchanged
-                                if RESCALE_OPT:
-                                    scaled_acc = _mul_f32x2(acc, alpha_1)
-                                    acc = tl.where(should_rescale, scaled_acc, acc)
-                                else:
-                                    acc = _mul_f32x2(acc, alpha_1)
-                                tlx.local_store(subslice, acc)
-                        else:
-                            # option 2: use a single scalar IfOp
-                            if RESCALE_OPT:
-                                should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
-                                should_rescale_scalar = tl.reshape(should_rescale_red, ())
-                            if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
-                                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                    subslice = tlx.subslice(
-                                        acc_tiles[cid],
-                                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                                        HEAD_DIM // NUM_MMA_SLICES,
-                                    )
-                                    acc = tlx.local_load(subslice)
-                                    acc = _mul_f32x2(acc, alpha_1)
-                                    tlx.local_store(subslice, acc)
-                        if USE_2CTA:
-                            tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
-                        else:
-                            tlx.barrier_arrive(acc_fulls[cid])
-                    accum_cnt += 1
-
-                _, phase = get_bufidx_phase(tile_count, 1)
-                for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cid * NUM_CTAS + cluster_cta_rank
-                    # epilogue
-                    tlx.barrier_wait(l_fulls[cid], phase)
-                    l_loaded = tlx.local_load(l_tiles[cid])
-                    m_loaded = tlx.local_load(m_tiles[cid])
-                    l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
-                    m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
-                    # Signal qk_empties after both l and m loads complete,
-                    # since both tiles share the same synchronization group.
-                    if USE_2CTA:
-                        tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
-                    else:
-                        tlx.barrier_arrive(qk_empties[cid])
-                    if RESCALE_OPT:
-                        # RESCALE_OPT stores unscaled row-max in m_tiles.
-                        # The bwd kernel expects scaled values (m * qk_scale),
-                        # so we scale here before storing M.
-                        m = m * sm_scale * 1.44269504
-                    m += tl.math.log2(l)
-                    offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
-                    m_ptrs = M + off_hz * N_CTX + offs_m
-                    tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
-
-                    tlx.barrier_wait(acc_empties[cid], phase)
-                    tlx.barrier_wait(o_empties[cid], phase ^ 1)
-                    scale = 1 / l
-                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        subslice = tlx.subslice(
-                            acc_tiles[cid],
-                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                            HEAD_DIM // NUM_MMA_SLICES,
-                        )
-                        acc = tlx.local_load(subslice)
-                        acc = _mul_f32x2(acc, scale)
-                        acc = acc.to(tlx.dtype_of(desc_o))
-                        subslice_o = tlx.local_slice(
-                            o_tiles[cid],
-                            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
-                            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
-                        )
-                        tlx.local_store(subslice_o, acc)
-                    tlx.barrier_arrive(o_fulls[cid])
-
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1
@@ -977,7 +1046,6 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 # FA4 update_row_sum has init_val being None for the first iteration, here
                 # we use initial value of 1.0
                 l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
-                acc = tl.zeros([BLOCK_M_SPLIT, HEAD_DIM], dtype=tl.float32)
                 qk_scale = sm_scale
                 qk_scale *= 1.44269504  # 1/log(2)
                 p_dtype = tlx.dtype_of(desc_v)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -591,7 +591,7 @@ def _fwd_load_1cta(
 
 
 @triton.jit
-def _fwd_mma_dots_1cta(
+def _fwd_mma_tile(
     tile_count,
     accum_cnt_kv,
     accum_cnt_qk,
@@ -616,10 +616,17 @@ def _fwd_mma_dots_1cta(
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
     NUM_MMA_SLICES: tl.constexpr,
+    v_tiles=None,
+    v_fulls=None,
+    v_empties=None,
+    USE_2CTA: tl.constexpr = False,
 ):
+    v_tiles = v_tiles if USE_2CTA else kv_tiles
+    v_fulls = v_fulls if USE_2CTA else kv_fulls
+    v_empties = v_empties if USE_2CTA else kv_empties
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
     # wait for the K buffer to be populated by the producer
     tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
@@ -636,6 +643,7 @@ def _fwd_mma_dots_1cta(
         qk_tiles[0],
         use_acc=False,
         mBarriers=[qk_fulls[0]],
+        two_ctas=USE_2CTA,
     )
 
     # -- compute q1 @ k ----
@@ -647,19 +655,20 @@ def _fwd_mma_dots_1cta(
         qk_tiles[1],
         use_acc=False,
         mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+        two_ctas=USE_2CTA,
     )
 
     _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
 
     # -- compute p0 @ v ----
     # wait for the V buffer to be populated by the producer
-    tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+    tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
     tlx.barrier_wait(acc_fulls[0], qk_phase)
     for slice_id in tl.static_range(0, NUM_MMA_SLICES):
         p_bufIdx = slice_id
         tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
         kv_slice = tlx.local_slice(
-            kv_tiles[v_bufIdx],
+            v_tiles[v_bufIdx],
             [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
             [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
         )
@@ -669,6 +678,7 @@ def _fwd_mma_dots_1cta(
             acc_tiles[0],
             use_acc=slice_id > 0,
             force_async=True,
+            two_ctas=USE_2CTA,
         )
 
     acc1_init = False
@@ -678,9 +688,9 @@ def _fwd_mma_dots_1cta(
         qk_phase_prev = qk_phase
 
         accum_cnt_qk += 1
-        accum_cnt_kv += 2
+        accum_cnt_kv += 1 if USE_2CTA else 2
         k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
         # -- compute q0 @ k ----
         # wait for the K buffer to be populated by the producer
@@ -694,6 +704,7 @@ def _fwd_mma_dots_1cta(
             qk_tiles[0],
             use_acc=False,
             mBarriers=[qk_fulls[0]],
+            two_ctas=USE_2CTA,
         )
 
         # -- compute p1 @ v from the previous iteration----
@@ -702,18 +713,19 @@ def _fwd_mma_dots_1cta(
             p_bufIdx = slice_id + NUM_MMA_SLICES
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
             kv_slice = tlx.local_slice(
-                kv_tiles[v_bufIdx_prev],
+                v_tiles[v_bufIdx_prev],
                 [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                 [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
             use_acc = acc1_init if slice_id == 0 else True
-            mBarriers = [kv_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+            mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
             tlx.async_dot(
                 p_tiles[p_bufIdx],
                 kv_slice,
                 acc_tiles[1],
                 use_acc=use_acc,
                 mBarriers=mBarriers,
+                two_ctas=USE_2CTA,
             )
 
         acc1_init = True
@@ -725,18 +737,19 @@ def _fwd_mma_dots_1cta(
             qk_tiles[1],
             use_acc=False,
             mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+            two_ctas=USE_2CTA,
         )
 
         # -- compute p0 @ v ----
         # wait for the V buffer to be populated by the producer
-        tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
 
         tlx.barrier_wait(acc_fulls[0], qk_phase)
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             p_bufIdx = slice_id
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
             kv_slice = tlx.local_slice(
-                kv_tiles[v_bufIdx],
+                v_tiles[v_bufIdx],
                 [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                 [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
@@ -746,11 +759,12 @@ def _fwd_mma_dots_1cta(
                 acc_tiles[0],
                 use_acc=True,
                 force_async=True,
+                two_ctas=USE_2CTA,
             )
 
-    tlx.tcgen05_commit(q_empties[q_bufIdx])
-    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q])
-    tlx.tcgen05_commit(acc_empties[0])
+    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
+    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
+    tlx.tcgen05_commit(acc_empties[0], two_ctas=USE_2CTA)
 
     # -- compute p1 @ v ----
     tlx.barrier_wait(acc_fulls[1], qk_phase)
@@ -758,22 +772,23 @@ def _fwd_mma_dots_1cta(
         p_bufIdx = slice_id + NUM_MMA_SLICES
         tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
         kv_slice = tlx.local_slice(
-            kv_tiles[v_bufIdx],
+            v_tiles[v_bufIdx],
             [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
             [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
         )
         use_acc = acc1_init if slice_id == 0 else True
-        mBarriers = [acc_empties[1], kv_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+        mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
         tlx.async_dot(
             p_tiles[p_bufIdx],
             kv_slice,
             acc_tiles[1],
             use_acc=use_acc,
             mBarriers=mBarriers,
+            two_ctas=USE_2CTA,
         )
 
     accum_cnt_qk += 1
-    accum_cnt_kv += 2
+    accum_cnt_kv += 1 if USE_2CTA else 2
     return accum_cnt_kv, accum_cnt_qk
 
 
@@ -1126,110 +1141,75 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
+                _, _, lo, hi, _, _ = _compute_offsets(
+                    tile_id // NUM_CTAS,
+                    H,
+                    num_pid_n,
+                    num_pid_in_group,
+                    N_CTX,
+                    EFFECTIVE_BLOCK_M,
+                    STAGE,
+                    GROUP_SIZE_N,
+                )
                 if USE_2CTA:
                     if is_leader:
-                        _, _, lo2, hi2, _, _ = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N)
-                        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-                        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-                        tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
-
-                        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-                        tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
-                        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
-                                      two_ctas=True)
-
-                        tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
-                        tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
-                        tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
-                                      mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
-
-                        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-
-                        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-                        tlx.barrier_wait(acc_fulls[0], qk_phase)
-                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                            p_bufIdx = slice_id
-                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=slice_id > 0,
-                                          force_async=True, two_ctas=True)
-
-                        acc1_init = False
-
-                        for i in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
-                            v_bufIdx_prev = v_bufIdx
-                            qk_phase_prev = qk_phase
-
-                            accum_cnt_qk += 1
-                            accum_cnt_kv += 1
-                            k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                            v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-                            tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-                            k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-                            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-
-                            tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
-                                          two_ctas=True)
-
-                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                p_bufIdx = slice_id + NUM_MMA_SLICES
-                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
-                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx_prev],
-                                                           [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                                use_acc = acc1_init if slice_id == 0 else True
-                                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
-                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
-                                              mBarriers=mBarriers, two_ctas=True)
-
-                            acc1_init = True
-
-                            tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
-                                          mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
-
-                            tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-                            tlx.barrier_wait(acc_fulls[0], qk_phase)
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                p_bufIdx = slice_id
-                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=True, force_async=True,
-                                              two_ctas=True)
-
-                        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
-                        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=True)
-                        tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
-
-                        tlx.barrier_wait(acc_fulls[1], qk_phase)
-                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                            p_bufIdx = slice_id + NUM_MMA_SLICES
-                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                            use_acc = acc1_init if slice_id == 0 else True
-                            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
-                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
-                                          mBarriers=mBarriers, two_ctas=True)
-
-                        accum_cnt_qk += 1
-                        accum_cnt_kv += 1
+                        accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
+                            tile_count,
+                            accum_cnt_kv,
+                            accum_cnt_qk,
+                            lo,
+                            hi,
+                            q_tiles,
+                            k_tiles,
+                            qk_tiles,
+                            p_tiles,
+                            acc_tiles,
+                            q_fulls,
+                            q_empties,
+                            k_fulls,
+                            k_empties,
+                            qk_fulls,
+                            qk_empties,
+                            p_fulls,
+                            acc_fulls,
+                            acc_empties,
+                            BLOCK_N,
+                            HEAD_DIM_KV,
+                            NUM_BUFFERS_Q,
+                            NUM_BUFFERS_KV,
+                            NUM_MMA_SLICES,
+                            v_tiles,
+                            v_fulls,
+                            v_empties,
+                            True,
+                        )
                 else:
-                    _, _, lo, hi, _, _ = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M,
-                                                          STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_dots_1cta(tile_count, accum_cnt_kv, accum_cnt_qk, lo, hi,
-                                                                    q_tiles, kv_tiles, qk_tiles, p_tiles, acc_tiles,
-                                                                    q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
-                                                                    qk_empties, p_fulls, acc_fulls, acc_empties,
-                                                                    BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
-                                                                    NUM_MMA_SLICES)
+                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
+                        tile_count,
+                        accum_cnt_kv,
+                        accum_cnt_qk,
+                        lo,
+                        hi,
+                        q_tiles,
+                        kv_tiles,
+                        qk_tiles,
+                        p_tiles,
+                        acc_tiles,
+                        q_fulls,
+                        q_empties,
+                        kv_fulls,
+                        kv_empties,
+                        qk_fulls,
+                        qk_empties,
+                        p_fulls,
+                        acc_fulls,
+                        acc_empties,
+                        BLOCK_N,
+                        HEAD_DIM_KV,
+                        NUM_BUFFERS_Q,
+                        NUM_BUFFERS_KV,
+                        NUM_MMA_SLICES,
+                    )
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -368,7 +368,7 @@ class FlashAttention:
             "BLOCK_M": 256,
             "BLOCK_N": 128,
             "NUM_BUFFERS_Q": 1,
-            "NUM_BUFFERS_KV": 5,
+            "NUM_BUFFERS_KV": 3,
             "NUM_BUFFERS_QK": 1,
             "NUM_MMA_GROUPS": 2,
             "NUM_MMA_SLICES": 2,


### PR DESCRIPTION
Summary: This change introduces the typed `ForwardPlan` and `_select_forward_plan` entry point. The plan owns the selected stage, pipelining mode, policy, and CTA count. The live forward host path reads those fields instead of rediscovering the same choices at multiple call sites. The change also consolidates the forward softmax helper behind one parameterized interface and makes optional MMA inputs explicit. At this boundary the selector deliberately reproduces the parent behavior: pipelining remains disabled, the dense policy remains selected, and the launch remains single-CTA. Alternate descriptor geometry, cooperative scheduling, compact probability publication, and optimized exponentiation are not activated here. Consequently this organizational boundary should not materially change timing. The following revision changes the plan values and activates the corresponding optimized kernel paths.

Reviewed By: htyu

Differential Revision: D116734329


