### PR TITLE
Select TLX CLC synchronization from frontend cluster options

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,26 +653,26 @@ CLC (Cluster Launch Control) is a Blackwell-specific feature **[Blackwell]** tha
     **Parameters:**
     - `num_consumers`: Number of consumers that will signal completion per tile (typically 3 async tasks × num_CTAs)
 
-- `tlx.clc_producer(context, p_producer=phase, multi_ctas=False)` **[Blackwell]**
+- `tlx.clc_producer(context, p_producer=phase, multi_ctas=True)` **[Blackwell]**
 
     Issue a CLC try_cancel request to acquire a new tile ID.
 
     **Parameters:**
     - `context`: CLC pipeline context from `clc_create_context`
     - `phase`: Current barrier phase (0 or 1, alternates each iteration)
-    - `multi_ctas`: Set to `True` for 2-CTA mode (cluster of 2 CTAs). When enabled, `pred_cta0` is computed internally from `cluster_cta_rank()`.
+    - `multi_ctas`: Enables cluster-aware synchronization by default when the compilation options specify multiple CTAs. For a `(1, 1, 1)` cluster, the frontend emits the local single-CTA path. Set to `False` to request the local-only path explicitly.
 
-- `tile_id = tlx.clc_consumer(context, p_consumer=phase, multi_ctas=False, k=0, return_3d=False)` **[Blackwell]**
+- `tile_id = tlx.clc_consumer(context, p_consumer=phase, multi_ctas=True, k=0, return_3d=False)` **[Blackwell]**
 
     Decode the tile ID from a CLC response and signal completion.
 
     **Parameters:**
     - `context`: CLC pipeline context from `clc_create_context`
     - `phase`: Current barrier phase
-    - `multi_ctas`: Set to `True` for 2-CTA mode. When enabled, `pred_cta0` is computed internally.
+    - `multi_ctas`: Enables cluster-aware synchronization by default when the compilation options specify multiple CTAs. For a `(1, 1, 1)` cluster, the frontend emits a local barrier arrival. Set to `False` to request the local-only path explicitly.
     - `return_3d`: Set to `True` to return `(ctaIdX, ctaIdY, ctaIdZ)` tuple instead of scalar tile_id.
 
-    **Returns:** The tile ID (already offset by `cluster_cta_rank()` for unique tile assignments), or -1 if no work available. With `return_3d=True`, returns `(ctaIdX, ctaIdY, ctaIdZ)` tuple.
+    **Returns:** The tile ID (offset by `cluster_cta_rank()` for unique tile assignments), or -1 if no work is available. With `return_3d=True`, returns `(ctaIdX, ctaIdY, ctaIdZ)`.
 
 #### How CLC Works
 

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -4,6 +4,7 @@ import torch
 import triton
 import triton.language as tl
 from triton._internal_testing import is_hopper_or_newer, is_blackwell
+from triton.backends.compiler import GPUTarget
 import triton.language.extra.tlx as tlx
 
 
@@ -453,12 +454,71 @@ def test_cluster_launch_control(BLOCK_SIZE, device):
     assert re.search((r"clusterlaunchcontrol.try_cancel"), ptx, flags=re.DOTALL)
     assert re.search((r"clusterlaunchcontrol.query_cancel.is_canceled.pred.b128"), ptx, flags=re.DOTALL)
     assert re.search((r"clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128"), ptx, flags=re.DOTALL)
+    assert "mapa.shared::cluster" not in ptx
 
     query_instr = ptx.index("clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128")
     fence_instr = ptx.index("fence.proxy.async.shared::cta")
     assert 0 < query_instr < fence_instr
 
     assert torch.count_nonzero(output) == size
