### PR TITLE
[triton][TLX] Re-infer transpose layouts after helper ABI specialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,28 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
         ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
     ```
 
+- `tlx.warp_all(pred)` / `tlx.warp_any(pred)` **[Hopper+, MI300+]**
+
+    Reduce one distributed predicate per physical lane to a warp-uniform
+    scalar `i1`. Non-boolean inputs are compared with zero first. `warp_all`
+    is true only if every lane contributes true; `warp_any` is true if at
+    least one lane contributes true.
+
+    These are physical-lane votes, not logical tensor-axis reductions.
+    `tl.all` and `tl.max` reduce a tensor dimension and retain tensor layout
+    semantics, whereas these operations produce a scalar suitable for a
+    uniform branch. The predicate must distribute exactly one element per
+    lane; compilation fails if its resolved layout gives a lane zero or
+    multiple elements.
+
+    ```python
+    all_safe = tlx.warp_all(per_lane_safe)
+    any_active = tlx.warp_any(per_lane_active)
+    ```
+
+    Prefer these semantic reductions when code only needs an all/any result.
+    They do not expose a hardware ballot bit mask.
+
 - `tlx.prefetch(pointer, level="L2", mask=None, tensormap=False)` **[Hopper+]** issues a non-blocking prefetch hint for pointer-based scattered/gather loads. This complements `tlx.async_descriptor_prefetch_tensor` (which works on TMA tensor descriptors) by supporting raw pointer tensors.
   Additionally, if `tensormap` is specified to `True`, the API instead does a prefetch of tensor map object (TMA descriptor) and ignores other parameters other than `pointer`.
 
@@ -1110,7 +1132,6 @@ TLX uses **CUDA-native cluster semantics** which differs from Triton's approach:
     consumer, for example when a dot-operand layout feeds a reduction. This is
     not a conversion request; use another `require_layout` when the replacement
     layout is part of the algorithm.
-
 - `tlx.assert_same_layout(lhs, rhs)` **[Hopper+, MI300+]**
 
     Compile-time assertion that two layouts are equivalent after layout

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -908,4 +908,22 @@ def TTG_WarpIdOp : TTG_Op<"warp_id", [Pure]> {
   let assemblyFormat = "attr-dict";
 }
 
+def TTG_WarpVoteOp : TTG_Op<"warp_vote", [Pure]> {
+  let summary = "Reduce one predicate per lane to a warp-uniform boolean";
+
+  let description = [{
+    Each lane contributes its single distributed `i1` value. The uniform i1
+    result is the logical `all` or `any` reduction across the physical warp,
+    selected by `kind`.
+
+    The predicate tensor must distribute exactly one element to each lane.
+  }];
+
+  let arguments = (ins TT_BoolTensor:$pred, StrAttr:$kind);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = "$pred $kind attr-dict `:` type($pred) `->` type($result)";
+  let hasVerifier = 1;
+}
+
 #endif // TRITONGPU_OPS

--- a/lib/Conversion/TritonGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/SPMDOpToLLVM.cpp
@@ -27,6 +27,39 @@ private:
   const TargetInfoBase &targetInfo;
 };
 
+struct WarpVoteOpConversion
+    : public ConvertOpToLLVMPattern<triton::gpu::WarpVoteOp> {
+  explicit WarpVoteOpConversion(LLVMTypeConverter &typeConverter,
+                                const TargetInfoBase &targetInfo,
+                                PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern<triton::gpu::WarpVoteOp>(typeConverter, benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::gpu::WarpVoteOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto predicates =
+        unpackLLElements(op.getLoc(), adaptor.getPred(), rewriter);
+    if (predicates.size() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "warp_vote predicate must have one element per lane");
+
+    int warpSize = triton::gpu::lookupThreadsPerWarp(rewriter);
+    Type hardwareMaskType = rewriter.getIntegerType(warpSize);
+    Value mask = targetInfo.ballot(rewriter, op.getLoc(), hardwareMaskType,
+                                   predicates.front());
+    TritonLLVMOpBuilder b(op.getLoc(), rewriter);
+    Value expected = b.int_val(warpSize, op.getKind() == "all" ? -1 : 0);
+    Value result = op.getKind() == "all" ? b.icmp_eq(mask, expected)
+                                         : b.icmp_ne(mask, expected);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  const TargetInfoBase &targetInfo;
+};
+
 } // namespace
 
 void mlir::triton::populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
@@ -34,4 +67,5 @@ void mlir::triton::populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                                const TargetInfoBase &targetInfo,
                                                PatternBenefit benefit) {
   patterns.add<GetProgramIdOpConversion>(typeConverter, targetInfo, benefit);
+  patterns.add<WarpVoteOpConversion>(typeConverter, targetInfo, benefit);
 }

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -117,7 +117,8 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
       triton::nvidia_gpu::WarpGroupDotWaitOp,
       triton::nvidia_gpu::VoteBallotSyncOp, triton::tlx::RequireLayoutOp,
       triton::tlx::ReleaseLayoutOp, triton::tlx::LocalAliasOp,
-      triton::tlx::DumpLayoutOp, triton::amdgpu::BufferLoadOp,
+      triton::tlx::DumpLayoutOp, triton::gpu::WarpVoteOp,
+      triton::amdgpu::BufferLoadOp,
       triton::amdgpu::BufferStoreOp, triton::amdgpu::BufferLoadToLocalOp,
       triton::amdgpu::RematerializedRangeOp, triton::amdgpu::RegisterHandoffOp>(
       [&](Operation *op) -> bool {

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -648,6 +648,8 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
 void populateTLXPatterns(TritonGPUTypeConverter &typeConverter,
                             RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
+  patterns.add<GenericOpPattern<triton::gpu::WarpVoteOp>>(typeConverter,
+                                                          context);
   patterns.add<GenericOpPattern<triton::tlx::RequireLayoutOp>>(typeConverter, context);
   patterns.add<GenericOpPattern<triton::tlx::ReleaseLayoutOp>>(typeConverter,
                                                            context);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -247,8 +247,11 @@ DotOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
   auto aEnc = cast<RankedTensorType>(operands[0].getType()).getEncoding();
   auto bEnc = cast<RankedTensorType>(operands[1].getType()).getEncoding();
   auto retEnc = accTy.getEncoding();
-  if (aEnc) {
-    assert(bEnc && retEnc);
+  if (encodingContainsTlxNoVerifyLayout(aEnc) ||
+      encodingContainsTlxNoVerifyLayout(bEnc) ||
+      encodingContainsTlxNoVerifyLayout(retEnc))
+    return success();
+  if (aEnc && bEnc && retEnc) {
     Dialect &dialect = retEnc.getDialect();
     auto interface = cast<DialectInferLayoutInterface>(&dialect);
     if (interface->inferDotOpEncoding(aEnc, 0, retEnc, location).failed())
@@ -268,13 +271,22 @@ LogicalResult DotOp::verify() {
         "element types of operands A and B must have same bit width");
   auto aEncoding = aTy.getEncoding();
   auto bEncoding = bTy.getEncoding();
+  auto accTy = getC().getType();
+  auto retEnc = accTy.getEncoding();
+  // A no_verify layout marks a frontend graph whose layout constraints are
+  // intentionally incomplete until TLX placeholder resolution. Helper ABI
+  // reconciliation can therefore expose a pinned operand/result beside an
+  // unencoded peer. Defer the whole compatibility check; the wrapper is
+  // removed before final layout verification.
+  if (encodingContainsTlxNoVerifyLayout(aEncoding) ||
+      encodingContainsTlxNoVerifyLayout(bEncoding) ||
+      encodingContainsTlxNoVerifyLayout(retEnc))
+    return success();
   if (!aEncoding && !bEncoding)
     return success();
   // Verify that the encodings are valid.
   if (!aEncoding || !bEncoding)
     return emitError("mismatching encoding between A and B operands");
-  auto accTy = getC().getType();
-  auto retEnc = accTy.getEncoding();
   if (!retEnc)
     return emitError("miss encoding of C operand");
   Dialect &dialect = retEnc.getDialect();

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1710,6 +1710,23 @@ unsigned WarpSpecializeOp::getTotalPartitionWarps() {
 }
 
 //===----------------------------------------------------------------------===//
+// WarpVoteOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult WarpVoteOp::verify() {
+  if (getKind() != "all" && getKind() != "any")
+    return emitOpError("kind must be \"all\" or \"any\"");
+  // Frontend TTIR is intentionally unencoded. TritonGPU conversion preserves
+  // this op while assigning its predicate a concrete distributed encoding, at
+  // which point the verifier can enforce physical per-lane cardinality.
+  auto predType = getPred().getType();
+  if (predType.getEncoding() && getTotalElemsPerThread(predType) != 1)
+    return emitOpError(
+        "predicate must distribute exactly one element per lane");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BarrierOp
 //===----------------------------------------------------------------------===//
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -400,6 +400,84 @@ def test_d64_dispatch_contract_is_ci_discovered(q_shape, k_shape, causal, family
 
 
 @triton.jit
+def _warp_vote_kernel(x_ptr, all_ptr, any_ptr, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    predicate = tl.load(x_ptr + offsets) != 0
+    all_value = tlx.warp_all(predicate).to(tl.int32)
+    any_value = tlx.warp_any(predicate).to(tl.int32)
+    tl.store(all_ptr + offsets, all_value)
+    tl.store(any_ptr + offsets, any_value)
+
+
+def test_amd_warp_votes_lower_without_public_ballot_gfx950():
+    compiled = compile_for_gfx950(
+        _warp_vote_kernel,
+        signature={
+            "x_ptr": "*i32",
+            "all_ptr": "*i32",
+            "any_ptr": "*i32",
+            "BLOCK": "constexpr",
+        },
+        constexprs={"BLOCK": 64},
+    )
+    assert 'ttg.warp_vote' in compiled.asm["ttgir"]
+    assert '"all"' in compiled.asm["ttgir"]
+    assert '"any"' in compiled.asm["ttgir"]
+    assert "warp_ballot" not in compiled.asm["ttgir"]
+    assert "llvm.amdgcn.ballot" in compiled.asm["llir"]
+
+
+@triton.jit
+def _warp_vote_scalar_predicate_kernel(output):
+    predicate = tl.program_id(0) == 0
+    tl.store(output, tlx.warp_all(predicate).to(tl.int32))
+
+
+def test_amd_warp_vote_rejects_scalar_predicate():
+    with pytest.raises(CompilationError, match="warp_all expects a distributed tensor predicate"):
+        compile_for_gfx950(
+            _warp_vote_scalar_predicate_kernel,
+            signature={"output": "*i32"},
+            constexprs={},
+        )
+
+
+def test_amd_warp_vote_rejects_multiple_elements_per_lane_gfx950():
+    with pytest.raises(RuntimeError, match="predicate must distribute exactly one element per lane"):
+        compile_for_gfx950(
+            _warp_vote_kernel,
+            signature={
+                "x_ptr": "*i32",
+                "all_ptr": "*i32",
+                "any_ptr": "*i32",
+                "BLOCK": "constexpr",
+            },
+            constexprs={"BLOCK": 512},
+        )
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_amd_warp_votes_correct_gfx950():
+    values = torch.ones(64, device="cuda", dtype=torch.int32)
+    all_output = torch.empty_like(values)
+    any_output = torch.empty_like(values)
+
+    _warp_vote_kernel[(1, )](values, all_output, any_output, BLOCK=64, num_warps=1)
+    torch.testing.assert_close(all_output, torch.ones_like(values))
+    torch.testing.assert_close(any_output, torch.ones_like(values))
+
+    values[17] = 0
+    _warp_vote_kernel[(1, )](values, all_output, any_output, BLOCK=64, num_warps=1)
+    torch.testing.assert_close(all_output, torch.zeros_like(values))
+    torch.testing.assert_close(any_output, torch.ones_like(values))
+
+    values.zero_()
+    _warp_vote_kernel[(1, )](values, all_output, any_output, BLOCK=64, num_warps=1)
+    torch.testing.assert_close(all_output, torch.zeros_like(values))
+    torch.testing.assert_close(any_output, torch.zeros_like(values))
+
+
+@triton.jit
 def _shared_concrete_helper(values):
     return values
 

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -1252,3 +1252,100 @@ def test_pinned_loop_carried_dot_operand_amd():
     assert "#ttg.amd_mfma" in ttgir
     _assert_no_layout_residue(ttgir)
     assert compiled.asm.get("amdgcn")
+
+
+@triton.jit
+def _fa_pin_helper_result(value, layout: tl.constexpr):
+    # The pin originates inside the helper, so its return operand is the only
+    # authoritative layout witness for the helper result ABI.
+    return tlx.require_layout(value, layout)
+
+
+@triton.jit
+def _fa_workitems_to_mfma_rows(workitems):
+    rows, _ = workitems.reshape([8, 2, 32]).permute(0, 2, 1).split()
+    return rows.reshape([256])
+
+
+@triton.jit
+def _fa_mfma_rows_to_workitems(rows):
+    per_warp_rows = rows.reshape([8, 32])
+    return tl.broadcast_to(per_warp_rows[:, None, :], (8, 2, 32)).reshape([512])
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_cute_layout_with_standard_casts_on_cdna4():
+    physical = tlx.layout(
+        shape=((64, ), ()),
+        stride=((1, ), ()),
+    )
+
+    @triton.jit
+    def kernel(X, Y, Bits, PHYSICAL: tl.constexpr):
+        offsets = tl.arange(0, 64)
+        values = tl.load(X + offsets)
+        pinned = tlx.require_layout(values, PHYSICAL)
+        narrowed = pinned.to(tl.bfloat16)
+        widened = narrowed.to(tl.float32)
+        bits = pinned.to(tl.int32, bitcast=True)
+        tl.store(Y + offsets, widened)
+        tl.store(Bits + offsets, bits)
+
+    x = torch.linspace(-3.0, 3.0, 64, device=DEVICE, dtype=torch.float32)
+    y = torch.empty_like(x)
+    bits = torch.empty(64, device=DEVICE, dtype=torch.int32)
+    compiled = kernel.warmup(x, y, bits, physical, grid=(1, ), num_warps=1)
+    kernel[(1, )](x, y, bits, physical, num_warps=1)
+
+    torch.testing.assert_close(y, x.to(torch.bfloat16).float(), atol=0, rtol=0)
+    torch.testing.assert_close(bits, x.view(torch.int32), atol=0, rtol=0)
+    assert "#ttg.linear" in compiled.asm["ttir"]
+    assert "#tlx.no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_internally_pinned_helper_result_specializes_abi_on_cdna4():
+    layout = tlx.amd_mfma_layout(4, [32, 32, 16], True, [8, 1])
+
+    @triton.jit
+    def kernel(Y, LAYOUT: tl.constexpr):
+        row = tl.arange(0, 256)
+        col = tl.arange(0, 32)
+        value = tl.full((256, 32), 3.0, tl.float32)
+        pinned = _fa_pin_helper_result(value, LAYOUT)
+        tl.store(Y + row[:, None] * 32 + col[None, :], pinned)
+
+    y = torch.empty((256 * 32, ), device=DEVICE, dtype=torch.float32)
+    compiled = kernel.warmup(y, layout, grid=(1, ), num_warps=8)
+    kernel[(1, )](y, layout, num_warps=8)
+    torch.testing.assert_close(y, torch.full_like(y, 3.0), atol=0, rtol=0)
+    assert "#tlx.no_verify_layout" not in compiled.asm["ttgir"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")
+def test_concrete_mfma_layout_reconciles_elementwise_broadcast_on_cdna4():
+    mma = tlx.amd_mfma_layout(4, [32, 32, 16], True, [8, 1])
+    store = tlx.layout(
+        shape=((64, 8), (16, )),
+        stride=((16, 1024), (1, )),
+    )
+
+    @triton.jit
+    def kernel(Y, MMA: tl.constexpr, STORE: tl.constexpr):
+        acc = tlx.require_layout(tl.full((256, 32), 2.0, tl.float32), MMA)
+        source_rows = tl.arange(0, 256).to(tl.float32) + 1.0
+        workitems = _fa_mfma_rows_to_workitems(source_rows)
+        rows = _fa_workitems_to_mfma_rows(workitems)
+        out = (acc * rows[:, None]).to(tl.bfloat16)
+        out = tlx.require_layout(out, STORE)
+        row = tl.arange(0, 256)
+        col = tl.arange(0, 32)
+        tl.store(Y + row[:, None] * 32 + col[None, :], out)
+
+    y = torch.full((256 * 32, ), float("nan"), device=DEVICE, dtype=torch.bfloat16)
+    compiled = kernel.warmup(y, mma, store, grid=(1, ), num_warps=8)
+    kernel[(1, )](y, mma, store, num_warps=8)
+    expected = (2 * torch.arange(1, 257, device=DEVICE, dtype=torch.float32)).to(torch.bfloat16)
+    expected = expected[:, None].broadcast_to((256, 32)).flatten()
+    torch.testing.assert_close(y, expected, atol=0, rtol=0)
+    assert "#tlx.no_verify_layout" not in compiled.asm["ttgir"]

--- a/test/TLX/concrete-helper-abi-reinference.mlir
+++ b/test/TLX/concrete-helper-abi-reinference.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --verify-each=false %s -pass-pipeline='builtin.module(triton-tlx-fixup{num-warps=4 target=cuda:100 num-ctas=1 threads-per-warp=32})' | FileCheck %s
+
+// The Python frontend constructs helper bodies with encoding-free tensor types.
+// A concrete call operand specializes the helper ABI during TLX fixup, so the
+// existing reshape and transpose results must be re-inferred before verification.
+
+// CHECK-DAG: #[[$SRC:.*]] = #ttg.linear<{{.*}}>
+// CHECK-LABEL: tt.func private @restructure(
+// CHECK-SAME: %[[ARG:.*]]: tensor<4x256xi8, #tlx.no_verify_layout<#[[$SRC]]>>)
+// CHECK: %[[RESHAPE:.*]] = tt.reshape %[[ARG]]
+// CHECK-SAME: -> tensor<4x4x16x2x2xi8, #tlx.no_verify_layout<#[[$RESHAPED:.*]]>>
+// CHECK: %[[TRANSPOSE:.*]] = tt.trans %[[RESHAPE]]
+// CHECK-SAME: -> tensor<4x2x16x2x4xi8, #tlx.no_verify_layout<#[[$TRANSPOSED:.*]]>>
+// CHECK: tt.return %[[TRANSPOSE]] : tensor<4x2x16x2x4xi8, #tlx.no_verify_layout<#[[$TRANSPOSED]]>>
+// CHECK-LABEL: tt.func public @kernel
+// CHECK: %[[PINNED:.*]] = tlx.require_layout
+// CHECK: %[[RESULT:.*]] = tt.call @restructure(%[[PINNED]])
+// CHECK-SAME: -> tensor<4x2x16x2x4xi8, #tlx.no_verify_layout<#[[$TRANSPOSED]]>>
+
+#physical = #ttg.linear<{
+  register = [[0, 1], [0, 2], [0, 4]],
+  lane = [[0, 8], [0, 16], [0, 32], [0, 64], [0, 128]],
+  warp = [[1, 0], [2, 0]],
+  block = []
+}>
+#pin = #tlx.no_verify_layout<#physical>
+
+"builtin.module"() ({
+  "tt.func"() <{
+    function_type = (tensor<4x256xi8, #pin>) -> tensor<4x2x16x2x4xi8>,
+    sym_name = "restructure",
+    sym_visibility = "private"
+  }> ({
+  ^bb0(%arg0: tensor<4x256xi8, #pin>):
+    %0 = "tt.reshape"(%arg0) <{allow_reorder}> :
+      (tensor<4x256xi8, #pin>) -> tensor<4x4x16x2x2xi8>
+    %1 = "tt.trans"(%0) <{order = array<i32: 0, 4, 2, 3, 1>}> :
+      (tensor<4x4x16x2x2xi8>) -> tensor<4x2x16x2x4xi8>
+    "tt.return"(%1) : (tensor<4x2x16x2x4xi8>) -> ()
+  }) : () -> ()
+  "tt.func"() <{
+    function_type = (tensor<4x256xi8>) -> (),
+    sym_name = "kernel",
+    sym_visibility = "public"
+  }> ({
+  ^bb0(%arg0: tensor<4x256xi8>):
+    %0 = "tlx.require_layout"(%arg0) :
+      (tensor<4x256xi8>) -> tensor<4x256xi8, #pin>
+    %1 = "tt.call"(%0) <{callee = @restructure}> :
+      (tensor<4x256xi8, #pin>) -> tensor<4x2x16x2x4xi8>
+    "tt.return"() : () -> ()
+  }) : () -> ()
+}) {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} : () -> ()

--- a/test/TLX/ops.mlir
+++ b/test/TLX/ops.mlir
@@ -1,5 +1,5 @@
 
-// RUN: triton-opt %s | FileCheck %s
+// RUN: triton-opt -split-input-file --verify-diagnostics %s | FileCheck %s
 
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
@@ -10,5 +10,41 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     // CHECK: tlx.require_layout
     %0 = tlx.require_layout %arg0 : !ttg.memdesc<128x64xf16, #shared1, #smem> -> !ttg.memdesc<128x64xf16, #shared2, #smem>
     tt.return
+  }
+}
+
+// -----
+
+#one_per_lane = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16], [32]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @warp_votes
+  tt.func @warp_votes(%pred: tensor<64xi1, #one_per_lane>) -> (i1, i1) {
+    // CHECK: %[[ALL:.*]] = ttg.warp_vote %{{.*}} "all"
+    %all = ttg.warp_vote %pred "all" : tensor<64xi1, #one_per_lane> -> i1
+    // CHECK: %[[ANY:.*]] = ttg.warp_vote %{{.*}} "any"
+    %any = ttg.warp_vote %pred "any" : tensor<64xi1, #one_per_lane> -> i1
+    tt.return %all, %any : i1, i1
+  }
+}
+
+// -----
+
+#one_per_lane = #ttg.linear<{register = [], lane = [[1], [2], [4], [8], [16], [32]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_vote_rejects_unknown_kind(%pred: tensor<64xi1, #one_per_lane>) -> i1 {
+    // expected-error @+1 {{'ttg.warp_vote' op kind must be "all" or "any"}}
+    %vote = ttg.warp_vote %pred "some" : tensor<64xi1, #one_per_lane> -> i1
+    tt.return %vote : i1
+  }
+}
+
+// -----
+
+#two_per_lane = #ttg.linear<{register = [[64]], lane = [[1], [2], [4], [8], [16], [32]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @warp_vote_rejects_multiple_elements(%pred: tensor<128xi1, #two_per_lane>) -> i1 {
+    // expected-error @+1 {{'ttg.warp_vote' op predicate must distribute exactly one element per lane}}
+    %vote = ttg.warp_vote %pred "all" : tensor<128xi1, #two_per_lane> -> i1
+    tt.return %vote : i1
   }
 }

--- a/test/TLX/placeholder-verifier-defer.mlir
+++ b/test/TLX/placeholder-verifier-defer.mlir
@@ -27,6 +27,26 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
 
 // -----
 
+#mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [8, 1], instrShape = [32, 32, 16], isTransposed = true}>
+#result = #tlx.no_verify_layout<#tlx.user_layout<#mma>>
+#operand_a = #tlx.no_verify_layout<#tlx.user_layout<#ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>>
+module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32, "ttg.num-ctas" = 1 : i32} {
+  // Helper ABI reconciliation can temporarily expose a pinned operand and
+  // accumulator beside an unresolved operand. The no_verify result defers dot
+  // compatibility until placeholder resolution gives all three concrete types.
+  // CHECK-LABEL: @dot_placeholder_with_unresolved_operand
+  tt.func @dot_placeholder_with_unresolved_operand(
+      %a: tensor<256x64xbf16, #operand_a>,
+      %b: tensor<64x64xbf16>,
+      %c: tensor<256x64xf32, #result>) -> tensor<256x64xf32, #result> {
+    // CHECK: tt.dot
+    %dot = tt.dot %a, %b, %c : tensor<256x64xbf16, #operand_a> * tensor<64x64xbf16> -> tensor<256x64xf32, #result>
+    tt.return %dot : tensor<256x64xf32, #result>
+  }
+}
+
+// -----
+
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
 #ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -63,20 +83,19 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32,
 #linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
 #ph = #tlx.no_verify_layout<#tlx.user_layout<#linear>>
 #slice = #ttg.slice<{dim = 1, parent = #ph}>
-#deferred_slice = #tlx.no_verify_layout<#slice>
 module {
-  // The nested placeholder keeps canonical slice-parent inference stable. The
-  // outer placeholder defers verification of the complete slice while frontend
-  // IR has no ttg.num-warps context and keeps later inference in the TLX dialect.
+  // The nested placeholder keeps canonical slice-parent inference stable and
+  // recursively defers verification while frontend IR has no ttg.num-warps
+  // context.
   // CHECK-LABEL: @nested_placeholder_slice
-  tt.func @nested_placeholder_slice(%x: tensor<128x128xf32, #ph>) -> tensor<128xf32, #deferred_slice> {
+  tt.func @nested_placeholder_slice(%x: tensor<128x128xf32, #ph>) -> tensor<128xf32, #slice> {
     // CHECK: "tt.reduce"
     %m = "tt.reduce"(%x) <{axis = 1 : i32}> ({
     ^bb0(%lhs: f32, %rhs: f32):
       %max = arith.maxnumf %lhs, %rhs : f32
       tt.reduce.return %max : f32
-    }) : (tensor<128x128xf32, #ph>) -> tensor<128xf32, #deferred_slice>
-    tt.return %m : tensor<128xf32, #deferred_slice>
+    }) : (tensor<128x128xf32, #ph>) -> tensor<128xf32, #slice>
+    tt.return %m : tensor<128xf32, #slice>
   }
 }
 

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -136,10 +136,11 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
           wrapNoVerifyLayout(slice.getParent()));
       auto deferredSlice = triton::gpu::SliceEncodingAttr::get(
           result.getContext(), slice.getDim(), parent);
-      // Keep the slice parent deferred for canonical slice inference, and also
-      // defer verification of the whole result while frontend TTIR has no
-      // ttg.num-warps context yet.
-      resultEncoding = wrapNoVerifyLayout(deferredSlice);
+      // Keep the slice parent deferred. The recursive placeholder query
+      // already defers verification of the result, while leaving the slice at
+      // the top level preserves the encoding shape inferred when the op was
+      // built and avoids no_verify<slice<no_verify<...>>> on re-inference.
+      resultEncoding = deferredSlice;
     } else {
       resultEncoding = wrapNoVerifyLayout(result);
     }
@@ -241,6 +242,23 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
   LogicalResult
   verifyDotOpEncodingCompatibility(Operation *op, Attribute operandEncodingA,
                                    Attribute operandEncodingB) const override {
+    Attribute resultEncoding;
+    if (op->getNumResults() == 1)
+      if (auto resultType =
+              dyn_cast<RankedTensorType>(op->getResult(0).getType()))
+        resultEncoding = resultType.getEncoding();
+
+    // no_verify denotes an intentionally incomplete frontend layout graph.
+    // In particular, helper boundaries may temporarily leave one dot operand
+    // unencoded while the accumulator/result already carries its pinned MFMA
+    // placeholder. The resolve pass removes every no_verify wrapper before
+    // final layout verification, so validating the partially resolved graph
+    // here rejects states that are both legal and required by that pipeline.
+    if (hasNoVerifyLayout(operandEncodingA) ||
+        hasNoVerifyLayout(operandEncodingB) ||
+        hasNoVerifyLayout(resultEncoding))
+      return success();
+
     // Peel TLX layout wrappers and delegate to the concrete result dialect's
     // verifier, so a pinned dot operand (e.g. no_verify<user<dot_op>>) is
     // actually checked as its concrete dot_op -- mirroring inferDotOpEncoding
@@ -249,10 +267,7 @@ struct TLXInferLayoutInterface : public triton::DialectInferLayoutInterface {
     // lands here, we unwrap, and hand ttg the raw encodings it expects.
     Attribute a = unwrapTlxLayoutWrappers(operandEncodingA);
     Attribute b = unwrapTlxLayoutWrappers(operandEncodingB);
-    Attribute ret;
-    if (op->getNumResults() == 1)
-      if (auto rt = dyn_cast<RankedTensorType>(op->getResult(0).getType()))
-        ret = unwrapTlxLayoutWrappers(rt.getEncoding());
+    Attribute ret = unwrapTlxLayoutWrappers(resultEncoding);
     const triton::DialectInferLayoutInterface *delegate =
         ret ? getInferLayoutInterfaceFor(ret) : nullptr;
     // No concrete result dialect yet (still fully wrapped) -> defer, matching

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -844,23 +844,35 @@ static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
       // A result-side user pin on transpose must be reflected through the
       // inverse permutation before normal forward type inference runs.
       if (auto trans = dyn_cast<::mlir::triton::TransOp>(op)) {
+        auto srcTy = trans.getSrc().getType();
         auto resultType = cast<RankedTensorType>(trans.getType());
+        Attribute srcEnc = srcTy.getEncoding();
         Attribute resultEnc = resultType.getEncoding();
         if (isPlaceholderEncoding(resultEnc)) {
           auto inverseOrder = invertPermutation(trans.getOrder());
-          Attribute srcEnc;
+          Attribute inferredSrcEnc;
           auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
               &resultEnc.getDialect());
           if (succeeded(layout->inferTransOpEncoding(
-                  resultEnc, resultType.getShape(), inverseOrder, srcEnc,
-                  trans.getLoc()))) {
-            changed |= retypeWithEncoding(trans.getSrc(), srcEnc);
+                  resultEnc, resultType.getShape(), inverseOrder,
+                  inferredSrcEnc, trans.getLoc()))) {
+            changed |= retypeWithEncoding(trans.getSrc(), inferredSrcEnc);
             return;
           }
         }
+        if (srcEnc && (!resultEnc || isPlaceholderEncoding(resultEnc))) {
+          auto *layout = cast<::mlir::triton::DialectInferLayoutInterface>(
+              &srcEnc.getDialect());
+          if (succeeded(layout->inferTransOpEncoding(
+                  srcEnc, srcTy.getShape(), trans.getOrder(), resultEnc,
+                  trans.getLoc())))
+            changed |= retypeWithEncoding(trans.getResult(), resultEnc);
+          return;
+        }
       }
+
       // Re-infer any op whose operands acquired a placeholder after frontend
-      // construction. This covers trans/split/reduce/expand-dims and future ops
+      // construction. This covers split/reduce/expand-dims and future ops
       // implementing InferTypeOpInterface.
       Attribute operandEnc;
       for (Value operand : op->getOperands())

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -16,6 +16,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/LogicalResult.h"
 
 namespace ttg = mlir::triton::gpu;
@@ -503,12 +504,47 @@ static SmallVector<Value> collectForwardedValues(Value root) {
   return visited;
 }
 
-static bool flowsToValue(Value root, Value target) {
-  return llvm::is_contained(collectForwardedValues(root), target);
+static bool flowsPreservingEncodingToValue(Value root, Value target) {
+  SmallVector<Value> worklist{root};
+  SmallVector<Value> visited;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (llvm::is_contained(visited, value))
+      continue;
+    visited.push_back(value);
+    if (value == target)
+      return true;
+
+    for (OpOperand &use : value.getUses()) {
+      Operation *user = use.getOwner();
+      if (isa<scf::YieldOp, scf::ForOp>(user)) {
+        appendForwardedValues(use, worklist);
+        continue;
+      }
+      if (!isEncodingUniformArithOp(user) &&
+          !hasSameOperandsAndResultEncodingTrait(user))
+        continue;
+      for (Value result : user->getResults())
+        if (isa<RankedTensorType>(result.getType()))
+          worklist.push_back(result);
+    }
+  }
+  return false;
 }
 
-static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
+static LogicalResult reconcileVerifierLayouts(ModuleOp mod) {
   bool conflict = false;
+  // Concrete tlx.require_layout results are explicit local ownership anchors.
+  // Track only those anchors and the encoding-uniform results derived from
+  // them: an arbitrary concrete tensor type selected elsewhere in TTIR is not
+  // authority to retag its producer graph.
+  llvm::DenseSet<Value> concreteLayoutAnchors;
+  mod.walk([&](RequireLayoutOp op) {
+    auto type = dyn_cast<RankedTensorType>(op.getType());
+    if (type && type.getEncoding() &&
+        !isPlaceholderEncoding(type.getEncoding()))
+      concreteLayoutAnchors.insert(op.getResult());
+  });
   // Find a placeholder encoding among a set of linked values (values an op
   // requires to share one encoding). If two of them carry *different* pinned
   // placeholders, that is a user error (two conflicting tlx.local_load(layout=)
@@ -528,6 +564,28 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
           if (!enc)
             enc = t.getEncoding();
         }
+    return enc;
+  };
+
+  // Find the concrete layout required by an explicitly anchored value in an
+  // encoding-uniform operation. Two distinct anchors are an ambiguous source
+  // contract: neither one may silently override the other.
+  auto findConcreteAnchor = [&](ArrayRef<Value> vs,
+                                Operation *op) -> Attribute {
+    Attribute enc;
+    for (Value v : vs) {
+      if (!concreteLayoutAnchors.contains(v))
+        continue;
+      auto type = cast<RankedTensorType>(v.getType());
+      Attribute candidate = type.getEncoding();
+      if (enc && enc != candidate) {
+        op->emitError("conflicting explicit layouts meet on this operation; "
+                      "insert tlx.release_layout before combining them");
+        conflict = true;
+        return {};
+      }
+      enc = candidate;
+    }
     return enc;
   };
 
@@ -562,10 +620,106 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
   while (changed) {
     changed = false;
     if (++iter > kMaxIter) {
-      mod.emitError(
-          "TLX placeholder layout propagation exceeded iteration limit");
+      mod.emitError("TLX verifier layout reconciliation exceeded iteration "
+                    "limit");
       return failure();
     }
+
+    // A helper can establish a pin internally and return it without receiving
+    // any pinned argument. The frontend still gives that helper and its call
+    // sites encoding-free result types. Synchronize those result ABIs from
+    // the return operands before walking calls, including flattened aggregate
+    // results and unreachable poison returns. Input-driven call
+    // specialization below cannot discover this case because there is no
+    // placeholder on the call operands.
+    SmallVector<::mlir::triton::FuncOp> funcs;
+    mod.walk([&](::mlir::triton::FuncOp func) { funcs.push_back(func); });
+    for (auto func : funcs) {
+      SmallVector<::mlir::triton::ReturnOp> returns;
+      func.walk([&](::mlir::triton::ReturnOp ret) { returns.push_back(ret); });
+      if (returns.empty() || func.getFunctionType().getNumResults() == 0)
+        continue;
+
+      SmallVector<Type> resultTypes(func.getFunctionType().getResults().begin(),
+                                    func.getFunctionType().getResults().end());
+      bool signatureChanged = false;
+      for (unsigned i = 0; i < resultTypes.size(); ++i) {
+        SmallVector<Value> candidates;
+        for (auto ret : returns)
+          if (i < ret.getNumOperands())
+            candidates.push_back(ret.getOperand(i));
+        Attribute enc = findPlaceholder(candidates, func);
+        if (!enc)
+          continue;
+
+        auto declared = dyn_cast<RankedTensorType>(resultTypes[i]);
+        if (!declared) {
+          func.emitError() << "pinned helper result " << i
+                           << " is not a ranked tensor";
+          conflict = true;
+          continue;
+        }
+        Type target = RankedTensorType::get(declared.getShape(),
+                                            declared.getElementType(), enc);
+        for (auto ret : returns) {
+          if (i >= ret.getNumOperands())
+            continue;
+          Value operand = ret.getOperand(i);
+          auto type = dyn_cast<RankedTensorType>(operand.getType());
+          if (!type || type.getShape() != declared.getShape() ||
+              type.getElementType() != declared.getElementType()) {
+            ret.emitError() << "pinned helper result " << i
+                            << " has inconsistent tensor payload type";
+            conflict = true;
+            continue;
+          }
+          if (type.getEncoding() && type.getEncoding() != enc) {
+            ret.emitError()
+                << "conflicting layout for pinned helper result " << i;
+            conflict = true;
+            continue;
+          }
+          if (type != target) {
+            OpBuilder b(ret);
+            Value converted =
+                RequireLayoutOp::create(b, ret.getLoc(), target, operand);
+            ret.setOperand(i, converted);
+            changed = true;
+          }
+        }
+        if (resultTypes[i] != target) {
+          resultTypes[i] = target;
+          signatureChanged = true;
+        }
+      }
+      if (signatureChanged) {
+        func.setType(FunctionType::get(func.getContext(),
+                                       func.getFunctionType().getInputs(),
+                                       resultTypes));
+        changed = true;
+      }
+    }
+    if (conflict)
+      return failure();
+
+    // Mirror repaired helper result types onto every call before result users
+    // participate in this fixpoint iteration.
+    mod.walk([&](::mlir::triton::CallOp call) {
+      auto callee =
+          SymbolTable::lookupNearestSymbolFrom<::mlir::triton::FuncOp>(
+              call, call.getCalleeAttr());
+      if (!callee)
+        return;
+      auto results = callee.getFunctionType().getResults();
+      if (results.size() != call.getNumResults())
+        return;
+      for (unsigned i = 0; i < results.size(); ++i)
+        if (call.getResult(i).getType() != results[i]) {
+          call.getResult(i).setType(results[i]);
+          changed = true;
+        }
+    });
+
     // tt.calls whose shared helper callee must be privatized (cloned) before it
     // can be specialized. Collected during the walk and applied afterwards, so
     // we never insert into the module while traversing it.
@@ -577,18 +731,37 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
         SmallVector<Value> linked(op->getOperands());
         linked.append(op->getResults().begin(), op->getResults().end());
         Attribute enc = findPlaceholder(linked, op);
+        if (enc) {
+          for (Value v : op->getResults())
+            changed |= retypeWithEncoding(v, enc);
+          bool isSelect = isa<arith::SelectOp>(op);
+          for (auto en : llvm::enumerate(op->getOperands())) {
+            // arith.select's condition (operand 0) must carry the encoding too,
+            // but its producer may be un-retypeable (e.g. a tt.call mask), so
+            // force a require_layout bridge for it.
+            bool isSelectCond = isSelect && en.index() == 0;
+            bridgeOrRetype(en.value(), enc, op, en.index(), isSelectCond);
+          }
+          return;
+        }
+
+        enc = findConcreteAnchor(linked, op);
         if (!enc)
           return;
+
+        // The operation owns its result types, so carrying the anchor forward
+        // is safe. Operand producers remain untouched: bridge only this use so
+        // helper calls, broadcasts, and other shared values keep their own
+        // contracts and normal layout propagation can later fold a free
+        // conversion or materialize a real one.
         for (Value v : op->getResults())
           changed |= retypeWithEncoding(v, enc);
-        bool isSelect = isa<arith::SelectOp>(op);
-        for (auto en : llvm::enumerate(op->getOperands())) {
-          // arith.select's condition (operand 0) must carry the encoding too,
-          // but its producer may be un-retypeable (e.g. a tt.call mask), so
-          // force a require_layout bridge for it.
-          bool isSelectCond = isSelect && en.index() == 0;
-          bridgeOrRetype(en.value(), enc, op, en.index(), isSelectCond);
-        }
+        for (Value v : op->getResults())
+          if (isa<RankedTensorType>(v.getType()))
+            concreteLayoutAnchors.insert(v);
+        for (auto en : llvm::enumerate(op->getOperands()))
+          bridgeOrRetype(en.value(), enc, op, en.index(),
+                         /*forceBridge=*/true);
         return;
       }
       // Ops declaring a same-encoding trait keep their ranked tensor values in
@@ -836,7 +1009,8 @@ static LogicalResult propagatePlaceholderLayouts(ModuleOp mod) {
               if (!argT || !isPlaceholderEncoding(argT.getEncoding()) ||
                   argT.getShape() != callRt.getShape() ||
                   argIdx >= entry.getNumArguments() ||
-                  !flowsToValue(entry.getArgument(argIdx), retV))
+                  !flowsPreservingEncodingToValue(entry.getArgument(argIdx),
+                                                  retV))
                 continue;
               target = RankedTensorType::get(callRt.getShape(),
                                              callRt.getElementType(),
@@ -1087,15 +1261,17 @@ public:
         setUserPostWsSyncOnMod(mod, /*value=*/true);
     }
 
-    // Make placeholder (no_verify) layouts pinned by tlx.local_load(layout=...)
-    // consistent across arith/math elementwise, select and scf region-carried
-    // values, so make_ttir's verifier (arith verifiers don't honor no_verify)
-    // accepts the module. Runs after the ttg.num-warps metadata above is set,
-    // since validating the pinned #linear layout needs it. Concrete layouts are
-    // resolved later in make_ttgir.
+    // First specialize helper ABIs carrying concrete distributed values, then
+    // reconcile explicit layouts across verifier-uniform operations so
+    // make_ttir's verifier accepts the module. Placeholder (no_verify) layouts
+    // pinned by tlx.local_load(layout=...) propagate through linked producer
+    // graphs; concrete require_layout anchors constrain only their local
+    // arithmetic chain and bridge mismatched inputs at the consuming use. Runs
+    // after the ttg.num-warps metadata above is set, since validating a pinned
+    // #linear layout needs it. Concrete conversions resolve in make_ttgir.
     if (failed(synchronizeConcreteHelperABI(mod)))
       return signalPassFailure();
-    if (failed(propagatePlaceholderLayouts(mod)))
+    if (failed(reconcileVerifierLayouts(mod)))
       return signalPassFailure();
   }
 };

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -817,6 +817,12 @@ void init_triton_tlx_ir(py::module_ &m) {
            [](TritonOpBuilder &self, int32_t mask) {
              self.create<ROCDL::SchedBarrier>(mask);
            })
+      .def("create_warp_vote",
+           [](TritonOpBuilder &self, Value pred,
+              const std::string &kind) -> mlir::Value {
+             return self.create<ttg::WarpVoteOp>(
+                 pred, self.getBuilder().getStringAttr(kind));
+           })
       .def("create_barrier_expect",
            [](TritonOpBuilder &self, Value mbarrerLoc, int expectBytes,
               Value pred) -> void {

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -126,7 +126,7 @@ from .utility import (
     thread_id,
 )
 from .mxfp8_utils import _to_mxfp8_block
-from .warp_ops import vote_ballot_sync, warp_redux
+from .warp_ops import vote_ballot_sync, warp_all, warp_any, warp_redux
 from .warp_pipeline import warp_pipeline_stage
 
 __all__ = [
@@ -254,6 +254,8 @@ __all__ = [
     # MXFP8
     "_to_mxfp8_block",
     # warp_ops
+    "warp_all",
+    "warp_any",
     "vote_ballot_sync",
     # warp_pipeline
     "warp_pipeline_stage",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -225,7 +225,10 @@ def require_layout(
     assert isinstance(pin, bool), f"pin must be a constexpr bool, got {type(pin).__name__}"
     assert isinstance(late_address_compute, bool), ("late_address_compute must be a constexpr bool, got "
                                                     f"{type(late_address_compute).__name__}")
-    enc = layout.to_ir(_semantic.builder, x.shape, x.dtype)
+    if isinstance(layout, tlx.layout):
+        enc = layout.to_ir(_semantic.builder, x.shape, x.dtype)
+    else:
+        enc = layout.to_ir(_semantic.builder)
     handle = _semantic.builder.create_require_layout(
         x.handle,
         enc,
@@ -237,11 +240,7 @@ def require_layout(
 
 @tl.builtin
 def release_layout(x, _semantic=None):
-    """Release a register tensor's explicit layout for a flexible consumer.
-
-    This is the inverse boundary to :func:`require_layout`: layout propagation
-    may select a new encoding after this point without changing tensor values.
-    """
+    """Release a register tensor's explicit layout for a flexible consumer."""
     assert isinstance(x, tl.tensor) and x.type.is_block(), "x must be a distributed tensor"
     handle = _semantic.builder.create_release_layout(x.handle)
     return tl.tensor(handle, x.type)

--- a/third_party/tlx/language/tlx/warp_ops.py
+++ b/third_party/tlx/language/tlx/warp_ops.py
@@ -1,13 +1,32 @@
 """
 TLX Warp-Level Operations
 
-This module provides warp-level synchronization and voting primitives
-for NVIDIA GPUs.
+This module provides GPU warp-level synchronization and voting primitives.
 """
 
 import triton
 import triton.language as tl_module
 import triton.language.core as tl
+
+
+def _warp_vote(pred: tl.tensor, kind: tl.constexpr, _semantic=None) -> tl.tensor:
+    if pred.dtype != tl.int1:
+        pred = pred != 0
+    if not pred.type.is_block():
+        raise TypeError(f"warp_{kind} expects a distributed tensor predicate")
+    return _semantic.tensor(_semantic.builder.create_warp_vote(pred.handle, kind), tl.int1)
+
+
+@tl.builtin
+def warp_all(pred: tl.tensor, _semantic=None) -> tl.tensor:
+    """Return whether every physical lane's predicate is true."""
+    return _warp_vote(pred, "all", _semantic=_semantic)
+
+
+@tl.builtin
+def warp_any(pred: tl.tensor, _semantic=None) -> tl.tensor:
+    """Return whether any physical lane's predicate is true."""
+    return _warp_vote(pred, "any", _semantic=_semantic)
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/README.md
+++ b/third_party/tlx/tutorials/README.md
@@ -1,0 +1,29 @@
+# Adaptive FlashAttention tutorial
+
+[`amd_fa_adaptive.py`](amd_fa_adaptive.py) implements adaptive and
+fixed-reference non-causal FlashAttention for BF16 tensors on gfx950.  Its
+module documentation contains the online-softmax equations, numerical
+contracts, pipeline structure, and detailed variant guidance.
+
+The general TLX APIs used to express its register ownership and uniform votes
+are documented in the repository [root README](../../../README.md#other-operations).
+
+## API
+
+```python
+from third_party.tlx.tutorials.amd_fa_adaptive import attention
+
+# General-purpose adaptive reference tracking.
+out = attention(q, k, v)
+
+# Fixed reference for comparison; require proven bounds and profile the target.
+out = attention(q, k, v, qk_max_abs=1.0)
+```
+
+See the tutorial module docstring for the online-softmax equations, numerical
+contracts, pipeline structure, and guidance for selecting the adaptive or
+fixed-reference specialization.  The current gfx950 LLVM code is fastest with
+adaptive reference tracking; the bounded specialization is not a performance
+shortcut unless measurements on the exact target prove otherwise.  Run
+`python third_party/tlx/tutorials/amd_fa_adaptive_bench.py --help` for the
+correctness/performance driver.

--- a/third_party/tlx/tutorials/amd_fa_adaptive.py
+++ b/third_party/tlx/tutorials/amd_fa_adaptive.py
@@ -1,0 +1,1716 @@
+"""Adaptive non-causal FlashAttention for BF16 tensors on gfx950.
+
+Public contract
+---------------
+
+``attention(q, k, v, sm_scale=None, *, qk_max_abs=None, out=None)`` computes
+
+    S[i, j] = sm_scale * sum_d Q[i, d] K[j, d]
+    P[i, j] = exp(S[i, j]) / sum_t exp(S[i, t])
+    O[i, d] = sum_j P[i, j] V[j, d].
+
+``q``, ``k``, and ``v`` must be contiguous BF16 tensors with shape
+``(batch, heads, sequence, 128)``.  The sequence length must be at least 256
+and divisible by 256.  The kernel is non-causal and uses eight 64-lane AMD
+warps per program.  One program computes a 256-row query tile; K and V advance
+in 64-row tiles through four explicitly synchronized LDS stages.
+
+The implementation uses base-2 exponentials.  Defining
+``x = log2(e) * S`` gives ``exp(S) = 2**x``, so this change of base does not
+alter the result.
+
+Online-softmax state
+--------------------
+
+For each query row, the kernel carries a reference ``r``, denominator ``l``,
+and unnormalized output accumulator ``a``:
+
+    l = sum_j 2**(x_j - r)
+    a = sum_j 2**(x_j - r) V_j
+    O = a / l.
+
+Changing the reference from ``r`` to ``r_new`` is exact in real arithmetic:
+
+    alpha = 2**(r - r_new)
+    l_new = alpha * l + sum_{j in tile} 2**(x_j - r_new)
+    a_new = alpha * a + sum_{j in tile} 2**(x_j - r_new) V_j.
+
+Scaling both accumulated terms by ``alpha`` preserves their ratio.  The two
+specializations differ only in how they choose ``r``.
+
+Adaptive-reference variant (the default)
+----------------------------------------
+
+Let ``m`` be the maximum of the next score tile and ``c = max(r, m)``.  The
+kernel keeps the old reference while ``c - r <= 8`` for every row owned by a
+warp.  This permits weights up to ``2**8`` and avoids repeatedly scaling the
+64 FP32 output accumulators.  If any owned row exceeds that headroom, the
+warp-uniform branch rebases all of its rows to ``c``.  Rebasing extra rows is
+algebraically harmless and a uniform vote avoids divergent control flow.
+
+Use this default for ordinary model inputs, unknown or loose activation
+ranges, and any workload whose Q/K bound cannot be proved.  It is the robust
+general-purpose variant: the reference adapts to the data and does not depend
+on a caller assertion.
+
+Fixed-reference bounded variant
+-------------------------------
+
+Passing ``qk_max_abs=A`` asserts ``abs(Q) <= A`` and ``abs(K) <= A``.  For
+head dimension ``D`` this proves
+
+    abs(S[i, j]) <= D * abs(sm_scale) * A**2
+
+and therefore the base-2 score bound
+
+    B = log2(e) * D * abs(sm_scale) * A**2.
+
+The specialization fixes ``r = B``.  Every exponent argument is non-positive,
+and the full possible span is ``2*B``.  The API rejects non-finite bounds,
+bounds that can overflow the FP32 dot product, and spans greater than or equal
+to 126 where the smallest weights could flush below the normal FP32 range.
+The API cannot inspect every tensor element, so understating ``A`` violates the
+contract and can invalidate the numerical guarantee.
+
+Use the bounded variant only when the input producer already guarantees a
+tight finite magnitude bound.  It removes adaptive maximum tracking, voting,
+and rebasing at the algorithm level, but that does not guarantee faster
+machine code.  The current gfx950 LLVM compilation of the advertised shape
+spills its fixed-path live state and is substantially slower than the adaptive
+specialization.  Adaptive reference tracking is therefore the production
+choice for this implementation today; retain the bounded path for numerical
+comparison, compiler work, or a target where repeated measurements prove a
+benefit.  Do not derive ``A`` by scanning Q and K at launch time: that extra
+pass generally costs more than the saved work and introduces another global
+synchronization point.
+
+Pipeline and benchmark variants
+-------------------------------
+
+QK products use transposed 32x32x16 MFMA fragments.  Score packets are pinned
+to their physical register ownership while maxima, exponentials, and casts are
+performed.  Ordinary casts retain that ownership; compiler-internal release
+boundaries keep the pins local to the register-level helpers.  PV is split
+into a short prefix and thirteen
+remaining MFMAs so independent preparation for the next score tile can be
+scheduled between them.  Direct-to-LDS transfers are consumed only through
+explicit ``wait_group`` token dependencies.  ``tlx.amd_sched_barrier`` is a
+compiler scheduling boundary, not memory synchronization.
+
+``amd_fa_adaptive_bench.py`` reports three input distributions for the default
+variant.  ``bounded-distribution`` is representative bounded random data but
+still exercises adaptive reference tracking.  ``sparse-rebase`` makes one of
+each warp's 32 logical rows exceed the headroom on every K/V tile; it tests
+that one row correctly triggers the uniform group rebase.  ``forced-rebase``
+makes every row exceed the headroom on every tile and measures the worst-case
+rebase arithmetic.  The latter two are adversarial test distributions, not
+additional APIs or recommended application modes.  Supplying ``--qk-max-abs``
+instead benchmarks the fixed-reference specialization on bounded data.
+"""
+
+import math
+
+import torch
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+from triton.language.core import _aggregate as aggregate
+
+BLOCK_M = tl.constexpr(256)
+BLOCK_N = tl.constexpr(64)
+HEAD_DIM = tl.constexpr(128)
+LDS_STAGES = tl.constexpr(4)
+XCDS = tl.constexpr(8)
+
+# Let ``x_i`` denote a base-2-scaled attention logit.  After processing some
+# tiles, the online-softmax state represented with reference ``r`` is
+#
+#     denominator = sum_i 2 ** (x_i - r)
+#     accumulator = sum_i 2 ** (x_i - r) * v_i.
+#
+# Their ratio is the softmax result, independently of ``r``.  Conventional
+# online softmax keeps ``r`` equal to the largest logit seen so far.  For a new
+# tile with maximum ``m``, it chooses ``c = max(r, m)`` and changes reference by
+# rescaling the old state with
+#
+#                         alpha = 2 ** (r - c).
+#
+# This kernel deliberately allows ``r`` to lag behind the true maximum.  If it
+# retains ``r``, every term in both state components is larger than the state
+# represented at ``c`` by the same common factor ``2 ** (c - r)``.  The factor
+# cancels in ``accumulator / denominator``.  Therefore delaying the reference
+# change neither clips nor approximates the softmax; in exact arithmetic it
+# only selects a different common scale for its numerator and denominator.
+#
+# The reason not to retain ``r`` indefinitely is numerical range.  The largest
+# positive exponent argument introduced by the new tile is bounded by
+# ``m - r <= c - r``.  We retain ``r`` only while ``c - r <= H``, which caps
+# every positive weight at ``2 ** H``.  With H=8 that cap is 256.  Once the
+# bound is exceeded, the state is rebased to ``c`` using ``alpha`` exactly as
+# in conventional online softmax.  H controls when that exact rebase occurs;
+# it is not a score bound or an approximation tolerance.
+SOFTMAX_REFERENCE_HEADROOM_LOG2 = tl.constexpr(8.0)
+
+# The bounded specialization fixes its reference at the positive score bound,
+# so its smallest exponent argument can be twice that bound below zero.  The
+# gfx950 exp2 path flushes values below the f32 normal range; keep every accepted
+# envelope strictly above that boundary to prevent a zero softmax denominator.
+FIXED_REFERENCE_MAX_LOG2_SPAN = 126.0
+
+# A BF16 product is exact in FP32.  Bound the 128 subsequent accumulation
+# roundings with gamma_n = n*u/(1-n*u), u=2^-24, then keep the absolute dot sum
+# strictly below the largest finite FP32 value before applying the softmax scale.
+_FP32_UNIT_ROUNDOFF = 2.0**-24
+_QK_ACCUMULATION_ERROR = (128 * _FP32_UNIT_ROUNDOFF) / (1.0 - 128 * _FP32_UNIT_ROUNDOFF)
+MAX_QK_ABS_FOR_FINITE_F32_DOT = math.sqrt(torch.finfo(torch.float32).max / (128 * (1.0 + _QK_ACCUMULATION_ERROR)))
+
+# The current symbolic address expressions are signed i32.  Keep both the
+# materialized tensor stride and every flattened element offset representable
+# until the kernel migrates those expressions to i64.
+MAX_SIGNED_I32 = (1 << 31) - 1
+
+RESERVED_LAUNCH_OPTIONS = frozenset({
+    "Q",
+    "K",
+    "V",
+    "Out",
+    "grid",
+    "N_CTX",
+    "BATCH",
+    "HEADS",
+    "TOTAL_HEADS",
+    "SM_SCALE",
+    "LOG2_SCORE_BOUND",
+    "ADAPTIVE_REFERENCE",
+    "num_warps",
+})
+
+
+@triton.jit
+def _split_last_2(value):
+    rows: tl.constexpr = value.shape[0]
+    columns: tl.constexpr = value.shape[1]
+    return value.reshape([rows, 2, columns // 2]).permute(0, 2, 1).split()
+
+
+@triton.jit
+def _join_last_2(lower, upper):
+    rows: tl.constexpr = lower.shape[0]
+    columns: tl.constexpr = lower.shape[1]
+    return tl.join(lower, upper).permute(0, 2, 1).reshape([rows, columns * 2])
+
+
+@triton.jit
+def _mfma_packet_to_registers(packet):
+    """Expose one 32-column MFMA packet's physical register axis.
+
+    The binary axes of each transposed 32x32 MFMA accumulator packet are:
+
+      row[7:0], column[4:0]
+        = warp[2:0], lane[4:0], register[3:2],
+          lane[5], register[1:0].
+
+    Moving lane[5] next to the other workitem bits produces a
+    ``[workitem, register]`` packet without exchanging values between lanes.
+    """
+    binary = packet.reshape([2] * 13)
+    workitem_register = binary.permute(
+        0,
+        1,
+        2,
+        10,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        11,
+        12,
+    )
+    return workitem_register.reshape([8 * 64, 16])
+
+
+@triton.jit
+def _registers_to_mfma_packet(registers):
+    """Invert :func:`_mfma_packet_to_registers`."""
+    binary = registers.reshape([2] * 13)
+    logical = binary.permute(
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        3,
+        11,
+        12,
+    )
+    return logical.reshape([BLOCK_M, BLOCK_N // 2])
+
+
+@triton.jit
+def _registers_to_probability_fragments(registers, p_layout: tl.constexpr):
+    """Invert and split a pinned register packet before releasing it."""
+    binary = registers.reshape([2] * 13)
+    logical = binary.permute(
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        3,
+        11,
+        12,
+    )
+    packet = logical.reshape([BLOCK_M, BLOCK_N // 2])
+    lower, upper = packet.reshape([BLOCK_M, 2, BLOCK_N // 4]).permute(0, 2, 1).split()
+    lower = tlx.require_layout(lower, p_layout)
+    upper = tlx.require_layout(upper, p_layout)
+    return tlx.release_layout(lower), tlx.release_layout(upper)
+
+
+@triton.jit
+def _pin_score_register_layout(registers):
+    # Threads enumerate rows and each thread's values enumerate columns.
+    score_register_layout: tl.constexpr = tlx.layout(
+        shape=((8 * 64, ), (16, )),
+        stride=((16, ), (1, )),
+    )
+    return tlx.require_layout(registers, score_register_layout)
+
+
+@triton.jit
+def _pin_workitem_layout(value):
+    # One scalar workitem is owned by each of the eight warps' 64 lanes.
+    workitem_layout: tl.constexpr = tlx.layout(
+        shape=((8 * 64, ), ()),
+        stride=((1, ), ()),
+    )
+    return tlx.release_layout(tlx.require_layout(value, workitem_layout))
+
+
+@triton.jit
+def _duplicate_rows_to_workitems(rows):
+    # The reduction produces one value per logical row. Lanes enumerate the
+    # 32 rows within each pair, the first two warp bits enumerate the four row
+    # pairs, and the final warp bit duplicates that ownership across the two
+    # warp groups that covered the score columns.
+    row_layout: tl.constexpr = tlx.layout(
+        shape=((2, 32, 4, 2), ()),
+        stride=((32, 1, 64, 0), ()),
+    )
+    rows = tlx.release_layout(tlx.require_layout(rows, row_layout))
+    per_warp_rows = rows.reshape([8, 32])
+    per_workitem = tl.broadcast_to(per_warp_rows[:, None, :], (8, 2, 32))
+    return _pin_workitem_layout(per_workitem.reshape([8 * 64]))
+
+
+@triton.jit
+def _reduce_score_registers(registers0, registers1):
+    scores0 = _registers_to_mfma_packet(registers0)
+    scores1 = _registers_to_mfma_packet(registers1)
+    scores = _join_last_2(scores0, scores1)
+    return _duplicate_rows_to_workitems(tl.sum(scores, axis=1))
+
+
+@triton.jit
+def _reduce_max_score_registers(registers0, registers1):
+    scores0 = _registers_to_mfma_packet(registers0)
+    scores1 = _registers_to_mfma_packet(registers1)
+    scores = _join_last_2(scores0, scores1)
+    return _duplicate_rows_to_workitems(tl.max(scores, axis=1))
+
+
+@triton.jit
+def _prepare_adaptive_score_registers(scores, qk_scale: tl.constexpr):
+    """Expose score registers and compute their scaled row maximum."""
+    score0, score1 = _split_last_2(scores)
+    registers0 = _pin_score_register_layout(_mfma_packet_to_registers(score0))
+    registers1 = _pin_score_register_layout(_mfma_packet_to_registers(score1))
+    if qk_scale < 0.0:
+        registers0 = registers0 * qk_scale
+        registers1 = registers1 * qk_scale
+        tile_max = _reduce_max_score_registers(registers0, registers1)
+    else:
+        tile_max = _reduce_max_score_registers(registers0, registers1) * qk_scale
+    return registers0, registers1, tile_max
+
+
+@triton.jit
+def _adaptive_rebase_decision(row_max, tile_max):
+    """Return the next row maximum and one uniform headroom vote per warp.
+
+    Each 64-lane warp owns 32 rows, duplicated across its two lane halves by the
+    reduction.  ``warp_all`` therefore tests whether every one of the 32 rows
+    remains within the logarithmic headroom.  If any row exceeds it, rebasing
+    every row in the warp is algebraically safe: scaling its old denominator
+    and accumulator by the same factor preserves their ratio.  Ordered
+    comparison also makes a NaN take the rebase path and continue propagating.
+    """
+    candidate = tl.maximum(
+        row_max,
+        tile_max,
+        propagate_nan=tl.PropagateNan.ALL,
+    )
+    advance = candidate - row_max
+    row_is_within_headroom = advance <= SOFTMAX_REFERENCE_HEADROOM_LOG2
+    all_rows_within_headroom = tlx.warp_all(row_is_within_headroom)
+    return candidate, all_rows_within_headroom
+
+
+@triton.jit
+def _scale_accumulator_rows(accumulator, scale):
+    """Scale an MFMA accumulator through its physical register packet."""
+    registers = _mfma_packet_to_registers(accumulator)
+    registers = registers * scale[:, None]
+    return _registers_to_mfma_packet(registers)
+
+
+@triton.jit
+def _pv_mfma(
+    probabilities,
+    values,
+    accumulator,
+    p_layout: tl.constexpr,
+    v_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+):
+    probabilities = tlx.require_layout(probabilities, p_layout)
+    values = tlx.require_layout(values, v_layout)
+    accumulator = tlx.require_layout(accumulator, mma_layout)
+    accumulator = tl.dot(probabilities, values, accumulator)
+    return accumulator
+
+
+@triton.jit
+def _load_value_fragment(
+    value_view,
+    wait_token,
+    ROW: tl.constexpr,
+    COLUMN: tl.constexpr,
+    ROWS: tl.constexpr,
+    COLUMNS: tl.constexpr,
+    v_layout: tl.constexpr,
+):
+    fragment_view = tlx.local_slice(
+        value_view,
+        [ROW, COLUMN],
+        [ROWS, COLUMNS],
+    )
+    fragment = tlx.local_load(
+        fragment_view,
+        token=wait_token,
+        layout=v_layout,
+        relaxed=True,
+    )
+    return fragment
+
+
+@aggregate
+class ExponentiatedScores:
+    registers0: tl.tensor
+    registers1: tl.tensor
+
+
+@aggregate
+class ProbabilityFragments:
+    p0: tl.tensor
+    p1: tl.tensor
+    p2: tl.tensor
+    p3: tl.tensor
+
+
+@aggregate
+class ValueFragments:
+    v00: tl.tensor
+    v01: tl.tensor
+    v02: tl.tensor
+    v03: tl.tensor
+    v10: tl.tensor
+    v11: tl.tensor
+    v12: tl.tensor
+    v13: tl.tensor
+    v20: tl.tensor
+    v21: tl.tensor
+    v22: tl.tensor
+    v23: tl.tensor
+    v30: tl.tensor
+    v31: tl.tensor
+    v32: tl.tensor
+    v33: tl.tensor
+
+
+@triton.jit
+def _exponentiate_adaptive_scores(
+    registers0,
+    registers1,
+    reference,
+    qk_scale: tl.constexpr,
+):
+    # Keep the scale and translation as a multiply-add expression.  The global
+    # fast-math policy permits contraction, so the backend can form one FMA
+    # without a kernel-specific operation.
+    if qk_scale < 0.0:
+        logits0 = registers0 - reference[:, None]
+        logits1 = registers1 - reference[:, None]
+    else:
+        logits0 = registers0 * qk_scale - reference[:, None]
+        logits1 = registers1 * qk_scale - reference[:, None]
+    return ExponentiatedScores(
+        tl.math.exp2(logits0),
+        tl.math.exp2(logits1),
+    )
+
+
+@aggregate
+class SoftmaxState:
+    acc0: tl.tensor
+    acc1: tl.tensor
+    acc2: tl.tensor
+    acc3: tl.tensor
+    row_max: tl.tensor
+    row_sum: tl.tensor
+
+    @triton.jit
+    def create():
+        return SoftmaxState(
+            tl.zeros((BLOCK_M, HEAD_DIM // 4), tl.float32),
+            tl.zeros((BLOCK_M, HEAD_DIM // 4), tl.float32),
+            tl.zeros((BLOCK_M, HEAD_DIM // 4), tl.float32),
+            tl.zeros((BLOCK_M, HEAD_DIM // 4), tl.float32),
+            _pin_workitem_layout(tl.full((8 * 64, ), -1.0e30, tl.float32), ),
+            _pin_workitem_layout(tl.zeros((8 * 64, ), tl.float32), ),
+        )
+
+    @triton.jit
+    def rebase(self, reference):
+        alpha_rows = tl.math.exp2(self.row_max - reference)
+        return SoftmaxState(
+            _scale_accumulator_rows(self.acc0, alpha_rows),
+            _scale_accumulator_rows(self.acc1, alpha_rows),
+            _scale_accumulator_rows(self.acc2, alpha_rows),
+            _scale_accumulator_rows(self.acc3, alpha_rows),
+            reference,
+            self.row_sum * alpha_rows,
+        )
+
+    @triton.jit
+    def prepare(
+        self,
+        scores,
+        qk_scale: tl.constexpr,
+        log2_score_bound: tl.constexpr,
+        INITIAL: tl.constexpr,
+        ADAPTIVE_REFERENCE: tl.constexpr,
+    ):
+        state = self
+        if ADAPTIVE_REFERENCE:
+            score_registers0, score_registers1, tile_max = _prepare_adaptive_score_registers(
+                scores,
+                qk_scale,
+            )
+            if INITIAL:
+                reference = tile_max
+            else:
+                candidate, all_rows_within_headroom = _adaptive_rebase_decision(
+                    self.row_max,
+                    tile_max,
+                )
+                if all_rows_within_headroom:
+                    reference = self.row_max
+                else:
+                    reference = candidate
+                    state = self.rebase(reference)
+            if INITIAL:
+                state = SoftmaxState(
+                    self.acc0,
+                    self.acc1,
+                    self.acc2,
+                    self.acc3,
+                    reference,
+                    self.row_sum,
+                )
+            exponentiated_scores = _exponentiate_adaptive_scores(
+                score_registers0,
+                score_registers1,
+                reference,
+                qk_scale,
+            )
+        else:
+            score0, score1 = _split_last_2(scores)
+            score0 = score0 * qk_scale + (-log2_score_bound)
+            score1 = score1 * qk_scale + (-log2_score_bound)
+            registers0 = _mfma_packet_to_registers(score0)
+            registers1 = _mfma_packet_to_registers(score1)
+            exponentiated_scores = ExponentiatedScores(
+                tl.math.exp2(registers0),
+                tl.math.exp2(registers1),
+            )
+        return state, exponentiated_scores
+
+    @triton.jit
+    def prepare_adaptive_pending(
+        self,
+        scores,
+        qk_scale: tl.constexpr,
+    ):
+        """Prepare the next score tile without rebasing the current PV state.
+
+        Keeping the rebase commit separate lets the scheduler overlap this independent
+        score work with the remaining PV MFMAs.  The reference is still chosen
+        by the same warp-uniform vote as prepare; only the state scaling
+        is deferred until the current PV tile is fully accumulated.
+        """
+        score_registers0, score_registers1, tile_max = _prepare_adaptive_score_registers(
+            scores,
+            qk_scale,
+        )
+        candidate, all_rows_within_headroom = _adaptive_rebase_decision(
+            self.row_max,
+            tile_max,
+        )
+        reference = tl.where(all_rows_within_headroom, self.row_max, candidate)
+        exponentiated_scores = _exponentiate_adaptive_scores(
+            score_registers0,
+            score_registers1,
+            reference,
+            qk_scale,
+        )
+        return (
+            exponentiated_scores,
+            reference,
+            all_rows_within_headroom,
+        )
+
+    @triton.jit
+    def commit_adaptive_reference(
+        self,
+        reference,
+        all_rows_within_headroom,
+    ):
+        state = self
+        if all_rows_within_headroom:
+            state = self
+        else:
+            state = self.rebase(reference)
+        return state
+
+    @triton.jit
+    def finish(
+        self,
+        exponentiated_scores,
+        out_dtype: tl.constexpr,
+        p_layout: tl.constexpr,
+    ):
+        registers0 = _pin_score_register_layout(exponentiated_scores.registers0)
+        registers1 = _pin_score_register_layout(exponentiated_scores.registers1)
+        tile_sum = _reduce_score_registers(registers0, registers1)
+        row_sum = self.row_sum + tile_sum
+        registers0 = registers0.to(out_dtype)
+        registers1 = registers1.to(out_dtype)
+        p0, p1 = _registers_to_probability_fragments(registers0, p_layout)
+        p2, p3 = _registers_to_probability_fragments(registers1, p_layout)
+        probabilities = ProbabilityFragments(
+            p0,
+            p1,
+            p2,
+            p3,
+        )
+        return (
+            SoftmaxState(
+                self.acc0,
+                self.acc1,
+                self.acc2,
+                self.acc3,
+                self.row_max,
+                row_sum,
+            ),
+            probabilities,
+        )
+
+
+@triton.jit
+def _load_value_fragments(
+    value_view,
+    wait_token,
+    v_layout: tl.constexpr,
+):
+    return ValueFragments(
+        _load_value_fragment(value_view, wait_token, 0, 0, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 0, 32, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 0, 64, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 0, 96, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 16, 0, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 16, 32, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 16, 64, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 16, 96, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 32, 0, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 32, 32, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 32, 64, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 32, 96, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 48, 0, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 48, 32, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 48, 64, 16, 32, v_layout),
+        _load_value_fragment(value_view, wait_token, 48, 96, 16, 32, v_layout),
+    )
+
+
+@triton.jit
+def _accumulate_prefix_body(
+    state,
+    probability_fragments,
+    value_fragments,
+    next_scores,
+    p_layout: tl.constexpr,
+    v_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+    qk_scale: tl.constexpr,
+    log2_score_bound: tl.constexpr,
+    ADAPTIVE_REFERENCE: tl.constexpr,
+):
+    """Accumulate one PV tile using a 3+13 MFMA split.
+
+    The split exposes individual MFMA candidates to the scheduler.  The
+    barrier fixes only the three-instruction prefix; later independent MFMAs
+    may interleave with preparation of the next score tile.
+    """
+    p0 = probability_fragments.p0
+    p1 = probability_fragments.p1
+    p2 = probability_fragments.p2
+    p3 = probability_fragments.p3
+    acc0 = state.acc0
+    acc1 = state.acc1
+    acc2 = state.acc2
+    acc3 = state.acc3
+
+    acc0 = _pv_mfma(p0, value_fragments.v00, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p0, value_fragments.v01, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p0, value_fragments.v02, acc2, p_layout, v_layout, mma_layout)
+    tlx.amd_sched_barrier()
+    acc3 = _pv_mfma(p0, value_fragments.v03, acc3, p_layout, v_layout, mma_layout)
+    acc0 = _pv_mfma(p1, value_fragments.v10, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p1, value_fragments.v11, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p1, value_fragments.v12, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p1, value_fragments.v13, acc3, p_layout, v_layout, mma_layout)
+    if ADAPTIVE_REFERENCE:
+        exponentiated_scores, reference, all_rows_within_headroom = state.prepare_adaptive_pending(
+            next_scores,
+            qk_scale,
+        )
+    acc0 = _pv_mfma(p2, value_fragments.v20, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p2, value_fragments.v21, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p2, value_fragments.v22, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p2, value_fragments.v23, acc3, p_layout, v_layout, mma_layout)
+    acc0 = _pv_mfma(p3, value_fragments.v30, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p3, value_fragments.v31, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p3, value_fragments.v32, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p3, value_fragments.v33, acc3, p_layout, v_layout, mma_layout)
+    state = SoftmaxState(
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        state.row_max,
+        state.row_sum,
+    )
+    if ADAPTIVE_REFERENCE:
+        return (
+            state.commit_adaptive_reference(reference, all_rows_within_headroom),
+            exponentiated_scores,
+        )
+    return state.prepare(
+        next_scores,
+        qk_scale,
+        log2_score_bound,
+        False,
+        ADAPTIVE_REFERENCE,
+    )
+
+
+@triton.jit
+def _accumulate_value_fragments(
+    state,
+    probability_fragments,
+    value_fragments,
+    p_layout: tl.constexpr,
+    v_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+):
+    p0 = probability_fragments.p0
+    p1 = probability_fragments.p1
+    p2 = probability_fragments.p2
+    p3 = probability_fragments.p3
+    acc0 = _pv_mfma(p0, value_fragments.v00, state.acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p0, value_fragments.v01, state.acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p0, value_fragments.v02, state.acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p0, value_fragments.v03, state.acc3, p_layout, v_layout, mma_layout)
+    acc0 = _pv_mfma(p1, value_fragments.v10, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p1, value_fragments.v11, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p1, value_fragments.v12, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p1, value_fragments.v13, acc3, p_layout, v_layout, mma_layout)
+    acc0 = _pv_mfma(p2, value_fragments.v20, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p2, value_fragments.v21, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p2, value_fragments.v22, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p2, value_fragments.v23, acc3, p_layout, v_layout, mma_layout)
+    acc0 = _pv_mfma(p3, value_fragments.v30, acc0, p_layout, v_layout, mma_layout)
+    acc1 = _pv_mfma(p3, value_fragments.v31, acc1, p_layout, v_layout, mma_layout)
+    acc2 = _pv_mfma(p3, value_fragments.v32, acc2, p_layout, v_layout, mma_layout)
+    acc3 = _pv_mfma(p3, value_fragments.v33, acc3, p_layout, v_layout, mma_layout)
+    return SoftmaxState(
+        acc0,
+        acc1,
+        acc2,
+        acc3,
+        state.row_max,
+        state.row_sum,
+    )
+
+
+@triton.jit
+def _load_query(
+    Q,
+    q_base,
+    pid_m,
+    stride_qm,
+    q_load_layout: tl.constexpr,
+    q_layout: tl.constexpr,
+):
+    """Load Q directly in MFMA operand ownership.
+
+    Pinning the offsets and result prevents a 64 KiB blocked-to-dot scratch
+    redistribution, which would not fit beside the four K/V stage rings.
+    """
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    offsets = offs_m[:, None] * stride_qm + offs_d[None, :]
+    offsets = tlx.require_layout(offsets, q_load_layout)
+    q = tlx.buffer_load(Q + q_base, offsets)
+    q = tlx.require_layout(q, q_layout)
+    return tlx.release_layout(q)
+
+
+@triton.jit
+def _workitems_to_rows(workitems):
+    per_warp_rows, _ = workitems.reshape([8, 2, 32]).permute(0, 2, 1).split()
+    return per_warp_rows.reshape([BLOCK_M])
+
+
+@triton.jit
+def _normalize_output_fragment(
+    inverse_row_sum,
+    acc,
+    out_dtype: tl.constexpr,
+    mma_layout: tl.constexpr,
+):
+    acc = tlx.require_layout(acc, mma_layout)
+    row_scale = _workitems_to_rows(inverse_row_sum)
+    output = acc * row_scale[:, None]
+    output = output.to(out_dtype)
+    return tlx.release_layout(output)
+
+
+@triton.jit
+def _store_output(
+    Out,
+    o_base,
+    pid_m,
+    stride_om: tl.constexpr,
+    row_sum,
+    acc0,
+    acc1,
+    acc2,
+    acc3,
+    store_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+):
+    # Each lane initially owns sixteen values from each 32-column MFMA packet.
+    # Join the four packets and redistribute them to the coalesced IO layout:
+    # lane bits 0..4 select the row, lane bit 5 selects columns 0/8, and the
+    # first three register bits select eight consecutive columns.  Each lane
+    # can then publish its output using eight 128-bit stores.
+    inverse_row_sum = 1.0 / row_sum
+    output0 = _normalize_output_fragment(
+        inverse_row_sum,
+        acc0,
+        Out.dtype.element_ty,
+        mma_layout,
+    )
+    output1 = _normalize_output_fragment(
+        inverse_row_sum,
+        acc1,
+        Out.dtype.element_ty,
+        mma_layout,
+    )
+    output2 = _normalize_output_fragment(
+        inverse_row_sum,
+        acc2,
+        Out.dtype.element_ty,
+        mma_layout,
+    )
+    output3 = _normalize_output_fragment(
+        inverse_row_sum,
+        acc3,
+        Out.dtype.element_ty,
+        mma_layout,
+    )
+    output01 = _join_last_2(output0, output1)
+    output23 = _join_last_2(output2, output3)
+    output = _join_last_2(output01, output23)
+    output = tlx.require_layout(output, store_layout)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_DIM)
+    offsets = offs_m[:, None] * stride_om + offs_d[None, :]
+    offsets = tlx.require_layout(offsets, store_layout)
+    tlx.buffer_store(
+        output,
+        Out + o_base,
+        offsets,
+    )
+
+
+@triton.jit
+def _issue_tile(
+    pointers,
+    tile,
+    stride_n,
+    buffer,
+    slot,
+    LDS_PADDING: tl.constexpr,
+):
+    # The padding value is part of the JIT specialization key.  K and V use
+    # distinct padded memdesc layouts even though issuing the DMA itself does
+    # not inspect the padding value.
+    _ = LDS_PADDING
+    tile_offset = tile * BLOCK_N * stride_n
+    token = tlx.async_load(
+        pointers + tile_offset,
+        tlx.local_view(buffer, slot),
+    )
+    return tlx.async_load_commit_group([token])
+
+
+@triton.jit
+def _stage_end():
+    """Converge the program before advancing to the next pipeline stage."""
+    tl.debug_barrier()
+
+
+@triton.jit
+def _wait_stage_end(PENDING: tl.constexpr, tokens):
+    """Publish an explicit async wait at a standalone stage boundary."""
+    ready = tlx.async_load_wait_group(PENDING, tokens=tokens)
+    return ready
+
+
+@triton.jit
+def _score_phase(
+    state,
+    exponentiated_scores,
+    current_ready,
+    q,
+    k_buffer,
+    current_k_slot: tl.constexpr,
+    q_layout: tl.constexpr,
+    k_layout: tl.constexpr,
+    p_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+):
+    q = tlx.require_layout(q, q_layout)
+    current_k = tlx.local_load(
+        tlx.local_trans(tlx.local_view(k_buffer, current_k_slot)),
+        token=current_ready,
+        layout=k_layout,
+        relaxed=True,
+    )
+    state, probability_fragments = state.finish(
+        exponentiated_scores,
+        q.dtype,
+        p_layout,
+    )
+    _stage_end()
+    score_acc = tlx.zeros(
+        (BLOCK_M, BLOCK_N),
+        tl.float32,
+        layout=mma_layout,
+    )
+    next_scores = tl.dot(q, current_k, score_acc)
+    next_scores = tlx.release_layout(next_scores)
+    q = tlx.release_layout(q)
+    return state, probability_fragments, next_scores
+
+
+@triton.jit
+def _warp_pipeline_phase(
+    state,
+    exponentiated_scores,
+    q,
+    k_ptrs,
+    v_ptrs,
+    k_buffer,
+    v_buffer,
+    stride_kn,
+    stride_vn,
+    tile,
+    current_k_ready,
+    previous_v_ready,
+    prefetched_v_ready,
+    PHASE: tl.constexpr,
+    q_layout: tl.constexpr,
+    k_layout: tl.constexpr,
+    p_layout: tl.constexpr,
+    v_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+    qk_scale: tl.constexpr,
+    log2_score_bound: tl.constexpr,
+    ADAPTIVE_REFERENCE: tl.constexpr,
+):
+    previous_v_slot: tl.constexpr = PHASE
+    current_k_slot: tl.constexpr = (PHASE + 1) % LDS_STAGES
+    k_prefetch_slot: tl.constexpr = (PHASE + 3) % LDS_STAGES
+    v_prefetch_slot: tl.constexpr = (PHASE + 2) % LDS_STAGES
+
+    current_ready = tlx.async_load_wait_group(
+        2,
+        tokens=[current_k_ready, previous_v_ready],
+    )
+
+    with tlx.warp_pipeline_stage("softmax"):
+        q = tlx.require_layout(q, q_layout)
+        current_k = tlx.local_load(
+            tlx.local_trans(tlx.local_view(k_buffer, current_k_slot)),
+            token=current_ready,
+            layout=k_layout,
+            relaxed=True,
+        )
+        state, probability_fragments = state.finish(
+            exponentiated_scores,
+            q.dtype,
+            p_layout,
+        )
+
+    with tlx.warp_pipeline_stage("qk"):
+        next_k_ready = _issue_tile(
+            k_ptrs,
+            tile + 3,
+            stride_kn,
+            k_buffer,
+            k_prefetch_slot,
+            8,
+        )
+        score_acc = tlx.zeros(
+            (BLOCK_M, BLOCK_N),
+            tl.float32,
+            layout=mma_layout,
+        )
+        next_scores = tl.dot(q, current_k, score_acc)
+        next_scores = tlx.release_layout(next_scores)
+        q = tlx.release_layout(q)
+
+    with tlx.warp_pipeline_stage("value"):
+        value_fragments = _load_value_fragments(
+            tlx.local_view(v_buffer, previous_v_slot),
+            current_ready,
+            v_layout,
+        )
+
+    # PV is the longest phase. Favor its warps so the companion pipeline group
+    # reaches the phase barriers with less skew.
+    with tlx.warp_pipeline_stage("pv", priority=1):
+        state, next_exponentiated_scores = _accumulate_prefix_body(
+            state,
+            probability_fragments,
+            value_fragments,
+            next_scores,
+            p_layout,
+            v_layout,
+            mma_layout,
+            qk_scale,
+            log2_score_bound,
+            ADAPTIVE_REFERENCE,
+        )
+        future_v_ready = _issue_tile(
+            v_ptrs,
+            tile + 2,
+            stride_vn,
+            v_buffer,
+            v_prefetch_slot,
+            32,
+        )
+
+    return (
+        state,
+        next_exponentiated_scores,
+        next_k_ready,
+        prefetched_v_ready,
+        future_v_ready,
+    )
+
+
+@triton.jit
+def _pipeline(
+    state,
+    q,
+    k_ptrs,
+    v_ptrs,
+    k_buffer,
+    v_buffer,
+    stride_kn,
+    stride_vn,
+    tile_count,
+    q_layout: tl.constexpr,
+    k_layout: tl.constexpr,
+    p_layout: tl.constexpr,
+    v_layout: tl.constexpr,
+    mma_layout: tl.constexpr,
+    qk_scale: tl.constexpr,
+    log2_score_bound: tl.constexpr,
+    ADAPTIVE_REFERENCE: tl.constexpr,
+):
+    q = tlx.require_layout(q, q_layout)
+    # Prime K0, V0, and K1.  Every completion used by a local load below comes
+    # from an explicit wait_group; LDS aliasing is never used as a dependency.
+    k_ready0 = _issue_tile(k_ptrs, 0, stride_kn, k_buffer, 0, 8)
+    v_ready0 = _issue_tile(v_ptrs, 0, stride_vn, v_buffer, 0, 32)
+    k_ready1 = _issue_tile(k_ptrs, 1, stride_kn, k_buffer, 1, 8)
+
+    # Only K0 is required for the first QK.  A FIFO wait retains V0 and K1 as
+    # issue-order dependencies without also demanding their completion.  The
+    # K0 local load consumes this explicit wait result; later V0/K1 loads
+    # consume the next explicit wait result.
+    wait_k0 = tlx.async_load_wait_group(2)
+    k0 = tlx.local_load(
+        tlx.local_trans(tlx.local_view(k_buffer, 0)),
+        token=wait_k0,
+        layout=k_layout,
+        relaxed=True,
+    )
+    _stage_end()
+    score_acc = tlx.zeros(
+        (BLOCK_M, BLOCK_N),
+        tl.float32,
+        layout=mma_layout,
+    )
+    scores = tl.dot(q, k0, score_acc)
+    scores = tlx.release_layout(scores)
+    _stage_end()
+    state, exponentiated_scores = state.prepare(
+        scores,
+        qk_scale,
+        log2_score_bound,
+        True,
+        ADAPTIVE_REFERENCE,
+    )
+
+    # K2 has its own physical slot; unlike the legacy cluster kernel, no
+    # barrier-and-overwrite of K0 is needed here.
+    k_ready2 = _issue_tile(k_ptrs, 2, stride_kn, k_buffer, 2, 8)
+    # Tile i consumes V[i] and K[i+1], reads K[i+2], and publishes K[i+3] and
+    # V[i+2].  Spell out all four ring phases so each physical slot remains
+    # static in the generated program.
+    # Peel phase zero so the loop enters with real PV accumulator values.  In
+    # addition to matching the four-slot ring, this keeps the MFMA
+    # accumulator register groups intact across the loop backedge.
+    q = tlx.release_layout(q)
+    v_ready1 = _issue_tile(
+        v_ptrs,
+        1,
+        stride_vn,
+        v_buffer,
+        1,
+        32,
+    )
+    (
+        state,
+        exponentiated_scores,
+        k_ready3,
+        previous_v_ready,
+        prefetched_v_ready,
+    ) = _warp_pipeline_phase(
+        state,
+        exponentiated_scores,
+        q,
+        k_ptrs,
+        v_ptrs,
+        k_buffer,
+        v_buffer,
+        stride_kn,
+        stride_vn,
+        0,
+        k_ready1,
+        v_ready0,
+        v_ready1,
+        0,
+        q_layout,
+        k_layout,
+        p_layout,
+        v_layout,
+        mma_layout,
+        qk_scale,
+        log2_score_bound,
+        ADAPTIVE_REFERENCE,
+    )
+    for first_tile in tl.range(1, tile_count - 3, 4, num_stages=0):
+        (
+            state,
+            exponentiated_scores,
+            k_ready0,
+            previous_v_ready,
+            prefetched_v_ready,
+        ) = _warp_pipeline_phase(
+            state,
+            exponentiated_scores,
+            q,
+            k_ptrs,
+            v_ptrs,
+            k_buffer,
+            v_buffer,
+            stride_kn,
+            stride_vn,
+            first_tile,
+            k_ready2,
+            previous_v_ready,
+            prefetched_v_ready,
+            1,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            mma_layout,
+            qk_scale,
+            log2_score_bound,
+            ADAPTIVE_REFERENCE,
+        )
+        (
+            state,
+            exponentiated_scores,
+            k_ready1,
+            previous_v_ready,
+            prefetched_v_ready,
+        ) = _warp_pipeline_phase(
+            state,
+            exponentiated_scores,
+            q,
+            k_ptrs,
+            v_ptrs,
+            k_buffer,
+            v_buffer,
+            stride_kn,
+            stride_vn,
+            first_tile + 1,
+            k_ready3,
+            previous_v_ready,
+            prefetched_v_ready,
+            2,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            mma_layout,
+            qk_scale,
+            log2_score_bound,
+            ADAPTIVE_REFERENCE,
+        )
+        (
+            state,
+            exponentiated_scores,
+            k_ready2,
+            previous_v_ready,
+            prefetched_v_ready,
+        ) = _warp_pipeline_phase(
+            state,
+            exponentiated_scores,
+            q,
+            k_ptrs,
+            v_ptrs,
+            k_buffer,
+            v_buffer,
+            stride_kn,
+            stride_vn,
+            first_tile + 2,
+            k_ready0,
+            previous_v_ready,
+            prefetched_v_ready,
+            3,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            mma_layout,
+            qk_scale,
+            log2_score_bound,
+            ADAPTIVE_REFERENCE,
+        )
+        (
+            state,
+            exponentiated_scores,
+            k_ready3,
+            previous_v_ready,
+            prefetched_v_ready,
+        ) = _warp_pipeline_phase(
+            state,
+            exponentiated_scores,
+            q,
+            k_ptrs,
+            v_ptrs,
+            k_buffer,
+            v_buffer,
+            stride_kn,
+            stride_vn,
+            first_tile + 3,
+            k_ready1,
+            previous_v_ready,
+            prefetched_v_ready,
+            0,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            mma_layout,
+            qk_scale,
+            log2_score_bound,
+            ADAPTIVE_REFERENCE,
+        )
+    # Drain the final three output tiles without out-of-range DMA requests.
+    tile_nm3 = tile_count - 3
+    tile_nm2 = tile_count - 2
+    tile_nm1 = tile_count - 1
+
+    v_ready_nm2 = prefetched_v_ready
+    ready_nm3 = _wait_stage_end(2, [k_ready2, previous_v_ready])
+    state, probability_fragments, next_scores = _score_phase(
+        state,
+        exponentiated_scores,
+        ready_nm3,
+        q,
+        k_buffer,
+        tile_nm2 % LDS_STAGES,
+        q_layout,
+        k_layout,
+        p_layout,
+        mma_layout,
+    )
+    _stage_end()
+    value_fragments = _load_value_fragments(
+        tlx.local_view(v_buffer, tile_nm3 % LDS_STAGES),
+        ready_nm3,
+        v_layout,
+    )
+    _stage_end()
+    state, exponentiated_scores = _accumulate_prefix_body(
+        state,
+        probability_fragments,
+        value_fragments,
+        next_scores,
+        p_layout,
+        v_layout,
+        mma_layout,
+        qk_scale,
+        log2_score_bound,
+        ADAPTIVE_REFERENCE,
+    )
+
+    v_ready_nm1 = _issue_tile(
+        v_ptrs,
+        tile_nm1,
+        stride_vn,
+        v_buffer,
+        tile_nm1 % LDS_STAGES,
+        32,
+    )
+    ready_nm2 = _wait_stage_end(1, [k_ready3, v_ready_nm2])
+    state, probability_fragments, next_scores = _score_phase(
+        state,
+        exponentiated_scores,
+        ready_nm2,
+        q,
+        k_buffer,
+        tile_nm1 % LDS_STAGES,
+        q_layout,
+        k_layout,
+        p_layout,
+        mma_layout,
+    )
+    _stage_end()
+    value_fragments = _load_value_fragments(
+        tlx.local_view(v_buffer, tile_nm2 % LDS_STAGES),
+        ready_nm2,
+        v_layout,
+    )
+    _stage_end()
+    state, exponentiated_scores = _accumulate_prefix_body(
+        state,
+        probability_fragments,
+        value_fragments,
+        next_scores,
+        p_layout,
+        v_layout,
+        mma_layout,
+        qk_scale,
+        log2_score_bound,
+        ADAPTIVE_REFERENCE,
+    )
+
+    state, probability_fragments = state.finish(
+        exponentiated_scores,
+        q.dtype,
+        p_layout,
+    )
+    ready_nm1 = _wait_stage_end(0, [v_ready_nm1])
+    value_fragments = _load_value_fragments(
+        tlx.local_view(v_buffer, tile_nm1 % LDS_STAGES),
+        ready_nm1,
+        v_layout,
+    )
+    _stage_end()
+    state = _accumulate_value_fragments(
+        state,
+        probability_fragments,
+        value_fragments,
+        p_layout,
+        v_layout,
+        mma_layout,
+    )
+    return state
+
+
+@triton.jit
+def _attn_fwd_adaptive_pipeline(
+    Q,
+    K,
+    V,
+    Out,
+    N_CTX: tl.constexpr,
+    BATCH: tl.constexpr,
+    HEADS: tl.constexpr,
+    TOTAL_HEADS: tl.constexpr,
+    SM_SCALE: tl.constexpr,
+    LOG2_SCORE_BOUND: tl.constexpr,
+    ADAPTIVE_REFERENCE: tl.constexpr,
+):
+    stride_m: tl.constexpr = HEAD_DIM
+    stride_h: tl.constexpr = N_CTX * HEAD_DIM
+    stride_z: tl.constexpr = HEADS * stride_h
+
+    raw_m = tl.program_id(0)
+    raw_head = tl.program_id(1)
+    m_blocks: tl.constexpr = N_CTX // BLOCK_M
+    total_programs: tl.constexpr = m_blocks * TOTAL_HEADS
+    tl.assume(raw_m < m_blocks)
+    tl.assume(raw_head < TOTAL_HEADS)
+    raw_pid = raw_head * m_blocks + raw_m
+    if total_programs % XCDS == 0:
+        programs_per_xcd: tl.constexpr = total_programs // XCDS
+        pid = (raw_pid % XCDS) * programs_per_xcd + raw_pid // XCDS
+    else:
+        pid = raw_pid
+    tl.assume(pid < total_programs)
+    pid_m = pid % m_blocks
+    flat_head = pid // m_blocks
+    head = flat_head % HEADS
+    batch = flat_head // HEADS
+    tl.assume(pid_m < N_CTX // BLOCK_M)
+    tl.assume(flat_head < TOTAL_HEADS)
+    tl.assume(head < HEADS)
+    tl.assume(batch < BATCH)
+
+    q_base = batch * stride_z + head * stride_h
+    k_base = batch * stride_z + head * stride_h
+    v_base = batch * stride_z + head * stride_h
+    o_base = batch * stride_z + head * stride_h
+
+    mma_layout: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[8, 1],
+    )
+    q_layout: tl.constexpr = tlx.dot_operand_layout(
+        0,
+        mma_layout,
+        k_width=8,
+    )
+    # Lane bits 0..4 and all warp bits select rows; lane bit 5 selects column
+    # 8. The two value modes select columns 0..7 and 16-element groups.
+    q_load_layout: tl.constexpr = tlx.layout(
+        shape=((32, 2, 8), (8, 8)),
+        stride=((128, 8, 4096), (1, 16)),
+    )
+    k_layout: tl.constexpr = tlx.dot_operand_layout(
+        1,
+        mma_layout,
+        k_width=8,
+    )
+    p_layout: tl.constexpr = tlx.dot_operand_layout(
+        0,
+        mma_layout,
+        k_width=4,
+    )
+    v_layout: tl.constexpr = tlx.dot_operand_layout(
+        1,
+        mma_layout,
+        k_width=4,
+    )
+    q = _load_query(
+        Q,
+        q_base,
+        pid_m,
+        stride_m,
+        q_load_layout,
+        q_layout,
+    )
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, HEAD_DIM)
+    k_ptrs = K + k_base + offs_n[:, None] * stride_m + offs_d[None, :]
+    v_ptrs = V + v_base + offs_n[:, None] * stride_m + offs_d[None, :]
+    k_shared_layout: tl.constexpr = (tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 8)],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [0, 64],
+        ],
+        [BLOCK_N, HEAD_DIM],
+    ))
+    v_shared_layout: tl.constexpr = (tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 32)],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [0, 64],
+        ],
+        [BLOCK_N, HEAD_DIM],
+    ))
+    k_buffer = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM),
+        K.dtype.element_ty,
+        LDS_STAGES,
+        layout=k_shared_layout,
+    )
+    v_buffer = tlx.local_alloc(
+        (BLOCK_N, HEAD_DIM),
+        V.dtype.element_ty,
+        LDS_STAGES,
+        layout=v_shared_layout,
+    )
+    state = SoftmaxState.create()
+    state = _pipeline(
+        state,
+        q,
+        k_ptrs,
+        v_ptrs,
+        k_buffer,
+        v_buffer,
+        stride_m,
+        stride_m,
+        N_CTX // BLOCK_N,
+        q_layout,
+        k_layout,
+        p_layout,
+        v_layout,
+        mma_layout,
+        SM_SCALE * 1.4426950408889634,
+        LOG2_SCORE_BOUND,
+        ADAPTIVE_REFERENCE,
+    )
+
+    _store_output(
+        Out,
+        o_base,
+        pid_m,
+        stride_m,
+        state.row_sum,
+        state.acc0,
+        state.acc1,
+        state.acc2,
+        state.acc3,
+        q_load_layout,
+        mma_layout,
+    )
+
+
+def _storage_ranges_overlap(lhs, rhs):
+    """Return whether two contiguous tensors address any common byte."""
+    if lhs.device != rhs.device or lhs.numel() == 0 or rhs.numel() == 0:
+        return False
+    lhs_begin = lhs.data_ptr()
+    rhs_begin = rhs.data_ptr()
+    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
+    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
+def _validate_attention_inputs(q, k, v, causal, compiler_options):
+    reserved_options = sorted(RESERVED_LAUNCH_OPTIONS.intersection(compiler_options))
+    if reserved_options:
+        names = ", ".join(reserved_options)
+        raise TypeError(f"amd_fa_adaptive compiler options must not override reserved launch keys: {names}")
+    if causal:
+        raise ValueError("amd_fa_adaptive only implements non-causal attention")
+    for name, tensor in (("q", q), ("k", k), ("v", v)):
+        if tensor.ndim != 4:
+            raise ValueError(f"{name} must be rank 4 (B, H, N, D), got rank {tensor.ndim}")
+        if tensor.dtype != torch.bfloat16:
+            raise ValueError(f"{name} must have dtype torch.bfloat16, got {tensor.dtype}")
+    for name, tensor in (("k", k), ("v", v)):
+        if tensor.device != q.device:
+            raise ValueError(f"{name} must be on the same device as q (q={q.device}, {name}={tensor.device})")
+        if tensor.shape != q.shape:
+            raise ValueError(f"{name} must have shape {tuple(q.shape)}, got {tuple(tensor.shape)}")
+    for name, tensor in (("q", q), ("k", k), ("v", v)):
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+
+    batch, heads, sequence, head_dim = q.shape
+    if batch <= 0 or heads <= 0:
+        raise ValueError(f"q batch and head dimensions must be positive, got B={batch}, H={heads}")
+    if sequence < 256 or sequence % 256 != 0:
+        raise ValueError(f"q sequence length must be a multiple of 256 and at least 256, got N={sequence}")
+    if head_dim != 128:
+        raise ValueError(f"q head dimension must be 128, got D={head_dim}")
+    batch_stride = heads * sequence * head_dim
+    last_element_offset = batch * batch_stride - 1
+    if batch_stride > MAX_SIGNED_I32 or last_element_offset > MAX_SIGNED_I32:
+        raise ValueError(f"amd_fa_adaptive batch stride ({batch_stride}) and last element offset "
+                         f"({last_element_offset}) must not exceed the signed-i32 address limit "
+                         f"({MAX_SIGNED_I32})")
+    return batch, heads, sequence, head_dim
+
+
+def _resolve_softmax_reference(head_dim, sm_scale, qk_max_abs):
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+    sm_scale = float(sm_scale)
+    if not math.isfinite(sm_scale):
+        raise ValueError("sm_scale must be finite")
+    adaptive_reference = qk_max_abs is None
+    if adaptive_reference:
+        return sm_scale, True, 0.0
+
+    if not math.isfinite(qk_max_abs) or qk_max_abs <= 0:
+        raise ValueError("qk_max_abs must be finite and greater than zero")
+    if qk_max_abs >= MAX_QK_ABS_FOR_FINITE_F32_DOT:
+        raise ValueError(f"qk_max_abs ({qk_max_abs:g}) exceeds the conservative raw FP32 QK limit "
+                         f"({MAX_QK_ABS_FOR_FINITE_F32_DOT:g}) for head dimension 128")
+    log2_score_bound = math.log2(math.e) * head_dim * abs(sm_scale) * qk_max_abs * qk_max_abs
+    log2_score_span = 2.0 * abs(log2_score_bound)
+    if not math.isfinite(log2_score_span) or log2_score_span >= FIXED_REFERENCE_MAX_LOG2_SPAN:
+        raise ValueError(f"fixed-reference log2 score span ({log2_score_span:g}) must be less than "
+                         f"{FIXED_REFERENCE_MAX_LOG2_SPAN:g}; use qk_max_abs=None for adaptive softmax")
+    return sm_scale, False, log2_score_bound
+
+
+def _prepare_output(q, k, v, out):
+    if out is None:
+        output = torch.empty_like(q)
+    else:
+        output = out
+        if output.ndim != 4:
+            raise ValueError(f"out must be rank 4 (B, H, N, D), got rank {output.ndim}")
+        if output.dtype != torch.bfloat16:
+            raise ValueError(f"out must have dtype torch.bfloat16, got {output.dtype}")
+        if output.device != q.device:
+            raise ValueError(f"out must be on the same device as q (q={q.device}, out={output.device})")
+        if output.shape != q.shape:
+            raise ValueError(f"out must have shape {tuple(q.shape)}, got {tuple(output.shape)}")
+        if not output.is_contiguous():
+            raise ValueError("out must be contiguous")
+    if _storage_ranges_overlap(output, k):
+        raise ValueError("amd_fa_adaptive out must not overlap k")
+    if _storage_ranges_overlap(output, v):
+        raise ValueError("amd_fa_adaptive out must not overlap v")
+    if _storage_ranges_overlap(output, q) and not output.is_set_to(q):
+        raise ValueError("amd_fa_adaptive out may overlap q only when it is exactly the same tensor view")
+    return output
+
+
+def _build_launch_options(batch, heads, sequence, sm_scale, log2_score_bound, adaptive_reference, compiler_options):
+    return {
+        **compiler_options,
+        "N_CTX": sequence,
+        "BATCH": batch,
+        "HEADS": heads,
+        "TOTAL_HEADS": batch * heads,
+        "SM_SCALE": sm_scale,
+        "LOG2_SCORE_BOUND": log2_score_bound,
+        "ADAPTIVE_REFERENCE": adaptive_reference,
+        "num_warps": 8,
+    }
+
+
+def attention(
+    q,
+    k,
+    v,
+    sm_scale=None,
+    causal=False,
+    *,
+    qk_max_abs=None,
+    out=None,
+    warmup=False,
+    **compiler_options,
+):
+    """Run adaptive or fixed-reference FlashAttention.
+
+    The default adaptive reference is numerically stable for unrestricted
+    inputs.  ``qk_max_abs`` explicitly selects the bounded specialization.
+    ``out`` may be exactly ``q``, but it must not partially overlap ``q`` or
+    overlap any part of ``k`` or ``v``.
+    """
+    batch, heads, sequence, head_dim = _validate_attention_inputs(q, k, v, causal, compiler_options)
+    sm_scale, adaptive_reference, log2_score_bound = _resolve_softmax_reference(head_dim, sm_scale, qk_max_abs)
+    output = _prepare_output(q, k, v, out)
+    grid = (sequence // 256, batch * heads, 1)
+    launch_options = _build_launch_options(
+        batch,
+        heads,
+        sequence,
+        sm_scale,
+        log2_score_bound,
+        adaptive_reference,
+        compiler_options,
+    )
+
+    args = (q, k, v, output)
+    if warmup:
+        return _attn_fwd_adaptive_pipeline.warmup(
+            *args,
+            grid=grid,
+            **launch_options,
+        )
+    _attn_fwd_adaptive_pipeline[grid](*args, **launch_options)
+    return output
+
+
+__all__ = ["attention"]

--- a/third_party/tlx/tutorials/amd_fa_adaptive_bench.py
+++ b/third_party/tlx/tutorials/amd_fa_adaptive_bench.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Correctness and performance driver for adaptive FlashAttention.
+
+With no bound, the driver runs bounded random data plus sparse- and
+forced-rebase stress distributions through the adaptive-reference variant.
+``--qk-max-abs`` selects the fixed-reference specialization and runs only data
+that satisfies the asserted magnitude bound.  See ``amd_fa_adaptive.py`` for
+the equations and selection guidance.
+"""
+
+import argparse
+import math
+
+import torch
+import torch.nn.functional as F
+
+import triton
+
+import amd_fa_adaptive
+
+ADVERTISED_SHAPE = (2, 64, 8192, 128)
+QUERY_TILE_SIZE = amd_fa_adaptive.BLOCK_M.value
+KV_TILE_SIZE = amd_fa_adaptive.BLOCK_N.value
+XCD_COUNT = amd_fa_adaptive.XCDS.value
+WARPS_PER_PROGRAM = 8
+ROWS_PER_WARP = QUERY_TILE_SIZE // WARPS_PER_PROGRAM
+FORCED_REBASE_K_STEP = 64.0
+FORCED_REBASE_LOG2_HEADROOM = amd_fa_adaptive.SOFTMAX_REFERENCE_HEADROOM_LOG2.value
+ADAPTIVE_PERFORMANCE_FLOOR_TFLOPS = 1000.0
+
+
+def nonnegative_int(text):
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {text!r}")
+    return value
+
+
+def positive_int(text):
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {text!r}")
+    return value
+
+
+def bounded_inputs(shape, device, *, seed):
+    """Match the standalone runner's bounded Q/K distribution."""
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+
+    def bounded_tensor():
+        values = torch.randint(
+            -8,
+            9,
+            shape,
+            dtype=torch.int8,
+            device=device,
+            generator=generator,
+        )
+        return (values * 0.125).to(torch.bfloat16)
+
+    q = bounded_tensor()
+    k = bounded_tensor()
+    v = (torch.rand(shape, dtype=torch.float32, device=device,
+                    generator=generator).mul_(2.0).sub_(1.0).to(torch.bfloat16))
+    return q, k, v
+
+
+def forced_rebase_inputs(shape, device, *, seed):
+    """Build an adaptive input whose score maximum advances every K/V tile."""
+    _, _, sequence, head_dim = shape
+    if sequence % KV_TILE_SIZE != 0:
+        raise ValueError(f"sequence length must be divisible by {KV_TILE_SIZE}")
+
+    q = torch.zeros(shape, dtype=torch.bfloat16, device=device)
+    q[..., 0] = 1.0
+    tile_indices = torch.arange(sequence // KV_TILE_SIZE, dtype=torch.int32, device=device)
+    tile_keys = (tile_indices * FORCED_REBASE_K_STEP).to(torch.bfloat16)
+    k = torch.zeros_like(q)
+    k[..., 0] = tile_keys.repeat_interleave(KV_TILE_SIZE)
+    # Keep the factory interface aligned with bounded_inputs; this pattern is
+    # intentionally deterministic because tile parity is part of the oracle.
+    del seed
+    tile_values = torch.where(tile_indices % 2 == 0, 64.0, 0.0).to(torch.bfloat16)
+    v = tile_values.repeat_interleave(KV_TILE_SIZE)[None, None, :, None].expand(shape).contiguous()
+
+    tile_log2_scores = tile_keys.float() * (math.log2(math.e) / math.sqrt(head_dim))
+    advances = tile_log2_scores.diff()
+    if not bool(torch.all(advances > FORCED_REBASE_LOG2_HEADROOM)):
+        raise ValueError("forced-rebase score construction does not exceed the adaptive headroom")
+    return q, k, v, advances.numel(), advances.min().item()
+
+
+def sparse_rebase_inputs(shape, device, *, seed):
+    """Force one logical row per warp to rebase on every K/V tile."""
+    q, k, v, rebase_count, minimum_advance = forced_rebase_inputs(
+        shape,
+        device,
+        seed=seed,
+    )
+    q.zero_()
+    q[..., ::ROWS_PER_WARP, 0] = 1.0
+    return q, k, v, rebase_count, minimum_advance
+
+
+def check_correctness(q, k, v, *, qk_max_abs, case):
+    output = amd_fa_adaptive.attention(q, k, v, qk_max_abs=qk_max_abs)
+    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
+        reference = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            scale=1.0 / math.sqrt(ADVERTISED_SHAPE[-1]),
+        )
+    difference = (output.float() - reference.float()).abs()
+    maximum = difference.max().item()
+    mean = difference.mean().item()
+    passed = bool(torch.isfinite(output).all()) and torch.allclose(
+        output,
+        reference,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    batch, heads, sequence, head_dim = ADVERTISED_SHAPE
+    print(f"  [{'PASS' if passed else 'FAIL'}] correctness {case} "
+          f"B={batch} H={heads} D={head_dim} N={sequence} max={maximum:.6f} mean={mean:.6f}")
+    return passed
+
+
+def measure_performance(q, k, v, *, warmup, rep, qk_max_abs):
+    batch, heads, sequence, head_dim = ADVERTISED_SHAPE
+    output = torch.empty_like(q)
+    amd_fa_adaptive.attention(q, k, v, qk_max_abs=qk_max_abs, out=output, warmup=True)
+    launch = lambda: amd_fa_adaptive.attention(q, k, v, qk_max_abs=qk_max_abs, out=output)
+    launch()
+    torch.cuda.synchronize()
+    milliseconds = triton.testing.do_bench(
+        launch,
+        warmup=warmup,
+        rep=rep,
+        return_mode="median",
+    )
+    operations = 4 * batch * heads * sequence * sequence * head_dim
+    return milliseconds, operations / milliseconds * 1e-9
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog="AMD TLX adaptive FlashAttention")
+    parser.add_argument("--warmup", type=nonnegative_int, default=50)
+    parser.add_argument("--rep", type=positive_int, default=500)
+    parser.add_argument(
+        "--min-tflops",
+        type=float,
+        help="required performance in TFLOPS; defaults to 1000 for adaptive reference tracking and 0 for bounded",
+    )
+    parser.add_argument(
+        "--qk-max-abs",
+        type=float,
+        help="explicit Q/K magnitude bound; generated inputs require a value >= 1",
+    )
+    args = parser.parse_args()
+    invalid_bound = args.qk_max_abs is not None and (not math.isfinite(args.qk_max_abs) or args.qk_max_abs < 1.0)
+    if invalid_bound:
+        parser.error("--qk-max-abs must be finite and at least 1")
+    return args
+
+
+def main():
+    args = parse_args()
+    device = triton.runtime.driver.active.get_active_torch_device()
+    minimum = args.min_tflops
+    if minimum is None:
+        minimum = ADAPTIVE_PERFORMANCE_FLOOR_TFLOPS if args.qk_max_abs is None else 0.0
+
+    mode = "adaptive" if args.qk_max_abs is None else f"bounded (|Q|, |K| <= {args.qk_max_abs:g})"
+    batch, heads, sequence, _ = ADVERTISED_SHAPE
+    program_count = batch * heads * (sequence // QUERY_TILE_SIZE)
+    if program_count != 4096 or program_count % XCD_COUNT != 0:
+        raise RuntimeError("advertised FA shape must exercise all 4096 programs across the eight-XCD swizzle")
+    backend = triton.runtime.driver.active.get_current_target().backend
+    print(f"Adaptive FA {mode} ({backend}, programs={program_count}, XCDs={XCD_COUNT})")
+    correctness_ok = True
+    performance_ok = True
+    performance_cases = ["bounded", "sparse", "forced"] if args.qk_max_abs is None else ["bounded"]
+    for input_case in performance_cases:
+        if input_case == "forced":
+            q, k, v, rebase_count, minimum_advance = forced_rebase_inputs(ADVERTISED_SHAPE, device, seed=17)
+            case = f"forced-rebase count={rebase_count} min-log2-advance={minimum_advance:.6f}"
+        elif input_case == "sparse":
+            q, k, v, rebase_count, minimum_advance = sparse_rebase_inputs(ADVERTISED_SHAPE, device, seed=17)
+            case = (f"sparse-rebase rows=1/{ROWS_PER_WARP} count={rebase_count} "
+                    f"min-log2-advance={minimum_advance:.6f}")
+        else:
+            q, k, v = bounded_inputs(ADVERTISED_SHAPE, device, seed=0)
+            case = "bounded-distribution"
+        case_correct = check_correctness(q, k, v, qk_max_abs=args.qk_max_abs, case=case)
+        correctness_ok = correctness_ok and case_correct
+        milliseconds, tflops = measure_performance(
+            q,
+            k,
+            v,
+            warmup=args.warmup,
+            rep=args.rep,
+            qk_max_abs=args.qk_max_abs,
+        )
+        case_ok = tflops >= minimum
+        performance_ok = performance_ok and case_ok
+        print(f"  [{'PASS' if case_ok else 'FAIL'}] performance {case} "
+              f"B=2 H=64 D=128 N=8192 {milliseconds:.6f} ms "
+              f"{tflops:.1f} TFLOPS ({tflops / 1000.0:.3f} PFLOPS, floor {minimum:.1f})")
+    passed = correctness_ok and performance_ok
+    print("RESULT:", "PASS" if passed else "FAIL")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/third_party/tlx/tutorials/amd_fa_compare.py
+++ b/third_party/tlx/tutorials/amd_fa_compare.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Compare equivalent gfx950 FlashAttention forward implementations.
+
+The benchmark gives every implementation the same deterministic BF16 tensors
+and computes non-causal square attention with ``D=128``.  These constraints are
+the intersection of the public adaptive, async, persistent, and cluster
+contracts.  The default bounded-input sweep compares every implementation.
+Two additional adaptive-only cases exercise sparse and forced reference
+rebasing.  Each result is checked against PyTorch SDPA before timing.
+
+Timing uses alternating forward/reverse variant order so that temperature and
+clock drift do not consistently favor one implementation.  The reported time
+is the median of the per-round medians.  Public launchers are measured, so the
+small Python dispatch and cached-output-allocation costs are included equally.
+
+Select a GPU before starting Python, for example:
+
+    ROCR_VISIBLE_DEVICES=7 python third_party/tlx/tutorials/amd_fa_compare.py
+
+Use ``--output results.csv`` to retain the complete measurements.
+"""
+
+import argparse
+import csv
+import gc
+import json
+import math
+import os
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# This benchmark only uses the in-tree AMD backend.  Ignoring external backend
+# entry points also keeps a stale optional plugin installation from changing
+# which checkout is measured.
+os.environ.setdefault("TRITON_BACKENDS_IN_TREE", "1")
+os.environ.setdefault("TRITON_USE_C_DISPATCHER", "0")
+
+import torch
+import torch.nn.functional as F
+
+import triton
+
+import amd_fa_adaptive
+import amd_fa_adaptive_bench
+import amd_fa_cluster
+import amd_fa_persistent
+import amd_fa_pipelined
+
+DEFAULT_SHAPES = ((1, 64, 4096, 128), (2, 64, 8192, 128), (1, 64, 16384, 128))
+DEFAULT_INPUT_CASES = ("bounded", "sparse_rebase", "forced_rebase")
+DEFAULT_VARIANTS = (
+    "adaptive",
+    "adaptive_bounded",
+    "async_simple",
+    "async_prefetch",
+    "persistent",
+    "cluster",
+    "cluster_persistent",
+    "torch_sdpa",
+)
+
+
+@dataclass(frozen=True)
+class Measurement:
+    batch: int
+    heads: int
+    sequence: int
+    head_dim: int
+    input_case: str
+    variant: str
+    correct: bool
+    max_abs: float
+    mean_abs: float
+    median_ms: float
+    tflops: float
+    range_ms: float
+    samples_ms: tuple[float, ...]
+
+
+def _positive_int(text):
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {text!r}")
+    return value
+
+
+def _nonnegative_int(text):
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"expected a non-negative integer, got {text!r}")
+    return value
+
+
+def _shape(text):
+    try:
+        shape = tuple(int(value) for value in text.split(","))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid shape {text!r}; expected B,H,N,D") from exc
+    if len(shape) != 4 or any(value <= 0 for value in shape):
+        raise argparse.ArgumentTypeError(f"invalid shape {text!r}; expected four positive integers B,H,N,D")
+    batch, heads, sequence, head_dim = shape
+    if head_dim != 128:
+        raise argparse.ArgumentTypeError("equivalent adaptive comparisons require D=128")
+    if sequence < 256 or sequence % 256:
+        raise argparse.ArgumentTypeError("equivalent adaptive comparisons require N >= 256 and divisible by 256")
+    return batch, heads, sequence, head_dim
+
+
+def _bounded_inputs(shape, device, seed):
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+
+    def bounded_tensor():
+        values = torch.randint(-8, 9, shape, dtype=torch.int8, device=device, generator=generator)
+        return (values * 0.125).to(torch.bfloat16)
+
+    q = bounded_tensor()
+    k = bounded_tensor()
+    v = torch.rand(shape, dtype=torch.float32, device=device, generator=generator)
+    v = v.mul_(2.0).sub_(1.0).to(torch.bfloat16)
+    return q, k, v
+
+
+def _inputs(input_case, shape, device, seed):
+    if input_case == "bounded":
+        return _bounded_inputs(shape, device, seed)
+    if input_case == "sparse_rebase":
+        q, k, v, _, _ = amd_fa_adaptive_bench.sparse_rebase_inputs(
+            shape,
+            device,
+            seed=seed,
+        )
+        return q, k, v
+    if input_case == "forced_rebase":
+        q, k, v, _, _ = amd_fa_adaptive_bench.forced_rebase_inputs(
+            shape,
+            device,
+            seed=seed,
+        )
+        return q, k, v
+    raise ValueError(f"unsupported input case: {input_case}")
+
+
+def _variant_launchers(q, k, v, scale):
+    return {
+        "adaptive":
+        lambda: amd_fa_adaptive.attention(q, k, v, sm_scale=scale),
+        "adaptive_bounded":
+        lambda: amd_fa_adaptive.attention(q, k, v, sm_scale=scale, qk_max_abs=1.0),
+        "async_simple":
+        lambda: amd_fa_pipelined.attention(
+            q,
+            k,
+            v,
+            scale,
+            False,
+            config={"BLOCK_M": 256, "BLOCK_N": 64, "num_warps": 4},
+        ),
+        "async_prefetch":
+        lambda: amd_fa_pipelined.attention(
+            q,
+            k,
+            v,
+            scale,
+            False,
+            config={"BLOCK_M": 256, "BLOCK_N": 64, "num_warps": 8, "PREFETCH": True},
+        ),
+        "persistent":
+        lambda: amd_fa_persistent.attention(q, k, v, scale, False),
+        "cluster":
+        lambda: amd_fa_cluster.attention(q, k, v, scale, False),
+        "cluster_persistent":
+        lambda: amd_fa_cluster.persistent_attention(q, k, v, scale, False),
+        "torch_sdpa":
+        lambda: F.scaled_dot_product_attention(q, k, v, scale=scale, is_causal=False),
+    }
+
+
+def _reference(q, k, v, scale):
+    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
+        result = F.scaled_dot_product_attention(q, k, v, scale=scale, is_causal=False)
+    torch.cuda.synchronize()
+    return result
+
+
+def _measure_shape(shape, input_case, variants, device, seed, warmup, rep, rounds):
+    batch, heads, sequence, head_dim = shape
+    q, k, v = _inputs(input_case, shape, device, seed)
+    scale = 1.0 / math.sqrt(head_dim)
+    all_launchers = _variant_launchers(q, k, v, scale)
+    launchers = {name: all_launchers[name] for name in variants}
+    reference = _reference(q, k, v, scale)
+
+    correctness = {}
+    for name, launch in launchers.items():
+        output = launch()
+        torch.cuda.synchronize()
+        difference = (output.float() - reference.float()).abs()
+        correct = bool(torch.isfinite(output).all()) and torch.allclose(output, reference, atol=2e-2, rtol=2e-2)
+        correctness[name] = (correct, difference.max().item(), difference.mean().item())
+        print(
+            f"correctness shape={shape} input_case={input_case} "
+            f"variant={name} pass={correct} "
+            f"max_abs={correctness[name][1]:.6g} mean_abs={correctness[name][2]:.6g}",
+            file=sys.stderr,
+            flush=True,
+        )
+        if not correct:
+            raise RuntimeError(f"correctness failed for {name} with {input_case} inputs at shape {shape}")
+
+    orders = []
+    forward = list(launchers)
+    reverse = list(reversed(forward))
+    for round_index in range(rounds):
+        orders.append(forward if round_index % 2 == 0 else reverse)
+
+    samples = {name: [] for name in launchers}
+    for round_index, order in enumerate(orders, 1):
+        for name in order:
+            milliseconds = float(triton.testing.do_bench(launchers[name], warmup=warmup, rep=rep, return_mode="median"))
+            samples[name].append(milliseconds)
+            print(
+                f"timing shape={shape} input_case={input_case} "
+                f"round={round_index}/{rounds} "
+                f"variant={name} ms={milliseconds:.6f}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    operations = 4 * batch * heads * sequence * sequence * head_dim
+    measurements = []
+    for name in launchers:
+        median_ms = statistics.median(samples[name])
+        tflops = operations / (median_ms * 1e-3) / 1e12
+        correct, max_abs, mean_abs = correctness[name]
+        measurements.append(
+            Measurement(
+                batch,
+                heads,
+                sequence,
+                head_dim,
+                input_case,
+                name,
+                correct,
+                max_abs,
+                mean_abs,
+                median_ms,
+                tflops,
+                max(samples[name]) - min(samples[name]),
+                tuple(samples[name]),
+            ))
+
+    del all_launchers, launchers, reference, q, k, v, output, difference
+    gc.collect()
+    torch.cuda.empty_cache()
+    return measurements
+
+
+def _write_csv(measurements, stream):
+    fields = tuple(Measurement.__dataclass_fields__)
+    writer = csv.DictWriter(stream, fieldnames=fields)
+    writer.writeheader()
+    for measurement in measurements:
+        row = dict(measurement.__dict__)
+        row["samples_ms"] = json.dumps(row["samples_ms"])
+        writer.writerow(row)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        dest="shapes",
+        action="append",
+        type=_shape,
+        help="B,H,N,D; repeat for multiple shapes (default: production comparison sweep)",
+    )
+    parser.add_argument(
+        "--input-case",
+        dest="input_cases",
+        action="append",
+        choices=DEFAULT_INPUT_CASES,
+        help="input distribution; repeat as needed (default: all)",
+    )
+    parser.add_argument(
+        "--variant",
+        dest="variants",
+        action="append",
+        choices=DEFAULT_VARIANTS,
+        help="variant to run; repeat as needed (default: all)",
+    )
+    parser.add_argument("--warmup", type=_nonnegative_int, default=50)
+    parser.add_argument("--rep", type=_positive_int, default=300)
+    parser.add_argument("--rounds", type=_positive_int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path, help="optional CSV output path")
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    target = triton.runtime.driver.active.get_current_target()
+    if target.backend != "hip" or target.arch != "gfx950":
+        raise RuntimeError(f"AMD FA comparison requires gfx950, got {target}")
+
+    shapes = tuple(args.shapes) if args.shapes else DEFAULT_SHAPES
+    input_cases = tuple(args.input_cases) if args.input_cases else DEFAULT_INPUT_CASES
+    variants = tuple(args.variants) if args.variants else DEFAULT_VARIANTS
+    if args.input_cases and "adaptive" not in variants:
+        adaptive_cases = set(input_cases) - {"bounded"}
+        if adaptive_cases:
+            cases = ", ".join(sorted(adaptive_cases))
+            raise ValueError(f"input cases {cases} require --variant adaptive")
+    device = triton.runtime.driver.active.get_active_torch_device()
+    print(
+        f"target={target} device={device} shapes={shapes} input_cases={input_cases} "
+        f"variants={variants} "
+        f"warmup={args.warmup} rep={args.rep} rounds={args.rounds} seed={args.seed}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    measurements = []
+    for shape in shapes:
+        for input_case in input_cases:
+            if input_case != "bounded" and "adaptive" not in variants:
+                continue
+            case_variants = variants if input_case == "bounded" else ("adaptive", )
+            measurements.extend(
+                _measure_shape(
+                    shape,
+                    input_case,
+                    case_variants,
+                    device,
+                    args.seed,
+                    args.warmup,
+                    args.rep,
+                    args.rounds,
+                ))
+
+    _write_csv(measurements, sys.stdout)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", newline="") as stream:
+            _write_csv(measurements, stream)
+        print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary:
TLX fixup can specialize a frontend-generated helper ABI with a concrete or deferred layout while leaving encoding-free reshape and transpose result types in the helper body. Once the transpose operand acquires an encoding, its stored result type becomes stale and later InferTypeOpInterface verification rejects it.

Re-infer `tt.trans` result encodings directly through `DialectInferLayoutInterface`. Preserve result-side pins by applying inverse inference first, then use forward inference from the source when the destination encoding is missing or deferred. Add regression coverage for concrete and deferred helper ABI propagation through reshape and transpose.

Differential Revision: D117026283
