### PR TITLE
[TritonGPU] Use dialect inference for reduce layouts

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -375,9 +375,15 @@ static Attribute inferDstEncoding(triton::ReduceOp op, Attribute encoding) {
   // If the input is rank 1, the output is a scalar value.
   if (cast<ttg::LayoutEncodingTrait>(encoding).getRank() == 1)
     return {};
-  return triton::gpu::SliceEncodingAttr::get(
-      op->getContext(), op.getAxis(),
-      cast<ttg::DistributedEncodingTrait>(encoding));
+  Attribute dstEncoding;
+  auto *inferLayout =
+      encoding.getDialect()
+          .getRegisteredInterface<DialectInferLayoutInterface>();
+  if (!inferLayout ||
+      failed(inferLayout->inferReduceOpEncoding(
+          encoding, op.getAxis(), dstEncoding, /*loc=*/std::nullopt)))
+    return {};
+  return dstEncoding;
 }
 
 static Attribute inferDstEncoding(triton::ExpandDimsOp op, Attribute encoding) {


### PR DESCRIPTION
Layout propagation previously constructed reduce result slice encodings directly. This bypassed DialectInferLayoutInterface and dropped metadata owned by wrapper dialects, causing TLX deferred no-verify layouts to disagree with tt.reduce type inference during RemoveLayoutConversions.

Route forward reduce layout inference through the encoding dialect's virtual inferReduceOpEncoding hook. Standard TritonGPU layouts retain their existing behavior, while TLX can preserve the complete no_verify_layout wrapper without adding TLX-specific handling to the pass.

This fixes facebookexperimental/triton#2927. Verified with test_pinned_online_softmax_amd, the related pinned-layout AMD tests, and the remove-layout-conversion lit tests.