### PR TITLE
[TLX][AMD] Support split-K in persistent addmm warp-pipe

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -573,15 +573,87 @@ class TestTLXTemplates(TestCase):
         code_str = "\n".join(code)
         self.assertIn("triton_tem", code_str)
 
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX persistent warp-pipe addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("K", (1024, 1032))
+    def test_tlx_addmm_persistent_warppipe_split_k(self, K: int):
+        """Persistent split-K handles complete and partial final K tiles."""
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry
+
+        # With the one 64x64 tile config this is 136 output tiles. SPLIT_K=2 creates
+        # 272 work items on 256 CUs, so the first 16 programs execute the persistent
+        # loop twice and exercise its cross-work-item LDS reuse. K=1024 covers full
+        # BLOCK_K tiles; K=1032 is fp16 16-byte aligned but leaves an 8-element tail.
+        M, N = 1088, 512
+        dtype = torch.float16
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        w = torch.randn(N, K, device=GPU_TYPE, dtype=dtype)
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, w):
+            return torch.addmm(bias, a, w.t())
+
+        def _only_persistent(templates, op_name="mm"):
+            from torch._inductor.kernel.mm import mm_template
+
+            uids = {getattr(t, "uid", None) for t in templates}
+            if op_name == "addmm" and mm_template.uid in uids:
+                if _tlx_mm.gfx950_addmm_persistent_warppipe_template.uid not in uids:
+                    templates.append(_tlx_mm.gfx950_addmm_persistent_warppipe_template)
+            return templates
+
+        heuristic = _tlx_registry.Gfx950AddMMPersistentWarpPipeConfigHeuristic
+        get_configs = heuristic._get_template_configs_impl
+
+        def _split_k_two_only(instance, kernel_inputs, op_name):
+            for template_kwargs in get_configs(instance, kernel_inputs, op_name):
+                if template_kwargs.get("SPLIT_K") == 2:
+                    yield template_kwargs
+
+        with (
+                mock.patch.object(_tlx_mm, "append_tlx", _only_persistent),
+                mock.patch.object(
+                    heuristic,
+                    "WARPPIPE_CONFIGS",
+                    [(64, 64, 64, 8, 8, 3)],
+                ),
+                mock.patch.object(
+                    heuristic,
+                    "_get_template_configs_impl",
+                    _split_k_two_only,
+                ),
+                mock.patch.dict(
+                    _tlx_registry.os.environ,
+                    {"TORCHINDUCTOR_TLX_SPLIT_K": "1"},
+                ),
+                config.patch({
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }),
+        ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, w)
+
+        c_expected = (a.float() @ w.t().float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=3e-2, rtol=3e-2)
+
+        code_str = "\n".join(code)
+        self.assertIn("split_k_ws", code_str)
+        self.assertIn("_reduce_k", code_str)
+
 
 class TestWarpPipeSplitKCodegen(TestCase):
-    """Deterministic codegen check for the AMD warp-pipe split-K template.
+    """Deterministic codegen checks for the AMD warp-pipe split-K templates.
 