+
+
+@triton.jit
+def _clc_default_multi_ctas_kernel(NUM_CONSUMERS: tl.constexpr):
+    clc_context = tlx.clc_create_context(NUM_CONSUMERS)
+    tlx.clc_producer(clc_context, 1)
+    tlx.clc_consumer(clc_context, 0)
+
+
+@triton.jit
+def _clc_explicit_multi_ctas_kernel(NUM_CONSUMERS: tl.constexpr, MULTI_CTAS: tl.constexpr):
+    clc_context = tlx.clc_create_context(NUM_CONSUMERS)
+    tlx.clc_producer(clc_context, 1, multi_ctas=MULTI_CTAS)
+    tlx.clc_consumer(clc_context, 0, multi_ctas=MULTI_CTAS)
+
+
+@pytest.mark.parametrize(
+    "ctas_per_cga,num_consumers,multi_ctas,expect_remote",
+    [
+        ((1, 1, 1), 1, None, False),
+        ((2, 1, 1), 2, None, True),
+        ((2, 1, 1), 1, False, False),
+    ],
+)
+def test_cluster_launch_control_multi_ctas_frontend(ctas_per_cga, num_consumers, multi_ctas, expect_remote):
+    if multi_ctas is None:
+        src = triton.compiler.ASTSource(
+            fn=_clc_default_multi_ctas_kernel,
+            signature={"NUM_CONSUMERS": "constexpr"},
+            constexprs={"NUM_CONSUMERS": num_consumers},
+        )
+    else:
+        src = triton.compiler.ASTSource(
+            fn=_clc_explicit_multi_ctas_kernel,
+            signature={"NUM_CONSUMERS": "constexpr", "MULTI_CTAS": "constexpr"},
+            constexprs={"NUM_CONSUMERS": num_consumers, "MULTI_CTAS": multi_ctas},
+        )
+    kernel = triton.compile(
+        src,
+        target=GPUTarget("cuda", 100, 32),
+        options={"ctas_per_cga": ctas_per_cga},
+    )
+    ttir = kernel.asm["ttir"]
+    ttgir = kernel.asm["ttgir"]
+    ptx = kernel.asm["ptx"]
+
+    assert ttir.count("nvg.cluster_id") == 1
+    expected_equalities = 2 if expect_remote else 1
+    assert ttir.count("arith.cmpi eq") == expected_equalities
+
+    if expect_remote:
+        assert "ttng.map_to_remote_buffer" in ttgir
+        assert "mapa.shared::cluster" in ptx
+    else:
+        assert "ttng.map_to_remote_buffer" not in ttgir
+        assert "mapa.shared::cluster" not in ptx
+
+    assert "multicast::cluster::all" in ptx
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
@@ -525,7 +585,7 @@ def test_cluster_launch_control_3d(GRID_DIMS, device):
 @pytest.mark.parametrize("CLUSTER_SIZE", [2, 4])
 def test_cluster_launch_control_multi_cta(CLUSTER_SIZE, device):
     """
-    Test CLC with 2-CTA clusters (multi_ctas=True).
+    Test CLC with multi-CTA clusters using the default cluster-aware path.
 
     Verifies that:
     1. Both CTAs call barrier_expect_bytes (unpredicated) on their own local bar_full,
@@ -555,7 +615,7 @@ def test_cluster_launch_control_multi_cta(CLUSTER_SIZE, device):
 
         while tile_id != -1:
             # CLC producer
-            tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=True)
+            tlx.clc_producer(clc_context, clc_phase_producer)
             clc_phase_producer ^= 1
 
             block_start = tile_id * BLOCK_SIZE
@@ -569,7 +629,7 @@ def test_cluster_launch_control_multi_cta(CLUSTER_SIZE, device):
             tl.store(z_ptr + offsets, output, mask=mask)
 
             # CLC consumer
-            tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=True)
+            tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
             clc_phase_consumer ^= 1
 
     torch.manual_seed(0)

--- a/third_party/tlx/language/tlx/dynamic_launch.py
+++ b/third_party/tlx/language/tlx/dynamic_launch.py
@@ -42,6 +42,15 @@ def _clc_issue(
     return _semantic.builder.clc_issue(clc_response_addr.handle, barrier.handle)
 
 
+def _use_multi_cta_sync(multi_ctas, _semantic):
+    multi_ctas = tl._unwrap_if_constexpr(multi_ctas)
+    if not multi_ctas:
+        return False
+    options = _semantic.builder.options
+    cluster_dims = options.cluster_dims or (1, 1, 1)
+    return options.num_ctas > 1 or any(dim > 1 for dim in cluster_dims)
+
+
 @tl.builtin
 def _clc_query(
     clc_response_addr: tlx.clc_response,
@@ -77,7 +86,7 @@ def clc_create_context(num_consumers, num_stages: tl.tensor = 1, _semantic=None)
 
 
 @tl.builtin
-def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _semantic=None):
+def clc_producer(context, p_producer=None, multi_ctas: bool = True, k=0, _semantic=None):
     """
     Issue a CLC try_cancel request from the first CTA in the cluster.
 
