### PR TITLE
[triton][tlx] Round-trip barrier allocations and their arrive counts in TTGIR-to-TLX

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-barriers.mlir
+++ b/test/TLX/print-ttgir-to-tlx-barriers.mlir
@@ -1,0 +1,129 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx -split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Test that barrier allocations round-trip with the arrive count they were
+// initialized with.
+//
+// A barrier allocation is recovered from the ttg.local_alloc that backs it,
+// whether a slot is selected out of it with ttg.memdesc_index or it is used
+// directly, and ttng.init_barrier's `count` selects the emitted form: a count
+// that is a positive multiple of the warp size is a warp barrier, any other
+// non-unit count is passed through, and the default count of 1 is left implicit.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // A single-slot barrier is used directly, with no memdesc_index selecting a
+  // slot. It is still a barrier allocation, not a plain buffer.
+  // CHECK-LABEL: def single_slot_barrier(
+  // CHECK: tlx.alloc_barriers(1)
+  // CHECK-NOT: tlx.local_alloc(
+  tt.func public @single_slot_barrier() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The count is read off init_barrier on the direct path too, not just when a
+  // slot is selected with memdesc_index.
+  // CHECK-LABEL: def single_slot_arrive_count(
+  // CHECK: tlx.alloc_barriers(1, 2)
+  tt.func public @single_slot_arrive_count() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A non-unit arrive count is emitted as the second argument.
+  // CHECK-LABEL: def non_unit_arrive_count(
+  // CHECK: tlx.alloc_barriers(1, 2)
+  tt.func public @non_unit_arrive_count() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<1x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %view, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // An arrive count that is a multiple of the warp size is a warp barrier,
+  // carrying the number of warps rather than the raw thread count.
+  // CHECK-LABEL: def warp_barrier(
+  // CHECK: tlx.alloc_warp_barrier(2, 4)
+  tt.func public @warp_barrier() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %view, 128 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The default arrive count of 1 stays implicit.
+  // CHECK-LABEL: def default_arrive_count(
+  // CHECK: tlx.alloc_barriers(2)
+  // CHECK-NOT: tlx.alloc_barriers(2, 1)
+  tt.func public @default_arrive_count() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64, #shared, #smem, mutable>
+    %view = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %view, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Warp size comes from the module, not a hardcoded 32: with 64-wide warps the
+// same count of 128 is two warps rather than four.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+
+  // CHECK-LABEL: def warp_barrier_64_wide(
+  // CHECK: tlx.alloc_warp_barrier(1, 2)
+  tt.func public @warp_barrier_64_wide() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 128 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// One allocation emits one alloc call, so slots that disagree on arrive count
+// cannot be represented: either count would be wrong for the other.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def conflicting_arrive_counts(
+  // CHECK: # unsupported: barrier slots with differing arrive counts
+  // CHECK-NOT: tlx.alloc_barriers(
+  tt.func public @conflicting_arrive_counts() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    // expected-error @+1 {{barrier slots with differing arrive counts do not round-trip to TLX}}
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2x1xi64, #shared, #smem, mutable>
+    %v0 = ttg.memdesc_index %bar[%c0_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %v1 = ttg.memdesc_index %bar[%c1_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %v0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %v1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-map-elementwise.mlir
+++ b/test/TLX/print-ttgir-to-tlx-map-elementwise.mlir
@@ -1,0 +1,73 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx -split-input-file %s | FileCheck %s
+
+// Test that tt.map_elementwise bodies are inlined as elementwise tensor ops.
+//
+// map_elementwise is a scheduling hint: the body is a scalar computation
+// applied over the operand tensors. tl.map_elementwise takes a callable, which
+// is gone once the body has been inlined into TTGIR, so emitting a flat call
+// would not recompile; the inlined elementwise form is equivalent.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The body ops are emitted in place and the op's result is bound to the
+  // value the region returned.
+  // CHECK-LABEL: def single_result_map(
+  // CHECK: [[SUM:[a-zA-Z_0-9]+]] = arg0 + arg1
+  // CHECK: {{[a-zA-Z_0-9]+}} = [[SUM]]
+  // CHECK-NOT: tl.map_elementwise(
+  tt.func public @single_result_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %r = "tt.map_elementwise"(%arg0, %arg1) <{pack = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      tt.map_elementwise.return %s : f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// The op is variadic in its results, so every result is bound, as one tuple.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def multi_result_map(
+  // CHECK: [[SUM:[a-zA-Z_0-9]+]] = arg0 + arg1
+  // CHECK: [[DIFF:[a-zA-Z_0-9]+]] = arg0 - arg1
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = [[SUM]], [[DIFF]]
+  tt.func public @multi_result_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %lo, %hi = "tt.map_elementwise"(%arg0, %arg1) <{pack = 1 : i32}> ({
+    ^bb0(%a: f32, %b: f32):
+      %s = arith.addf %a, %b : f32
+      %d = arith.subf %a, %b : f32
+      tt.map_elementwise.return %s, %d : f32, f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>)
+    tt.return
+  }
+}
+
+// -----
+
+// With pack > 1 the body's block arguments are num_operands * pack scalars
+// rather than one per operand, so substituting the operands for them would
+// misrepresent the op. Those are left on the existing non-inlined path.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def packed_map(
+  // CHECK: tl.map_elementwise(
+  tt.func public @packed_map(%arg0: tensor<128xf32, #blocked>, %arg1: tensor<128xf32, #blocked>) attributes {noinline = false} {
+    %lo, %hi = "tt.map_elementwise"(%arg0, %arg1) <{pack = 2 : i32}> ({
+    ^bb0(%a0: f32, %a1: f32, %b0: f32, %b1: f32):
+      %s0 = arith.addf %a0, %b0 : f32
+      %s1 = arith.addf %a1, %b1 : f32
+      %d0 = arith.subf %a0, %b0 : f32
+      %d1 = arith.subf %a1, %b1 : f32
+      tt.map_elementwise.return %s0, %s1, %d0, %d1 : f32, f32, f32, f32
+    }) : (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>) -> (tensor<128xf32, #blocked>, tensor<128xf32, #blocked>)
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -657,6 +657,10 @@ std::string getElementTypeName(Type type) {
 struct LocalAllocInfo {
   bool isBarrierAlloc = false;
   int barrierCount = 0;
+  // Arrive count of the barrier (init_barrier's `count`); default 1.
+  int arriveCount = 1;
+  // Set when the slots disagree on arrive count, which has no TLX spelling.
+  bool conflictingArriveCounts = false;
   // For regular allocs: shape (excluding first dim which is count),
   // element type, count
   SmallVector<int64_t> shape;
@@ -684,12 +688,35 @@ LocalAllocInfo analyzeLocalAlloc(Operation *localAllocOp) {
     bool foundInitBarrier = false;
     int initBarrierCount = 0;
 
+    // One allocation emits one alloc call, so its slots must agree on the
+    // arrive count; there is no TLX spelling for a per-slot count.
+    auto recordArriveCount = [&](Operation *initOp) {
+      auto cAttr = initOp->getAttrOfType<IntegerAttr>("count");
+      if (!cAttr)
+        return;
+      if (foundInitBarrier && cAttr.getInt() != info.arriveCount) {
+        localAllocOp->emitError("barrier slots with differing arrive counts do "
+                                "not round-trip to TLX");
+        info.conflictingArriveCounts = true;
+      }
+      info.arriveCount = cAttr.getInt();
+    };
+
     for (Operation *user : allocResult.getUsers()) {
-      if (user->getName().getStringRef() == "ttg.memdesc_index") {
+      StringRef userName = user->getName().getStringRef();
+      // Single-slot barrier, used directly with no memdesc_index.
+      if (userName == "ttng.init_barrier") {
+        recordArriveCount(user);
+        foundInitBarrier = true;
+        initBarrierCount++;
+        continue;
+      }
+      if (userName == "ttg.memdesc_index") {
         // Check if memdesc_index result is used by init_barrier
         for (Value result : user->getResults()) {
           for (Operation *indexUser : result.getUsers()) {
             if (indexUser->getName().getStringRef() == "ttng.init_barrier") {
+              recordArriveCount(indexUser);
               foundInitBarrier = true;
               initBarrierCount++;
             }
@@ -1368,12 +1395,30 @@ void printSimplifiedOp(
     auto it = allocInfoMap.find(op);
     if (it != allocInfoMap.end()) {
       const LocalAllocInfo &info = it->second;
+      if (info.isBarrierAlloc && info.conflictingArriveCounts) {
+        // Any single count here would be wrong for the other slots.
+        os << "# unsupported: barrier slots with differing arrive counts";
+        printLocComment(op, os);
+        return;
+      }
       if (info.isBarrierAlloc) {
         // Print as result = tlx.alloc_barriers(count)
         if (op->getNumResults() > 0) {
           os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
         }
-        os << "tlx.alloc_barriers(" << info.barrierCount << ")";
+        // An arrive count that is a positive multiple of the warp size is a
+        // warp barrier: every thread arrives, rather than one leader per warp.
+        ModuleOp mod = op->getParentOfType<ModuleOp>();
+        int warpSize = mod ? ttg::TritonGPUDialect::getThreadsPerWarp(mod) : 32;
+        if (info.arriveCount >= warpSize && info.arriveCount % warpSize == 0) {
+          os << "tlx.alloc_warp_barrier(" << info.barrierCount << ", "
+             << (info.arriveCount / warpSize) << ")";
+        } else if (info.arriveCount != 1) {
+          os << "tlx.alloc_barriers(" << info.barrierCount << ", "
+             << info.arriveCount << ")";
+        } else {
+          os << "tlx.alloc_barriers(" << info.barrierCount << ")";
+        }
         printLocComment(op, os);
         return;
       } else {
@@ -2816,6 +2861,15 @@ public:
   void runOnOperation() override {
     ModuleOp m = getOperation();
 
+    // Ops the printer cannot represent report a diagnostic. Count those so the
+    // pass fails, rather than handing back a silently incomplete kernel.
+    unsigned numErrors = 0;
+    ScopedDiagnosticHandler countErrors(m.getContext(), [&](Diagnostic &diag) {
+      if (diag.getSeverity() == DiagnosticSeverity::Error)
+        ++numErrors;
+      return failure();
+    });
+
     // Build the lookup map
     static llvm::StringMap<StringRef> opNameMap = buildOpNameMap();
 
@@ -2870,6 +2924,8 @@ public:
     }
 
     valueNameCacheStorage = nullptr;
+    if (numErrors > 0)
+      signalPassFailure();
   }
 };
 

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1868,6 +1868,60 @@ void printSimplifiedOp(
   printLocComment(op, os);
 }
 
+// tt.map_elementwise carries its per-element computation in a region; pack > 1
+// runs that body over several elements at once, which has no elementwise form.
+bool isInlinableMapElementwise(Operation *op) {
+  auto pack = op->getAttrOfType<IntegerAttr>("pack");
+  return op->getName().getStringRef() == "tt.map_elementwise" &&
+         op->getNumRegions() > 0 && op->getNumResults() > 0 &&
+         !op->getRegion(0).empty() && pack && pack.getInt() == 1;
+}
+
+// Inline a tt.map_elementwise body as elementwise tensor ops, as
+// map_elementwise is only a scheduling hint.
+void printMapElementwise(
+    Operation *op, llvm::raw_ostream &os,
+    const llvm::StringMap<StringRef> &opNameMap,
+    const DenseMap<Operation *, LocalAllocInfo> &allocInfoMap,
+    llvm::DenseSet<Operation *> &skippedOps, unsigned indent,
+    DenseMap<Value, Value> *argSubstitutionMap) {
+  DenseMap<Value, Value> bodySubst;
+  if (argSubstitutionMap)
+    bodySubst = *argSubstitutionMap;
+  Block &bb = op->getRegion(0).front();
+  for (unsigned i = 0; i < bb.getNumArguments() && i < op->getNumOperands();
+       ++i) {
+    Value target = op->getOperand(i);
+    if (argSubstitutionMap) {
+      auto it = argSubstitutionMap->find(target);
+      if (it != argSubstitutionMap->end())
+        target = it->second;
+    }
+    bodySubst[bb.getArgument(i)] = target;
+  }
+  for (Operation &bodyOp : bb) {
+    if (bodyOp.getName().getStringRef() == "tt.map_elementwise.return") {
+      for (unsigned k = 0; k < indent; ++k)
+        os << "  ";
+      // One tuple assignment so a multi-result map binds every result; result i
+      // is named in the enclosing scope, returned operand i in the inlined body.
+      assert(op->getNumResults() == bodyOp.getNumOperands() &&
+             "map_elementwise must return one value per result");
+      unsigned n = std::min(op->getNumResults(), bodyOp.getNumOperands());
+      for (unsigned i = 0; i < n; ++i)
+        os << (i ? ", " : "")
+           << getValueName(op->getResult(i), argSubstitutionMap);
+      os << " = ";
+      for (unsigned i = 0; i < n; ++i)
+        os << (i ? ", " : "") << getValueName(bodyOp.getOperand(i), &bodySubst);
+      printLocComment(op, os);
+    } else if (!shouldSkipOp(&bodyOp, allocInfoMap, skippedOps)) {
+      printSimplifiedOp(&bodyOp, os, opNameMap, allocInfoMap, indent,
+                        &bodySubst);
+    }
+  }
+}
+
 // Print a block
 void printBlock(Block &block, llvm::raw_ostream &os,
                 const llvm::StringMap<StringRef> &opNameMap,
@@ -2020,6 +2074,12 @@ void printBlock(Block &block, llvm::raw_ostream &os,
     if (op.getName().getStringRef() == "scf.while") {
       printWhileOp(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
                    argSubstitutionMap);
+      continue;
+    }
+
+    if (isInlinableMapElementwise(&op)) {
+      printMapElementwise(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
+                          argSubstitutionMap);
       continue;
     }
 
@@ -2176,6 +2236,11 @@ void printBlockOps(Block &block, llvm::raw_ostream &os,
     if (op.getName().getStringRef() == "scf.if") {
       printIfOp(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
                 argSubstitutionMap);
+      continue;
+    }
+    if (isInlinableMapElementwise(&op)) {
+      printMapElementwise(&op, os, opNameMap, allocInfoMap, skippedOps, indent,
+                          argSubstitutionMap);
       continue;
     }
     // Special handling for tt.reduce in CF printer


### PR DESCRIPTION
Summary:
The printer reconstructs a barrier allocation from the `local_alloc` that backs it, but it recovered neither of the two things that describe the barrier: which allocations are barriers at all, and how many arrivals each one takes.

**Detection.** An allocation was classified as a barrier only through the pattern `local_alloc -> memdesc_index -> init_barrier`, i.e. only when a slot is selected out of a barrier array. The MMA pipeliner also creates a standalone single-slot barrier to signal completion of a prefetched dot, and that one is used directly with no `memdesc_index` in between, so detection missed it and it fell through to the generic buffer path. That emitted `tlx.local_alloc((1,), tl.int64, 1)`, whose memdesc is two-dimensional, instead of `tlx.alloc_barriers(1)`, and recompiling the generated kernel failed to verify:

```
'ttng.wait_barrier' op barrier allocation must be a descriptor of Nxi64 type with N <= number of CTAs
```

**Arrive count.** Every barrier was emitted as `tlx.alloc_barriers(n)`, which is arrive count 1. The count lives on `init_barrier`, and dropping it changes the barrier's semantics: an arrive count of `k` releases after `k` arrivals, so emitting 1 releases the barrier after the first one. Capture `init_barrier`'s `count` and emit it. A count that is a positive multiple of the warp size is a warp barrier, where every thread arrives individually rather than one leader per warp, so those are emitted as `tlx.alloc_warp_barrier(n, num_warps)`; other non-unit counts become `tlx.alloc_barriers(n, count)`. Warp size is read from the module's `ttg.threads-per-warp` rather than assumed to be 32, so the classification also holds on 64-wide targets.

Both paths record the count, so a single-slot barrier keeps its arrive count too.

One allocation emits one alloc call, so its slots have to agree on the count. When they disagree there is no correct number to print, so that reports a diagnostic and emits an `# unsupported: barrier slots with differing arrive counts` marker instead of picking one and silently changing the others' semantics.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D116703255


