### PR TITLE
[AMD][TLX] Stop autotuning inside gfx950 tutorial correctness tests

### DIFF
--- a/third_party/tlx/tutorials/amd_addmm_gfx950.py
+++ b/third_party/tlx/tutorials/amd_addmm_gfx950.py
@@ -136,6 +136,32 @@ def _launch_inter_wave_with_tail(bias: torch.Tensor, a: torch.Tensor, b: torch.T
     return out
 
 
+def available_paths(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> tuple[str, ...]:
+    """Return the paths that are valid for these operands, in registry order.
+
+    Correctness tests iterate this and assert every path against a reference,
+    rather than letting `_autotune_path` race them and check only the winner.
+    That matters for more than wall clock: the race admits a candidate only if
+    it already agrees with `register`, so a genuinely wrong `inter_wave` would
+    be dropped from the timing pool and the suite would still pass green.
+    """
+    if _can_use_inter_wave(a):
+        return ("register", "inter_wave")
+    if _can_use_inter_wave_tail(a, b):
+        return ("register", "inter_wave_tail")
+    return ("register", )
+
+
+def _dispatch(path: str, bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, split_k, config=None):
+    if path == "inter_wave":
+        return _launch(a, b, bias=bias, SPLIT_K=split_k)
+    if path == "inter_wave_tail":
+        return _launch_inter_wave_with_tail(bias, a, b)
+    if path == "register":
+        return _launch_register(a, b, bias=bias, config=config)
+    raise ValueError(f"Unknown addmm path {path!r}; expected one of {available_paths(bias, a, b)}")
+
+
 def _autotune_path(
     bias: torch.Tensor,
     a: torch.Tensor,
@@ -175,8 +201,15 @@ def _autotune_path(
     return winner
 
 
-def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None):
-    """Return ``bias + a @ b`` using the fastest valid gfx950 TLX path."""
+def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None, path=None, config=None):
+    """Return ``bias + a @ b`` using a gfx950 TLX path.
+
+    ``path`` pins one of `available_paths`; the default (None) times the valid
+    paths against each other and keeps the winner per shape. ``config`` pins
+    the register path's kernel config, bypassing its autotuner. Correctness
+    tests should pass both: neither the path race nor the config sweep tells
+    them anything, and together they dominate the suite's wall clock.
+    """
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError("addmm expects two-dimensional matrix operands")
     if a.shape[1] != b.shape[0]:
@@ -195,10 +228,12 @@ def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None):
     if SPLIT_K not in (None, 1):
         if not _can_use_inter_wave(a):
             raise ValueError("SPLIT_K is only supported by the inter-wave kernel")
+        if path not in (None, "inter_wave"):
+            raise ValueError(f"SPLIT_K > 1 requires the inter_wave path, got {path!r}")
         return _launch(a, b, bias=bias_2d, SPLIT_K=SPLIT_K)
-    winner = _autotune_path(bias_2d, a, b, SPLIT_K)
-    if winner == "inter_wave":
-        return _launch(a, b, bias=bias_2d, SPLIT_K=SPLIT_K)
-    if winner == "inter_wave_tail":
-        return _launch_inter_wave_with_tail(bias_2d, a, b)
-    return _launch_register(a, b, bias=bias_2d)
+    if path is not None:
+        valid = available_paths(bias_2d, a, b)
+        if path not in valid:
+            raise ValueError(f"Path {path!r} is not valid for this shape; valid paths are {valid}")
+        return _dispatch(path, bias_2d, a, b, SPLIT_K, config=config)
+    return _dispatch(_autotune_path(bias_2d, a, b, SPLIT_K), bias_2d, a, b, SPLIT_K, config=config)

--- a/third_party/tlx/tutorials/amd_gemm_pipelined.py
+++ b/third_party/tlx/tutorials/amd_gemm_pipelined.py
@@ -233,8 +233,8 @@ def matmul_kernel_pipelined_mi300(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, strid
 
 
 def matmul(a, b, config=None):
-    # config is accepted for a uniform launcher signature; this kernel is
-    # autotuned over `configs`, so the argument is intentionally unused.
+    # config=None autotunes over `configs`; an explicit config dict launches
+    # that config directly, matching the other tutorial launchers.
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.is_contiguous(), "Matrix A must be contiguous"
@@ -242,13 +242,18 @@ def matmul(a, b, config=None):
     K, N = b.shape
     # Allocates output (dtype follows the inputs so fp16/bf16 both round-trip).
     c = torch.empty((M, N), device=a.device, dtype=a.dtype)
-    # 1D launch kernel where each block gets its own program.
-    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
-    matmul_kernel_pipelined_mi300[grid](
+    args = (
         a, b, c,  #
         M, N, K,  #
         a.stride(0), a.stride(1),  #
         b.stride(0), b.stride(1),  #
         c.stride(0), c.stride(1),  #
     )
+    if config is not None:
+        grid = (triton.cdiv(M, config['BLOCK_SIZE_M']) * triton.cdiv(N, config['BLOCK_SIZE_N']), )
+        matmul_kernel_pipelined_mi300.fn[grid](*args, **config)
+    else:
+        # 1D launch kernel where each block gets its own program.
+        grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+        matmul_kernel_pipelined_mi300[grid](*args)
     return c

--- a/third_party/tlx/tutorials/gfx950_gdpa.py
+++ b/third_party/tlx/tutorials/gfx950_gdpa.py
@@ -101,8 +101,15 @@ PROD_CONFIG: dict[str, Any] = {
 # attributed to either the kernel or the approximation rather than guessed at.
 
 # k = 2 * sqrt(2/pi), matching ads_mkl.
-GELU_TANH_K = 2.0 * 0.7978845608
-GELU_TANH_C = 0.044715
+#
+# Two spellings on purpose: `_fast_gelu` is @triton.jit and reads these as
+# module globals, which the code generator only permits for constexpr values
+# (plain floats raise NameError at compile time), while the torch mirror below
+# needs real Python floats to combine with tensors.
+_GELU_TANH_K = 2.0 * 0.7978845608
+_GELU_TANH_C = 0.044715
+GELU_TANH_K = tl.constexpr(_GELU_TANH_K)
+GELU_TANH_C = tl.constexpr(_GELU_TANH_C)
 
 
 def gelu_exact(x: torch.Tensor) -> torch.Tensor:
@@ -114,7 +121,7 @@ def gelu_exact(x: torch.Tensor) -> torch.Tensor:
 def fast_gelu_ref(x: torch.Tensor) -> torch.Tensor:
     """Torch mirror of the kernel's fast_gelu -- the ads_mkl AMD formula."""
     x = x.float()
-    return x * torch.sigmoid(GELU_TANH_K * x * (1.0 + GELU_TANH_C * x * x))
+    return x * torch.sigmoid(_GELU_TANH_K * x * (1.0 + _GELU_TANH_C * x * x))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -526,11 +533,7 @@ _FWD_WAVES_PER_EU = (0, 2, 4)
 
 def _get_fwd_configs() -> list[triton.Config]:
     if FULL_TUNING:
-        tiles = [(bm, bn, nw, nb)
-                 for bm in (64, 128, 256)
-                 for bn in (32, 64, 128)
-                 for nw in (4, 8)
-                 for nb in (2, 3, 4)]
+        tiles = [(bm, bn, nw, nb) for bm in (64, 128, 256) for bn in (32, 64, 128) for nw in (4, 8) for nb in (2, 3, 4)]
         waves = (0, 1, 2, 4)
         nonkdims = (16, 32)
     else:
@@ -569,7 +572,7 @@ def _check_and_prepare(q, k, v, q_offsets, dff):
     return total_q, H, d, B
 
 
-def _launch(kernel, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw):
+def _launch(kernel, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw, config=None):
     total_q, H, d, B = _check_and_prepare(q, k, v, q_offsets, dff)
     out = torch.empty_like(q)
     if total_q == 0:
@@ -581,7 +584,13 @@ def _launch(kernel, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw):
     if max_M == 0:
         return out
 
-    grid = lambda meta: (triton.cdiv(max_M, meta["BLOCK_M"]) * B * H, )  # noqa: E731
+    if config is not None:
+        # Pinned config: launch the JIT function directly, skipping the sweep.
+        grid = (triton.cdiv(max_M, config["BLOCK_M"]) * B * H, )
+        kernel = kernel.fn
+        kw = {**kw, **config}
+    else:
+        grid = lambda meta: (triton.cdiv(max_M, meta["BLOCK_M"]) * B * H, )  # noqa: E731
     kernel[grid](
         q,
         k,
@@ -617,6 +626,7 @@ def gdpa_forward(
     qk_scale: float = 1.0,
     max_M: Optional[int] = None,
     num_xcds: int = 8,
+    config=None,
     **kw,
 ) -> torch.Tensor:
     """GDPA forward, jagged Q x dense KV.
@@ -630,11 +640,13 @@ def gdpa_forward(
         max_M:     longest sequence, used to size the grid. Derived from
                    `q_offsets` when omitted, which costs a host sync -- pass it
                    explicitly from any benchmarked path.
+        config:    Pin a kernel config and bypass the autotuner
+                   (Blackwell/Hopper tutorial convention). None autotunes.
 
     Returns:
         [total_q, H, d], same dtype/layout as q.
     """
-    return _launch(_gdpa_fwd_pipelined_tuned, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw)
+    return _launch(_gdpa_fwd_pipelined_tuned, q, k, v, q_offsets, dff, qk_scale, max_M, num_xcds, kw, config=config)
 
 
 KERNEL_REGISTRY = {

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -315,8 +315,14 @@ def _register_kernel(
     tl.store(c_ptr + output_offsets, acc, mask=mask)
 
 
-def _launch_register(a, b, bias=None):
-    """Launch the autotuned register-resident gfx950 GEMM path."""
+def _launch_register(a, b, bias=None, config=None):
+    """Launch the register-resident gfx950 GEMM path.
+
+    ``config=None`` autotunes over `_REGISTER_CONFIGS`. Passing an explicit
+    config dict bypasses the autotuner and launches that config directly --
+    the same convention the Blackwell/Hopper tutorials use so correctness
+    tests can pin a config instead of paying for a sweep.
+    """
     M, K = a.shape
     b_k, N = b.shape
     if K != b_k:
@@ -327,11 +333,10 @@ def _launch_register(a, b, bias=None):
         if bias.device != a.device or bias.dtype != a.dtype:
             raise ValueError("Bias and matrix operands must have matching device and dtype")
     out = torch.empty((M, N), device=a.device, dtype=a.dtype)
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]), )
     disable_agpr = (K == 256 and N > 256) or (K > 512 and (K % BLOCK_K != 0 or M * N <= 2 * 1024 * 1024))
     launch_options = {"llvm_fn_attrs": (("amdgpu-agpr-alloc", "0,0"), )} if disable_agpr else {}
     bias_ptr = bias if bias is not None else out
-    _register_kernel[grid](
+    args = (
         a,
         b,
         bias_ptr,
@@ -345,9 +350,13 @@ def _launch_register(a, b, bias=None):
         b.stride(1),
         bias.stride(0) if bias is not None else 0,
         bias.stride(1) if bias is not None else 0,
-        ADD_BIAS=bias is not None,
-        **launch_options,
     )
+    if config is not None:
+        grid = (triton.cdiv(M, config["BLOCK_M"]) * triton.cdiv(N, config["BLOCK_N"]), )
+        _register_kernel.fn[grid](*args, ADD_BIAS=bias is not None, **config, **launch_options)
+    else:
+        grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]), )
+        _register_kernel[grid](*args, ADD_BIAS=bias is not None, **launch_options)
     return out
 
 

--- a/third_party/tlx/tutorials/ikbo/ikbo_fa_triton.py
+++ b/third_party/tlx/tutorials/ikbo/ikbo_fa_triton.py
@@ -324,6 +324,7 @@ def ikbo_fa(
     num_heads,
     d_head,
     max_seq_len,
+    config=None,
 ):
     """IKBO Flash Attention with in-kernel user broadcast.
 
@@ -337,19 +338,28 @@ def ikbo_fa(
         num_heads: Number of attention heads.
         d_head: Head dimension.
         max_seq_len: KV sequence length per user.
+        config: Pin a kernel config and bypass the autotuner (Blackwell/Hopper
+            tutorial convention). None autotunes.
 
     Returns:
         output: [B_cand, num_heads, n_seed, d_head] (SDPA-compatible layout)
     """
     output = torch.empty_like(query)
 
-    grid = lambda META: (
-        cand_grid.shape[0],
-        num_heads,
-        triton.cdiv(n_seed, META["BLOCK_M"]),
-    )
+    if config is not None:
+        grid = (cand_grid.shape[0], num_heads, triton.cdiv(n_seed, config["BLOCK_M"]))
+        kernel = _ikbo_fa_kernel.fn
+        extra = config
+    else:
+        grid = lambda META: (
+            cand_grid.shape[0],
+            num_heads,
+            triton.cdiv(n_seed, META["BLOCK_M"]),
+        )
+        kernel = _ikbo_fa_kernel
+        extra = {}
 
-    _ikbo_fa_kernel[grid](
+    kernel[grid](
         query,
         key,
         value,
@@ -375,6 +385,7 @@ def ikbo_fa(
         total_q_tokens=query.shape[0],
         total_kv_tokens=key.shape[0],
         ALLOW_TF32=not _is_hip,
+        **extra,
     )
 
     return output.view(-1, n_seed, num_heads, d_head).permute(0, 2, 1, 3)

--- a/third_party/tlx/tutorials/ikbo/ikbo_lce_triton.py
+++ b/third_party/tlx/tutorials/ikbo/ikbo_lce_triton.py
@@ -206,12 +206,16 @@ def ikbo_lce(
     embeddings_cand,
     embeddings_user,
     cand_to_user_index,
+    config=None,
 ):
     """IKBO LCE: candidate GEMM + in-kernel user broadcast.
 
     Two-phase computation:
       1. User: user_res = W_user @ E_user  (via torch.matmul, computed once)
       2. Fused: out[b] = W_cand @ E_cand[b] + user_res[u(b)]  (Triton kernel)
+
+    ``config=None`` autotunes over `_autotune_configs`; an explicit config dict
+    bypasses the autotuner, as in the Blackwell/Hopper tutorials.
     """
     B, K, N = embeddings_cand.shape
     M = compression_w_cand.size(0)
@@ -222,9 +226,7 @@ def ikbo_lce(
         dtype=embeddings_cand.dtype,
     )
 
-    grid = lambda META: (B * triton.cdiv(M, META["BM"]) * triton.cdiv(N, META["BN"]), )
-
-    _ikbo_lce_kernel[grid](
+    args = (
         compression_w_cand,
         embeddings_cand,
         cand_to_user_index,
@@ -242,5 +244,12 @@ def ikbo_lce(
         out.stride(1),
         out.stride(2),
     )
+
+    if config is not None:
+        grid = (B * triton.cdiv(M, config["BM"]) * triton.cdiv(N, config["BN"]), )
+        _ikbo_lce_kernel.fn[grid](*args, **config)
+    else:
+        grid = lambda META: (B * triton.cdiv(M, META["BM"]) * triton.cdiv(N, META["BN"]), )
+        _ikbo_lce_kernel[grid](*args)
 
     return out

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -110,7 +110,10 @@ from triton.language.extra.tlx.tutorials.gfx950_gdpa import (
     generate_gdpa_data as _gfx950_gdpa_gen,
     gelu_approx_error as _gfx950_gdpa_approx_error,
 )
-from triton.language.extra.tlx.tutorials.amd_addmm_gfx950 import addmm as _amd_addmm
+from triton.language.extra.tlx.tutorials.amd_addmm_gfx950 import (
+    addmm as _amd_addmm,
+    available_paths as _amd_addmm_paths,
+)
 from triton.language.extra.tlx.tutorials import amd_hstu_attn as _hstu
 from triton.tools.mxfp import MXScaleTensor
 
@@ -273,6 +276,32 @@ class Gemm:
             "SCALE_BLOCK": 32,
             "num_warps": 4,
             "waves_per_eu": 1,
+        },
+        "amd_gemm_pipelined": {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 4,
+            "NUM_STAGES": 2,
+            "kpack": 1,
+            "matrix_instr_nonkdim": 16,
+            "waves_per_eu": 0,
+            "num_warps": 8,
+        },
+        # Register path of the gfx950 standalone addmm. A mid-size 128x128x64
+        # tile is the safe pin for the whole shape list: the kernel masks its K
+        # tail and store, so it is valid down to K=24 and up to M=32768.
+        "amd_standalone_addmm_register": {
+            "BLOCK_M": 128,
+            "BLOCK_N": 128,
+            "BLOCK_K": 64,
+            "GROUP_M": 8,
+            "NUM_XCDS": 1,
+            "matrix_instr_nonkdim": 16,
+            "waves_per_eu": 0,
+            "kpack": 1,
+            "num_warps": 8,
+            "num_stages": 2,
         },
     }
 
@@ -1732,8 +1761,7 @@ def test_amd_gemm_pingpong(dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.skipif(not is_hip(), reason="Requires AMD GPU")
 def test_amd_gemm_pipelined(dtype):
-    # Autotuned kernel: no fixed config (config=None).
-    Gemm.run_test(_amd_gemm_pipelined, None, dtype=dtype)
+    Gemm.run_test(_amd_gemm_pipelined, Gemm.CONFIGS["amd_gemm_pipelined"], dtype=dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
@@ -1858,6 +1886,21 @@ def test_amd_mxfp_gemm_tdm_pipelined(TRANSPOSE_B):
 # =============================================================================
 
 
+# The addmm launcher's default `path=None` times its candidate paths against
+# each other with `do_bench` and keeps the winner. Correctness tests pin the
+# path instead, for two reasons: the timing race costs more wall clock than the
+# assertion it guards, and it admits a candidate only once that candidate
+# already agrees with `register` -- so a wrong `inter_wave` would be dropped
+# from the race and the suite would still pass. Iterating `available_paths`
+# asserts every path a shape can take against torch, independently.
+def _check_addmm_all_paths(bias, a, b, dtype=torch.float16):
+    ref = torch.addmm(bias, a, b)
+    config = Gemm.CONFIGS["amd_standalone_addmm_register"]
+    for path in _amd_addmm_paths(bias, a, b):
+        out = _amd_addmm(bias, a, b, path=path, config=config)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2, msg=lambda m, path=path: f"path={path}\n{m}")
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
 @pytest.mark.parametrize("bias_2d,split_k", [(False, 1), (True, 2)], ids=["1d-direct", "2d-split-k"])
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware (CDNA4)")
@@ -1868,10 +1911,14 @@ def test_amd_standalone_addmm(dtype, bias_2d, split_k):
     b = ((torch.randn(N, K, device=DEVICE, dtype=dtype) + 1) / K).T
     bias_shape = (1, N) if bias_2d else (N, )
     bias = torch.randn(bias_shape, device=DEVICE, dtype=dtype)
-
-    out = _amd_addmm(bias, a, b, SPLIT_K=split_k)
     ref = torch.addmm(bias, a, b)
-    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+    if split_k > 1:
+        # SPLIT_K > 1 is inter-wave only, and the launcher routes it directly.
+        out = _amd_addmm(bias, a, b, SPLIT_K=split_k)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+    else:
+        _check_addmm_all_paths(bias, a, b, dtype=dtype)
 
 
 @pytest.mark.parametrize(
@@ -1893,9 +1940,7 @@ def test_amd_standalone_addmm_stock_triton_shapes(M, N, K):
     b = ((torch.randn(N, K, device=DEVICE, dtype=torch.float16) + 1) / K).T
     bias = torch.randn(N, device=DEVICE, dtype=torch.float16)
 
-    out = _amd_addmm(bias, a, b)
-    ref = torch.addmm(bias, a, b)
-    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+    _check_addmm_all_paths(bias, a, b)
 
 
 # =============================================================================
@@ -1936,6 +1981,19 @@ def test_amd_addmm_glu(kernel_name, K):
 # relative L2 rather than elementwise max-rel: the reference has near-zero
 # elements (max_rel reaches 5e3 on them) which make elementwise ratios useless.
 
+# Pinned instead of sweeping the shipped 15-config space once per distinct
+# (H, MAX_M, DFF, QK_SCALE). BLOCK_M=128 is the smallest shipped m-tile, so it
+# covers the short-Q cases (max_M=64, 137) without wasting ragged-tail rows.
+GDPA_CONFIG = {
+    "BLOCK_M": 128,
+    "BLOCK_N": 64,
+    "NUM_BUFFERS": 2,
+    "matrix_instr_nonkdim": 16,
+    "waves_per_eu": 0,
+    "num_stages": 1,
+    "num_warps": 4,
+}
+
 
 @pytest.mark.parametrize(
     "B,max_M,H,dff,sparsity,seq_len_mode",
@@ -1957,7 +2015,7 @@ def test_amd_gfx950_gdpa(B, max_M, H, dff, sparsity, seq_len_mode):
     q, k, v, q_offsets = data["q"], data["k"], data["v"], data["q_offsets"]
 
     ref = _gfx950_gdpa_ref(q, k, v, q_offsets, dff, qk_scale=1.0)
-    out = _gfx950_gdpa(q, k, v, q_offsets, dff, qk_scale=1.0)
+    out = _gfx950_gdpa(q, k, v, q_offsets, dff, qk_scale=1.0, config=GDPA_CONFIG)
 
     assert out.shape == q.shape and out.dtype == q.dtype
     diff = (out.float() - ref.float()).abs()
@@ -2012,6 +2070,13 @@ def test_multi_cta_layer_norm_2d(num_ctas):
 # IKBO (In-Kernel Broadcast Optimization) Tests
 # =============================================================================
 
+# IKBO is the one tutorial pair that supports both backends explicitly
+# (`ikbo_fa_triton` carries separate `_amd_configs` / `_nvidia_configs` and
+# flips ALLOW_TF32 on `_is_hip`), so it is gated on "a GPU this kernel targets"
+# rather than on gfx950 alone -- a CDNA4-only gate would drop the NVIDIA
+# coverage the module is written for.
+_ikbo_supported = is_hip_cdna4() or is_hopper_or_newer()
+
 
 class IkboLce:
     """Common utilities for IKBO LCE tests."""
@@ -2021,6 +2086,11 @@ class IkboLce:
         (512, 128, 256, 1024, 1024, 70),
         (1024, 433, 256, 1184, 872, 100),
     ]
+
+    # Correctness pins the smallest tile rather than sweeping the 48-config
+    # space (2x2x2 tiles x 3 stages x 2 warp counts, and no early_config_prune)
+    # once per shape. 64x64x64 is valid for every shape: the K loop is masked.
+    CONFIG = {"BM": 64, "BN": 64, "BK": 64, "GROUP_SIZE_M": 8, "num_stages": 3, "num_warps": 4}
 
     ERROR_MULTIPLIER = 1.0
     ERROR_FLOOR = 1e-4
@@ -2043,12 +2113,22 @@ class IkboFa:
         (1024, 64, 2, 128, 1024, 64),
     ]
 
+    # Smallest tile on either backend; num_warps differs because the AMD and
+    # NVIDIA config lists do.
+    CONFIG = {
+        "BLOCK_M": 32,
+        "BLOCK_N": 32,
+        "num_stages": 2,
+        "num_warps": 2 if is_hip() else 4,
+    }
+
 
 @pytest.mark.parametrize(
     "B, M, N, K_USER, K_CAND, ratio",
     IkboLce.SHAPES,
     ids=[f"B{s[0]}_M{s[1]}" for s in IkboLce.SHAPES],
 )
+@pytest.mark.skipif(not _ikbo_supported, reason="Requires gfx950 (CDNA4) or Hopper+ GPU")
 def test_ikbo_lce(B, M, N, K_USER, K_CAND, ratio):
     torch.manual_seed(0)
     cw_c, cw_u, e_c, e_u, idx = _ikbo_lce_create_inputs(
@@ -2068,7 +2148,7 @@ def test_ikbo_lce(B, M, N, K_USER, K_CAND, ratio):
         idx,
     )
     ref_fp16 = _ikbo_lce_reference(cw_c, cw_u, e_c, e_u, idx)
-    out = _ikbo_lce(cw_c, cw_u, e_c, e_u, idx)
+    out = _ikbo_lce(cw_c, cw_u, e_c, e_u, idx, config=IkboLce.CONFIG)
     IkboLce.check_vs_fp32(out, ref_fp16, ref_fp32)
 
 
@@ -2077,6 +2157,7 @@ def test_ikbo_lce(B, M, N, K_USER, K_CAND, ratio):
     IkboFa.SHAPES,
     ids=[f"B{s[0]}_h{s[2]}_d{s[3]}" for s in IkboFa.SHAPES],
 )
+@pytest.mark.skipif(not _ikbo_supported, reason="Requires gfx950 (CDNA4) or Hopper+ GPU")
 def test_ikbo_fa(B, n_seed, num_heads, d_head, max_seq_len, ratio):
     random.seed(0)
     torch.manual_seed(0)
@@ -2109,5 +2190,6 @@ def test_ikbo_fa(B, n_seed, num_heads, d_head, max_seq_len, ratio):
         num_heads,
         d_head,
         max_seq_len,
+        config=IkboFa.CONFIG,
     )
     torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)


### PR DESCRIPTION
TLX tutorial kernel can be run in two ways:
- correctness test: covered by CI. no autotuning. sanity check for accuracy.
- performance test: no OSS CI. autotuning. for perf measurement.

Some gfx950 tutorial kernels enable autotuning and make the CI extremely slow, eating up OSS CI capacity heavily. This PR prunes the autotuning configs in CI runs following the patterns of TLX Blackwell.

## Test plan

`pytest third_party/tlx/tutorials/testing/test_correctness.py`