### PR TITLE
[CI] Fix test_second_call_preserves_cluster_config global access error

### DIFF
--- a/python/test/unit/runtime/test_fast_cache_edge_cases.py
+++ b/python/test/unit/runtime/test_fast_cache_edge_cases.py
@@ -778,8 +778,9 @@ class TestUnhashableKwargs(TestCase):
 
 # Module-level global referenced by the 2-CTA test kernel → populates
 # used_global_vals → __getitem__ returns the lambda fallback instead of
-# the C proxy, exercising the buggy path.
-_CLUSTER_SCALE = 1.0
+# the C proxy, exercising the buggy path.  Must be a tl.constexpr: @jit'ed
+# functions may only read globals instantiated as constexpr.
+_CLUSTER_SCALE = tl.constexpr(1.0)
 
 
 class TestCtasPerCgaAutotunerSteadyState(TestCase):


### PR DESCRIPTION
Fix broken CI

## Test plan

`pytest python/test/unit/runtime/test_fast_cache_edge_cases.py::TestCtasPerCgaAutotunerSteadyState::test_second_call_preserves_cluster_config`