### PR TITLE
[triton][tlx] Inline tt.map_elementwise as elementwise ops in TTGIR-to-TLX (#3244)

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-map-elementwise.mlir
+++ b/test/TLX/print-ttgir-to-tlx-map-elementwise.mlir
@@ -1,0 +1,73 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx -split-input-file %s | FileCheck %s
+
+// Test that tt.map_elementwise bodies are inlined as elementwise tensor ops.
+//
+// map_elementwise is a scheduling hint: the body is a scalar computation
+// applied over the operand tensors. tl.map_elementwise takes a callable, which
+// is gone once the body has been inlined into TTGIR, so emitting a flat call
+// would not recompile; the inlined elementwise form is equivalent.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The body ops are emitted in place and the op's result is bound to the
+  // value the region returned.
+  // CHECK-LABEL: def single_result_map(
+  // CHECK: [[SUM:[a-zA-Z_0-9]+]] = arg0 + arg1
+  // CHECK: {{[a-zA-Z_0-9]+}} = [[SUM]]
+  // CHECK-NOT: tl.map_elementwise(
+  tt.func public @single_result_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %r = "tt.map_elementwise"(%arg0, %arg1) <{pack = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      tt.map_elementwise.return %s : f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// The op is variadic in its results, so every result is bound, as one tuple.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def multi_result_map(
+  // CHECK: [[SUM:[a-zA-Z_0-9]+]] = arg0 + arg1
+  // CHECK: [[DIFF:[a-zA-Z_0-9]+]] = arg0 - arg1
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = [[SUM]], [[DIFF]]
+  tt.func public @multi_result_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %lo, %hi = "tt.map_elementwise"(%arg0, %arg1) <{pack = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      %d = arith.subf %a, %b : f32
+      tt.map_elementwise.return %s, %d : f32, f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>)
+    tt.return
+  }
+}
+
+// -----
+
+// With pack > 1 the body's block arguments are num_operands * pack scalars
+// rather than one per operand, so substituting the operands for them would
+// misrepresent the op. Those are left on the existing non-inlined path.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def packed_map(
+  // CHECK: tl.map_elementwise(
+  tt.func public @packed_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %lo, %hi = "tt.map_elementwise"(%arg0, %arg1) <{pack = 2 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      %s1 = arith.addf %a1, %b1 : f32
+      %d0 = arith.subf %a0, %b0 : f32
+      %d1 = arith.subf %a1, %b1 : f32
+      tt.map_elementwise.return %s0, %s1, %d0, %d1 : f32, f32, f32, f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>)
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1868,6 +1868,60 @@ void printSimplifiedOp(
   printLocComment(op, os);
 }
 
+// tt.map_elementwise carries its per-element computation in a region; pack > 1
+// runs that body over several elements at once, which has no elementwise form.
+bool isInlinableMapElementwise(Operation *op) {
+  auto pack = op->getAttrOfType<IntegerAttr>("pack");
+  return op->getName().getStringRef() == "tt.map_elementwise" &&
+         op->getNumRegions() > 0 && op->getNumResults() > 0 &&
+         !op->getRegion(0).empty() && pack && pack.getInt() == 1;
+}
+
+// Inline a tt.map_elementwise body as elementwise tensor ops, as
+// map_elementwise is only a scheduling hint.
+void printMapElementwise(
+    Operation *op, llvm::raw_ostream &os,
+    const llvm::StringMap<StringRef> &opNameMap,
+    const DenseMap<Operation *, LocalAllocInfo> &allocInfoMap,
+    llvm::DenseSet<Operation *> &skippedOps, unsigned indent,
+    DenseMap<Value, Value> *argSubstitutionMap) {
+  DenseMap<Value, Value> bodySubst;
+  if (argSubstitutionMap)
+    bodySubst = *argSubstitutionMap;
+  Block &bb = op->getRegion(0).front();
+  for (unsigned i = 0; i < bb.getNumArguments() && i < op->getNumOperands();
+       ++i) {
+    Value target = op->getOperand(i);
+    if (argSubstitutionMap) {
+      auto it = argSubstitutionMap->find(target);
+      if (it != argSubstitutionMap->end())
+        target = it->second;
+    }
+    bodySubst[bb.getArgument(i)] = target;
+  }
+  for (Operation &bodyOp : bb) {
+    if (bodyOp.getName().getStringRef() == "tt.map_elementwise.return") {
+      for (unsigned k = 0; k < indent; ++k)
+        os << "  ";
+      // One tuple assignment so a multi-result map binds every result; result i
+      // is named in the enclosing scope, returned operand i in the inlined body.
+      assert(op->getNumResults() == bodyOp.getNumOperands() &&
+             "map_elementwise must return one value per result");
+      unsigned n = std::min(op->getNumResults(), bodyOp.getNumOperands());
+      for (unsigned i = 0; i < n; ++i)
+        os << (i ? ", " : "")
+           << getValueName(op->getResult(i), argSubstitutionMap);
+      os << " = ";
+      for (unsigned i = 0; i < n; ++i)
+        os << (i ? ", " : "") << getValueName(bodyOp.getOperand(i), &bodySubst);
+      printLocComment(op, os);
+    } else if (!shouldSkipOp(&bodyOp, allocInfoMap, skippedOps)) {
+      printSimplifiedOp(&bodyOp, os, opNameMap, allocInfoMap, indent,
+                        &bodySubst);
+    }
+  }
+}
+
 // Print a block
 void printBlock(Block &block, llvm::raw_ostream &os,
                 const llvm::StringMap<StringRef> &opNameMap,
@@ -2020,6 +2074,12 @@ void printBlock(Block &block, llvm::raw_ostream &os,
     if (op.getName().getStringRef() == "scf.while") {
       printWhileOp(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
                    argSubstitutionMap);
+      continue;
+    }
+
+    if (isInlinableMapElementwise(&op)) {
+      printMapElementwise(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
+                          argSubstitutionMap);
       continue;
     }
 
@@ -2176,6 +2236,11 @@ void printBlockOps(Block &block, llvm::raw_ostream &os,
     if (op.getName().getStringRef() == "scf.if") {
       printIfOp(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
                 argSubstitutionMap);
+      continue;
+    }
+    if (isInlinableMapElementwise(&op)) {
+      printMapElementwise(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
+                          argSubstitutionMap);
       continue;
     }
     // Special handling for tt.reduce in CF printer


### PR DESCRIPTION
Summary:

`tt.map_elementwise` is a region-carrying op: at the source level `tl.map_elementwise(fn, *tensors)` applies a scalar `triton.jit` callable `fn` to one element at a time (a scheduling hint that improves ptxas's SASS). After inlining into TTGIR the callable is gone and only the body region remains, so the printer's generic flat emission -- `tl.map_elementwise(operands...)` -- is invalid: the `tl.map_elementwise` builtin expects a callable as its first argument, and a tensor is passed instead.

Inline the region body as elementwise tensor ops instead: map the body block args to the op operands, emit the body ops, and assign the op result to the returned value. This is semantically equivalent because the op is elementwise. Handle it in both the structured printer (`printBlock`) and the CF-aware printer (`printBlockOps`) so it also works inside loop bodies.

Authored with Claude.

Differential Revision: D113619166


