### PR TITLE
[TLX][FA] Pipeline the first cooperative K tile and output stores

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1958,11 +1958,17 @@ def _bwd_host_descriptor_pre_hook_tlx(nargs):
     nargs["desc_do"].block_shape = [1, 1, block_m, head_dim // num_ctas]
     nargs["desc_v"].block_shape = [1, 1, block_n, head_dim]
     nargs["desc_k"].block_shape = [1, 1, block_n, head_dim]
-    if num_ctas > 1:
+    direct_dq = nargs.get("SCALE_QK_IN_KERNEL", False) and num_ctas > 1 and head_dim == 128
+    if direct_dq:
+        dq_m = block_m // num_ctas
+        dq_slice = head_dim // nargs["EPILOGUE_SUBTILE"]
+    elif num_ctas > 1:
+        dq_m = block_m
         dq_slice = head_dim // nargs["EPILOGUE_SUBTILE"]
     else:
+        dq_m = block_m
         dq_slice = nargs["DQ_REDUCE_NCOL"]
-    nargs["desc_dq"].block_shape = [1, 1, block_m, dq_slice]
+    nargs["desc_dq"].block_shape = [1, 1, dq_m, dq_slice]
     dkv_slice = nargs["DKV_STORE_NCOL"]
     nargs["desc_dv"].block_shape = [1, 1, block_n, dkv_slice]
     nargs["desc_dk"].block_shape = [1, 1, block_n, dkv_slice]
@@ -2018,7 +2024,7 @@ configs_bwd_2cta = [
             "DKV_STORE_NCOL": 64,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
-            "EPILOGUE_SUBTILE": 4,
+            "EPILOGUE_SUBTILE": 8,
             "GROUP_SIZE_M": 1,
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
@@ -2031,6 +2037,25 @@ configs_bwd_2cta = [
 ]
 
 BWD_CONFIGS = configs_bwd_1cta + configs_bwd_2cta
+
+
+def prune_bwd_configs(configs, named_args, **kwargs):
+    n_ctx = kwargs["N_CTX"] if "N_CTX" in kwargs else named_args["N_CTX"]
+    configs = [
+        config
+        for config in configs
+        if (
+            (n_ctx + config.kwargs["BLOCK_N1"] - 1)
+            // config.kwargs["BLOCK_N1"]
+        )
+        % config.kwargs.get("NUM_CTAS", 1)
+        == 0
+    ]
+    if kwargs.get("SCALE_QK_IN_KERNEL", False):
+        assert kwargs["HEAD_DIM"] == 128
+        configs = [config for config in configs if config.kwargs.get("NUM_CTAS", 1) == 2]
+        assert configs
+    return configs
 
 
 @triton.jit
@@ -2229,7 +2254,7 @@ def _bwd_mma_dots_1cta(
         q_tiles[q_buf_id],
         dk_tiles[kv_buf_id],
         use_acc=num_steps > 1,
-        mBarriers=[q_empties[q_buf_id], dk_fulls[tmem_buf_id]],
+        mBarriers=[q_empties[q_buf_id], dk_fulls[kv_buf_id]],
     )
 
     # Compute dq = tl.dot(tl.trans(dsT), k)
@@ -2921,6 +2946,7 @@ def _bwd_compute_inner_loop(
     step_m,
     do_out_dtype,
     q_out_dtype,
+    qk_scale,
     N_CTX,
     NUM_BUFFERS_TMEM: tl.constexpr,
     NUM_BUFFERS_DS: tl.constexpr,
@@ -2933,6 +2959,7 @@ def _bwd_compute_inner_loop(
     D_STAGE: tl.constexpr,
     # 2-CTA params (defaults for 1-CTA)
     USE_2CTA: tl.constexpr = False,
+    SCALE_QK_IN_KERNEL: tl.constexpr = False,
     NUM_CTAS: tl.constexpr = 1,
     dsT_xchg_tiles=None,
     ds_xchg_tiles=None,
@@ -2973,7 +3000,10 @@ def _bwd_compute_inner_loop(
         # causal mask to the logits via the R2P bitmask helper (keep query-cols
         # m >= key-row n), then exp2 (exp2(-inf) = 0), avoiding the per-element
         # ISETP arithmetic of `offs_m >= offs_n`.
-        sT = _sub_f32x2(qkT, m[None, :])
+        if SCALE_QK_IN_KERNEL:
+            sT = _fma_f32x2(qkT, qk_scale, -m[None, :])
+        else:
+            sT = _sub_f32x2(qkT, m[None, :])
         if STAGE == 1:
             col_limit_left = (offs_n - curr_m)[:, None]
             sT = _apply_causal_mask(sT, col_limit_left, BLOCK_M1, keep_ge=True)
@@ -3065,7 +3095,11 @@ def _bwd_compute_inner_loop(
     return curr_m, blk_idx
 
 
-@triton.autotune(configs=BWD_CONFIGS, key=["N_CTX", "HEAD_DIM"])
+@triton.autotune(
+    configs=BWD_CONFIGS,
+    key=["N_CTX", "HEAD_DIM"],
+    prune_configs_by={"early_config_prune": prune_bwd_configs},
+)
 @triton.jit
 def _attn_bwd_ws(
     desc_q,
@@ -3105,6 +3139,7 @@ def _attn_bwd_ws(
     USE_WARP_BARRIER: tl.constexpr = False,
     EPILOGUE_SUBTILE: tl.constexpr = 4,
     NUM_CTAS: tl.constexpr = 1,
+    SCALE_QK_IN_KERNEL: tl.constexpr = False,
 ):
     # Runtime error if NUM_BUFFERS_DO != 1
     tl.static_assert(NUM_BUFFERS_DO == 1)
@@ -3117,6 +3152,14 @@ def _attn_bwd_ws(
     REUSE_DP_FOR_DQ: tl.constexpr = (BLOCK_M1 == 128) and (HEAD_DIM == 128) and (NUM_CTAS == 1)
 
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
+    tl.static_assert(
+        not SCALE_QK_IN_KERNEL or (USE_2CTA and HEAD_DIM == 128),
+        "direct dQ requires NUM_CTAS=2 and HEAD_DIM=128",
+    )
+    DIRECT_DQ_OUTPUT: tl.constexpr = SCALE_QK_IN_KERNEL
+    DQ_READ_DONE_BAR: tl.constexpr = 12
+    NUM_REDUCE_THREADS: tl.constexpr = 4 * 32
+    qk_scale = sm_scale * 1.4426950408889634
 
     # Compute bytes per element for each tensor type
     Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
@@ -3179,7 +3222,14 @@ def _attn_bwd_ws(
         dq_empties = tlx.alloc_warp_barrier(num_barriers=NUM_BUFFERS_TMEM, num_warps=4)
     else:
         dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM, arrive_count=NUM_CTAS)
-
+    if DIRECT_DQ_OUTPUT:
+        dq_stage_fulls = tlx.alloc_warp_barrier(
+            num_barriers=2, num_warps=4
+        )
+        dq_stage_empties = tlx.alloc_barriers(num_barriers=2)
+    else:
+        dq_stage_fulls = None
+        dq_stage_empties = None
     dv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     if USE_WARP_BARRIER:
         dv_empties = tlx.alloc_warp_barrier(num_barriers=NUM_BUFFERS_KV, num_warps=8)
@@ -3234,7 +3284,8 @@ def _attn_bwd_ws(
     DQ_SLICE_N: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     if USE_2CTA:
         DQ_STORE_STAGES: tl.constexpr = 1 if EPILOGUE_SUBTILE == 4 else 2
-        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_STORE_STAGES)
+        DQ_BUFFER_STAGES: tl.constexpr = 2 if DIRECT_DQ_OUTPUT else DQ_STORE_STAGES
+        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_BUFFER_STAGES)
     else:
         DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
         dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES)
@@ -3384,7 +3435,7 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    with tlx.async_tasks(exclusive=True):
+    with tlx.async_tasks(exclusive=not DIRECT_DQ_OUTPUT):
         # compute
         with tlx.async_task("default"):
             blk_idx = 0
@@ -3420,6 +3471,7 @@ def _attn_bwd_ws(
                     step_m,
                     do_out_dtype,
                     q_out_dtype,
+                    qk_scale,
                     N_CTX,
                     NUM_BUFFERS_TMEM,
                     NUM_BUFFERS_DS,
@@ -3431,6 +3483,7 @@ def _attn_bwd_ws(
                     M_STAGE=M_STAGE,
                     D_STAGE=D_STAGE,
                     USE_2CTA=USE_2CTA,
+                    SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                     NUM_CTAS=NUM_CTAS,
                     dsT_xchg_tiles=None,
                     ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3468,6 +3521,7 @@ def _attn_bwd_ws(
                         step_m,
                         do_out_dtype,
                         q_out_dtype,
+                        qk_scale,
                         N_CTX,
                         NUM_BUFFERS_TMEM,
                         NUM_BUFFERS_DS,
@@ -3479,6 +3533,7 @@ def _attn_bwd_ws(
                         M_STAGE=M_STAGE,
                         D_STAGE=D_STAGE,
                         USE_2CTA=USE_2CTA,
+                        SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                         NUM_CTAS=NUM_CTAS,
                         dsT_xchg_tiles=None,
                         ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3514,6 +3569,7 @@ def _attn_bwd_ws(
                         step_m,
                         do_out_dtype,
                         q_out_dtype,
+                        qk_scale,
                         N_CTX,
                         NUM_BUFFERS_TMEM,
                         NUM_BUFFERS_DS,
@@ -3525,6 +3581,7 @@ def _attn_bwd_ws(
                         M_STAGE=M_STAGE,
                         D_STAGE=D_STAGE,
                         USE_2CTA=USE_2CTA,
+                        SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                         NUM_CTAS=NUM_CTAS,
                         dsT_xchg_tiles=None,
                         ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3604,30 +3661,61 @@ def _attn_bwd_ws(
                 tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
                 if USE_2CTA:
                     dq_m_offset = cluster_cta_rank * DQ_STORE_M
-                    packed_row_base = 2 * (curr_m + dq_m_offset)
                     DQ_PACK_ITERS: tl.constexpr = (HEAD_DIM // NUM_CTAS) // DQ_SLICE_N
-                    dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
-                    if USE_WARP_BARRIER:
-                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
-                    else:
-                        tlx.barrier_arrive(dq_empties[tmem_buf_id], 1, remote_cta_rank=0)
-                    dq_full = dq_full * LN2
-                    dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
-                    for slice_id in tl.static_range(DQ_PACK_ITERS):
-                        dq_smem = dq_store_buf[slice_id % DQ_STORE_STAGES]
-                        tlx.async_descriptor_store_wait(DQ_STORE_STAGES - 1)
-                        tlx.local_store(dq_smem, dq_slices[slice_id].to(tlx.dtype_of(desc_dq)))
-                        tlx.async_descriptor_store(
-                            desc_dq,
-                            dq_smem,
-                            [
-                                batch,
-                                head,
-                                packed_row_base,
-                                slice_id * DQ_SLICE_N,
-                            ],
-                            store_reduce="add",
+                    if DIRECT_DQ_OUTPUT:
+                        dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
+                        tlx.named_barrier_wait(DQ_READ_DONE_BAR, NUM_REDUCE_THREADS)
+                        tlx.barrier_arrive(
+                            dq_empties[tmem_buf_id], 1, remote_cta_rank=0
                         )
+                        dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
+                        for slice_id in tl.static_range(DQ_PACK_ITERS):
+                            dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
+                            dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(
+                                dq_stage_count, 2
+                            )
+                            tlx.barrier_wait(
+                                dq_stage_empties[dq_stage_buf_id],
+                                dq_stage_phase ^ 1,
+                            )
+                            dq_smem = dq_store_buf[dq_stage_buf_id]
+                            tlx.local_store(
+                                dq_smem,
+                                (dq_slices[slice_id] * sm_scale).to(
+                                    tlx.dtype_of(desc_dq)
+                                ),
+                            )
+                            tlx.fence("async_shared")
+                            tlx.barrier_arrive(dq_stage_fulls[dq_stage_buf_id])
+                    else:
+                        packed_row_base = 2 * (curr_m + dq_m_offset)
+                        dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
+                        if USE_WARP_BARRIER:
+                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
+                        else:
+                            tlx.barrier_arrive(
+                                dq_empties[tmem_buf_id], 1, remote_cta_rank=0
+                            )
+                        dq_full = dq_full * LN2
+                        dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
+                        for slice_id in tl.static_range(DQ_PACK_ITERS):
+                            dq_smem = dq_store_buf[slice_id % DQ_STORE_STAGES]
+                            tlx.async_descriptor_store_wait(DQ_STORE_STAGES - 1)
+                            tlx.local_store(
+                                dq_smem,
+                                dq_slices[slice_id].to(tlx.dtype_of(desc_dq)),
+                            )
+                            tlx.async_descriptor_store(
+                                desc_dq,
+                                dq_smem,
+                                [
+                                    batch,
+                                    head,
+                                    packed_row_base,
+                                    slice_id * DQ_SLICE_N,
+                                ],
+                                store_reduce="add",
+                            )
                 else:
                     HALF_HD: tl.constexpr = HEAD_DIM // 2
                     SLICES_PER_HALF: tl.constexpr = HALF_HD // DQ_REDUCE_NCOL
@@ -3639,7 +3727,10 @@ def _attn_bwd_ws(
                             [BLOCK_M1, DQ_REDUCE_NCOL],
                         )
                         dq = tlx.local_load(dq_slice)
-                        dq = dq * LN2
+                        if SCALE_QK_IN_KERNEL:
+                            dq = dq * sm_scale
+                        else:
+                            dq = dq * LN2
                         tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
                         tlx.local_store(
                             dq_store_buf[dq_smem_idx],
@@ -3666,6 +3757,62 @@ def _attn_bwd_ws(
 
             # Wait for the final tile
             tlx.async_descriptor_store_wait(0)
+
+        if USE_2CTA and DIRECT_DQ_OUTPUT:
+            with tlx.async_task(num_warps=1, registers=88):
+                curr_m = start_m
+                dq_m_offset = cluster_cta_rank * DQ_STORE_M
+                DQ_PACK_ITERS: tl.constexpr = (
+                    HEAD_DIM // NUM_CTAS // DQ_SLICE_N
+                )
+                for blk_idx in range(num_steps):
+                    for slice_id in tl.static_range(DQ_PACK_ITERS):
+                        dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
+                        dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(
+                            dq_stage_count, 2
+                        )
+                        if dq_stage_count >= 2:
+                            tlx.async_descriptor_store_wait(2)
+                            tlx.barrier_arrive(
+                                dq_stage_empties[dq_stage_buf_id]
+                            )
+                        tlx.barrier_wait(
+                            dq_stage_fulls[dq_stage_buf_id], dq_stage_phase
+                        )
+                        dq_smem = dq_store_buf[dq_stage_buf_id]
+                        dq_smem_lo = tlx.local_slice(
+                            dq_smem, [0, 0], [DQ_STORE_M, DQ_SLICE_N]
+                        )
+                        dq_smem_hi = tlx.local_slice(
+                            dq_smem,
+                            [DQ_STORE_M, 0],
+                            [DQ_STORE_M, DQ_SLICE_N],
+                        )
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_smem_lo,
+                            [
+                                batch,
+                                head,
+                                curr_m + dq_m_offset,
+                                slice_id * DQ_SLICE_N,
+                            ],
+                            store_reduce="add",
+                        )
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_smem_hi,
+                            [
+                                batch,
+                                head,
+                                curr_m + dq_m_offset,
+                                HEAD_DIM // NUM_CTAS
+                                + slice_id * DQ_SLICE_N,
+                            ],
+                            store_reduce="add",
+                        )
+                    curr_m += BLOCK_M1
+                tlx.async_descriptor_store_wait(0)
 
         # mma
         with tlx.async_task(num_warps=1, registers=88):
@@ -4050,17 +4197,24 @@ class _attention(torch.autograd.Function):
         q, k, v, o, M = ctx.saved_tensors
         assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous()
         assert o.is_contiguous() and do.is_contiguous()
-        dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
+        assert ctx.HEAD_DIM in (64, 128), "backward requires head dimension 64 or 128"
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
+        direct_dq_output = ctx.HEAD_DIM == 128 and N_CTX % 256 == 0
+        if direct_dq_output:
+            dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+        else:
+            dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
-        BATCH, N_HEAD, N_CTX = q.shape[:3]
         _HALF_HD = ctx.HEAD_DIM // 2
-        dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
+        if direct_dq_output:
+            dq_accum = dq
+        else:
+            dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
         PRE_BLOCK = 128
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
-        arg_k = k
-        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
+        arg_k = k if direct_dq_output else k * (ctx.sm_scale * RCP_LN2)
         assert N_CTX % PRE_BLOCK == 0
         pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
         delta = torch.empty_like(M)
@@ -4099,8 +4253,12 @@ class _attention(torch.autograd.Function):
             strides=desc_strides,
             block_shape=dummy_block,
         )
-        packed_shape = [BATCH, N_HEAD, 2 * N_CTX, _HALF_HD]
-        packed_strides = [N_HEAD * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
+        if direct_dq_output:
+            packed_shape = desc_shape
+            packed_strides = desc_strides
+        else:
+            packed_shape = [BATCH, N_HEAD, 2 * N_CTX, _HALF_HD]
+            packed_strides = [N_HEAD * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
         desc_dq = TensorDescriptor(
             dq_accum,
             shape=packed_shape,
@@ -4160,16 +4318,18 @@ class _attention(torch.autograd.Function):
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
+            SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 
-        _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
-        post_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
-        _attn_bwd_dq_postprocess[post_grid](
-            dq_accum, dq,  #
-            N_CTX,  #
-            BLK=_blk, HALF_HD=_HALF_HD,  #
-            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
-        )
+        if not direct_dq_output:
+            _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
+            post_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+            _attn_bwd_dq_postprocess[post_grid](
+                dq_accum, dq,  #
+                N_CTX,  #
+                BLK=_blk, HALF_HD=_HALF_HD,  #
+                BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
+            )
 
         return dq, dk, dv, None, None
 

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -2,10 +2,12 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
+from triton.language import core
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _sub_f32x2
-from triton.language.extra.subtile_ops import _split_n_2D
+from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
+
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
@@ -99,6 +101,42 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
                 continue
         pruned.append(conf)
     return pruned
+
+
+@core.builtin
+def _s2_exp2_bf16(x, a2, b2m, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
+            mov.b64 ra, { $1, $2 };
+            mov.b64 rb, { $3, $4 };
+            mov.b64 rc, { $5, $6 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { v0, v1 }, rd;
+            prmt.b32 pk, v0, v1, 0x5410;
+            mov.b32 zz, 0;
+            mov.b32 mk, 0x00400040;
+            add.s16x2 uu, pk, mk;
+            mov.b32 c0, 0x3f3b3f3b;
+            fma.rn.bf16x2 pk, uu, c0, pk;
+            max.bf16x2 pk, pk, zz;
+            mov.b32 $0, pk;
+        }
+        """,
+        "=r,r,r,r,r,r,r",
+        [x, a2, b2m],
+        dtype=core.bfloat16,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
+@triton.jit
+def _reduce_bf16(a, b):
+    return (a + b).to(tl.bfloat16)
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -3133,6 +3133,7 @@ def _attn_bwd_ws(
     NUM_COMPUTE_SLICES: tl.constexpr,
     DQ_REDUCE_STAGES: tl.constexpr,
     DQ_REDUCE_NCOL: tl.constexpr,
+    DQ_STAGE_COUNT: tl.constexpr,
     DKV_STORE_NCOL: tl.constexpr,
     STAGE: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
@@ -3224,9 +3225,9 @@ def _attn_bwd_ws(
         dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM, arrive_count=NUM_CTAS)
     if DIRECT_DQ_OUTPUT:
         dq_stage_fulls = tlx.alloc_warp_barrier(
-            num_barriers=2, num_warps=4
+            num_barriers=DQ_STAGE_COUNT, num_warps=4
         )
-        dq_stage_empties = tlx.alloc_barriers(num_barriers=2)
+        dq_stage_empties = tlx.alloc_barriers(num_barriers=DQ_STAGE_COUNT)
     else:
         dq_stage_fulls = None
         dq_stage_empties = None
@@ -3284,7 +3285,7 @@ def _attn_bwd_ws(
     DQ_SLICE_N: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     if USE_2CTA:
         DQ_STORE_STAGES: tl.constexpr = 1 if EPILOGUE_SUBTILE == 4 else 2
-        DQ_BUFFER_STAGES: tl.constexpr = 2 if DIRECT_DQ_OUTPUT else DQ_STORE_STAGES
+        DQ_BUFFER_STAGES: tl.constexpr = DQ_STAGE_COUNT if DIRECT_DQ_OUTPUT else DQ_STORE_STAGES
         dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_BUFFER_STAGES)
     else:
         DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
@@ -3672,7 +3673,7 @@ def _attn_bwd_ws(
                         for slice_id in tl.static_range(DQ_PACK_ITERS):
                             dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
                             dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(
-                                dq_stage_count, 2
+                                dq_stage_count, DQ_STAGE_COUNT
                             )
                             tlx.barrier_wait(
                                 dq_stage_empties[dq_stage_buf_id],
@@ -3769,10 +3770,10 @@ def _attn_bwd_ws(
                     for slice_id in tl.static_range(DQ_PACK_ITERS):
                         dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
                         dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(
-                            dq_stage_count, 2
+                            dq_stage_count, DQ_STAGE_COUNT
                         )
-                        if dq_stage_count >= 2:
-                            tlx.async_descriptor_store_wait(2)
+                        if dq_stage_count >= DQ_STAGE_COUNT:
+                            tlx.async_descriptor_store_wait(DQ_STAGE_COUNT - 1)
                             tlx.barrier_arrive(
                                 dq_stage_empties[dq_stage_buf_id]
                             )
@@ -4318,6 +4319,7 @@ class _attention(torch.autograd.Function):
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
+            DQ_STAGE_COUNT=2,
             SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -361,6 +361,149 @@ def _softmax_inner_loop(
 
 
 @triton.jit
+def _fwd_control_tile(
+    tile_id,
+    tile_count,
+    accum_cnt,
+    sm_scale,
+    M,
+    H,
+    num_pid_n,
+    num_pid_in_group,
+    N_CTX,
+    desc_o,
+    alpha_empties,
+    alpha_fulls,
+    alpha_tiles,
+    acc_empties,
+    acc_fulls,
+    acc_tiles,
+    l_fulls,
+    l_tiles,
+    m_tiles,
+    qk_empties,
+    o_empties,
+    o_fulls,
+    o_tiles,
+    cluster_cta_rank,
+    BLOCK_M_SPLIT,
+    BLOCK_N,
+    EFFECTIVE_BLOCK_M,
+    GROUP_SIZE_N,
+    HEAD_DIM,
+    NUM_CTAS,
+    NUM_GROUPS_PER_CTA,
+    NUM_MMA_SLICES,
+    RESCALE_OPT,
+    SCALAR_N,
+    STAGE,
+    USE_2CTA,
+    USE_WHERE,
+):
+    start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+        tile_id // NUM_CTAS,
+        H,
+        num_pid_n,
+        num_pid_in_group,
+        N_CTX,
+        EFFECTIVE_BLOCK_M,
+        STAGE,
+        GROUP_SIZE_N,
+    )
+    # Rescale the live output accumulator when the online-softmax gauge changes.
+    for _ in tl.range(lo, hi, BLOCK_N):
+        _, phase = get_bufidx_phase(accum_cnt, 1)
+        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+            tlx.barrier_wait(alpha_fulls[cid], phase)
+            alpha_loaded = tlx.local_load(alpha_tiles[cid])
+            alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
+            tlx.barrier_arrive(alpha_empties[cid])
+            if RESCALE_OPT:
+                # One warp vote skips the whole accumulator update when no lane
+                # changed its online-softmax gauge.
+                pred = alpha_1 < 1.0
+                ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
+                should_rescale = ballot_result != 0
+
+            if USE_WHERE:
+                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                    subslice = tlx.subslice(
+                        acc_tiles[cid],
+                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                        HEAD_DIM // NUM_MMA_SLICES,
+                    )
+                    acc = tlx.local_load(subslice)
+                    if RESCALE_OPT:
+                        scaled_acc = _mul_f32x2(acc, alpha_1)
+                        acc = tl.where(should_rescale, scaled_acc, acc)
+                    else:
+                        acc = _mul_f32x2(acc, alpha_1)
+                    tlx.local_store(subslice, acc)
+            else:
+                if RESCALE_OPT:
+                    should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
+                    should_rescale_scalar = tl.reshape(should_rescale_red, ())
+                if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        subslice = tlx.subslice(
+                            acc_tiles[cid],
+                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                            HEAD_DIM // NUM_MMA_SLICES,
+                        )
+                        acc = tlx.local_load(subslice)
+                        acc = _mul_f32x2(acc, alpha_1)
+                        tlx.local_store(subslice, acc)
+            if USE_2CTA:
+                tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
+            else:
+                tlx.barrier_arrive(acc_fulls[cid])
+        accum_cnt += 1
+
+    _, phase = get_bufidx_phase(tile_count, 1)
+    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+        group_id = cid * NUM_CTAS + cluster_cta_rank
+        # l and m share a synchronization group, so release QK only after both loads.
+        tlx.barrier_wait(l_fulls[cid], phase)
+        l_loaded = tlx.local_load(l_tiles[cid])
+        m_loaded = tlx.local_load(m_tiles[cid])
+        l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
+        m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
+        if USE_2CTA:
+            tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
+        else:
+            tlx.barrier_arrive(qk_empties[cid])
+        if RESCALE_OPT:
+            m = m * sm_scale * 1.44269504
+        m += tl.math.log2(l)
+        offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+        m_ptrs = M + off_hz * N_CTX + offs_m
+        tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
+
+        # Normalize the completed accumulator into the output staging tile;
+        # the epilog task owns publication to global memory.
+        tlx.barrier_wait(acc_empties[cid], phase)
+        tlx.barrier_wait(o_empties[cid], phase ^ 1)
+        scale = 1 / l
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            subslice = tlx.subslice(
+                acc_tiles[cid],
+                HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                HEAD_DIM // NUM_MMA_SLICES,
+            )
+            acc = tlx.local_load(subslice)
+            acc = _mul_f32x2(acc, scale)
+            acc = acc.to(tlx.dtype_of(desc_o))
+            subslice_o = tlx.local_slice(
+                o_tiles[cid],
+                [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
+                [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
+            )
+            tlx.local_store(subslice_o, acc)
+        tlx.barrier_arrive(o_fulls[cid])
+    return accum_cnt
+
+
+@triton.jit
 def _fwd_load_1cta(
     tile_count,
     accum_cnt_kv,
@@ -830,127 +973,53 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         # correction group
         with tlx.async_task("default"):
             accum_cnt = 0
-            phase = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_producer = 1
             clc_phase_consumer = 0
             while tile_id != -1:
-                # CLC producer: announce work to all consumer tasks
+                # Publish this persistent tile, then finalize its M and O outputs.
                 tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=USE_2CTA)
                 clc_phase_producer ^= 1
-
-                # initialize offsets
-                start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id // NUM_CTAS,
+                accum_cnt = _fwd_control_tile(
+                    tile_id,
+                    tile_count,
+                    accum_cnt,
+                    sm_scale,
+                    M,
                     H,
                     num_pid_n,
                     num_pid_in_group,
                     N_CTX,
+                    desc_o,
+                    alpha_empties,
+                    alpha_fulls,
+                    alpha_tiles,
+                    acc_empties,
+                    acc_fulls,
+                    acc_tiles,
+                    l_fulls,
+                    l_tiles,
+                    m_tiles,
+                    qk_empties,
+                    o_empties,
+                    o_fulls,
+                    o_tiles,
+                    cluster_cta_rank,
+                    BLOCK_M_SPLIT,
+                    BLOCK_N,
                     EFFECTIVE_BLOCK_M,
-                    STAGE,
                     GROUP_SIZE_N,
+                    HEAD_DIM,
+                    NUM_CTAS,
+                    NUM_GROUPS_PER_CTA,
+                    NUM_MMA_SLICES,
+                    RESCALE_OPT,
+                    SCALAR_N,
+                    STAGE,
+                    USE_2CTA,
+                    USE_WHERE,
                 )
-                for _ in tl.range(lo, hi, BLOCK_N):
-                    _, phase = get_bufidx_phase(accum_cnt, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        # -- update output accumulator --
-                        tlx.barrier_wait(alpha_fulls[cid], phase)
-                        alpha_loaded = tlx.local_load(alpha_tiles[cid])
-                        alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
-                        tlx.barrier_arrive(alpha_empties[cid])
-                        # Perform warp-level ballot vote to check if any thread needs rescaling
-                        # 0xFFFFFFFF means all 32 threads in the warp participate
-                        if RESCALE_OPT:
-                            pred = alpha_1 < 1.0
-                            # ballot_result is a tensor with the same shape as pred
-                            # All elements contain the same warp-level ballot value
-                            # Non-zero means at least one thread has alpha_1 < 1.0
-                            ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
-                            should_rescale = ballot_result != 0
-
-                        if USE_WHERE:
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                subslice = tlx.subslice(
-                                    acc_tiles[cid],
-                                    HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                                    HEAD_DIM // NUM_MMA_SLICES,
-                                )
-                                acc = tlx.local_load(subslice)
-                                # Use tl.where to conditionally apply rescaling
-                                # acc = acc * alpha_1 where should_rescale, else acc unchanged
-                                if RESCALE_OPT:
-                                    scaled_acc = _mul_f32x2(acc, alpha_1)
-                                    acc = tl.where(should_rescale, scaled_acc, acc)
-                                else:
-                                    acc = _mul_f32x2(acc, alpha_1)
-                                tlx.local_store(subslice, acc)
-                        else:
-                            # option 2: use a single scalar IfOp
-                            if RESCALE_OPT:
-                                should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
-                                should_rescale_scalar = tl.reshape(should_rescale_red, ())
-                            if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
-                                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                    subslice = tlx.subslice(
-                                        acc_tiles[cid],
-                                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                                        HEAD_DIM // NUM_MMA_SLICES,
-                                    )
-                                    acc = tlx.local_load(subslice)
-                                    acc = _mul_f32x2(acc, alpha_1)
-                                    tlx.local_store(subslice, acc)
-                        if USE_2CTA:
-                            tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
-                        else:
-                            tlx.barrier_arrive(acc_fulls[cid])
-                    accum_cnt += 1
-
-                _, phase = get_bufidx_phase(tile_count, 1)
-                for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cid * NUM_CTAS + cluster_cta_rank
-                    # epilogue
-                    tlx.barrier_wait(l_fulls[cid], phase)
-                    l_loaded = tlx.local_load(l_tiles[cid])
-                    m_loaded = tlx.local_load(m_tiles[cid])
-                    l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
-                    m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
-                    # Signal qk_empties after both l and m loads complete,
-                    # since both tiles share the same synchronization group.
-                    if USE_2CTA:
-                        tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
-                    else:
-                        tlx.barrier_arrive(qk_empties[cid])
-                    if RESCALE_OPT:
-                        # RESCALE_OPT stores unscaled row-max in m_tiles.
-                        # The bwd kernel expects scaled values (m * qk_scale),
-                        # so we scale here before storing M.
-                        m = m * sm_scale * 1.44269504
-                    m += tl.math.log2(l)
-                    offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
-                    m_ptrs = M + off_hz * N_CTX + offs_m
-                    tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
-
-                    tlx.barrier_wait(acc_empties[cid], phase)
-                    tlx.barrier_wait(o_empties[cid], phase ^ 1)
-                    scale = 1 / l
-                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        subslice = tlx.subslice(
-                            acc_tiles[cid],
-                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                            HEAD_DIM // NUM_MMA_SLICES,
-                        )
-                        acc = tlx.local_load(subslice)
-                        acc = _mul_f32x2(acc, scale)
-                        acc = acc.to(tlx.dtype_of(desc_o))
-                        subslice_o = tlx.local_slice(
-                            o_tiles[cid],
-                            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
-                            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
-                        )
-                        tlx.local_store(subslice_o, acc)
-                    tlx.barrier_arrive(o_fulls[cid])
-
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -23,7 +23,7 @@ class ForwardPlan(NamedTuple):
     stage: int
     pipelined: bool
     policy: int
-    dense_regs: int
+    num_ctas: int
 
 
 POLICY_DENSE = tl.constexpr(int(Policy.DENSE))
@@ -65,6 +65,7 @@ configs = [
             "RESCALE_OPT": rescale_opt,
             "USE_WHERE": where,  # used when RESCALE_OPT is True
             "USE_WARP_BARRIER": uwb,
+            "FAST_FIXED": fast_fixed,
         },
         num_stages=1,
         num_warps=4,
@@ -72,7 +73,12 @@ configs = [
     )
     for kv in [3, 6]
     for grp_n in [1, 4]
-    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
+    for (rescale_opt, where, fast_fixed) in [
+        (False, False, True),
+        (False, False, False),
+        (True, False, False),
+        (True, True, False),
+    ]
     for uwb in [False, True]
 ] + [
     triton.Config(
@@ -89,6 +95,7 @@ configs = [
             "USE_WHERE": where,
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
+            "FAST_FIXED": fast_fixed,
         },
         num_stages=1,
         num_warps=4,
@@ -97,12 +104,18 @@ configs = [
     )
     for kv in [4, 5, 6, 7, 8, 9]
     for grp_n in [1]
-    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
+    for (rescale_opt, where, fast_fixed) in [
+        (False, False, True),
+        (False, False, False),
+        (True, False, False),
+        (True, True, False),
+    ]
 ]
 
 
 def prune_configs_by_hdim(configs, named_args, **kwargs):
     HEAD_DIM = kwargs["HEAD_DIM"]
+    N_CTX = kwargs["N_CTX"]
     STAGE = kwargs["STAGE"]
     target_kv_buffers = 6 if HEAD_DIM == 64 else 3
     target_group_size_n = 4 if STAGE == 3 else 1
@@ -114,6 +127,9 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
         if grp_n != target_group_size_n:
             continue
         if is_2cta:
+            num_ctas = conf.kwargs["NUM_CTAS"]
+            if N_CTX % (conf.kwargs["BLOCK_M"] * num_ctas) != 0:
+                continue
             if kv not in (4, 5, 6, 7):
                 continue
         else:
@@ -279,7 +295,7 @@ def _apply_causal_mask(qk, col_limit, BLOCK: tl.constexpr, keep_ge: tl.constexpr
 
 
 @triton.jit
-def _fwd_softmax_tile(
+def _fwd_softmax_tile_1cta(
     qk_fulls,
     qk_tiles,
     p_fulls,
@@ -302,10 +318,56 @@ def _fwd_softmax_tile(
     STAGE: tl.constexpr,
     RESCALE_OPT: tl.constexpr,
     SCALAR_N: tl.constexpr,
-    USE_2CTA: tl.constexpr = False,
+    FAST_FIXED: tl.constexpr,
 ):
-    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
+    if FAST_FIXED:
+        lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
+        gauge_cnt = 0
+        for start_n in tl.range(lo, hi, BLOCK_N):
+            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+            tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+            if gauge_cnt == 0:
+                for fragment_id in tl.static_range(0, 4):
+                    qk_fragment = tlx.local_load(
+                        tlx.subslice(
+                            tlx.local_view(qk_tiles, cid),
+                            fragment_id * 32,
+                            32,
+                        )
+                    )
+                    m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
+                m_i = tl.ceil(m_i) + 0.055517269
+            l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+            p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
+            for fragment_id in tl.static_range(0, 4):
+                qk_fragment = tlx.local_load(
+                    tlx.subslice(
+                        tlx.local_view(qk_tiles, cid),
+                        fragment_id * 32,
+                        32,
+                    )
+                )
+                p_h = _s2_exp2_bf16(
+                    qk_fragment,
+                    qk_scale * 128.0,
+                    12582912.0 + 128.0 * (126.0 - m_i[:, None]),
+                )
+                if fragment_id % 2 == 0:
+                    p_pending = p_h
+                else:
+                    p_bufIdx = cid * 2 + fragment_id // 2
+                    tlx.local_store(
+                        tlx.local_view(p_tiles, p_bufIdx),
+                        _join_n_2D([p_pending, p_h]),
+                    )
+                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+                l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
+            l_i += l_ij
+            accum_cnt_qk += 1
+            gauge_cnt += 1
+        return m_i, l_i, accum_cnt_qk
 
+    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
     for start_n in tl.range(lo, hi, BLOCK_N):
         qk_buf = cid
         qk_buf_phase = accum_cnt_qk & 1
@@ -366,18 +428,293 @@ def _fwd_softmax_tile(
             # prepare p for the v dot
             p_bufIdx = qk_buf * NUM_MMA_SLICES + slice_id
             p_i = tl.math.exp2(qks[slice_id])
-            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_i.to(out_dtype))
-            if USE_2CTA:
-                tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx), 1, remote_cta_rank=0)
-            else:
-                tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+            p_h = p_i.to(out_dtype)
+            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
+            tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
             l_ij += tl.sum(p_i, 1)
 
         l_i += l_ij
         m_i = m_ij
         accum_cnt_qk += 1
-
     return m_i, l_i, accum_cnt_qk
+
+
+@triton.jit
+def _fwd_softmax_tile_2cta(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    cid,
+    accum_cnt_qk,
+    qk_scale,
+    m_i,
+    l_i,
+    start_m,
+    N_CTX,
+    out_dtype,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    tl.static_assert(NUM_MMA_SLICES == 2)
+    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
+    gauge_cnt = 0
+    for start_n in tl.range(lo, hi, BLOCK_N):
+        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+        if gauge_cnt == 0:
+            for fragment_id in tl.static_range(0, 4):
+                qk_fragment = tlx.local_load(
+                    tlx.subslice(
+                        tlx.local_view(qk_tiles, cid),
+                        fragment_id * 32,
+                        32,
+                    )
+                )
+                m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
+            m_i = tl.ceil(m_i) + 0.055517269
+        l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+        p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
+        for fragment_id in tl.static_range(0, 4):
+            qk_fragment = tlx.local_load(
+                tlx.subslice(
+                    tlx.local_view(qk_tiles, cid),
+                    fragment_id * 32,
+                    32,
+                )
+            )
+            p_h = _s2_exp2_bf16(
+                qk_fragment,
+                qk_scale * 128.0,
+                12582912.0 + 128.0 * (126.0 - m_i[:, None]),
+            )
+            if fragment_id < 2:
+                p_fragment = tlx.local_slice(
+                    tlx.local_view(p_tiles, cid * 2),
+                    [0, fragment_id * 32],
+                    [BLOCK_M // 2, 32],
+                )
+                tlx.local_store(p_fragment, p_h)
+                tlx.barrier_arrive(
+                    tlx.local_view(p_fulls, cid * 3 + fragment_id),
+                    1,
+                    remote_cta_rank=0,
+                )
+            elif fragment_id == 2:
+                p_pending = p_h
+            else:
+                tlx.local_store(
+                    tlx.local_view(p_tiles, cid * 2 + 1),
+                    _join_n_2D([p_pending, p_h]),
+                )
+                tlx.barrier_arrive(
+                    tlx.local_view(p_fulls, cid * 3 + 2),
+                    1,
+                    remote_cta_rank=0,
+                )
+            l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
+        l_i += l_ij
+        accum_cnt_qk += 1
+        gauge_cnt += 1
+    return m_i, l_i, accum_cnt_qk
+
+
+@triton.jit
+def _fwd_softmax_tile_2cta_online(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    acc_fulls,
+    acc_tiles,
+    cid,
+    accum_cnt_qk,
+    qk_scale,
+    m_i,
+    l_i,
+    start_m,
+    N_CTX,
+    out_dtype,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    STAGE: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
+):
+    tl.static_assert(NUM_MMA_SLICES == 2)
+    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
+    block_count = 0
+    for start_n in tl.range(lo, hi, BLOCK_N):
+        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+        qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
+        if RESCALE_OPT:
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            alpha_ = (m_i - m_ij) * qk_scale
+            alpha = tl.math.exp2(alpha_)
+            rescale_mask = alpha_ >= -8.0
+            alpha = tl.where(rescale_mask, 1.0, alpha)
+            m_ij = tl.where(rescale_mask, m_i, m_ij)
+        else:
+            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+            alpha = tl.math.exp2(m_i - m_ij)
+        if block_count > 0:
+            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                acc_slice = tlx.subslice(
+                    tlx.local_view(acc_tiles, cid),
+                    HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                    HEAD_DIM // NUM_MMA_SLICES,
+                )
+                acc = tlx.local_load(acc_slice)
+                tlx.local_store(acc_slice, _mul_f32x2(acc, alpha[:, None]))
+        tlx.barrier_arrive(
+            tlx.local_view(acc_fulls, cid),
+            1,
+            remote_cta_rank=0,
+        )
+        l_i *= alpha
+        if RESCALE_OPT:
+            qk = _fma_f32x2(qk, qk_scale, -(m_ij * qk_scale)[:, None])
+        else:
+            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        qk_fragments = _split_n_2D(qk, 4)
+        l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+        p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
+        for fragment_id in tl.static_range(0, 4):
+            p_i = tl.math.exp2(qk_fragments[fragment_id])
+            p_h = p_i.to(out_dtype)
+            if fragment_id < 2:
+                p_fragment = tlx.local_slice(
+                    tlx.local_view(p_tiles, cid * 2),
+                    [0, fragment_id * 32],
+                    [BLOCK_M // 2, 32],
+                )
+                tlx.local_store(p_fragment, p_h)
+                tlx.barrier_arrive(
+                    tlx.local_view(p_fulls, cid * 3 + fragment_id),
+                    1,
+                    remote_cta_rank=0,
+                )
+            elif fragment_id == 2:
+                p_pending = p_h
+            else:
+                tlx.local_store(
+                    tlx.local_view(p_tiles, cid * 2 + 1),
+                    _join_n_2D([p_pending, p_h]),
+                )
+                tlx.barrier_arrive(
+                    tlx.local_view(p_fulls, cid * 3 + 2),
+                    1,
+                    remote_cta_rank=0,
+                )
+            l_ij += tl.sum(p_i, 1)
+        l_i += l_ij
+        m_i = m_ij
+        accum_cnt_qk += 1
+        block_count += 1
+    return m_i, l_i, accum_cnt_qk
+
+
+@triton.jit
+def _fwd_softmax_tile(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    alpha_empties,
+    alpha_fulls,
+    alpha_tiles,
+    acc_fulls,
+    acc_tiles,
+    cid,
+    accum_cnt_qk,
+    qk_scale,
+    offs_m,
+    m_i,
+    l_i,
+    start_m,
+    N_CTX,
+    out_dtype,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    STAGE: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
+    SCALAR_N: tl.constexpr,
+    USE_2CTA: tl.constexpr,
+    FAST_FIXED: tl.constexpr,
+):
+    if USE_2CTA:
+        if FAST_FIXED:
+            return _fwd_softmax_tile_2cta(
+                qk_fulls,
+                qk_tiles,
+                p_fulls,
+                p_tiles,
+                cid,
+                accum_cnt_qk,
+                qk_scale,
+                m_i,
+                l_i,
+                start_m,
+                N_CTX,
+                out_dtype,
+                BLOCK_M,
+                BLOCK_N,
+                NUM_MMA_SLICES,
+                STAGE,
+            )
+        return _fwd_softmax_tile_2cta_online(
+            qk_fulls,
+            qk_tiles,
+            p_fulls,
+            p_tiles,
+            acc_fulls,
+            acc_tiles,
+            cid,
+            accum_cnt_qk,
+            qk_scale,
+            m_i,
+            l_i,
+            start_m,
+            N_CTX,
+            out_dtype,
+            BLOCK_M,
+            BLOCK_N,
+            HEAD_DIM,
+            NUM_MMA_SLICES,
+            STAGE,
+            RESCALE_OPT,
+        )
+    return _fwd_softmax_tile_1cta(
+        qk_fulls,
+        qk_tiles,
+        p_fulls,
+        p_tiles,
+        alpha_empties,
+        alpha_fulls,
+        alpha_tiles,
+        cid,
+        accum_cnt_qk,
+        qk_scale,
+        offs_m,
+        m_i,
+        l_i,
+        start_m,
+        N_CTX,
+        out_dtype,
+        BLOCK_M,
+        BLOCK_N,
+        NUM_MMA_SLICES,
+        STAGE,
+        RESCALE_OPT,
+        SCALAR_N,
+        FAST_FIXED,
+    )
 
 
 @triton.jit
@@ -419,6 +756,7 @@ def _fwd_control_tile(
     STAGE,
     USE_2CTA,
     USE_WHERE,
+    FAST_FIXED,
 ):
     start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
         tile_id // NUM_CTAS,
@@ -430,8 +768,9 @@ def _fwd_control_tile(
         STAGE,
         GROUP_SIZE_N,
     )
+    control_lo = hi if FAST_FIXED else lo
     # Rescale the live output accumulator when the online-softmax gauge changes.
-    for _ in tl.range(lo, hi, BLOCK_N):
+    for _ in tl.range(control_lo, hi, BLOCK_N):
         _, phase = get_bufidx_phase(accum_cnt, 1)
         for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
             tlx.barrier_wait(alpha_fulls[cid], phase)
@@ -519,7 +858,14 @@ def _fwd_control_tile(
                 [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
             )
             tlx.local_store(subslice_o, acc)
-        tlx.barrier_arrive(o_fulls[cid])
+        tlx.fence("async_shared")
+        if FAST_FIXED:
+            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+            tlx.async_descriptor_store_wait(0)
+            tlx.barrier_arrive(o_empties[cid])
+        else:
+            tlx.barrier_arrive(o_fulls[cid])
     return accum_cnt
 
 
@@ -651,6 +997,19 @@ def _fwd_load_tile(
 
 
 @triton.jit
+def _fwd_pv_32_32_64(p0, p1, b0, b1, b2, phase, v, acc, use_acc, done, HEAD_DIM: tl.constexpr):
+    tlx.barrier_wait(b0, phase)
+    tlx.async_dot(tlx.local_slice(p0, [0, 0], [128, 32]), tlx.local_slice(v, [0, 0], [32, HEAD_DIM // 2]), acc,
+                  use_acc=use_acc, force_async=True, two_ctas=True)
+    tlx.barrier_wait(b1, phase)
+    tlx.async_dot(tlx.local_slice(p0, [0, 32], [128, 32]), tlx.local_slice(v, [32, 0], [32, HEAD_DIM // 2]), acc,
+                  use_acc=True, force_async=True, two_ctas=True)
+    tlx.barrier_wait(b2, phase)
+    tlx.async_dot(p1, tlx.local_slice(v, [64, 0], [64, HEAD_DIM // 2]), acc,
+                  use_acc=True, mBarriers=done, force_async=True, two_ctas=True)
+
+
+@triton.jit
 def _fwd_mma_tile(
     tile_count,
     accum_cnt_kv,
@@ -680,6 +1039,7 @@ def _fwd_mma_tile(
     v_fulls=None,
     v_empties=None,
     USE_2CTA: tl.constexpr = False,
+    SKIP_RESCALE: tl.constexpr = False,
 ):
     v_tiles = v_tiles if USE_2CTA else kv_tiles
     v_fulls = v_fulls if USE_2CTA else kv_fulls
@@ -723,23 +1083,32 @@ def _fwd_mma_tile(
     # -- compute p0 @ v ----
     # wait for the V buffer to be populated by the producer
     tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-    tlx.barrier_wait(acc_fulls[0], qk_phase)
-    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-        p_bufIdx = slice_id
-        tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-        kv_slice = tlx.local_slice(
-            v_tiles[v_bufIdx],
-            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-            [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+    if USE_2CTA:
+        if not SKIP_RESCALE:
+            tlx.barrier_wait(acc_fulls[0], qk_phase)
+        _fwd_pv_32_32_64(
+            p_tiles[0], p_tiles[1], p_fulls[0], p_fulls[1], p_fulls[2],
+            qk_phase, v_tiles[v_bufIdx], acc_tiles[0], False, [], HEAD_DIM_KV * 2,
         )
-        tlx.async_dot(
-            p_tiles[p_bufIdx],
-            kv_slice,
-            acc_tiles[0],
-            use_acc=slice_id > 0,
-            force_async=True,
-            two_ctas=USE_2CTA,
-        )
+    else:
+        if not SKIP_RESCALE:
+            tlx.barrier_wait(acc_fulls[0], qk_phase)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            p_bufIdx = slice_id
+            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+            kv_slice = tlx.local_slice(
+                v_tiles[v_bufIdx],
+                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+            )
+            tlx.async_dot(
+                p_tiles[p_bufIdx],
+                kv_slice,
+                acc_tiles[0],
+                use_acc=slice_id > 0,
+                force_async=True,
+                two_ctas=USE_2CTA,
+            )
 
     acc1_init = False
 
@@ -768,25 +1137,36 @@ def _fwd_mma_tile(
         )
 
         # -- compute p1 @ v from the previous iteration----
-        tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            p_bufIdx = slice_id + NUM_MMA_SLICES
-            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
-            kv_slice = tlx.local_slice(
-                v_tiles[v_bufIdx_prev],
-                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+        if USE_2CTA:
+            if not SKIP_RESCALE:
+                tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+            _fwd_pv_32_32_64(
+                p_tiles[2], p_tiles[3], p_fulls[3], p_fulls[4], p_fulls[5],
+                qk_phase_prev, v_tiles[v_bufIdx_prev], acc_tiles[1], acc1_init,
+                [v_empties[v_bufIdx_prev]], HEAD_DIM_KV * 2,
             )
-            use_acc = acc1_init if slice_id == 0 else True
-            mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
-            tlx.async_dot(
-                p_tiles[p_bufIdx],
-                kv_slice,
-                acc_tiles[1],
-                use_acc=use_acc,
-                mBarriers=mBarriers,
-                two_ctas=USE_2CTA,
-            )
+        else:
+            if not SKIP_RESCALE:
+                tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                p_bufIdx = slice_id + NUM_MMA_SLICES
+                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
+                kv_slice = tlx.local_slice(
+                    v_tiles[v_bufIdx_prev],
+                    [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                    [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                )
+                use_acc = acc1_init if slice_id == 0 else True
+                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                tlx.async_dot(
+                    p_tiles[p_bufIdx],
+                    kv_slice,
+                    acc_tiles[1],
+                    use_acc=use_acc,
+                    mBarriers=mBarriers,
+                    force_async=SKIP_RESCALE,
+                    two_ctas=USE_2CTA,
+                )
 
         acc1_init = True
 
@@ -804,48 +1184,67 @@ def _fwd_mma_tile(
         # wait for the V buffer to be populated by the producer
         tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
 
-        tlx.barrier_wait(acc_fulls[0], qk_phase)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            p_bufIdx = slice_id
-            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-            kv_slice = tlx.local_slice(
-                v_tiles[v_bufIdx],
-                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+        if USE_2CTA:
+            if not SKIP_RESCALE:
+                tlx.barrier_wait(acc_fulls[0], qk_phase)
+            _fwd_pv_32_32_64(
+                p_tiles[0], p_tiles[1], p_fulls[0], p_fulls[1], p_fulls[2],
+                qk_phase, v_tiles[v_bufIdx], acc_tiles[0], True, [], HEAD_DIM_KV * 2,
             )
-            tlx.async_dot(
-                p_tiles[p_bufIdx],
-                kv_slice,
-                acc_tiles[0],
-                use_acc=True,
-                force_async=True,
-                two_ctas=USE_2CTA,
-            )
+        else:
+            if not SKIP_RESCALE:
+                tlx.barrier_wait(acc_fulls[0], qk_phase)
+            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                p_bufIdx = slice_id
+                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                kv_slice = tlx.local_slice(
+                    v_tiles[v_bufIdx],
+                    [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                    [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                )
+                tlx.async_dot(
+                    p_tiles[p_bufIdx],
+                    kv_slice,
+                    acc_tiles[0],
+                    use_acc=True,
+                    force_async=True,
+                    two_ctas=USE_2CTA,
+                )
 
     tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
     tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
     tlx.tcgen05_commit(acc_empties[0], two_ctas=USE_2CTA)
 
     # -- compute p1 @ v ----
-    tlx.barrier_wait(acc_fulls[1], qk_phase)
-    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-        p_bufIdx = slice_id + NUM_MMA_SLICES
-        tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-        kv_slice = tlx.local_slice(
-            v_tiles[v_bufIdx],
-            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-            [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+    if USE_2CTA:
+        if not SKIP_RESCALE:
+            tlx.barrier_wait(acc_fulls[1], qk_phase)
+        _fwd_pv_32_32_64(
+            p_tiles[2], p_tiles[3], p_fulls[3], p_fulls[4], p_fulls[5],
+            qk_phase, v_tiles[v_bufIdx], acc_tiles[1], acc1_init,
+            [acc_empties[1], v_empties[v_bufIdx]], HEAD_DIM_KV * 2,
         )
-        use_acc = acc1_init if slice_id == 0 else True
-        mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
-        tlx.async_dot(
-            p_tiles[p_bufIdx],
-            kv_slice,
-            acc_tiles[1],
-            use_acc=use_acc,
-            mBarriers=mBarriers,
-            two_ctas=USE_2CTA,
-        )
+    else:
+        if not SKIP_RESCALE:
+            tlx.barrier_wait(acc_fulls[1], qk_phase)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            p_bufIdx = slice_id + NUM_MMA_SLICES
+            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+            kv_slice = tlx.local_slice(
+                v_tiles[v_bufIdx],
+                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+            )
+            use_acc = acc1_init if slice_id == 0 else True
+            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+            tlx.async_dot(
+                p_tiles[p_bufIdx],
+                kv_slice,
+                acc_tiles[1],
+                use_acc=use_acc,
+                mBarriers=mBarriers,
+                two_ctas=USE_2CTA,
+            )
 
     accum_cnt_qk += 1
     accum_cnt_kv += 1 if USE_2CTA else 2
@@ -877,10 +1276,12 @@ def _attn_fwd_ws(sm_scale, M,  #
                  PIPELINED: tl.constexpr = False,
                  POLICY: tl.constexpr = POLICY_DENSE,
                  DENSE_REGS: tl.constexpr = 200,
+                 FAST_FIXED: tl.constexpr = True,
                  ):
     _attn_fwd_ws_kernel(sm_scale, M, Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX, HEAD_DIM, BLOCK_M, BLOCK_N, STAGE,
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_BUFFERS_QK, NUM_MMA_GROUPS, NUM_MMA_SLICES, GROUP_SIZE_N,
-                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS)
+                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS,
+                        FAST_FIXED)
 
 
 @triton.jit
@@ -903,12 +1304,18 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         PIPELINED: tl.constexpr = False,
                         POLICY: tl.constexpr = POLICY_DENSE,
                         DENSE_REGS: tl.constexpr = 200,
+                        FAST_FIXED: tl.constexpr = True,
                         ):
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
     tl.static_assert(NUM_BUFFERS_Q == 1)
 
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
+    tl.static_assert(not USE_2CTA or BLOCK_M == 256)
+    USE_FAST_FIXED: tl.constexpr = (
+        FAST_FIXED and tlx.dtype_of(desc_v) == tl.bfloat16 and POLICY == POLICY_DENSE
+        and NUM_MMA_SLICES == 2 and STAGE == 1 and not RESCALE_OPT
+    )
     cluster_cta_rank = tlx.cluster_cta_rank() if USE_2CTA else 0
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
@@ -930,10 +1337,12 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     # original grid
     #   triton.cdiv(q.shape[2], META["BLOCK_M"]),
     #   q.shape[0] * q.shape[1],
-    start_pid = tl.program_id(0)
+    start_pid = tl.program_id(0) // NUM_CTAS
     num_pid_m = tl.cdiv(N_CTX, EFFECTIVE_BLOCK_M)
     num_pid_n = Z * H
     num_pid_in_group = num_pid_m * GROUP_SIZE_N
+    num_tiles = num_pid_m * num_pid_n
+    persistent_stride = tl.num_programs(0) // NUM_CTAS
 
     # allocate SMEM buffers and barriers
     NUM_Q_BUFS: tl.constexpr = NUM_GROUPS_PER_CTA * NUM_BUFFERS_Q
@@ -1028,22 +1437,49 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     acc_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
 
     # Cross-CTA barriers: must use mbarriers for 2-CTA (arrive_count=NUM_CTAS).
-    if USE_WARP_BARRIER:
+    if USE_2CTA:
+        qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
+        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * 3, arrive_count=NUM_CTAS)
+        acc_fulls = (
+            acc_empties if USE_FAST_FIXED
+            else tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
+        )
+    elif USE_WARP_BARRIER:
         qk_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
         p_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, num_warps=4)
-        acc_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+        acc_fulls = (
+            acc_empties if USE_FAST_FIXED
+            else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+        )
     else:
         qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
         p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, arrive_count=NUM_CTAS)
-        acc_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
-    # Intra-CTA barriers: always use fast warp barriers (no cross-CTA traffic).
-    alpha_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
-    alpha_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+        acc_fulls = (
+            acc_empties if USE_FAST_FIXED
+            else tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
+        )
+    # Alpha/l stay within the compute role and use warp barriers. The 2-CTA
+    # output handoff below uses an mbarrier for the separate epilog role.
+    alpha_fulls = (
+        qk_fulls if USE_FAST_FIXED
+        else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    )
+    alpha_empties = (
+        qk_empties if USE_FAST_FIXED
+        else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    )
     l_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
-    o_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    o_fulls = (
+        tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
+        if USE_2CTA
+        else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    )
 
     # CLC consumers per CTA: correction(1) + softmax(NUM_GROUPS_PER_CTA) + mma(1) + load(1) + epilog(1).
-    clc_context = tlx.clc_create_context(num_consumers=(4 + NUM_GROUPS_PER_CTA) * NUM_CTAS)
+    if not USE_2CTA:
+        clc_context = tlx.clc_create_context(
+            num_consumers=3 + NUM_GROUPS_PER_CTA if USE_FAST_FIXED else 4 + NUM_GROUPS_PER_CTA
+        )
 
     # In 2-CTA mode, cross-CTA barrier_arrive (to the leader's mbarriers) requires
     # the mbarrier.init to be visible cluster-wide before any remote arrive.
@@ -1061,61 +1497,69 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             clc_phase_consumer = 0
             while tile_id != -1:
                 # Publish this persistent tile, then finalize its M and O outputs.
-                tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=USE_2CTA)
-                clc_phase_producer ^= 1
-                accum_cnt = _fwd_control_tile(
-                    tile_id,
-                    tile_count,
-                    accum_cnt,
-                    sm_scale,
-                    M,
-                    H,
-                    num_pid_n,
-                    num_pid_in_group,
-                    N_CTX,
-                    desc_o,
-                    alpha_empties,
-                    alpha_fulls,
-                    alpha_tiles,
-                    acc_empties,
-                    acc_fulls,
-                    acc_tiles,
-                    l_fulls,
-                    l_tiles,
-                    m_tiles,
-                    qk_empties,
-                    o_empties,
-                    o_fulls,
-                    o_tiles,
-                    cluster_cta_rank,
-                    BLOCK_M_SPLIT,
-                    BLOCK_N,
-                    EFFECTIVE_BLOCK_M,
-                    GROUP_SIZE_N,
-                    HEAD_DIM,
-                    NUM_CTAS,
-                    NUM_GROUPS_PER_CTA,
-                    NUM_MMA_SLICES,
-                    RESCALE_OPT,
-                    SCALAR_N,
-                    STAGE,
-                    USE_2CTA,
-                    USE_WHERE,
-                )
+                if not USE_2CTA:
+                    tlx.clc_producer(clc_context, clc_phase_producer)
+                    clc_phase_producer ^= 1
+                if not USE_2CTA:
+                    accum_cnt = _fwd_control_tile(
+                        tile_id,
+                        tile_count,
+                        accum_cnt,
+                        sm_scale,
+                        M,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        N_CTX,
+                        desc_o,
+                        alpha_empties,
+                        alpha_fulls,
+                        alpha_tiles,
+                        acc_empties,
+                        acc_fulls,
+                        acc_tiles,
+                        l_fulls,
+                        l_tiles,
+                        m_tiles,
+                        qk_empties,
+                        o_empties,
+                        o_fulls,
+                        o_tiles,
+                        cluster_cta_rank,
+                        BLOCK_M_SPLIT,
+                        BLOCK_N,
+                        EFFECTIVE_BLOCK_M,
+                        GROUP_SIZE_N,
+                        HEAD_DIM,
+                        NUM_CTAS,
+                        NUM_GROUPS_PER_CTA,
+                        NUM_MMA_SLICES,
+                        RESCALE_OPT,
+                        SCALAR_N,
+                        STAGE,
+                        USE_2CTA,
+                        USE_WHERE,
+                        USE_FAST_FIXED,
+                    )
                 tile_count += 1
-                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
-                clc_phase_consumer ^= 1
+                if USE_2CTA:
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+                else:
+                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    clc_phase_consumer ^= 1
 
         # softmax groups
-        with tlx.async_task(num_warps=4, registers=256 if (USE_2CTA and HEAD_DIM >= 256) else 168,
+        with tlx.async_task(num_warps=4, registers=DENSE_REGS if USE_2CTA else 168,
                             replicate=NUM_GROUPS_PER_CTA):
             accum_cnt_qk = 0
+            tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id // NUM_CTAS,
+                    tile_id,
                     H,
                     num_pid_n,
                     num_pid_in_group,
@@ -1128,7 +1572,9 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
                 # FA4 update_row_sum has init_val being None for the first iteration, here
                 # we use initial value of 1.0
-                l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
+                l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32)
+                if not USE_FAST_FIXED:
+                    l_i += 1.0
                 acc = tl.zeros([BLOCK_M_SPLIT, HEAD_DIM], dtype=tl.float32)
                 qk_scale = sm_scale
                 qk_scale *= 1.44269504  # 1/log(2)
@@ -1150,6 +1596,8 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         alpha_empties,
                         alpha_fulls,
                         alpha_tiles,
+                        acc_fulls,
+                        acc_tiles,
                         cid,
                         accum_cnt_qk,
                         qk_scale,
@@ -1161,11 +1609,13 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         p_dtype,
                         BLOCK_M,
                         BLOCK_N,
+                        HEAD_DIM,
                         NUM_MMA_SLICES,
                         STAGE=4 - STAGE,
                         RESCALE_OPT=RESCALE_OPT,
                         SCALAR_N=SCALAR_N,
                         USE_2CTA=USE_2CTA,
+                        FAST_FIXED=USE_FAST_FIXED,
                     )
                 if STAGE & 2:
                     m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
@@ -1176,6 +1626,8 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         alpha_empties,
                         alpha_fulls,
                         alpha_tiles,
+                        acc_fulls,
+                        acc_tiles,
                         cid,
                         accum_cnt_qk,
                         qk_scale,
@@ -1187,19 +1639,51 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         p_dtype,
                         BLOCK_M,
                         BLOCK_N,
+                        HEAD_DIM,
                         NUM_MMA_SLICES,
                         STAGE=2,
                         RESCALE_OPT=RESCALE_OPT,
                         SCALAR_N=SCALAR_N,
                         USE_2CTA=USE_2CTA,
+                        FAST_FIXED=USE_FAST_FIXED,
                     )
 
-                # prepare l_i for the epilog
-                tlx.local_store(l_tiles[cid], tl.join(l_i, l_i) if SCALAR_N == 2 else l_i[:, None])
-                tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
-                tlx.barrier_arrive(l_fulls[cid])
-                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
-                clc_phase_consumer ^= 1
+                if USE_2CTA:
+                    tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
+                    m_out = m_i * qk_scale if RESCALE_OPT else m_i
+                    tl.store(M + off_hz * N_CTX + offs_m, tl.math.log2(l_i) + m_out)
+                    _, phase = get_bufidx_phase(tile_count, 1)
+                    tlx.barrier_wait(acc_empties[cid], phase)
+                    tlx.barrier_wait(o_empties[cid], phase ^ 1)
+                    scale = (1 / l_i)[:, None]
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        subslice = tlx.subslice(
+                            acc_tiles[cid],
+                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                            HEAD_DIM // NUM_MMA_SLICES,
+                        )
+                        acc = _mul_f32x2(tlx.local_load(subslice), scale)
+                        acc = acc.to(tlx.dtype_of(desc_o))
+                        subslice_o = tlx.local_slice(
+                            o_tiles[cid],
+                            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
+                            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
+                        )
+                        tlx.local_store(subslice_o, acc)
+                    tlx.fence("async_shared")
+                    tlx.barrier_arrive(o_fulls[cid])
+                else:
+                    # prepare l_i for the epilog
+                    tlx.local_store(l_tiles[cid], tl.join(l_i, l_i) if SCALAR_N == 2 else l_i[:, None])
+                    tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
+                    tlx.barrier_arrive(l_fulls[cid])
+                tile_count += 1
+                if USE_2CTA:
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+                else:
+                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    clc_phase_consumer ^= 1
 
         # mma group
         with tlx.async_task(num_warps=1, registers=24):
@@ -1211,7 +1695,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             clc_phase_consumer = 0
             while tile_id != -1:
                 _, _, lo, hi, _, _ = _compute_offsets(
-                    tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
+                    tile_id, H, num_pid_n, num_pid_in_group,
                     N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N,
                 )
                 if USE_2CTA:
@@ -1223,6 +1707,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                             qk_empties, p_fulls, acc_fulls, acc_empties,
                             BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
                             NUM_MMA_SLICES, v_tiles, v_fulls, v_empties, True,
+                            SKIP_RESCALE=USE_FAST_FIXED,
                         )
                 else:
                     accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
@@ -1232,10 +1717,15 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         qk_empties, p_fulls, acc_fulls, acc_empties,
                         BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
                         NUM_MMA_SLICES, None, None, None, False,
+                        SKIP_RESCALE=USE_FAST_FIXED,
                     )
                 tile_count += 1
-                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
-                clc_phase_consumer ^= 1
+                if USE_2CTA:
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+                else:
+                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    clc_phase_consumer ^= 1
 
         # Q/K/V loader role; output publication remains in the epilog task.
         with tlx.async_task(num_warps=1, registers=24):
@@ -1245,7 +1735,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             clc_phase_consumer = 0
             while tile_id != -1:
                 _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
+                    tile_id, H, num_pid_n, num_pid_in_group,
                     N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N,
                 )
                 if USE_2CTA:
@@ -1268,39 +1758,48 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     )
 
                 tile_count += 1
-                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
-                clc_phase_consumer ^= 1
+                if USE_2CTA:
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+                else:
+                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    clc_phase_consumer ^= 1
 
         # epilog group
-        with tlx.async_task(num_warps=1, registers=24):
-            # initialize offsets
-            tile_count = 0
-            tile_id = start_pid
-            clc_phase_consumer = 0
-            while tile_id != -1:
+        if USE_2CTA or not USE_FAST_FIXED:
+            with tlx.async_task(num_warps=1, registers=24):
                 # initialize offsets
-                _, _, _, _, qo_offset_y, _ = _compute_offsets(
-                    tile_id // NUM_CTAS,
-                    H,
-                    num_pid_n,
-                    num_pid_in_group,
-                    N_CTX,
-                    EFFECTIVE_BLOCK_M,
-                    STAGE,
-                    GROUP_SIZE_N,
-                )
-                _, phase = get_bufidx_phase(tile_count, 1)
-                for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                    group_id = cid * NUM_CTAS + cluster_cta_rank
-                    tlx.barrier_wait(o_fulls[cid], phase)
-                    qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                    tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
-                    tlx.async_descriptor_store_wait(0)
-                    tlx.barrier_arrive(o_empties[cid])
+                tile_count = 0
+                tile_id = start_pid
+                clc_phase_consumer = 0
+                while tile_id != -1:
+                    # initialize offsets
+                    _, _, _, _, qo_offset_y, _ = _compute_offsets(
+                        tile_id,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        N_CTX,
+                        EFFECTIVE_BLOCK_M,
+                        STAGE,
+                        GROUP_SIZE_N,
+                    )
+                    _, phase = get_bufidx_phase(tile_count, 1)
+                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                        group_id = cid * NUM_CTAS + cluster_cta_rank
+                        tlx.barrier_wait(o_fulls[cid], phase)
+                        qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                        tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                        tlx.async_descriptor_store_wait(0)
+                        tlx.barrier_arrive(o_empties[cid])
 
-                tile_count += 1
-                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
-                clc_phase_consumer ^= 1
+                    tile_count += 1
+                    if USE_2CTA:
+                        next_tile_id = tile_id + persistent_stride
+                        tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+                    else:
+                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                        clc_phase_consumer ^= 1
 
 
 @triton.jit
@@ -3336,12 +3835,29 @@ def _attn_bwd_ws(
         #     pass
 
 
-def _select_forward_plan(causal):
+def _select_forward_plan(q, k, v, causal):
+    head_dim = q.shape[-1]
+    n_ctx = q.shape[2]
+    pipelined = (
+        head_dim == 64 and q.shape == k.shape and q.shape == v.shape
+        and n_ctx >= 32768 and n_ctx % 256 == 0
+    ) or (
+        head_dim == 128 and not causal and q.shape == k.shape and q.shape == v.shape
+        and n_ctx >= 1024 and n_ctx % 256 == 0
+    )
+    policy = int(Policy.DENSE) if not causal else min(
+        int(Policy.CAUSAL_512K),
+        max(int(Policy.CAUSAL_64K), n_ctx.bit_length() - CAUSAL_POLICY_BIT_OFFSET),
+    )
     return ForwardPlan(
         stage=3 if causal else 1,
-        pipelined=False,
-        policy=int(Policy.DENSE),
-        dense_regs=200,
+        pipelined=pipelined,
+        policy=policy,
+        num_ctas=(
+            2 if head_dim == 128 and q.dtype == torch.bfloat16 and not causal
+            and q.shape == k.shape and q.shape == v.shape
+            and (n_ctx == 1024 or n_ctx >= 4096) else 1
+        ),
     )
 
 
@@ -3354,7 +3870,7 @@ class _attention(torch.autograd.Function):
         assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
         assert HEAD_DIM_K in {16, 32, 64, 128, 256}
 
-        plan = _select_forward_plan(causal)
+        plan = _select_forward_plan(q, k, v, causal)
 
         o = torch.empty_like(q)
         extra_kern_args = {}
@@ -3363,6 +3879,7 @@ class _attention(torch.autograd.Function):
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
+        use_s1_2cta = plan.num_ctas == 2
         dummy_block = [128, HEAD_DIM_K] if plan.pipelined else [1, 1]
         desc_q = TensorDescriptor(
             q,
@@ -3374,13 +3891,13 @@ class _attention(torch.autograd.Function):
             v,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=dummy_block,
+            block_shape=[128, 64] if use_s1_2cta else dummy_block,
         )
         desc_k = TensorDescriptor(
             k,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=dummy_block,
+            block_shape=[64, 128] if use_s1_2cta else dummy_block,
         )
         desc_o = TensorDescriptor(
             o,
@@ -3395,7 +3912,14 @@ class _attention(torch.autograd.Function):
         triton.set_allocator(alloc_fn)
 
         if plan.pipelined:
-            grid = (triton.cdiv(q.shape[2], FWD_BLOCK_M.value) * q.shape[0] * q.shape[1],)
+            work_ctas = (
+                triton.cdiv(q.shape[2], FWD_BLOCK_M.value * plan.num_ctas)
+                * q.shape[0] * q.shape[1] * plan.num_ctas
+            )
+            grid = (
+                min(torch.cuda.get_device_properties(q.device).multi_processor_count, work_ctas)
+                if use_s1_2cta else work_ctas,
+            )
             _attn_fwd_ws.fn[grid](
                 sm_scale,
                 M,  #
@@ -3420,19 +3944,23 @@ class _attention(torch.autograd.Function):
                 ),
                 GROUP_SIZE_N=4 if plan.policy == 1 else 1,
                 RESCALE_OPT=False, USE_WHERE=False, USE_WARP_BARRIER=True,
-                NUM_CTAS=1, PIPELINED=True, POLICY=plan.policy,
-                DENSE_REGS=plan.dense_regs, num_stages=1, num_warps=4,
+                NUM_CTAS=plan.num_ctas, PIPELINED=True, POLICY=plan.policy,
+                DENSE_REGS=176 if use_s1_2cta else 168,
+                num_stages=1, num_warps=4,
+                **({"ctas_per_cga": (2, 1, 1)} if use_s1_2cta else {}),
                 **extra_kern_args,
             )
         else:
             def grid(META):
                 num_ctas = META.get("NUM_CTAS") or 1
-                n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
-                return (triton.cdiv(n_ctas, num_ctas) * num_ctas, )
+                n_clusters = triton.cdiv(
+                    q.shape[2], META["BLOCK_M"] * num_ctas
+                ) * q.shape[0] * q.shape[1]
+                return (n_clusters * num_ctas, )
             _attn_fwd_ws[grid](
                 sm_scale, M, q.shape[0], q.shape[1], desc_q, desc_k, desc_v, desc_o,
                 N_CTX=q.shape[2], HEAD_DIM=HEAD_DIM_K, STAGE=plan.stage,
-                PIPELINED=False, POLICY=plan.policy, DENSE_REGS=plan.dense_regs,
+                PIPELINED=False, POLICY=plan.policy, DENSE_REGS=168,
                 **extra_kern_args,
             )
         ctx.grid = grid
@@ -3599,8 +4127,13 @@ def attention(q, k, v, sm_scale, causal, config=None):
     triton.set_allocator(alloc_fn)
 
     num_ctas = config.get("NUM_CTAS", 1)
-    grid0 = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
-    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas
+    assert q.shape[2] % (config["BLOCK_M"] * num_ctas) == 0 or num_ctas == 1
+    grid0 = (
+        triton.cdiv(q.shape[2], config["BLOCK_M"] * num_ctas)
+        * q.shape[0]
+        * q.shape[1]
+        * num_ctas
+    )
     grid = (grid0, 1, 1)
     launch_kwargs = {}
     if num_ctas > 1:

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -504,7 +504,7 @@ def _fwd_control_tile(
 
 
 @triton.jit
-def _fwd_load_1cta(
+def _fwd_load_tile(
     tile_count,
     accum_cnt_kv,
     lo,
@@ -528,8 +528,47 @@ def _fwd_load_1cta(
     HEAD_DIM: tl.constexpr,
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
+    cluster_cta_rank=0,
+    v_tiles=None,
+    v_fulls=None,
+    v_empties=None,
+    NUM_GROUPS_PER_CTA: tl.constexpr = 2,
+    NUM_CTAS: tl.constexpr = 1,
 ):
+    USE_2CTA: tl.constexpr = NUM_CTAS == 2
     # load q0
+    if USE_2CTA:
+        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+        for group_id in tl.static_range(0, NUM_GROUPS_PER_CTA):
+            q_id = q_bufIdx + group_id * NUM_BUFFERS_Q
+            tlx.barrier_wait(q_empties[q_id], q_phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(q_fulls[q_id], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+            tlx.async_descriptor_load(
+                desc_q, q_tiles[q_id],
+                [qo_offset_y + (group_id * NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
+                q_fulls[q_id], two_ctas=True,
+            )
+        for _ in tl.range(lo, hi, BLOCK_N):
+            buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+            tlx.barrier_wait(kv_empties[buf], phase ^ 1)
+            tlx.barrier_wait(v_empties[buf], phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(kv_fulls[buf], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                tlx.barrier_expect_bytes(v_fulls[buf], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+            tlx.async_descriptor_load(
+                desc_k, kv_tiles[buf],
+                [kv_offset_y + cluster_cta_rank * (BLOCK_N // NUM_CTAS), 0],
+                kv_fulls[buf], two_ctas=True,
+            )
+            tlx.async_descriptor_load(
+                desc_v, v_tiles[buf],
+                [kv_offset_y, cluster_cta_rank * (HEAD_DIM // NUM_CTAS)],
+                v_fulls[buf], two_ctas=True,
+            )
+            kv_offset_y += BLOCK_N
+            accum_cnt_kv += 1
+        return accum_cnt_kv
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
     tlx.barrier_expect_bytes(q_fulls[q_bufIdx], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
@@ -879,7 +918,9 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         # V loaded as (N, D/2).
         k_tiles = tlx.local_alloc((BLOCK_N_KV, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM_KV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
-        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA, reuse=q_tiles)
+        o_tiles = tlx.local_alloc(
+            (BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA
+        )
     else:
         kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
@@ -1170,89 +1211,35 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1
 
-        # load
+        # Q/K/V loader role; output publication remains in the epilog task.
         with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
+                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
+                    N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N,
+                )
                 if USE_2CTA:
-                    _, off_hz2, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n,
-                                                                      num_pid_in_group, N_CTX, EFFECTIVE_BLOCK_M, STAGE,
-                                                                      GROUP_SIZE_N)
-
-                    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-                    # Q and O share SMEM (o_tiles reuses q_tiles). Wait for the
-                    # epilog to finish storing the previous tile's O before
-                    # overwriting the buffer with new Q data.
-                    _, o_phase = get_bufidx_phase(tile_count, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        tlx.barrier_wait(o_empties[cid], o_phase ^ 1)
-                    # load Q0
-                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx],
-                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo2 + cluster_cta_rank * BLOCK_M_SPLIT, 0],
-                                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
-                    # load Q1
-                    q_bufIdx1 = q_bufIdx + NUM_BUFFERS_Q
-                    tlx.barrier_wait(q_empties[q_bufIdx1], q_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx1],
-                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx1],
-                                              [qo2 + (NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
-                                              q_fulls[q_bufIdx1], two_ctas=tl.constexpr(True))
-
-                    kv_offset_y = kv2
-
-                    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
-                    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
-                                              [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
-                                              two_ctas=tl.constexpr(True))
-
-                    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-                    if is_leader:
-                        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-                    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
-                                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
-
-                    kv_offset_y += BLOCK_N
-                    accum_cnt_kv += 1
-
-                    for _ in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
-                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
-                        if is_leader:
-                            tlx.barrier_expect_bytes(k_fulls[k_bufIdx],
-                                                     K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
-                        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
-                                                  [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
-                                                  two_ctas=tl.constexpr(True))
-
-                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
-                        if is_leader:
-                            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-                        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx],
-                                                  [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV], v_fulls[v_bufIdx],
-                                                  two_ctas=tl.constexpr(True))
-
-                        kv_offset_y += BLOCK_N
-                        accum_cnt_kv += 1
+                    accum_cnt_kv = _fwd_load_tile(
+                        tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y,
+                        desc_q, desc_k, desc_v, q_tiles, k_tiles, q_fulls, q_empties,
+                        k_fulls, k_empties, Q_BYTES_PER_ELEM, K_BYTES_PER_ELEM,
+                        V_BYTES_PER_ELEM, BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM,
+                        NUM_BUFFERS_Q, NUM_BUFFERS_KV, cluster_cta_rank,
+                        v_tiles, v_fulls, v_empties,
+                        NUM_GROUPS_PER_CTA, NUM_CTAS,
+                    )
                 else:
-                    _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group,
-                                                                              N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv = _fwd_load_1cta(tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y, desc_q,
-                                                  desc_k, desc_v, q_tiles, kv_tiles, q_fulls, q_empties, kv_fulls,
-                                                  kv_empties, Q_BYTES_PER_ELEM, K_BYTES_PER_ELEM, V_BYTES_PER_ELEM,
-                                                  BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM, NUM_BUFFERS_Q, NUM_BUFFERS_KV)
+                    accum_cnt_kv = _fwd_load_tile(
+                        tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y,
+                        desc_q, desc_k, desc_v, q_tiles, kv_tiles, q_fulls, q_empties,
+                        kv_fulls, kv_empties, Q_BYTES_PER_ELEM, K_BYTES_PER_ELEM,
+                        V_BYTES_PER_ELEM, BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM,
+                        NUM_BUFFERS_Q, NUM_BUFFERS_KV,
+                    )
 
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -592,7 +592,7 @@ def _fwd_load_1cta(
 
 
 @triton.jit
-def _fwd_mma_dots_1cta(
+def _fwd_mma_tile(
     tile_count,
     accum_cnt_kv,
     accum_cnt_qk,
@@ -617,10 +617,17 @@ def _fwd_mma_dots_1cta(
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
     NUM_MMA_SLICES: tl.constexpr,
+    v_tiles=None,
+    v_fulls=None,
+    v_empties=None,
+    USE_2CTA: tl.constexpr = False,
 ):
+    v_tiles = v_tiles if USE_2CTA else kv_tiles
+    v_fulls = v_fulls if USE_2CTA else kv_fulls
+    v_empties = v_empties if USE_2CTA else kv_empties
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
     # wait for the K buffer to be populated by the producer
     tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
@@ -637,6 +644,7 @@ def _fwd_mma_dots_1cta(
         qk_tiles[0],
         use_acc=False,
         mBarriers=[qk_fulls[0]],
+        two_ctas=USE_2CTA,
     )
 
     # -- compute q1 @ k ----
@@ -648,19 +656,20 @@ def _fwd_mma_dots_1cta(
         qk_tiles[1],
         use_acc=False,
         mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+        two_ctas=USE_2CTA,
     )
 
     _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
 
     # -- compute p0 @ v ----
     # wait for the V buffer to be populated by the producer
-    tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+    tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
     tlx.barrier_wait(acc_fulls[0], qk_phase)
     for slice_id in tl.static_range(0, NUM_MMA_SLICES):
         p_bufIdx = slice_id
         tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
         kv_slice = tlx.local_slice(
-            kv_tiles[v_bufIdx],
+            v_tiles[v_bufIdx],
             [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
             [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
         )
@@ -670,6 +679,7 @@ def _fwd_mma_dots_1cta(
             acc_tiles[0],
             use_acc=slice_id > 0,
             force_async=True,
+            two_ctas=USE_2CTA,
         )
 
     acc1_init = False
@@ -679,9 +689,9 @@ def _fwd_mma_dots_1cta(
         qk_phase_prev = qk_phase
 
         accum_cnt_qk += 1
-        accum_cnt_kv += 2
+        accum_cnt_kv += 1 if USE_2CTA else 2
         k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
+        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
         # -- compute q0 @ k ----
         # wait for the K buffer to be populated by the producer
@@ -695,6 +705,7 @@ def _fwd_mma_dots_1cta(
             qk_tiles[0],
             use_acc=False,
             mBarriers=[qk_fulls[0]],
+            two_ctas=USE_2CTA,
         )
 
         # -- compute p1 @ v from the previous iteration----
@@ -703,18 +714,19 @@ def _fwd_mma_dots_1cta(
             p_bufIdx = slice_id + NUM_MMA_SLICES
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
             kv_slice = tlx.local_slice(
-                kv_tiles[v_bufIdx_prev],
+                v_tiles[v_bufIdx_prev],
                 [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                 [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
             use_acc = acc1_init if slice_id == 0 else True
-            mBarriers = [kv_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+            mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
             tlx.async_dot(
                 p_tiles[p_bufIdx],
                 kv_slice,
                 acc_tiles[1],
                 use_acc=use_acc,
                 mBarriers=mBarriers,
+                two_ctas=USE_2CTA,
             )
 
         acc1_init = True
@@ -726,18 +738,19 @@ def _fwd_mma_dots_1cta(
             qk_tiles[1],
             use_acc=False,
             mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
+            two_ctas=USE_2CTA,
         )
 
         # -- compute p0 @ v ----
         # wait for the V buffer to be populated by the producer
-        tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
 
         tlx.barrier_wait(acc_fulls[0], qk_phase)
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             p_bufIdx = slice_id
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
             kv_slice = tlx.local_slice(
-                kv_tiles[v_bufIdx],
+                v_tiles[v_bufIdx],
                 [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
                 [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
@@ -747,11 +760,12 @@ def _fwd_mma_dots_1cta(
                 acc_tiles[0],
                 use_acc=True,
                 force_async=True,
+                two_ctas=USE_2CTA,
             )
 
-    tlx.tcgen05_commit(q_empties[q_bufIdx])
-    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q])
-    tlx.tcgen05_commit(acc_empties[0])
+    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
+    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
+    tlx.tcgen05_commit(acc_empties[0], two_ctas=USE_2CTA)
 
     # -- compute p1 @ v ----
     tlx.barrier_wait(acc_fulls[1], qk_phase)
@@ -759,22 +773,23 @@ def _fwd_mma_dots_1cta(
         p_bufIdx = slice_id + NUM_MMA_SLICES
         tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
         kv_slice = tlx.local_slice(
-            kv_tiles[v_bufIdx],
+            v_tiles[v_bufIdx],
             [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
             [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
         )
         use_acc = acc1_init if slice_id == 0 else True
-        mBarriers = [acc_empties[1], kv_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+        mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
         tlx.async_dot(
             p_tiles[p_bufIdx],
             kv_slice,
             acc_tiles[1],
             use_acc=use_acc,
             mBarriers=mBarriers,
+            two_ctas=USE_2CTA,
         )
 
     accum_cnt_qk += 1
-    accum_cnt_kv += 2
+    accum_cnt_kv += 1 if USE_2CTA else 2
     return accum_cnt_kv, accum_cnt_qk
 
 
@@ -1128,110 +1143,29 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
+                _, _, lo, hi, _, _ = _compute_offsets(
+                    tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
+                    N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N,
+                )
                 if USE_2CTA:
                     if is_leader:
-                        _, _, lo2, hi2, _, _ = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
-                                                                N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N)
-                        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-                        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-                        tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
-
-                        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-                        tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
-                        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
-                                      two_ctas=True)
-
-                        tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
-                        tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
-                        tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
-                                      mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
-
-                        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-
-                        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-                        tlx.barrier_wait(acc_fulls[0], qk_phase)
-                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                            p_bufIdx = slice_id
-                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=slice_id > 0,
-                                          force_async=True, two_ctas=True)
-
-                        acc1_init = False
-
-                        for i in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
-                            v_bufIdx_prev = v_bufIdx
-                            qk_phase_prev = qk_phase
-
-                            accum_cnt_qk += 1
-                            accum_cnt_kv += 1
-                            k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-                            v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-
-                            tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
-                            k_tile = tlx.local_trans(k_tiles[k_bufIdx])
-                            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-
-                            tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
-                                          two_ctas=True)
-
-                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                p_bufIdx = slice_id + NUM_MMA_SLICES
-                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
-                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx_prev],
-                                                           [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                                use_acc = acc1_init if slice_id == 0 else True
-                                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
-                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
-                                              mBarriers=mBarriers, two_ctas=True)
-
-                            acc1_init = True
-
-                            tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
-                                          mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
-
-                            tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-                            tlx.barrier_wait(acc_fulls[0], qk_phase)
-                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                                p_bufIdx = slice_id
-                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=True, force_async=True,
-                                              two_ctas=True)
-
-                        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
-                        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=True)
-                        tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
-
-                        tlx.barrier_wait(acc_fulls[1], qk_phase)
-                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                            p_bufIdx = slice_id + NUM_MMA_SLICES
-                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
-                            use_acc = acc1_init if slice_id == 0 else True
-                            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
-                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
-                                          mBarriers=mBarriers, two_ctas=True)
-
-                        accum_cnt_qk += 1
-                        accum_cnt_kv += 1
+                        accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
+                            tile_count, accum_cnt_kv, accum_cnt_qk, lo, hi,
+                            q_tiles, k_tiles, qk_tiles, p_tiles, acc_tiles,
+                            q_fulls, q_empties, k_fulls, k_empties, qk_fulls,
+                            qk_empties, p_fulls, acc_fulls, acc_empties,
+                            BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
+                            NUM_MMA_SLICES, v_tiles, v_fulls, v_empties, True,
+                        )
                 else:
-                    _, _, lo, hi, _, _ = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M,
-                                                          STAGE, GROUP_SIZE_N)
-                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_dots_1cta(tile_count, accum_cnt_kv, accum_cnt_qk, lo, hi,
-                                                                    q_tiles, kv_tiles, qk_tiles, p_tiles, acc_tiles,
-                                                                    q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
-                                                                    qk_empties, p_fulls, acc_fulls, acc_empties,
-                                                                    BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
-                                                                    NUM_MMA_SLICES)
+                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
+                        tile_count, accum_cnt_kv, accum_cnt_qk, lo, hi,
+                        q_tiles, kv_tiles, qk_tiles, p_tiles, acc_tiles,
+                        q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
+                        qk_empties, p_fulls, acc_fulls, acc_empties,
+                        BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
+                        NUM_MMA_SLICES,
+                    )
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
                 clc_phase_consumer ^= 1

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -4201,8 +4201,16 @@ class _attention(torch.autograd.Function):
         assert ctx.HEAD_DIM in (64, 128), "backward requires head dimension 64 or 128"
         BATCH, N_HEAD, N_CTX = q.shape[:3]
         direct_dq_output = ctx.HEAD_DIM == 128 and N_CTX % 256 == 0
+        bf16_dq_output = (
+            direct_dq_output
+            and q.dtype == torch.bfloat16
+            and not ctx.causal
+        )
         if direct_dq_output:
-            dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
+            if bf16_dq_output:
+                dq = torch.zeros(q.shape, device=q.device, dtype=torch.bfloat16)
+            else:
+                dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
         else:
             dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -545,6 +545,7 @@ def _fwd_softmax_tile_2cta(
     for start_n in tl.range(lo, hi, BLOCK_N):
         _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
         tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
+        qk_head0 = tl.zeros([BLOCK_M // 2, 32], dtype=tl.float32)
         if gauge_cnt == 0:
             for fragment_id in tl.static_range(0, 4):
                 qk_fragment = tlx.local_load(
@@ -554,18 +555,23 @@ def _fwd_softmax_tile_2cta(
                         32,
                     )
                 )
+                if fragment_id == 0:
+                    qk_head0 = qk_fragment
                 m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
             m_i = tl.ceil(m_i) + 0.055517269
         l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
         p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
         for fragment_id in tl.static_range(0, 4):
-            qk_fragment = tlx.local_load(
-                tlx.subslice(
-                    tlx.local_view(qk_tiles, cid),
-                    fragment_id * 32,
-                    32,
+            if gauge_cnt == 0 and fragment_id == 0:
+                qk_fragment = qk_head0
+            else:
+                qk_fragment = tlx.local_load(
+                    tlx.subslice(
+                        tlx.local_view(qk_tiles, cid),
+                        fragment_id * 32,
+                        32,
+                    )
                 )
-            )
             p_h = _s2_exp2_bf16(
                 qk_fragment,
                 qk_scale * 128.0,

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -139,6 +139,40 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
     return pruned
 
 
+_S2_F16_GAUGE: tl.constexpr = 0.055517269
+
+
+@core.builtin
+def _s2_exp2_f16(x, a2, b2m, _semantic=None):
+    return core.inline_asm_elementwise(
+        """
+        {
+            .reg .b64 ra, rb, rc, rd;
+            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
+            mov.b64 ra, { $1, $2 };
+            mov.b64 rb, { $3, $4 };
+            mov.b64 rc, { $5, $6 };
+            fma.rn.f32x2 rd, ra, rb, rc;
+            mov.b64 { v0, v1 }, rd;
+            prmt.b32 pk, v0, v1, 0x5410;
+            mov.b32 zz, 0;
+            mov.b32 mk, 0x02000200;
+            add.s16x2 uu, pk, mk;
+            mov.b32 c0, 0x39AB39AB;
+            fma.rn.f16x2 pk, uu, c0, pk;
+            max.f16x2 pk, pk, zz;
+            mov.b32 $0, pk;
+        }
+        """,
+        "=r,r,r,r,r,r,r",
+        [x, a2, b2m],
+        dtype=core.float16,
+        is_pure=True,
+        pack=2,
+        _semantic=_semantic,
+    )
+
+
 @core.builtin
 def _s2_exp2_bf16(x, a2, b2m, _semantic=None):
     return core.inline_asm_elementwise(
@@ -305,6 +339,7 @@ def _fwd_softmax_tile_1cta(
     alpha_tiles,
     cid,
     accum_cnt_qk,
+    gauge_cnt,
     qk_scale,
     offs_m,
     m_i,
@@ -320,9 +355,11 @@ def _fwd_softmax_tile_1cta(
     SCALAR_N: tl.constexpr,
     FAST_FIXED: tl.constexpr,
 ):
+    FAST_BF16: tl.constexpr = FAST_FIXED and out_dtype == tl.bfloat16
+    FAST_F16: tl.constexpr = FAST_FIXED and out_dtype == tl.float16
+    NUM_P_SLICES: tl.constexpr = 2 if FAST_F16 else NUM_MMA_SLICES
     if FAST_FIXED:
         lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-        gauge_cnt = 0
         for start_n in tl.range(lo, hi, BLOCK_N):
             _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
             tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
@@ -335,8 +372,15 @@ def _fwd_softmax_tile_1cta(
                             32,
                         )
                     )
+                    if STAGE == 2:
+                        col_limit_right = (
+                            offs_m - (start_n + fragment_id * 32) + 1
+                        )[:, None]
+                        qk_fragment = _apply_causal_mask(
+                            qk_fragment, col_limit_right, 32
+                        )
                     m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-                m_i = tl.ceil(m_i) + 0.055517269
+                m_i = tl.ceil(m_i) + _S2_F16_GAUGE
             l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
             p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
             for fragment_id in tl.static_range(0, 4):
@@ -347,25 +391,50 @@ def _fwd_softmax_tile_1cta(
                         32,
                     )
                 )
-                p_h = _s2_exp2_bf16(
-                    qk_fragment,
-                    qk_scale * 128.0,
-                    12582912.0 + 128.0 * (126.0 - m_i[:, None]),
-                )
-                if fragment_id % 2 == 0:
-                    p_pending = p_h
+                if STAGE == 2:
+                    col_limit_right = (
+                        offs_m - (start_n + fragment_id * 32) + 1
+                    )[:, None]
+                    qk_fragment = _apply_causal_mask(
+                        qk_fragment, col_limit_right, 32
+                    )
+                if FAST_BF16:
+                    p_h = _s2_exp2_bf16(
+                        qk_fragment,
+                        qk_scale * 128.0,
+                        12582912.0 + 128.0 * (126.0 - m_i[:, None]),
+                    )
+                elif STAGE == 2:
+                    p_i = tl.math.exp2(
+                        _fma_f32x2(qk_fragment, qk_scale, -m_i[:, None])
+                    )
+                    p_h = p_i.to(out_dtype)
                 else:
+                    p_h = _s2_exp2_f16(
+                        qk_fragment,
+                        qk_scale * 1024.0,
+                        12582912.0 + 1024.0 * (14.0 - m_i[:, None]),
+                    )
+                if (FAST_BF16 or FAST_F16) and fragment_id % 2 == 0:
+                    p_pending = p_h
+                elif FAST_BF16 or FAST_F16:
                     p_bufIdx = cid * 2 + fragment_id // 2
                     tlx.local_store(
-                        tlx.local_view(p_tiles, p_bufIdx),
-                        _join_n_2D([p_pending, p_h]),
+                        tlx.local_view(p_tiles, p_bufIdx), _join_n_2D([p_pending, p_h])
                     )
                     tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-                l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
+                if FAST_BF16:
+                    l_ij += tl.reduce(
+                        p_h, axis=1, combine_fn=_reduce_bf16
+                    ).to(tl.float32)
+                elif STAGE == 2:
+                    l_ij += tl.sum(p_i, 1)
+                else:
+                    l_ij += tl.sum(p_h, 1).to(tl.float32)
             l_i += l_ij
             accum_cnt_qk += 1
             gauge_cnt += 1
-        return m_i, l_i, accum_cnt_qk
+        return m_i, l_i, accum_cnt_qk, gauge_cnt
 
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
     for start_n in tl.range(lo, hi, BLOCK_N):
@@ -424,19 +493,31 @@ def _fwd_softmax_tile_1cta(
         # the loop is unrolled twice likely for vectorization
         qks = _split_n_2D(qk, NUM_MMA_SLICES)
         l_ij = tl.zeros_like(l_i)
+        p_pending = tl.zeros([BLOCK_M // 2, BLOCK_N // NUM_MMA_SLICES], dtype=out_dtype)
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             # prepare p for the v dot
-            p_bufIdx = qk_buf * NUM_MMA_SLICES + slice_id
             p_i = tl.math.exp2(qks[slice_id])
             p_h = p_i.to(out_dtype)
-            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
-            tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+            if FAST_F16:
+                if slice_id % 2 == 0:
+                    p_pending = p_h
+                else:
+                    p_bufIdx = qk_buf * NUM_P_SLICES + slice_id // 2
+                    tlx.local_store(
+                        tlx.local_view(p_tiles, p_bufIdx),
+                        _join_n_2D([p_pending, p_h]),
+                    )
+                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+            else:
+                p_bufIdx = qk_buf * NUM_P_SLICES + slice_id
+                tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
+                tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
             l_ij += tl.sum(p_i, 1)
 
         l_i += l_ij
         m_i = m_ij
         accum_cnt_qk += 1
-    return m_i, l_i, accum_cnt_qk
+    return m_i, l_i, accum_cnt_qk, gauge_cnt
 
 
 @triton.jit
@@ -447,6 +528,7 @@ def _fwd_softmax_tile_2cta(
     p_tiles,
     cid,
     accum_cnt_qk,
+    gauge_cnt,
     qk_scale,
     m_i,
     l_i,
@@ -460,7 +542,6 @@ def _fwd_softmax_tile_2cta(
 ):
     tl.static_assert(NUM_MMA_SLICES == 2)
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-    gauge_cnt = 0
     for start_n in tl.range(lo, hi, BLOCK_N):
         _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
         tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
@@ -518,7 +599,7 @@ def _fwd_softmax_tile_2cta(
         l_i += l_ij
         accum_cnt_qk += 1
         gauge_cnt += 1
-    return m_i, l_i, accum_cnt_qk
+    return m_i, l_i, accum_cnt_qk, gauge_cnt
 
 
 @triton.jit
@@ -531,6 +612,7 @@ def _fwd_softmax_tile_2cta_online(
     acc_tiles,
     cid,
     accum_cnt_qk,
+    gauge_cnt,
     qk_scale,
     m_i,
     l_i,
@@ -546,7 +628,6 @@ def _fwd_softmax_tile_2cta_online(
 ):
     tl.static_assert(NUM_MMA_SLICES == 2)
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-    block_count = 0
     for start_n in tl.range(lo, hi, BLOCK_N):
         _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
         tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
@@ -561,7 +642,7 @@ def _fwd_softmax_tile_2cta_online(
         else:
             m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
             alpha = tl.math.exp2(m_i - m_ij)
-        if block_count > 0:
+        if gauge_cnt > 0:
             for slice_id in tl.static_range(0, NUM_MMA_SLICES):
                 acc_slice = tlx.subslice(
                     tlx.local_view(acc_tiles, cid),
@@ -614,8 +695,8 @@ def _fwd_softmax_tile_2cta_online(
         l_i += l_ij
         m_i = m_ij
         accum_cnt_qk += 1
-        block_count += 1
-    return m_i, l_i, accum_cnt_qk
+        gauge_cnt += 1
+    return m_i, l_i, accum_cnt_qk, gauge_cnt
 
 
 @triton.jit
@@ -631,6 +712,7 @@ def _fwd_softmax_tile(
     acc_tiles,
     cid,
     accum_cnt_qk,
+    gauge_cnt,
     qk_scale,
     offs_m,
     m_i,
@@ -657,6 +739,7 @@ def _fwd_softmax_tile(
                 p_tiles,
                 cid,
                 accum_cnt_qk,
+                gauge_cnt,
                 qk_scale,
                 m_i,
                 l_i,
@@ -677,6 +760,7 @@ def _fwd_softmax_tile(
             acc_tiles,
             cid,
             accum_cnt_qk,
+            gauge_cnt,
             qk_scale,
             m_i,
             l_i,
@@ -700,6 +784,7 @@ def _fwd_softmax_tile(
         alpha_tiles,
         cid,
         accum_cnt_qk,
+        gauge_cnt,
         qk_scale,
         offs_m,
         m_i,
@@ -756,7 +841,8 @@ def _fwd_control_tile(
     STAGE,
     USE_2CTA,
     USE_WHERE,
-    FAST_FIXED,
+    SKIP_RESCALE,
+    FUSE_EPILOG,
 ):
     start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
         tile_id // NUM_CTAS,
@@ -768,7 +854,7 @@ def _fwd_control_tile(
         STAGE,
         GROUP_SIZE_N,
     )
-    control_lo = hi if FAST_FIXED else lo
+    control_lo = hi if SKIP_RESCALE else lo
     # Rescale the live output accumulator when the online-softmax gauge changes.
     for _ in tl.range(control_lo, hi, BLOCK_N):
         _, phase = get_bufidx_phase(accum_cnt, 1)
@@ -859,7 +945,7 @@ def _fwd_control_tile(
             )
             tlx.local_store(subslice_o, acc)
         tlx.fence("async_shared")
-        if FAST_FIXED:
+        if FUSE_EPILOG:
             qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
             tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
             tlx.async_descriptor_store_wait(0)
@@ -1034,7 +1120,7 @@ def _fwd_mma_tile(
     HEAD_DIM_KV: tl.constexpr,
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
+    NUM_P_SLICES: tl.constexpr,
     v_tiles=None,
     v_fulls=None,
     v_empties=None,
@@ -1093,13 +1179,13 @@ def _fwd_mma_tile(
     else:
         if not SKIP_RESCALE:
             tlx.barrier_wait(acc_fulls[0], qk_phase)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+        for slice_id in tl.static_range(0, NUM_P_SLICES):
             p_bufIdx = slice_id
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
             kv_slice = tlx.local_slice(
                 v_tiles[v_bufIdx],
-                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                [BLOCK_N * slice_id // NUM_P_SLICES, 0],
+                [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
             )
             tlx.async_dot(
                 p_tiles[p_bufIdx],
@@ -1148,16 +1234,16 @@ def _fwd_mma_tile(
         else:
             if not SKIP_RESCALE:
                 tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                p_bufIdx = slice_id + NUM_MMA_SLICES
+            for slice_id in tl.static_range(0, NUM_P_SLICES):
+                p_bufIdx = slice_id + NUM_P_SLICES
                 tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
                 kv_slice = tlx.local_slice(
                     v_tiles[v_bufIdx_prev],
-                    [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                    [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                    [BLOCK_N * slice_id // NUM_P_SLICES, 0],
+                    [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
                 )
                 use_acc = acc1_init if slice_id == 0 else True
-                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_P_SLICES - 1 else []
                 tlx.async_dot(
                     p_tiles[p_bufIdx],
                     kv_slice,
@@ -1194,13 +1280,13 @@ def _fwd_mma_tile(
         else:
             if not SKIP_RESCALE:
                 tlx.barrier_wait(acc_fulls[0], qk_phase)
-            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            for slice_id in tl.static_range(0, NUM_P_SLICES):
                 p_bufIdx = slice_id
                 tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
                 kv_slice = tlx.local_slice(
                     v_tiles[v_bufIdx],
-                    [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                    [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                    [BLOCK_N * slice_id // NUM_P_SLICES, 0],
+                    [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
                 )
                 tlx.async_dot(
                     p_tiles[p_bufIdx],
@@ -1227,16 +1313,16 @@ def _fwd_mma_tile(
     else:
         if not SKIP_RESCALE:
             tlx.barrier_wait(acc_fulls[1], qk_phase)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            p_bufIdx = slice_id + NUM_MMA_SLICES
+        for slice_id in tl.static_range(0, NUM_P_SLICES):
+            p_bufIdx = slice_id + NUM_P_SLICES
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
             kv_slice = tlx.local_slice(
                 v_tiles[v_bufIdx],
-                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
-                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+                [BLOCK_N * slice_id // NUM_P_SLICES, 0],
+                [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
             )
             use_acc = acc1_init if slice_id == 0 else True
-            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_P_SLICES - 1 else []
             tlx.async_dot(
                 p_tiles[p_bufIdx],
                 kv_slice,
@@ -1312,10 +1398,18 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
 
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
     tl.static_assert(not USE_2CTA or BLOCK_M == 256)
-    USE_FAST_FIXED: tl.constexpr = (
-        FAST_FIXED and tlx.dtype_of(desc_v) == tl.bfloat16 and POLICY == POLICY_DENSE
+    FAST_BF16: tl.constexpr = (
+        tlx.dtype_of(desc_v) == tl.bfloat16 and POLICY == POLICY_DENSE
         and NUM_MMA_SLICES == 2 and STAGE == 1 and not RESCALE_OPT
     )
+    FAST_F16_CAPABLE: tl.constexpr = (
+        tlx.dtype_of(desc_v) == tl.float16 and NUM_MMA_SLICES == 4
+        and not RESCALE_OPT and not USE_2CTA
+    )
+    USE_FAST_FIXED: tl.constexpr = FAST_FIXED and (FAST_BF16 or FAST_F16_CAPABLE)
+    USE_FAST_F16: tl.constexpr = USE_FAST_FIXED and FAST_F16_CAPABLE
+    FUSE_EPILOG: tl.constexpr = USE_FAST_FIXED and not USE_2CTA
+    DIRECT_SCHED: tl.constexpr = USE_2CTA or USE_FAST_F16
     cluster_cta_rank = tlx.cluster_cta_rank() if USE_2CTA else 0
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
@@ -1377,10 +1471,11 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     qk_storage_alias = tlx.storage_alias_spec(storage=tlx.storage_kind.tmem)
     qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), qk_dtype, NUM_MMA_GROUPS, tlx.storage_kind.tmem,
                                reuse=qk_storage_alias)
+    NUM_P_SLICES: tl.constexpr = 2 if USE_FAST_F16 else NUM_MMA_SLICES
     p_tiles = tlx.local_alloc(
-        (BLOCK_M_SPLIT, BLOCK_N // NUM_MMA_SLICES),
+        (BLOCK_M_SPLIT, BLOCK_N // NUM_P_SLICES),
         tlx.dtype_of(desc_v),
-        NUM_MMA_GROUPS * NUM_MMA_SLICES,
+        NUM_MMA_GROUPS * NUM_P_SLICES,
         tlx.storage_kind.tmem,
         reuse=qk_storage_alias,
     )
@@ -1422,7 +1517,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         tlx.reuse_group(
             qk_tiles,
             tlx.reuse_group(
-                tlx.reuse_group(p_tiles, group_size=NUM_MMA_SLICES),
+                tlx.reuse_group(p_tiles, group_size=NUM_P_SLICES),
                 alpha_tiles,
                 l_tiles,
                 m_tiles,
@@ -1446,14 +1541,14 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         )
     elif USE_WARP_BARRIER:
         qk_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
-        p_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, num_warps=4)
+        p_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS * NUM_P_SLICES, num_warps=4)
         acc_fulls = (
             acc_empties if USE_FAST_FIXED
             else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
         )
     else:
         qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
-        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, arrive_count=NUM_CTAS)
+        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_P_SLICES, arrive_count=NUM_CTAS)
         acc_fulls = (
             acc_empties if USE_FAST_FIXED
             else tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
@@ -1476,9 +1571,9 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
     )
 
     # CLC consumers per CTA: correction(1) + softmax(NUM_GROUPS_PER_CTA) + mma(1) + load(1) + epilog(1).
-    if not USE_2CTA:
+    if not DIRECT_SCHED:
         clc_context = tlx.clc_create_context(
-            num_consumers=3 + NUM_GROUPS_PER_CTA if USE_FAST_FIXED else 4 + NUM_GROUPS_PER_CTA
+            num_consumers=3 + NUM_GROUPS_PER_CTA if FUSE_EPILOG else 4 + NUM_GROUPS_PER_CTA
         )
 
     # In 2-CTA mode, cross-CTA barrier_arrive (to the leader's mbarriers) requires
@@ -1498,9 +1593,9 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
             while tile_id != -1:
                 # Publish this persistent tile, then finalize its M and O outputs.
                 if not USE_2CTA:
-                    tlx.clc_producer(clc_context, clc_phase_producer)
-                    clc_phase_producer ^= 1
-                if not USE_2CTA:
+                    if not DIRECT_SCHED:
+                        tlx.clc_producer(clc_context, clc_phase_producer)
+                        clc_phase_producer ^= 1
                     accum_cnt = _fwd_control_tile(
                         tile_id,
                         tile_count,
@@ -1539,10 +1634,10 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         STAGE,
                         USE_2CTA,
                         USE_WHERE,
-                        USE_FAST_FIXED,
+                        USE_FAST_FIXED, FUSE_EPILOG,
                     )
                 tile_count += 1
-                if USE_2CTA:
+                if DIRECT_SCHED:
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
@@ -1553,10 +1648,12 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
         with tlx.async_task(num_warps=4, registers=DENSE_REGS if USE_2CTA else 168,
                             replicate=NUM_GROUPS_PER_CTA):
             accum_cnt_qk = 0
+            gauge_cnt = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
+                gauge_cnt = 0
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
                     tile_id,
@@ -1588,7 +1685,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     group_id = cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
-                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
+                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1600,6 +1697,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         acc_tiles,
                         cid,
                         accum_cnt_qk,
+                        gauge_cnt,
                         qk_scale,
                         offs_m,
                         m_i,
@@ -1618,7 +1716,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         FAST_FIXED=USE_FAST_FIXED,
                     )
                 if STAGE & 2:
-                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
+                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1630,6 +1728,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         acc_tiles,
                         cid,
                         accum_cnt_qk,
+                        gauge_cnt,
                         qk_scale,
                         offs_m,
                         m_i,
@@ -1678,7 +1777,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
                     tlx.barrier_arrive(l_fulls[cid])
                 tile_count += 1
-                if USE_2CTA:
+                if DIRECT_SCHED:
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
@@ -1706,7 +1805,8 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                             q_fulls, q_empties, k_fulls, k_empties, qk_fulls,
                             qk_empties, p_fulls, acc_fulls, acc_empties,
                             BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
-                            NUM_MMA_SLICES, v_tiles, v_fulls, v_empties, True,
+                            NUM_P_SLICES,
+                            v_tiles, v_fulls, v_empties, True,
                             SKIP_RESCALE=USE_FAST_FIXED,
                         )
                 else:
@@ -1716,11 +1816,11 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
                         qk_empties, p_fulls, acc_fulls, acc_empties,
                         BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
-                        NUM_MMA_SLICES, None, None, None, False,
-                        SKIP_RESCALE=USE_FAST_FIXED,
+                        NUM_P_SLICES,
+                        None, None, None, False, SKIP_RESCALE=USE_FAST_FIXED,
                     )
                 tile_count += 1
-                if USE_2CTA:
+                if DIRECT_SCHED:
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
@@ -1758,7 +1858,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     )
 
                 tile_count += 1
-                if USE_2CTA:
+                if DIRECT_SCHED:
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
@@ -1766,7 +1866,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     clc_phase_consumer ^= 1
 
         # epilog group
-        if USE_2CTA or not USE_FAST_FIXED:
+        if USE_2CTA or not FUSE_EPILOG:
             with tlx.async_task(num_warps=1, registers=24):
                 # initialize offsets
                 tile_count = 0
@@ -1794,7 +1894,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         tlx.barrier_arrive(o_empties[cid])
 
                     tile_count += 1
-                    if USE_2CTA:
+                    if DIRECT_SCHED:
                         next_tile_id = tile_id + persistent_stride
                         tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                     else:
@@ -3946,6 +4046,7 @@ class _attention(torch.autograd.Function):
                 RESCALE_OPT=False, USE_WHERE=False, USE_WARP_BARRIER=True,
                 NUM_CTAS=plan.num_ctas, PIPELINED=True, POLICY=plan.policy,
                 DENSE_REGS=176 if use_s1_2cta else 168,
+                FAST_FIXED=True,
                 num_stages=1, num_warps=4,
                 **({"ctas_per_cga": (2, 1, 1)} if use_s1_2cta else {}),
                 **extra_kern_args,

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -4327,7 +4327,9 @@ class _attention(torch.autograd.Function):
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
-            DQ_STAGE_COUNT=2,
+            DQ_STAGE_COUNT=(
+                4 if bf16_dq_output and N_CTX >= 4096 else 2
+            ),
             SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -962,6 +962,39 @@ def _fwd_control_tile(
 
 
 @triton.jit
+def _fwd_load_first_k_tile(
+    accum_cnt_k,
+    lo,
+    hi,
+    kv_offset_y,
+    desc_k,
+    k_tiles,
+    k_fulls,
+    k_empties,
+    K_BYTES_PER_ELEM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    cluster_cta_rank,
+    NUM_CTAS: tl.constexpr,
+):
+    buf, phase = get_bufidx_phase(accum_cnt_k, NUM_BUFFERS_KV)
+    tlx.barrier_wait(k_empties[buf], phase ^ 1)
+    if cluster_cta_rank == 0:
+        tlx.barrier_expect_bytes(
+            k_fulls[buf], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM
+        )
+    tlx.async_descriptor_load(
+        desc_k,
+        k_tiles[buf],
+        [kv_offset_y + cluster_cta_rank * (BLOCK_N // NUM_CTAS), 0],
+        k_fulls[buf],
+        two_ctas=True,
+    )
+    return accum_cnt_k + (hi - lo) // BLOCK_N
+
+
+@triton.jit
 def _fwd_load_tile(
     tile_count,
     accum_cnt_kv,
@@ -992,6 +1025,7 @@ def _fwd_load_tile(
     v_empties=None,
     NUM_GROUPS_PER_CTA: tl.constexpr = 2,
     NUM_CTAS: tl.constexpr = 1,
+    SKIP_FIRST_K: tl.constexpr = False,
 ):
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
     # load q0
@@ -1007,7 +1041,25 @@ def _fwd_load_tile(
                 [qo_offset_y + (group_id * NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
                 q_fulls[q_id], two_ctas=True,
             )
-        for _ in tl.range(lo, hi, BLOCK_N):
+        if SKIP_FIRST_K:
+            buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+            tlx.barrier_wait(v_empties[buf], phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(
+                    v_fulls[buf], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM
+                )
+            tlx.async_descriptor_load(
+                desc_v,
+                v_tiles[buf],
+                [kv_offset_y, cluster_cta_rank * (HEAD_DIM // NUM_CTAS)],
+                v_fulls[buf],
+                two_ctas=True,
+            )
+            kv_offset_y += BLOCK_N
+            accum_cnt_kv += 1
+
+        loop_start = lo + BLOCK_N if SKIP_FIRST_K else lo
+        for _ in tl.range(loop_start, hi, BLOCK_N):
             buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
             tlx.barrier_wait(kv_empties[buf], phase ^ 1)
             tlx.barrier_wait(v_empties[buf], phase ^ 1)
@@ -1833,6 +1885,42 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
+        # Use the otherwise idle sixteenth warp to publish K0 independently.
+        if USE_2CTA and USE_FAST_FIXED:
+            with tlx.async_task(num_warps=1, registers=24):
+                accum_cnt_k = 0
+                tile_id = start_pid
+                while tile_id != -1:
+                    _, _, lo, hi, _, kv_offset_y = _compute_offsets(
+                        tile_id,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        N_CTX,
+                        EFFECTIVE_BLOCK_M,
+                        STAGE,
+                        GROUP_SIZE_N,
+                    )
+                    accum_cnt_k = _fwd_load_first_k_tile(
+                        accum_cnt_k,
+                        lo,
+                        hi,
+                        kv_offset_y,
+                        desc_k,
+                        k_tiles,
+                        k_fulls,
+                        k_empties,
+                        K_BYTES_PER_ELEM,
+                        BLOCK_N,
+                        HEAD_DIM,
+                        NUM_BUFFERS_KV,
+                        cluster_cta_rank,
+                        NUM_CTAS,
+                    )
+                    tlx.named_barrier_wait(15, 64)
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+
         # Q/K/V loader role; output publication remains in the epilog task.
         with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
@@ -1853,7 +1941,10 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, cluster_cta_rank,
                         v_tiles, v_fulls, v_empties,
                         NUM_GROUPS_PER_CTA, NUM_CTAS,
+                        SKIP_FIRST_K=USE_FAST_FIXED,
                     )
+                    if USE_FAST_FIXED:
+                        tlx.named_barrier_arrive(15, 64)
                 else:
                     accum_cnt_kv = _fwd_load_tile(
                         tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y,
@@ -1891,13 +1982,28 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         GROUP_SIZE_N,
                     )
                     _, phase = get_bufidx_phase(tile_count, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        group_id = cid * NUM_CTAS + cluster_cta_rank
-                        tlx.barrier_wait(o_fulls[cid], phase)
-                        qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                        tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                    if USE_2CTA and USE_FAST_FIXED and NUM_GROUPS_PER_CTA == 2:
+                        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                            group_id = cid * NUM_CTAS + cluster_cta_rank
+                            tlx.barrier_wait(o_fulls[cid], phase)
+                            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                            tlx.async_descriptor_store(
+                                desc_o, o_tiles[cid], [qo_offset_y_split, 0]
+                            )
+                        tlx.async_descriptor_store_wait(1)
+                        tlx.barrier_arrive(o_empties[0])
                         tlx.async_descriptor_store_wait(0)
-                        tlx.barrier_arrive(o_empties[cid])
+                        tlx.barrier_arrive(o_empties[1])
+                    else:
+                        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                            group_id = cid * NUM_CTAS + cluster_cta_rank
+                            tlx.barrier_wait(o_fulls[cid], phase)
+                            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                            tlx.async_descriptor_store(
+                                desc_o, o_tiles[cid], [qo_offset_y_split, 0]
+                            )
+                            tlx.async_descriptor_store_wait(0)
+                            tlx.barrier_arrive(o_empties[cid])
 
                     tile_count += 1
                     if DIRECT_SCHED:

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1940,94 +1940,67 @@ def _attn_bwd_dq_postprocess(DQ_ACCUM, DQ_OUT,  #
     dst = DQ_OUT + off_hz * N_CTX * HEAD_DIM + q * HEAD_DIM + h
     tl.store(dst, val.to(DQ_OUT.dtype.element_ty))
 
-
-@triton.jit
-def bwd_calculate_offsets(
-    tile_idx,
-    n_tile_num,
-    num_pid_m,
-    H,
-    N_CTX,  #
-    BLOCK_M1: tl.constexpr,
-    BLOCK_N1: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    STAGE: tl.constexpr,
-):
-    bhid = tile_idx // n_tile_num
-    pid = tile_idx % n_tile_num
-    pid, bhid = tl.swizzle2d(pid, bhid, n_tile_num, num_pid_m, GROUP_SIZE_M)
-    batch = bhid // H
-    head = bhid % H
-    off_chz = (bhid * N_CTX).to(tl.int64)
-    start_n = pid
-    start_m = _get_start_m_bwd(start_n, BLOCK_N1, STAGE)
-    num_steps = (N_CTX - start_m) // BLOCK_M1
-    return off_chz, batch, head, start_m, start_n, num_steps
-
-
 _bwd_selected_meta = {}
 
 
 def _bwd_host_descriptor_pre_hook_tlx(nargs):
-    BLOCK_M1 = nargs["BLOCK_M1"]
-    BLOCK_N1 = nargs["BLOCK_N1"]
-    HEAD_DIM = nargs["HEAD_DIM"]
-    NUM_CTAS = nargs.get("NUM_CTAS", 1)
-
-    _bwd_selected_meta["BLOCK_M1"] = BLOCK_M1
-    _bwd_selected_meta["NUM_CTAS"] = NUM_CTAS
-
+    block_m = nargs["BLOCK_M1"]
+    block_n = nargs["BLOCK_N1"]
+    head_dim = nargs["HEAD_DIM"]
+    num_ctas = nargs.get("NUM_CTAS", 1)
+    _bwd_selected_meta["BLOCK_M1"] = block_m
+    _bwd_selected_meta["NUM_CTAS"] = num_ctas
     # Reset dq accumulator to zeros before each autotuner warmup run.
     # dq uses TMA reduce-add, so stale values accumulate across runs.
     # dk/dv don't need zeroing — they use use_acc=False on the first iteration.
     nargs["desc_dq"].base.zero_()
-
-    nargs["desc_q"].block_shape = [1, 1, BLOCK_M1, HEAD_DIM // NUM_CTAS]
-    nargs["desc_do"].block_shape = [1, 1, BLOCK_M1, HEAD_DIM // NUM_CTAS]
-    nargs["desc_v"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
-    nargs["desc_k"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
-    if NUM_CTAS > 1:
-        EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
-        DQ_SLICE_N = HEAD_DIM // EPILOGUE_SUBTILE
-        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_SLICE_N]
+    nargs["desc_q"].block_shape = [1, 1, block_m, head_dim // num_ctas]
+    nargs["desc_do"].block_shape = [1, 1, block_m, head_dim // num_ctas]
+    nargs["desc_v"].block_shape = [1, 1, block_n, head_dim]
+    nargs["desc_k"].block_shape = [1, 1, block_n, head_dim]
+    if num_ctas > 1:
+        dq_slice = head_dim // nargs["EPILOGUE_SUBTILE"]
     else:
-        DQ_REDUCE_NCOL = nargs["DQ_REDUCE_NCOL"]
-        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_REDUCE_NCOL]
-    DKV_STORE_NCOL = nargs["DKV_STORE_NCOL"]
-    nargs["desc_dv"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
-    nargs["desc_dk"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
-    nargs["desc_m"].block_shape = [BLOCK_M1]
-    nargs["desc_delta"].block_shape = [BLOCK_M1]
+        dq_slice = nargs["DQ_REDUCE_NCOL"]
+    nargs["desc_dq"].block_shape = [1, 1, block_m, dq_slice]
+    dkv_slice = nargs["DKV_STORE_NCOL"]
+    nargs["desc_dv"].block_shape = [1, 1, block_n, dkv_slice]
+    nargs["desc_dk"].block_shape = [1, 1, block_n, dkv_slice]
+    if "desc_m" in nargs:
+        nargs["desc_m"].block_shape = [block_m]
+    if "desc_delta" in nargs:
+        nargs["desc_delta"].block_shape = [block_m]
     # 2-CTA: separate B-operand descriptors for the transposed views.
     if "desc_kt" in nargs and "desc_qt" in nargs:
-        nargs["desc_kt"].block_shape = [1, 1, BLOCK_N1 * NUM_CTAS, HEAD_DIM // NUM_CTAS]
-        nargs["desc_qt"].block_shape = [1, 1, BLOCK_M1 // NUM_CTAS, HEAD_DIM]
-        nargs["desc_dot"].block_shape = [1, 1, BLOCK_M1 // NUM_CTAS, HEAD_DIM]
+        nargs["desc_kt"].block_shape = [1, 1, block_n * num_ctas, head_dim // num_ctas]
+        nargs["desc_qt"].block_shape = [1, 1, block_m // num_ctas, head_dim]
+        nargs["desc_dot"].block_shape = [1, 1, block_m // num_ctas, head_dim]
 
 
 configs_bwd_1cta = [
     triton.Config(
         {
-            "BLOCK_M1": bm1,
+            "BLOCK_M1": 64,
             "BLOCK_N1": 128,
             "NUM_BUFFERS_KV": 1,
             "NUM_BUFFERS_Q": 2,
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
-            "DKV_STORE_NCOL": 64,
             "NUM_COMPUTE_SLICES": 2,
+            "DKV_STORE_NCOL": 64,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
             "EPILOGUE_SUBTILE": 4,
             "GROUP_SIZE_M": 1,
-            "USE_WARP_BARRIER": uwb,
+            "USE_WARP_BARRIER": use_warp_barrier,
             "NUM_CTAS": 1,
         },
         num_warps=8,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for bm1 in [64] for uwb in [False, True]
+    )
+    for use_warp_barrier in (False, True)
 ]
 
 configs_bwd_2cta = [
@@ -2041,8 +2014,8 @@ configs_bwd_2cta = [
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
-            "DKV_STORE_NCOL": 64,
             "NUM_COMPUTE_SLICES": 2,
+            "DKV_STORE_NCOL": 64,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
             "EPILOGUE_SUBTILE": 4,
@@ -2054,10 +2027,10 @@ configs_bwd_2cta = [
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
         ctas_per_cga=(2, 1, 1),
-    ),
+    )
 ]
 
-configs_bwd_tlx = configs_bwd_1cta + configs_bwd_2cta
+BWD_CONFIGS = configs_bwd_1cta + configs_bwd_2cta
 
 
 @triton.jit
@@ -3092,7 +3065,7 @@ def _bwd_compute_inner_loop(
     return curr_m, blk_idx
 
 
-@triton.autotune(configs=configs_bwd_tlx, key=["N_CTX", "HEAD_DIM"])
+@triton.autotune(configs=BWD_CONFIGS, key=["N_CTX", "HEAD_DIM"])
 @triton.jit
 def _attn_bwd_ws(
     desc_q,

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1,3 +1,5 @@
+from enum import IntEnum
+from typing import NamedTuple
 import torch
 import triton
 import triton.language as tl
@@ -9,6 +11,24 @@ from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 
+class Policy(IntEnum):
+    DENSE = 0
+    CAUSAL_64K = 1
+    CAUSAL_128K = 2
+    CAUSAL_256K = 3
+    CAUSAL_512K = 4
+
+
+class ForwardPlan(NamedTuple):
+    stage: int
+    pipelined: bool
+    policy: int
+    dense_regs: int
+
+
+POLICY_DENSE = tl.constexpr(int(Policy.DENSE))
+CAUSAL_POLICY_BIT_OFFSET = 16
+FWD_BLOCK_M = tl.constexpr(256)
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
@@ -259,7 +279,7 @@ def _apply_causal_mask(qk, col_limit, BLOCK: tl.constexpr, keep_ge: tl.constexpr
 
 
 @triton.jit
-def _softmax_inner_loop(
+def _fwd_softmax_tile(
     qk_fulls,
     qk_tiles,
     p_fulls,
@@ -854,10 +874,13 @@ def _attn_fwd_ws(sm_scale, M,  #
                  USE_WHERE: tl.constexpr,  #
                  USE_WARP_BARRIER: tl.constexpr,  #
                  NUM_CTAS: tl.constexpr = 1,  #
+                 PIPELINED: tl.constexpr = False,
+                 POLICY: tl.constexpr = POLICY_DENSE,
+                 DENSE_REGS: tl.constexpr = 200,
                  ):
     _attn_fwd_ws_kernel(sm_scale, M, Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX, HEAD_DIM, BLOCK_M, BLOCK_N, STAGE,
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_BUFFERS_QK, NUM_MMA_GROUPS, NUM_MMA_SLICES, GROUP_SIZE_N,
-                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS)
+                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS)
 
 
 @triton.jit
@@ -877,6 +900,9 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         USE_WHERE: tl.constexpr,  #
                         USE_WARP_BARRIER: tl.constexpr,  #
                         NUM_CTAS: tl.constexpr = 1,  #
+                        PIPELINED: tl.constexpr = False,
+                        POLICY: tl.constexpr = POLICY_DENSE,
+                        DENSE_REGS: tl.constexpr = 200,
                         ):
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -1116,7 +1142,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                     group_id = cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
-                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1142,7 +1168,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         USE_2CTA=USE_2CTA,
                     )
                 if STAGE & 2:
-                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
+                    m_i, l_i, accum_cnt_qk = _fwd_softmax_tile(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1205,7 +1231,7 @@ def _attn_fwd_ws_kernel(sm_scale, M,  #
                         q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
                         qk_empties, p_fulls, acc_fulls, acc_empties,
                         BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
-                        NUM_MMA_SLICES,
+                        NUM_MMA_SLICES, None, None, None, False,
                     )
                 tile_count += 1
                 tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
@@ -3310,6 +3336,15 @@ def _attn_bwd_ws(
         #     pass
 
 
+def _select_forward_plan(causal):
+    return ForwardPlan(
+        stage=3 if causal else 1,
+        pipelined=False,
+        policy=int(Policy.DENSE),
+        dense_regs=200,
+    )
+
+
 class _attention(torch.autograd.Function):
 
     @staticmethod
@@ -3319,7 +3354,7 @@ class _attention(torch.autograd.Function):
         assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
         assert HEAD_DIM_K in {16, 32, 64, 128, 256}
 
-        stage = 3 if causal else 1
+        plan = _select_forward_plan(causal)
 
         o = torch.empty_like(q)
         extra_kern_args = {}
@@ -3328,7 +3363,7 @@ class _attention(torch.autograd.Function):
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
-        dummy_block = [1, 1]
+        dummy_block = [128, HEAD_DIM_K] if plan.pipelined else [1, 1]
         desc_q = TensorDescriptor(
             q,
             shape=[y_dim, HEAD_DIM_K],
@@ -3359,27 +3394,48 @@ class _attention(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
 
-        def grid(META):
-            num_ctas = META.get("NUM_CTAS") or 1
-            n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
-            n_ctas = triton.cdiv(n_ctas, num_ctas) * num_ctas
-            return (n_ctas, )
-
+        if plan.pipelined:
+            grid = (triton.cdiv(q.shape[2], FWD_BLOCK_M.value) * q.shape[0] * q.shape[1],)
+            _attn_fwd_ws.fn[grid](
+                sm_scale,
+                M,  #
+                q.shape[0],
+                q.shape[1],  #
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,  #
+                N_CTX=q.shape[2],  #
+                HEAD_DIM=HEAD_DIM_K,  #
+                BLOCK_M=256, BLOCK_N=128,
+                STAGE=plan.stage,  #
+                NUM_BUFFERS_Q=1,
+                NUM_BUFFERS_KV=3 if HEAD_DIM_K == 128 else 6,
+                NUM_BUFFERS_QK=1, NUM_MMA_GROUPS=2,
+                NUM_MMA_SLICES=(
+                    2
+                    if HEAD_DIM_K == 128
+                    or (q.dtype != torch.float16 and plan.policy in (1, 2))
+                    else 4
+                ),
+                GROUP_SIZE_N=4 if plan.policy == 1 else 1,
+                RESCALE_OPT=False, USE_WHERE=False, USE_WARP_BARRIER=True,
+                NUM_CTAS=1, PIPELINED=True, POLICY=plan.policy,
+                DENSE_REGS=plan.dense_regs, num_stages=1, num_warps=4,
+                **extra_kern_args,
+            )
+        else:
+            def grid(META):
+                num_ctas = META.get("NUM_CTAS") or 1
+                n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+                return (triton.cdiv(n_ctas, num_ctas) * num_ctas, )
+            _attn_fwd_ws[grid](
+                sm_scale, M, q.shape[0], q.shape[1], desc_q, desc_k, desc_v, desc_o,
+                N_CTX=q.shape[2], HEAD_DIM=HEAD_DIM_K, STAGE=plan.stage,
+                PIPELINED=False, POLICY=plan.policy, DENSE_REGS=plan.dense_regs,
+                **extra_kern_args,
+            )
         ctx.grid = grid
-        _attn_fwd_ws[grid](
-            sm_scale,
-            M,  #
-            q.shape[0],
-            q.shape[1],  #
-            desc_q,
-            desc_k,
-            desc_v,
-            desc_o,  #
-            N_CTX=q.shape[2],  #
-            HEAD_DIM=HEAD_DIM_K,  #
-            STAGE=stage,  #
-            **extra_kern_args,
-        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1118,6 +1118,7 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,
             HEAD_DIM=HEAD_DIM,
             STAGE=stage,
+            DQ_STAGE_COUNT=2,
             SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -30,6 +30,7 @@ from triton.language.extra.tlx.tutorials.blackwell_fa_ws_pipelined_persistent im
     configs_bwd_1cta as _configs_bwd_1cta,
     configs_bwd_2cta as _configs_bwd_2cta,
     _bwd_selected_meta,
+    prune_bwd_configs as _prune_bwd_configs,
 )
 from triton.language.extra.tlx.tutorials.blackwell_fa_clc import (
     attention as _blackwell_fa_clc, )
@@ -965,10 +966,15 @@ def test_blackwell_fa_clc(N_CTX, causal, RESCALE_OPT, USE_WHERE):
 
 
 @pytest.mark.parametrize("NUM_CTAS", [1, 2])
+@pytest.mark.parametrize("USE_WARP_BARRIER", [False, True])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("RESCALE_OPT,USE_WHERE", [(False, False), (True, False), (True, True)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
-def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE, NUM_CTAS):
+def test_blackwell_fa_ws_pipelined_persistent_bwd(
+    causal, RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS
+):
+    if NUM_CTAS == 2 and USE_WARP_BARRIER:
+        pytest.skip("the 2-CTA configuration uses cluster barriers")
     fwd_config: dict[str,
                      bool | int] = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent_warp_barrier"].copy()
     fwd_config["RESCALE_OPT"] = RESCALE_OPT
@@ -976,6 +982,7 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
     sm_scale = 0.5
 
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
+        direct_dq_output = NUM_CTAS == 2 and HEAD_DIM == 128
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
 
         # Reference backward via PyTorch autograd
@@ -1029,19 +1036,23 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
 
         # Backward: preprocess
         RCP_LN2 = 1.4426950408889634
-        arg_k = k * (sm_scale * RCP_LN2)
+        arg_k = k if direct_dq_output else k * (sm_scale * RCP_LN2)
         PRE_BLOCK = 128
         pre_grid = (N_CTX // PRE_BLOCK, Z * H)
         delta = torch.empty_like(M)
         _blackwell_fa_bwd_preprocess[pre_grid](o, do, delta, N_CTX, BLOCK_M=PRE_BLOCK, HEAD_DIM=HEAD_DIM)
 
         # Backward: main kernel
-        dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
+        dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32) if direct_dq_output else torch.empty(
+            q.shape, device=q.device, dtype=torch.float32
+        )
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
 
         _HALF_HD = HEAD_DIM // 2
-        dq_accum = torch.zeros([Z, H, N_CTX, HEAD_DIM], device=q.device, dtype=torch.float32)
+        dq_accum = dq if direct_dq_output else torch.zeros(
+            [Z, H, N_CTX, HEAD_DIM], device=q.device, dtype=torch.float32
+        )
 
         dummy_block_4d = [1, 1, 1, 1]
         desc_shape = [Z, H, N_CTX, HEAD_DIM]
@@ -1050,8 +1061,12 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
         desc_bv = TensorDescriptor(v, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_bq = TensorDescriptor(q, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_do = TensorDescriptor(do, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
-        _dq_desc_shape = [Z, H, 2 * N_CTX, _HALF_HD]
-        _dq_desc_strides = [H * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
+        if direct_dq_output:
+            _dq_desc_shape = desc_shape
+            _dq_desc_strides = desc_strides
+        else:
+            _dq_desc_shape = [Z, H, 2 * N_CTX, _HALF_HD]
+            _dq_desc_strides = [H * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
         desc_dq = TensorDescriptor(dq_accum, shape=_dq_desc_shape, strides=_dq_desc_strides, block_shape=dummy_block_4d)
         desc_dk = TensorDescriptor(dk, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
         desc_dv = TensorDescriptor(dv, shape=desc_shape, strides=desc_strides, block_shape=dummy_block_4d)
@@ -1066,7 +1081,13 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
 
         BLK_SLICE_FACTOR = 2
 
-        bwd_configs = _configs_bwd_1cta if NUM_CTAS == 1 else _configs_bwd_2cta
+        source_configs = _configs_bwd_1cta if NUM_CTAS == 1 else _configs_bwd_2cta
+        bwd_configs = [
+            config
+            for config in source_configs
+            if config.kwargs["USE_WARP_BARRIER"] == USE_WARP_BARRIER
+        ]
+        assert len(bwd_configs) == 1
         bwd_kernel = triton.autotune(configs=bwd_configs, key=["N_CTX", "HEAD_DIM"])(_blackwell_fa_bwd_ws.fn)
 
         def grid_persistent(meta):
@@ -1097,23 +1118,56 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(causal, RESCALE_OPT, USE_WHERE
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,
             HEAD_DIM=HEAD_DIM,
             STAGE=stage,
+            SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 
-        _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
-        post_grid = (N_CTX // PRE_BLOCK, Z * H)
-        _blackwell_fa_bwd_dq_postprocess[post_grid](
-            dq_accum,
-            dq,
-            N_CTX,
-            BLK=_blk,
-            HALF_HD=HEAD_DIM // 2,
-            BLOCK_M=PRE_BLOCK,
-            HEAD_DIM=HEAD_DIM,
-        )
+        if not direct_dq_output:
+            _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
+            post_grid = (N_CTX // PRE_BLOCK, Z * H)
+            _blackwell_fa_bwd_dq_postprocess[post_grid](
+                dq_accum,
+                dq,
+                N_CTX,
+                BLK=_blk,
+                HALF_HD=HEAD_DIM // 2,
+                BLOCK_M=PRE_BLOCK,
+                HEAD_DIM=HEAD_DIM,
+            )
 
         torch.testing.assert_close(dv, ref_dv, atol=1e-2, rtol=0)
         torch.testing.assert_close(dk, ref_dk, atol=1e-2, rtol=0)
         torch.testing.assert_close(dq.to(ref_dq.dtype), ref_dq, atol=1e-2, rtol=0)
+
+
+def test_blackwell_fa_ws_pipelined_persistent_direct_dq_pruning():
+    configs = _configs_bwd_1cta + _configs_bwd_2cta
+    selected = _prune_bwd_configs(
+        configs,
+        {},
+        SCALE_QK_IN_KERNEL=True,
+        HEAD_DIM=128,
+        N_CTX=1024,
+    )
+    assert selected
+    assert all(config.kwargs.get("NUM_CTAS", 1) == 2 for config in selected)
+    with pytest.raises(AssertionError):
+        _prune_bwd_configs(
+            configs,
+            {},
+            SCALE_QK_IN_KERNEL=True,
+            HEAD_DIM=64,
+            N_CTX=1024,
+        )
+
+    odd_tiles = _prune_bwd_configs(
+        configs,
+        {},
+        SCALE_QK_IN_KERNEL=False,
+        HEAD_DIM=128,
+        N_CTX=384,
+    )
+    assert odd_tiles
+    assert all(config.kwargs.get("NUM_CTAS", 1) == 1 for config in odd_tiles)
 
 
 @pytest.mark.parametrize("HEAD_DIM", [64, 128])

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -27,9 +27,11 @@ from triton.language.extra.tlx.tutorials.blackwell_fa_ws_pipelined_persistent im
     _attn_bwd_ws as _blackwell_fa_bwd_ws,
     _attn_fwd_ws as _blackwell_fa_fwd_ws,
     _host_descriptor_pre_hook as _blackwell_fa_fwd_pre_hook,
+    configs as _configs_fwd,
     configs_bwd_1cta as _configs_bwd_1cta,
     configs_bwd_2cta as _configs_bwd_2cta,
     _bwd_selected_meta,
+    prune_configs_by_hdim as _prune_fwd_configs,
     prune_bwd_configs as _prune_bwd_configs,
 )
 from triton.language.extra.tlx.tutorials.blackwell_fa_clc import (
@@ -861,20 +863,213 @@ def test_blackwell_fa_ws_pipelined_persistent_2cta(RESCALE_OPT, USE_WHERE):
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
 
 
+def _run_blackwell_fa_numeric(q, k, v, sm_scale, *, fast_fixed=True, rescale_opt=False):
+    Z, H, N_CTX, HEAD_DIM = q.shape
+    config = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent_2cta"].copy()
+    config.update({
+        "NUM_BUFFERS_KV": 3,
+        "RESCALE_OPT": rescale_opt,
+        "USE_WHERE": False,
+        "USE_WARP_BARRIER": True,
+        "PIPELINED": True,
+        "DENSE_REGS": 176,
+        "FAST_FIXED": fast_fixed,
+    })
+
+    o = torch.full_like(q, float("nan"))
+    m = torch.full((Z, H, N_CTX), float("nan"), device=q.device, dtype=torch.float32)
+    y_dim = Z * H * N_CTX
+    dummy_block = [1, 1]
+    desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM], strides=[HEAD_DIM, 1], block_shape=dummy_block)
+    nargs = {
+        **config,
+        "HEAD_DIM": HEAD_DIM,
+        "desc_q": desc_q,
+        "desc_k": desc_k,
+        "desc_v": desc_v,
+        "desc_o": desc_o,
+    }
+    _blackwell_fa_fwd_pre_hook(nargs)
+
+    def alloc_fn(size: int, align: int, _):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+    num_ctas = config["NUM_CTAS"]
+    work_ctas = triton.cdiv(N_CTX, config["BLOCK_M"] * num_ctas) * Z * H * num_ctas
+    grid_ctas = min(torch.cuda.get_device_properties(q.device).multi_processor_count, work_ctas)
+    grid_ctas -= grid_ctas % num_ctas
+    _blackwell_fa_fwd_ws.fn[(grid_ctas, 1, 1)](
+        sm_scale,
+        m,
+        Z,
+        H,
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        N_CTX=N_CTX,
+        HEAD_DIM=HEAD_DIM,
+        STAGE=1,
+        num_stages=1,
+        num_warps=4,
+        ctas_per_cga=(2, 1, 1),
+        **config,
+    )
+    return o, m
+
+
+def _make_attention_numeric_inputs(shape, dtype, distribution):
+    torch.manual_seed(20)
+    if distribution == "uniform_random":
+        return tuple(torch.empty(shape, device=DEVICE, dtype=dtype).uniform_(-0.5, 0.5) for _ in range(3))
+    if distribution == "normal_random":
+        return tuple(
+            torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5)
+            for _ in range(3)
+        )
+    q = torch.ones(shape, device=DEVICE, dtype=dtype)
+    q[:, :, shape[2] // 2:, :] = -1
+    amplitude = 0.625 if shape[3] == 128 else 0.2
+    k = torch.full(shape, amplitude, device=DEVICE, dtype=dtype)
+    k[:, :, :128, :] = -amplitude
+    v = torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5)
+    return q, k, v
+
+
+@pytest.mark.parametrize("distribution", ["uniform_random", "normal_random", "far_apart"])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_ws_pipelined_persistent_fast_fixed_bf16_numerics(distribution):
+    Z, H, N_CTX, HEAD_DIM = 4, 48, 1024, 128
+    shape = (Z, H, N_CTX, HEAD_DIM)
+    sm_scale = 0.5
+    q, k, v = _make_attention_numeric_inputs(shape, torch.bfloat16, distribution)
+
+    scores = torch.matmul(q.float(), k.float().transpose(-2, -1)) * sm_scale
+    ref_o = torch.matmul(torch.softmax(scores, dim=-1), v.float())
+    ref_m = torch.logsumexp(scores, dim=-1) * math.log2(math.e)
+
+    outputs = [_run_blackwell_fa_numeric(q, k, v, sm_scale) for _ in range(3)]
+    tri_o, tri_m = outputs[0]
+    for repeat_o, repeat_m in outputs:
+        assert torch.isfinite(repeat_o).all()
+        assert torch.isfinite(repeat_m).all()
+        torch.testing.assert_close(repeat_o, tri_o, atol=0, rtol=0)
+        torch.testing.assert_close(repeat_m, tri_m, atol=0, rtol=0)
+    o_error = (tri_o.float() - ref_o).abs()
+    print(
+        f"{distribution}: O max/RMSE="
+        f"{o_error.max().item():.8g}/{o_error.square().mean().sqrt().item():.8g}"
+    )
+    torch.testing.assert_close(tri_o.float(), ref_o, atol=1e-2, rtol=0)
+    # The fixed-gauge BF16 exp approximation has a bounded bias in the saved
+    # base-2 log-sum-exp; backward consumes the matching value from forward.
+    torch.testing.assert_close(tri_m, ref_m, atol=0.125, rtol=0)
+
+
+@pytest.mark.parametrize("rescale_opt", [False, True])
+@pytest.mark.parametrize("distribution", ["uniform_random", "normal_random", "far_apart"])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_ws_pipelined_persistent_2cta_non_fast_fixed_numerics(distribution, rescale_opt):
+    Z, H, N_CTX, HEAD_DIM = 4, 48, 1024, 128
+    shape = (Z, H, N_CTX, HEAD_DIM)
+    sm_scale = 0.5
+    q, k, v = _make_attention_numeric_inputs(shape, torch.bfloat16, distribution)
+
+    scores = torch.matmul(q.float(), k.float().transpose(-2, -1)) * sm_scale
+    ref_o = torch.matmul(torch.softmax(scores, dim=-1), v.float())
+    ref_m = torch.logsumexp(scores, dim=-1) * math.log2(math.e)
+    outputs = [
+        _run_blackwell_fa_numeric(
+            q,
+            k,
+            v,
+            sm_scale,
+            fast_fixed=False,
+            rescale_opt=rescale_opt,
+        )
+        for _ in range(3)
+    ]
+    tri_o, tri_m = outputs[0]
+    for repeat_o, repeat_m in outputs:
+        assert torch.isfinite(repeat_o).all()
+        assert torch.isfinite(repeat_m).all()
+        torch.testing.assert_close(repeat_o, tri_o, atol=0, rtol=0)
+        torch.testing.assert_close(repeat_m, tri_m, atol=0, rtol=0)
+    o_error = (tri_o.float() - ref_o).abs()
+    print(
+        f"{distribution}, RESCALE_OPT={rescale_opt}: "
+        f"O max/RMSE={o_error.max().item():.8g}/{o_error.square().mean().sqrt().item():.8g}"
+    )
+    torch.testing.assert_close(tri_o.float(), ref_o, atol=1e-2, rtol=0)
+    torch.testing.assert_close(tri_m, ref_m, atol=0.125, rtol=0)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_ws_pipelined_persistent_fp16_fixed_gauge_opt_out(causal):
+    shape = (1, 1, 1024, 64)
+    q, k, v = _make_attention_numeric_inputs(shape, torch.float16, "far_apart")
+    config = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent"].copy()
+    config.update({
+        "NUM_CTAS": 1,
+        "NUM_MMA_SLICES": 2,
+        "RESCALE_OPT": False,
+        "USE_WHERE": False,
+        "FAST_FIXED": False,
+    })
+    ref_o = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, scale=0.5, is_causal=causal
+    )
+    outputs = [
+        _blackwell_fa_ws_pipelined_persistent(
+            q, k, v, 0.5, causal, config=config
+        )
+        for _ in range(3)
+    ]
+    for repeat_o in outputs:
+        assert torch.isfinite(repeat_o).all()
+        torch.testing.assert_close(repeat_o, outputs[0], atol=0, rtol=0)
+    torch.testing.assert_close(outputs[0], ref_o, atol=1e-2, rtol=0)
+
+
+def test_blackwell_fa_ws_pipelined_persistent_2cta_pruning():
+    selected = _prune_fwd_configs(
+        _configs_fwd,
+        {},
+        HEAD_DIM=128,
+        STAGE=1,
+        N_CTX=768,
+    )
+    assert selected
+    assert all(config.kwargs.get("NUM_CTAS", 1) == 1 for config in selected)
+
+    selected = _prune_fwd_configs(
+        _configs_fwd,
+        {},
+        HEAD_DIM=128,
+        STAGE=1,
+        N_CTX=1024,
+    )
+    assert any(config.kwargs.get("NUM_CTAS", 1) == 2 for config in selected)
+
+
 @pytest.mark.parametrize("Z,H", [(4, 8), (4, 48), (24, 8)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_fa_ws_pipelined_persistent_2cta_probe(Z, H):
-    # Isolation probe (deadlock already fixed; single launch is enough for
-    # correctness). Distinguish grid-size/tile-pairing vs head-count as the
-    # cause of the H=48 correctness failure:
-    #   (4,8)  128 tiles  (baseline, expect pass)
-    #   (4,48) 768 tiles / 192 (batch,head) groups (known fail)
-    #   (24,8) 768 tiles / 192 groups -- SAME tile layout as (4,48) but H=8.
-    # (24,8) fail -> grid-size / work-steal pairing (head-agnostic);
-    # (24,8) pass -> failure is specific to head count.
+    # Cover multiple persistent waves and equivalent batch/head decompositions.
     config = FlashAttention.CONFIGS["blackwell_fa_ws_pipelined_persistent_2cta"].copy()
-    config["RESCALE_OPT"] = True
-    config["USE_WHERE"] = False
+    config.update({
+        "NUM_BUFFERS_KV": 3,
+        "RESCALE_OPT": True,
+        "USE_WHERE": False,
+        "USE_WARP_BARRIER": True,
+        "PIPELINED": True,
+        "DENSE_REGS": 176,
+    })
     sm_scale = 0.5
     N_CTX, HEAD_DIM = 1024, 128
     q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
@@ -967,11 +1162,12 @@ def test_blackwell_fa_clc(N_CTX, causal, RESCALE_OPT, USE_WHERE):
 
 @pytest.mark.parametrize("NUM_CTAS", [1, 2])
 @pytest.mark.parametrize("USE_WARP_BARRIER", [False, True])
+@pytest.mark.parametrize("HEAD_DIM", [64, 128])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("RESCALE_OPT,USE_WHERE", [(False, False), (True, False), (True, True)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_fa_ws_pipelined_persistent_bwd(
-    causal, RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS
+    causal, RESCALE_OPT, USE_WHERE, HEAD_DIM, USE_WARP_BARRIER, NUM_CTAS
 ):
     if NUM_CTAS == 2 and USE_WARP_BARRIER:
         pytest.skip("the 2-CTA configuration uses cluster barriers")
@@ -981,7 +1177,7 @@ def test_blackwell_fa_ws_pipelined_persistent_bwd(
     fwd_config["USE_WHERE"] = USE_WHERE
     sm_scale = 0.5
 
-    for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
+    for Z, H, N_CTX, _ in FlashAttention.SHAPES:
         direct_dq_output = NUM_CTAS == 2 and HEAD_DIM == 128
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
 
@@ -1169,6 +1365,49 @@ def test_blackwell_fa_ws_pipelined_persistent_direct_dq_pruning():
     )
     assert odd_tiles
     assert all(config.kwargs.get("NUM_CTAS", 1) == 1 for config in odd_tiles)
+
+
+@pytest.mark.parametrize(
+    "dtype,N_CTX,causal",
+    [
+        (torch.float16, 128, False),
+        (torch.float16, 384, False),
+        (torch.float16, 1024, False),
+        (torch.bfloat16, 1024, False),
+        (torch.bfloat16, 1024, True),
+        (torch.bfloat16, 4096, False),
+    ],
+)
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_ws_pipelined_persistent_backward_public_paths(dtype, N_CTX, causal):
+    shape = (1, 1, N_CTX, 128)
+    torch.manual_seed(20)
+    q0, k0, v0 = [
+        torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5)
+        for _ in range(3)
+    ]
+    do = torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5)
+
+    ref_q, ref_k, ref_v = [tensor.detach().clone().requires_grad_() for tensor in (q0, k0, v0)]
+    ref_o = torch.nn.functional.scaled_dot_product_attention(
+        ref_q, ref_k, ref_v, scale=0.5, is_causal=causal
+    )
+    ref_o.backward(do)
+    reference = (ref_q.grad, ref_k.grad, ref_v.grad)
+
+    results = []
+    for _ in range(3):
+        q, k, v = [tensor.detach().clone().requires_grad_() for tensor in (q0, k0, v0)]
+        out = _blackwell_fa_ws_pipelined_persistent(q, k, v, 0.5, causal)
+        out.backward(do)
+        result = (q.grad, k.grad, v.grad)
+        assert all(torch.isfinite(grad).all() for grad in result)
+        results.append(result)
+
+    atol = 6.25e-2 if dtype == torch.bfloat16 else 1.5e-2
+    for result in results:
+        for grad, ref_grad in zip(result, reference):
+            torch.testing.assert_close(grad, ref_grad, atol=atol, rtol=0)
 
 
 @pytest.mark.parametrize("HEAD_DIM", [64, 128])

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -823,6 +823,25 @@ def test_blackwell_fa_ws_pipelined_persistent(causal, RESCALE_OPT, USE_WHERE, BL
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
 
 
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_blackwell_fa_ws_pipelined_persistent_fast_f16(causal):
+    # Exercise the selected production route: long FP16 D64 uses the four-slice
+    # fixed-gauge path by default. Numerically sensitive callers can opt out via
+    # an explicit configuration; that path is covered separately.
+    Z, H, N_CTX, HEAD_DIM = 1, 1, 32768, 64
+    sm_scale = 0.5
+    q, k, v = FlashAttention.create_inputs(
+        Z, H, N_CTX, HEAD_DIM, dtype=torch.float16
+    )
+    ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal)
+    tri_out = _blackwell_fa_ws_pipelined_persistent(
+        q, k, v, sm_scale, causal
+    )
+    assert torch.isfinite(tri_out).all()
+    torch.testing.assert_close(tri_out, ref_out, atol=1.5e-2, rtol=0)
+
+
 @pytest.mark.parametrize("RESCALE_OPT,USE_WHERE", [(False, False), (True, False), (True, True)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_fa_ws_pipelined_persistent_2cta(RESCALE_OPT, USE_WHERE):


### PR DESCRIPTION
Summary: Workaround for smallest shapes: if we have small shapes, we don't load all warps. Using last 16th warp for pipelining the store. Generally, we can do that only during underload, so restricting to smaller shapes.

Differential Revision: D117213730