@@ -95,7 +104,8 @@ def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _seman
         context: CLC pipeline context created by clc_create_context
         k: Stage index
         p_producer: Phase for producer
-        multi_ctas: If True, compute pred_cta0 internally from cluster_cta_rank()
+        multi_ctas: If True (the default), use cluster-aware synchronization
+            when the compilation options specify multiple CTAs.
 
     PTX instruction generated:
         clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
@@ -104,8 +114,10 @@ def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _seman
     bar_full = local_view(context._clc_mbars_full, k, _semantic=_semantic)
     response = local_view(context._clc_responses, k, _semantic=_semantic)
 
+    use_multi_cta_sync = _use_multi_cta_sync(multi_ctas, _semantic)
+
     # Compute pred_cta0 internally for multi-CTA mode
-    if multi_ctas:
+    if use_multi_cta_sync:
         cta_rank = cluster_cta_rank(_semantic=_semantic)
         zero = _semantic.builder.get_int32(0)
         pred_cta0_handle = _semantic.builder.create_icmpEQ(cta_rank.handle, zero)
@@ -130,7 +142,7 @@ def clc_producer(context, p_producer=None, multi_ctas: bool = False, k=0, _seman
 
 
 @tl.builtin
-def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return_3d: bool = False, _semantic=None):
+def clc_consumer(context, p_consumer=None, multi_ctas: bool = True, k=0, return_3d: bool = False, _semantic=None):
     """
     Decode the tile ID from a CLC response and signal completion.
 
@@ -148,7 +160,8 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return
         context: CLC pipeline context created by clc_create_context
         k: Stage index
         p_consumer: Phase for consumer
-        multi_ctas: If True, compute pred_cta0 internally and use remote signaling
+        multi_ctas: If True (the default), use cluster-aware remote signaling
+            when the compilation options specify multiple CTAs.
         return_3d: If True, return (ctaIdX, ctaIdY, ctaIdZ) tuple instead of scalar tile_id
 
     Returns the tile ID if successful, otherwise -1.
@@ -168,6 +181,8 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return
     # before reading the CLC response.
     barrier_wait(bar_full, p_consumer, _semantic=_semantic)
 
+    use_multi_cta_sync = _use_multi_cta_sync(multi_ctas, _semantic)
+
     # Extract tile_id from the CLC response.
     stolen_tile_ids = _clc_query(response, _semantic=_semantic)
     stolen_tile_id = stolen_tile_ids[0]
@@ -180,7 +195,7 @@ def clc_consumer(context, p_consumer=None, multi_ctas: bool = False, k=0, return
     zero = _semantic.builder.get_int32(0)
     pred_has_tile_handle = _semantic.builder.create_icmpSGE(stolen_tile_id.handle, zero)
     pred_has_tile = tl.tensor(pred_has_tile_handle, tl.int1)
-    if multi_ctas:
+    if use_multi_cta_sync:
         # Arrive at CTA 0's bar_empty via remote_cta_rank=0
         # (barrier_arrive handles remote_view internally)
         barrier_arrive(bar_empty, tl.constexpr(1), 0, pred=pred_has_tile, _semantic=_semantic)


### PR DESCRIPTION
Summary: Make `multi_ctas=True` the default for `tlx.clc_producer` and `tlx.clc_consumer`, while emitting cluster synchronization only when both the API flag is enabled and the compilation options specify multiple CTAs. The frontend omits the producer CTA-0 predicate and consumer remote barrier arrival for single-CTA compilations. CLC query rank adjustment and NVIDIA CLC instruction lowering remain unchanged.

Reviewed By: htyu

Differential Revision: D116680322