-    The e2e test above relies on autotune *selecting* a SPLIT_K > 1 config (highly
-    reliable on a 2-tile shape, but a timing decision). This test renders the
-    `gfx950_addmm_warppipe` jinja template directly with SPLIT_K=2 vs SPLIT_K=1 -- no
-    GPU, no autotune -- so the split-K branches are *guaranteed* covered even if
-    autotune ever stops picking split-K, and it runs on any host (not gfx950-gated).
+    The per-tile e2e test relies on autotune *selecting* a SPLIT_K > 1 config. These
+    tests render both warp-pipe Jinja templates directly with SPLIT_K=2 vs SPLIT_K=1,
+    so their split-K interfaces are covered without a GPU or autotune timing decision.
     """
 
     @unittest.skipIf(not has_tlx(), "TLX not available")
@@ -613,6 +685,34 @@ class TestWarpPipeSplitKCodegen(TestCase):
         # SPLIT_K == 1 must take the plain data-parallel path: no split-id, no workspace,
         # full-K loop, and store via store_output (not the reduce workspace).
         self.assertNotIn("split_id = (pid % SPLIT_K)", nosplit)
+        self.assertNotIn("split_k_ws", nosplit)
+        self.assertIn("k_lo = 0", nosplit)
+        self.assertIn("store_output", nosplit)
+
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_persistent_warppipe_split_k_template_render(self):
+        import jinja2
+        from triton.language.extra.tlx.inductor.mm_templates import load_tlx_template
+
+        source = load_tlx_template("gfx950_addmm_persistent_warppipe")
+        hooks = {
+            "def_kernel": lambda *a, **k: "def _kernel(A, B, out_ptr0):",
+            "size": lambda *a, **k: "0",
+            "stride": lambda *a, **k: "1",
+            "output_ptr": lambda *a, **k: "out_ptr0",
+            "store_output": lambda *a, **k: "# store_output(...)",
+        }
+        tmpl = jinja2.Environment().from_string(source)
+        split = tmpl.render(SPLIT_K=2, **hooks)
+        nosplit = tmpl.render(SPLIT_K=1, **hooks)
+
+        self.assertIn("num_work_items = num_tiles * SPLIT_K", split)
+        self.assertIn("split_id = (work_id % SPLIT_K)", split)
+        self.assertIn("base = K_ITERS // SPLIT_K", split)
+        self.assertIn("k_lo = split_id * base", split)
+        self.assertIn("tl.store(split_k_ws + ws_off, acc", split)
+
+        self.assertNotIn("split_id = (work_id % SPLIT_K)", nosplit)
         self.assertNotIn("split_k_ws", nosplit)
         self.assertIn("k_lo = 0", nosplit)
         self.assertIn("store_output", nosplit)

--- a/third_party/tlx/language/tlx/inductor/gfx950_addmm_persistent_warppipe.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/gfx950_addmm_persistent_warppipe.py.jinja
@@ -1,12 +1,12 @@
 {{def_kernel("A", "B")}}
     # PERSISTENT TLX warp-pipelined addmm for AMD (MI350X / gfx950), COL-MAJOR B (stride_bk == 1).
     # Persistent variant of gfx950_addmm_warppipe: the grid is capped at NUM_SMS (see
-    # _persistent_mm_grid_split_k) and each program strides over output tiles by NUM_SMS.
+    # _persistent_mm_grid_split_k) and each program strides over work items by NUM_SMS.
     # The per-tile body (col-major B loaded as (BLOCK_N, BLOCK_K) + tlx.local_trans, XCD chiplet
     # swizzle, "mfma"/"mem" warp-pipeline stages, single combined A+B commit, loop-tail wait) is
-    # copied verbatim from the proven per-tile template -- the ONLY change is wrapping it in the
-    # `for tile_iter in tl.range(start_pid, num_tiles, NUM_SMS)` loop and allocating the SMEM
-    # buffers once outside that loop. Bias is applied by store_output via epilogue_fn / prefix_args.
+    # copied from the proven per-tile template, wrapped in a persistent work-item loop with the SMEM
+    # buffers allocated once outside it. A work item is one (output tile, K split) pair. SPLIT_K=1
+    # stores through store_output; larger splits write fp32 partials for the shared reduce_k epilogue.
     #
     # NOTE: this nesting (warp_pipeline_stage inside a K-loop inside the persistent tile-loop) is
     # exactly what failed to lower on fbcode beta triton 3.6 ("barrier or wait op cannot appear
@@ -32,14 +32,15 @@
     grid_m = (M + BLOCK_M - 1) // BLOCK_M
     grid_n = (N + BLOCK_N - 1) // BLOCK_N
     num_tiles = grid_m * grid_n
+    num_work_items = num_tiles * SPLIT_K
     width = GROUP_M * grid_n
 
     K_ITERS = tl.cdiv(K, BLOCK_K)
     offs_k = tl.arange(0, BLOCK_K).to(INDEX_DTYPE)
 
-    # Persistent: allocate the multi-buffered LDS staging ONCE and reuse it across tiles.
-    # Each tile's epilogue drains all in-flight loads (async_load_wait_group(0)) before the next
-    # tile's prologue reuses the buffers.
+    # Persistent: allocate the multi-buffered LDS staging ONCE and reuse it across work items.
+    # Each work item's epilogue drains all in-flight loads (async_load_wait_group(0)) before the
+    # next one reuses the buffers.
     smemA = tlx.local_alloc((BLOCK_M, BLOCK_K), tlx.dtype_of(A), NUM_BUFFERS)
     smemB = tlx.local_alloc((BLOCK_N, BLOCK_K), tlx.dtype_of(B), NUM_BUFFERS)   # holds Bᵀ tile
 
@@ -48,10 +49,17 @@
     XCD_CHUNK: tl.constexpr = 4
     aligned = (num_tiles // (NUM_XCDS * XCD_CHUNK)) * (NUM_XCDS * XCD_CHUNK)
 
-    for tile_iter in tl.range(start_pid, num_tiles, NUM_SMS):
+    for work_id in tl.range(start_pid, num_work_items, NUM_SMS):
+{% if SPLIT_K > 1 %}
+        # Interleave splits within each output tile so the persistent grid can cover the same
+        # flattened (tile, split) space as the per-tile kernel while remaining capped at NUM_SMS.
+        split_id = (work_id % SPLIT_K).to(INDEX_DTYPE)
+        pid = work_id // SPLIT_K
+{% else %}
+        pid = work_id
+{% endif %}
         # XCD chiplet swizzle: group adjacent tiles onto the same XCD in chunks for warm L2.
         # NUM_XCDS is 8 for gfx942/gfx950 (else 1 -> identity). Trailing remainder passes through.
-        pid = tile_iter
         if pid < aligned:
             xcd = pid % NUM_XCDS
             local_pid = pid // NUM_XCDS
@@ -69,10 +77,22 @@
         a_base = offs_m[:, None] * stride_am
         b_base = offs_n[:, None] * stride_bn          # B as (BLOCK_N, BLOCK_K)
 
-        # prologue: prefetch the first NUM_BUFFERS K-tiles (heuristic guarantees K_ITERS > NUM_BUFFERS).
+{% if SPLIT_K > 1 %}
+        # Balanced contiguous K-iteration partition. The heuristic guarantees every split has at
+        # least NUM_BUFFERS iterations, so the shared prologue/drain remains well formed.
+        base = K_ITERS // SPLIT_K
+        rem = K_ITERS - base * SPLIT_K
+        k_lo = split_id * base + tl.minimum(split_id, rem)
+        n_iters = base + (split_id < rem).to(INDEX_DTYPE)
+{% else %}
+        k_lo = 0
+        n_iters = K_ITERS
+{% endif %}
+
+        # prologue: prefetch the first NUM_BUFFERS K-tiles.
         # A and B share a SINGLE async_load_commit_group per K-tile (wait counts tiles directly).
         for i in tl.range(0, NUM_BUFFERS, loop_unroll_factor=NUM_BUFFERS):
-            k_start = i * BLOCK_K
+            k_start = (k_lo + i) * BLOCK_K
             a_offs = a_base + (k_start + offs_k[None, :]) * stride_ak
             b_offs = b_base + (k_start + offs_k[None, :]) * stride_bk
             tok_a = tlx.async_load(A + a_offs.to(tl.int32), tlx.local_view(smemA, i), mask=offs_k[None, :] < K - k_start)
@@ -85,11 +105,11 @@
 
         acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
 
-        for k_id in tl.range(0, K_ITERS - NUM_BUFFERS):
+        for k_id in tl.range(0, n_iters - NUM_BUFFERS):
             # buffer indices MUST be int32 (local_view feeds them to the block-ptr index check).
             prefetch_buf = (k_id % NUM_BUFFERS).to(tl.int32)
             next_buf = ((k_id + 1) % NUM_BUFFERS).to(tl.int32)
-            k_prefetch = (k_id + NUM_BUFFERS) * BLOCK_K
+            k_prefetch = (k_lo + k_id + NUM_BUFFERS) * BLOCK_K
 
             with tlx.warp_pipeline_stage("mfma", priority=0):
                 acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
@@ -111,7 +131,7 @@
         acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
         tlx.async_load_wait_group(0)
         for i in tl.range(0, NUM_BUFFERS - 1, loop_unroll_factor=NUM_BUFFERS - 1):
-            buf = ((K_ITERS - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
+            buf = ((n_iters - (NUM_BUFFERS - 1) + i) % NUM_BUFFERS).to(tl.int32)   # int32 buffer index
             a_tile = tlx.local_load(tlx.local_view(smemA, buf))
             b_tile = tlx.local_load(tlx.local_trans(tlx.local_view(smemB, buf)))
             acc = tl.dot(a_tile, b_tile, acc, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE)
@@ -123,8 +143,16 @@
         idx_n = rn[None, :]
         mask = (idx_m < M) & (idx_n < N)
 
+{% if SPLIT_K > 1 %}
+        # The reducer owns bias/epilogue application after summing all fp32 partials. Keep the real
+        # output pointer in the signature even though this kernel only writes the workspace.
+        keep_out_ptr = {{output_ptr()}}  # noqa: F841
+        ws_off = split_id * (M * N) + idx_m * N + idx_n
+        tl.store(split_k_ws + ws_off, acc, mask=mask)
+{% else %}
         # inductor generates a suffix (bias add via epilogue_fn + prefix_args, cast, store).
         # store_output inside a persistent tile-loop is supported (see blackwell_gemm_ws.py.jinja);
         # indent_width=8 is REQUIRED so the generated epilogue body lands at the loop-body indent
         # (default 4 would emit it outside the loop -> idx_m/idx_n/mask NameError).
         {{store_output(("idx_m", "idx_n"), "acc", "mask", val_shape=("BLOCK_M", "BLOCK_N"), indent_width=8)}}
+{% endif %}


### PR DESCRIPTION
Summary:
Update the persistent gfx950 addmm warp-pipe template to use the same split-K contract as the per-tile template. Persistent work items represent output-tile and K-split pairs, use the existing balanced K partition, and write fp32 partials to the shared reduction workspace. SPLIT_K=1 retains the direct epilogue path.

With the template honoring this contract, the registry-side filtering proposed by D115345022 is unnecessary.

Add deterministic template-render coverage and forced gfx950 correctness cases that exercise multiple persistent work items per program for both complete BLOCK_K tiles and an aligned partial final K tile.

Authored with Codex.

Reviewed By: htyu

Differential Revision: D117243359


