### PR TITLE
[Performance-Fix][triton][beta] Make NVPTX v2i32 register legalization opt-in (#3256)

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -32,15 +32,19 @@ def test_config_backend_options():
     tree_config = triton.Config(kwargs={}, enable_tree_reduction=True)
     linear_config = triton.Config(kwargs={}, enable_tree_reduction=False)
     dependent_two_cta_config = triton.Config(kwargs={}, allowDependentTwoCTA=True)
+    packed_i32_config = triton.Config(kwargs={}, enable_nvptx_v2i32=True)
 
     assert "enable_tree_reduction" not in default_config.all_kwargs()
+    assert "enable_nvptx_v2i32" not in default_config.all_kwargs()
     assert tree_config.all_kwargs()["enable_tree_reduction"] is True
     assert linear_config.all_kwargs()["enable_tree_reduction"] is False
     assert "allowDependentTwoCTA" not in default_config.all_kwargs()
     assert dependent_two_cta_config.all_kwargs()["allowDependentTwoCTA"] is True
+    assert packed_i32_config.all_kwargs()["enable_nvptx_v2i32"] is True
 
     amd_backend = HIPBackend(GPUTarget("hip", "gfx942", 64))
     assert amd_backend.parse_options(default_config.all_kwargs()).enable_tree_reduction is False
+    assert amd_backend.parse_options(packed_i32_config.all_kwargs()).enable_nvptx_v2i32 is True
     assert amd_backend.parse_options(tree_config.all_kwargs()).enable_tree_reduction is True
     assert amd_backend.parse_options(linear_config.all_kwargs()).enable_tree_reduction is False
 
@@ -51,6 +55,8 @@ def test_config_backend_options():
     assert h100_backend.parse_options(linear_config.all_kwargs()).enable_tree_reduction is False
     assert blackwell_backend.parse_options(tree_config.all_kwargs()).enable_tree_reduction is True
     assert blackwell_backend.parse_options(dependent_two_cta_config.all_kwargs()).allowDependentTwoCTA is True
+    assert blackwell_backend.parse_options(default_config.all_kwargs()).enable_nvptx_v2i32 is False
+    assert blackwell_backend.parse_options(packed_i32_config.all_kwargs()).enable_nvptx_v2i32 is True
 
 
 @pytest.mark.parametrize('use_cuda_graph', [False, True])

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1089,6 +1089,9 @@ class Config:
     :ivar enable_tree_reduction: use tree-shaped, vectorized in-thread reductions. If unset, use the
         backend's architecture-specific default.
     :type enable_tree_reduction: bool | None
+    :ivar enable_nvptx_v2i32: opt in to NVPTX v2i32 register legalization. Off by default;
+        the packed form costs an unpack/repack per use and no integer op is legal on it.
+    :type enable_nvptx_v2i32: bool | None
     """
 
     @staticmethod
@@ -1121,6 +1124,7 @@ class Config:
         auto_tma=None,
         enable_tree_reduction=None,
         allowDependentTwoCTA=None,
+        enable_nvptx_v2i32=None,
     ):
         self.kwargs = kwargs
         self.num_warps = num_warps
@@ -1145,6 +1149,7 @@ class Config:
         # knob; True/False lets the autotuner A/B auto-TMA per shape.
         self.auto_tma = auto_tma
         self.enable_tree_reduction = enable_tree_reduction
+        self.enable_nvptx_v2i32 = enable_nvptx_v2i32
 
     def __setstate__(self, state):
         self.kwargs = state.get("kwargs", {})
@@ -1166,6 +1171,7 @@ class Config:
         self.allowDependentTwoCTA = state.get("allowDependentTwoCTA", None)
         self.auto_tma = state.get("auto_tma", None)
         self.enable_tree_reduction = state.get("enable_tree_reduction", None)
+        self.enable_nvptx_v2i32 = state.get("enable_nvptx_v2i32", None)
 
     def all_kwargs(self):
         return {
@@ -1190,6 +1196,7 @@ class Config:
                     ("auto_tma", self.auto_tma),
                     ("enable_tree_reduction", self.enable_tree_reduction),
                     ("allowDependentTwoCTA", self.allowDependentTwoCTA),
+                    ("enable_nvptx_v2i32", self.enable_nvptx_v2i32),
                 ) if v is not None
             },
         }
@@ -1213,6 +1220,7 @@ class Config:
         res.append(f"multicast: {self.multicast}")
         res.append(f"auto_tma: {self.auto_tma}")
         res.append(f"enable_tree_reduction: {self.enable_tree_reduction}")
+        res.append(f"enable_nvptx_v2i32: {self.enable_nvptx_v2i32}")
         return ", ".join(res)
 
     def __hash__(self):

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -107,6 +107,7 @@ class HIPOptions:
     launch_cluster: bool = False  # No-op placeholder
     multicast: bool = False  # No-op placeholder (TMA multicast is NVIDIA-only)
     enable_tree_reduction: bool = False
+    enable_nvptx_v2i32: bool = False  # No-op placeholder (NVPTX-only)
     matrix_instr_nonkdim: int = 0
     kpack: int = 1
     allow_flush_denorm: bool = False

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -241,6 +241,7 @@ class CUDAOptions:
     # instead of host TMA recipes. Falls back to knobs.nvidia.auto_tma_device.
     auto_tma_device: bool = False
     enable_tree_reduction: bool = False
+    enable_nvptx_v2i32: bool = False
 
     def __post_init__(self):
         default_libdir = Path(__file__).parent / "lib"
@@ -1296,6 +1297,8 @@ class CUDABackend(BaseBackend):
         proc = sm_arch_from_capability(cap_llvm)
         features = get_features(opt, cap_llvm)
         flags = ["nvptx-mad-wide-opt"]
+        if opt.enable_nvptx_v2i32:
+            flags.append("nvptx-v2i32")
         canonicalize_gep = "fpsan" in opt.instrumentation_mode
         ret = llvm.translate_to_asm(src, triple, proc, features, flags, opt.enable_fp_fusion, False, canonicalize_gep)
         # Find kernel names (there should only be one)


### PR DESCRIPTION
Summary:

The LLVM 22 to 23 roll in Triton 3.8 added `addRegisterClass(MVT::v2i32, &NVPTX::B64RegClass)` to the NVPTX backend on Blackwell. LLVM 22 registered only `v2f32` and had no `v2i32` register class at all.

`v2i32` is now legal as **storage** while `NVPTXISelLowering.cpp` still expands essentially every integer operation on it (`// v2i32 is not supported for any arithmetic operations`). There is no packed-integer ALU to exploit, so the type legalizer keeps pairs packed and every scalar use pays an unpack and a repack for no benefit.

The direct cost of those moves is small. The damage is second order: the extra pack/unpack inflates the kernel by ~31% of SASS, which raises register pressure at the 128-register cap, which multiplies spill stores to local memory by 5.9x. The spill traffic and the instruction-fetch pressure from the larger footprint are what cost the time.

Add `hasV2I32Registers()`, gated on a new hidden NVPTX option, and use it for the `v2i32` register class, for `EXTRACT_VECTOR_ELT`, and for the `v2i32`/`v4i32`/`v8i32` cases in `getVectorLoweringShape`. The option is **opt-in to enable**: the default restores LLVM 22 behaviour, and `enable_nvptx_v2i32=True` on a `triton.Config` opts a kernel back in. Expose it through `triton.Config`, include it in backend cache keys, and accept it as a no-op on AMD.

Because the safe behaviour is now the default, **no kernel needs an annotation** and this change touches no kernel code.

`getVectorLoweringShape` also picks the packed shape for `v2i32`/`v4i32`/`v8i32` vector loads and stores. Gating only the register class left that function asking for a packed `v2i32` result with no register class, so any `<4 x i32>` load or store aborted with `Unhandled custom legalization`. The integer cases now follow `hasV2I32Registers()` while the float cases keep `hasF32x2Instructions()`; with v2i32 off the predicates differ only for integers, and float codegen is unchanged.

Mirrored into the beta tree so the patch survives the next stable promotion, which `require_beta_patches_for_stable` enforces. The beta hunks are byte-identical to the stable hunks.

This diff now carries the `beta/` tree only. The identical change for `3.8/` is a separate, independent diff, and the `stable/` mirror will be re-derived from this diff with `fbcode/scripts/agrontsai/mirror_triton_beta_diff_to_stable.sh` once the 3.8.0 promotion (D115081437) lands — rebasing the stable hunks onto master's 3.5.0 stable tree would have been a throwaway port.

Reviewed By: njriasan

Differential Revision: D116829318


