### PR TITLE
[kernel] [AutoWS][HSTU] Add reproducible CLC self-attention backward (#3262)

### DIFF
--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -15,6 +15,17 @@ inline constexpr StringLiteral kScheduledMaxStageAttrName =
 inline constexpr StringLiteral kDataPartitionFactorAttrName =
     "tt.data_partition_factor";
 
+// AutoWS annotation on an MMA op: a JSON object carrying the desired schedule
+// and, optionally, the channels the operands travel through, e.g.
+//   {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,0"]}
+// The names below are the single source of truth for everyone who reads or
+// writes that annotation (ScheduleLoops, AssignLatencies, WSMemoryPlanner).
+inline constexpr StringLiteral kAutoWSAnnotationAttrName = "tt.autows";
+inline constexpr StringLiteral kAutoWSStageKey = "stage";
+inline constexpr StringLiteral kAutoWSOrderKey = "order";
+inline constexpr StringLiteral kAutoWSChannelsKey = "channels";
+inline constexpr StringLiteral kAutoWSOperandDTag = "opndD";
+
 enum class AutoWSLoopAttrPropagation {
   NotForwarded,
   ForwardToInnerLoop,

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/AssignLatencies.cpp
@@ -1,4 +1,5 @@
 #include "triton/Analysis/AxisInfo.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -8,6 +9,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/JSON.h"
 
 #define DEBUG_TYPE "triton-loop-pipeline"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -20,6 +22,31 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace mlir::triton::gpu {
 namespace {
+
+// Return true when AutoWS will communicate the MMA result through an opndD
+// channel.  That channel already carries MMA completion to the consumer and
+// prevents the accumulator from being reused until the consumer releases it.
+// In that case LowerLoops does not need a second, private completion pipeline
+// for the MMA.
+bool hasAutoWSOutputChannel(Operation *op) {
+  auto attr = op->getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName);
+  if (!attr)
+    return false;
+  auto parsed = llvm::json::parse(attr.getValue());
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return false;
+  }
+  auto *object = parsed->getAsObject();
+  auto *channels = object ? object->getArray(tt::kAutoWSChannelsKey) : nullptr;
+  if (!channels)
+    return false;
+  const std::string operandDPrefix = (tt::kAutoWSOperandDTag + ",").str();
+  return llvm::any_of(*channels, [&](const llvm::json::Value &channel) {
+    auto value = channel.getAsString();
+    return value && value->starts_with(operandDPrefix);
+  });
+}
 
 //===----------------------------------------------------------------------===//
 // assignLatencies
@@ -251,6 +278,21 @@ public:
             }
           }
         }
+        // An AutoWS opndD channel already synchronizes MMA completion and
+        // accumulator reuse.  Keeping self_latency=1 would make LowerLoops
+        // add a redundant completion wait one stage after the MMA.  For an
+        // MMA in the last scheduled stage that wait alone deepens the whole
+        // software pipeline and duplicates the compute prologue.  Record zero
+        // explicitly even when the generic MMA-pipelining heuristic declines
+        // the op so LowerLoops cannot infer a private completion pipeline.
+        //
+        // TODO: this states the conclusion (no self latency) rather than the
+        // reason (the accumulator's completion is already owned by a channel).
+        // The durable fix is for LowerLoops to ask who synchronizes the
+        // accumulator instead of inferring it from self_latency, so the
+        // annotation and the WS channel state cannot disagree.
+        if (useMetaWS && hasAutoWSOutputChannel(&op))
+          mmaSelfLatency[mma] = 0;
       }
     }
     serializeSelfLatencies(forOp->getParentOfType<ModuleOp>(), mmaSelfLatency);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/Dominance.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/MMAv5PipelineUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
@@ -712,7 +713,8 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
 
   for (auto &op : forOp.getBody()->without_terminator()) {
     if (auto mmaOp = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
-      if (auto attr = op.getAttrOfType<StringAttr>("tt.autows")) {
+      if (auto attr =
+              op.getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName)) {
         auto parsed = llvm::json::parse(attr.getValue());
         if (!parsed) {
           llvm::consumeError(parsed.takeError());
@@ -721,8 +723,8 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
         auto *obj = parsed->getAsObject();
         if (!obj)
           continue;
-        auto stageStr = obj->getString("stage");
-        auto clusterStr = obj->getString("order");
+        auto stageStr = obj->getString(tt::kAutoWSStageKey);
+        auto clusterStr = obj->getString(tt::kAutoWSOrderKey);
         if (!stageStr || !clusterStr)
           continue;
         int stage = std::stoi(stageStr->str());
@@ -908,7 +910,8 @@ void scheduleLoop(scf::ForOp forOp, const DenseMap<Operation *, int> &opLatency,
   // Check if any MMA op has tt.autows annotations.
   bool hasAnnotations = false;
   for (auto &op : forOp.getBody()->without_terminator()) {
-    if (isa<ttng::MMAv5OpInterface>(&op) && op.hasAttr("tt.autows")) {
+    if (isa<ttng::MMAv5OpInterface>(&op) &&
+        op.hasAttr(tt::kAutoWSAnnotationAttrName)) {
       hasAnnotations = true;
       break;
     }

--- a/test/TritonGPU/pipeline-assign-latencies-ws-bwd-attn.mlir
+++ b/test/TritonGPU/pipeline-assign-latencies-ws-bwd-attn.mlir
@@ -103,12 +103,12 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       %65 = ttng.tc_gen5_mma %result_18, %39, %result_5[%arg49], %arg45, %true : !ttg.memdesc<128x128xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       %66 = ttg.local_alloc %64 : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
       %67 = ttg.memdesc_trans %66 {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared2, #smem> -> !ttg.memdesc<128x128xbf16, #shared, #smem>
-      // dq MMA is not assigned a latency because its inputs aren't pipelineable
-      // and the output is a tmem_load
-      // CHECK: ttng.tc_gen5_mma
-      // CHECK-NOT: tt.self_latency
-      // CHECK-SAME: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-      %68 = ttng.tc_gen5_mma %67, %19, %result_7[%arg50], %false, %true : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      // dq's result is transferred to another AutoWS partition. The opndD
+      // channel owns completion and accumulator reuse, so a private
+      // self-latency pipeline would be redundant even though the generic MMA
+      // pipelining heuristic declines this op.
+      // CHECK: ttng.tc_gen5_mma {{.*}}tt.self_latency = 0 : i32
+      %68 = ttng.tc_gen5_mma %67, %19, %result_7[%arg50], %false, %true {tt.autows = "{\22channels\22: [\22opndD,tmem,1,5\22]}"} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       %result_19, %token_20 = ttng.tmem_load %result_7[%68] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
       %69 = arith.mulf %result_19, %cst : tensor<128x128xf32, #blocked>
       %70 = ttg.convert_layout %69 : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blocked1>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -938,7 +938,7 @@ static std::optional<unsigned> getChannelAnnotationOperandIdx(StringRef name) {
     return 0;
   if (name == "opndB")
     return 1;
-  if (name == "opndD")
+  if (name == tt::kAutoWSOperandDTag)
     return 2;
   // In TCGen5MMAScaledOp, acc_dep is operand 3, so scales are operands 4/5.
   if (name == "opndAScale" || name == "opndA_scale")
@@ -960,9 +960,9 @@ parseChannelAnnotations(Operation *parentOp) {
   std::map<unsigned, std::pair<unsigned, Operation *>> bufferIdToInfo;
 
   parentOp->walk([&](Operation *op) {
-    if (!op->hasAttr("tt.autows"))
+    if (!op->hasAttr(tt::kAutoWSAnnotationAttrName))
       return;
-    auto attr = op->getAttrOfType<StringAttr>("tt.autows");
+    auto attr = op->getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName);
     if (!attr)
       return;
     auto parsed = llvm::json::parse(attr.getValue());
@@ -973,7 +973,7 @@ parseChannelAnnotations(Operation *parentOp) {
     auto *obj = parsed->getAsObject();
     if (!obj)
       return;
-    auto *channelsArr = obj->getArray("channels");
+    auto *channelsArr = obj->getArray(tt::kAutoWSChannelsKey);
     if (!channelsArr)
       return;
     for (auto &elem : *channelsArr) {
@@ -1059,7 +1059,8 @@ parseChannelAnnotations(Operation *parentOp) {
       }
 
       // Check for operand D annotated as SMEM (always TMEM).
-      if (ann.operand == "opndD" && ann.memType != "tmem") {
+      if (StringRef(ann.operand) == tt::kAutoWSOperandDTag &&
+          ann.memType != "tmem") {
         LDBG("WARNING: opndD must be tmem, got '" << ann.memType
                                                   << "' — correcting to tmem");
         ann.memType = "tmem";

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -22,6 +22,7 @@ Usage (from this dir, on a Blackwell GPU):
   CUDA_VISIBLE_DEVICES=1 ~/.conda/envs/metamain2/bin/python bench_self.py --perf --nrep 5
   ... --perf --variants autows,tlx --seqlens 512,1024,4096 --batch 2
 """
+import logging
 import os
 import sys
 
@@ -32,6 +33,8 @@ import triton  # noqa: E402
 
 import triton_hstu_attention as A  # noqa: E402
 import tlx_bw_hstu_attention as T  # noqa: E402
+
+logger: logging.Logger = logging.getLogger("bench_self")
 
 D = 128
 # heads/sparsity are env-driven so they flow to the per-variant perf subprocesses
@@ -203,13 +206,111 @@ _PERF_ENV = {
         "HSTU_SELF_DQ_ITERS": "4",
         "TRITON_WS_SMEM_PLAN_SEARCH": "1",
     },
+    "autows_clc": {
+        "HSTU_SELF_AUTOWS": "1",
+        "HSTU_SELF_DQ_REDUCE": "1",
+        "HSTU_SELF_DQ_REUSE": "1",
+        "HSTU_SELF_AUTOWS_CLC": "1",
+        "HSTU_SELF_AUTOWS_CLC_SMEM_ALGO": "2",
+        "HSTU_SELF_DP": "1",
+        "HSTU_SELF_AUTOWS_BWD_BM": "128",
+        "HSTU_SELF_AUTOWS_BWD_BN": "128",
+        "HSTU_SELF_AUTOWS_BWD_STAGES": "2",
+        "HSTU_SELF_AUTOWS_WARPS": "4",
+        "HSTU_SELF_PIN": "1",
+        "HSTU_SELF_DQ_ITERS": "4",
+        "TRITON_WS_SMEM_PLAN_SEARCH": "1",
+    },
 }
 
 
-def _bench_one(variant, L, Z, nrep):
+def _clc_bwd(q, k, v, do, so, asc, L, num_targets):
+    """Backward-only closure for the CLC variant: call the production backward
+    wrapper directly so forward compilation/autotuning is excluded from both
+    setup and timing while retaining backward-side allocations and preprocessing.
+
+    dq is zeroed rather than left uninitialized: the CLC path writes it with
+    store_reduce="add", so garbage (possibly inf/NaN) would be accumulated into.
+    The buffers are still reused across calls, so dq keeps summing across
+    repetitions -- this closure is for timing only and its gradients are not
+    meaningful. Zeroing per call would put a memset inside the timed region and
+    bias the CLC number against the other variants."""
+    dq = torch.zeros_like(q)
+    dk, dv = torch.empty_like(k), torch.empty_like(v)
+
+    def bwd():
+        A.triton_hstu_attention_bwd(
+            dout=do,
+            q=q,
+            k=k,
+            v=v,
+            dq=dq,
+            dk=dk,
+            dv=dv,
+            seq_offsets=so,
+            attn_scale=asc,
+            max_seq_len=L,
+            alpha=1.0 / D,
+            max_q_len=None,
+            seq_offsets_q=None,
+            sort_by_length_indices=None,
+            enable_tma=True,
+            num_targets=num_targets,
+            max_attn_len=0,
+            contextual_seq_len=0,
+        )
+
+    return bwd
+
+
+def _time_variant(variant, L, Z, nrep, run, kw, tensors, mode):
+    """Compile, warm and time fwd+bwd for ONE variant inside the caller's knobs
+    scope. `mode` selects the work done after the warm-up backward: "bench"
+    times fwd/bwd, "run_once" stops after a single backward, "profile" prints a
+    torch-profiler table for one backward."""
+    import statistics
+    q, k, v, do, so, asc = tensors
+    warmup = int(os.environ.get("BENCH_WARMUP", "25"))
+    rep = int(os.environ.get("BENCH_REP", "100"))
+    if variant == "autows_clc":
+        bwd = _clc_bwd(q, k, v, do, so, asc, L, kw.get("num_targets"))
+        fwd_s = [float("nan")] * nrep
+    else:
+        fwd = lambda: run(q, k, v, so, L, asc, **kw)  # noqa: E731
+        out = fwd()  # warm / compile / autotune
+        logger.info("%s forward-ready", variant)
+        torch.cuda.synchronize()
+        fwd_s = [triton.testing.do_bench(fwd, warmup=warmup, rep=rep) for _ in range(nrep)]
+
+        def bwd():
+            for t in (q, k, v):
+                t.grad = None
+            out.backward(do, retain_graph=True)
+
+    bwd()  # warm
+    if mode == "run_once":
+        torch.cuda.synchronize()
+        print(f"PERF {variant} L={L} Z={Z} run_once=ok", flush=True)
+        return
+    if mode == "profile":
+        from torch.profiler import ProfilerActivity, profile
+        torch.cuda.synchronize()
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+            bwd()
+            torch.cuda.synchronize()
+        print(prof.key_averages().table(sort_by="self_cuda_time_total", row_limit=20))
+        return
+    logger.info("%s backward-ready", variant)
+    bwd_s = [triton.testing.do_bench(bwd, warmup=warmup, rep=rep) for _ in range(nrep)]
+    fm, bm = statistics.mean(fwd_s), statistics.mean(bwd_s)
+    fsd = (float("nan") if variant == "autows_clc" else (statistics.stdev(fwd_s) if len(fwd_s) > 1 else 0.0))
+    bsd = statistics.stdev(bwd_s) if len(bwd_s) > 1 else 0.0
+    print(f"PERF {variant} L={L} Z={Z} fwd={fm:.4f} fwd_sd={fsd:.4f} bwd={bm:.4f} bwd_sd={bsd:.4f}")
+
+
+def _bench_one(variant, L, Z, nrep, mode="bench"):
     """Time fwd + bwd of ONE variant in THIS process (env already set by parent).
     Prints a machine-parseable PERF line."""
-    import statistics
     torch.manual_seed(0)
     _sp = os.environ.get("BENCH_SPARSITY")
     q, k, v, do, so, asc = make(L, Z, sparsity=float(_sp) if _sp else None)
@@ -224,43 +325,40 @@ def _bench_one(variant, L, Z, nrep):
         lo = 1 if _ts < 400 else _ts // 2
         nt = torch.randint(lo, _ts + 1, (Z, ), device=so.device, dtype=torch.int64)
         kw["num_targets"] = torch.minimum(nt, lens)
-    meta_ws = variant == "autows"
+    meta_ws = variant in ("autows", "autows_clc")
+    # The scope has to stay open across compilation AND timing: the first JIT
+    # compile happens inside _time_variant, so an earlier exit would reset the
+    # knobs before the kernel is built.
     with triton.knobs.nvidia.scope():
         triton.knobs.nvidia.use_meta_ws = meta_ws
         triton.knobs.nvidia.disable_wsbarrier_reorder = True
-        fwd = lambda: run(q, k, v, so, L, asc, **kw)  # noqa: E731
-        out = fwd()  # warm / compile / autotune
-        torch.cuda.synchronize()
-        fwd_s = [triton.testing.do_bench(fwd, warmup=25, rep=100) for _ in range(nrep)]
-
-        def bwd():
-            for t in (q, k, v):
-                t.grad = None
-            out.backward(do, retain_graph=True)
-
-        bwd()  # warm
-        bwd_s = [triton.testing.do_bench(bwd, warmup=25, rep=100) for _ in range(nrep)]
-    fm, bm = statistics.mean(fwd_s), statistics.mean(bwd_s)
-    fsd = statistics.stdev(fwd_s) if len(fwd_s) > 1 else 0.0
-    bsd = statistics.stdev(bwd_s) if len(bwd_s) > 1 else 0.0
-    print(f"PERF {variant} L={L} Z={Z} fwd={fm:.4f} fwd_sd={fsd:.4f} bwd={bm:.4f} bwd_sd={bsd:.4f}")
+        _time_variant(variant, L, Z, nrep, run, kw, (q, k, v, do, so, asc), mode)
 
 
-def run_perf(shapes, variants, nrep=1, heads=None, sparsity=None, timeout=3600):
+def run_perf(shapes, variants, nrep=1, heads=None, sparsity=None, timeout=3600, mode="bench", log_level="WARNING"):
     """Time each variant's fwd+bwd in its own subprocess and tabulate (speedup vs tlx).
-    heads/sparsity flow to the children via env (BENCH_HEADS / BENCH_SPARSITY)."""
+    heads/sparsity flow to the children via env (BENCH_HEADS / BENCH_SPARSITY); the
+    run mode and log level are passed on the child command line.
+
+    Only mode="bench" produces the timings the table is built from. "run_once"
+    and "profile" make each child emit a status line or a profiler table
+    instead, so for those the child output is relayed verbatim rather than
+    matched against the PERF timing format."""
     import re
     import subprocess
 
+    tabulate = mode == "bench"
     hh = heads if heads is not None else H
     inp = "uniform-dense" if sparsity is None else f"jagged sparsity={sparsity}"
-    print(f"\n=== Perf (self-attn fwd/bwd latency, nrep={nrep}, heads={hh}, {inp}) "
+    what = "fwd/bwd latency" if tabulate else f"mode={mode}"
+    print(f"\n=== Perf (self-attn {what}, nrep={nrep}, heads={hh}, {inp}) "
           f"— each variant in its own process ===")
     for (L, Z) in shapes:
         print(f"\n  maxL={L} Z={Z} H={hh} D={D}")
-        hdr = f"  {'variant':<10}{'fwd ms':>10}{'bwd ms':>10}"
-        hdr += f"{'fwd sd':>9}{'bwd sd':>9}" if nrep > 1 else f"{'fwd/tlx':>9}{'bwd/tlx':>9}"
-        print(hdr)
+        if tabulate:
+            hdr = f"  {'variant':<10}{'fwd ms':>10}{'bwd ms':>10}"
+            hdr += f"{'fwd sd':>9}{'bwd sd':>9}" if nrep > 1 else f"{'fwd/tlx':>9}{'bwd/tlx':>9}"
+            print(hdr)
         rows = []
         for var in variants:
             env = dict(os.environ)
@@ -271,10 +369,13 @@ def run_perf(shapes, variants, nrep=1, heads=None, sparsity=None, timeout=3600):
                 env["BENCH_SPARSITY"] = str(sparsity)
             try:
                 r = subprocess.run(
-                    [sys.executable,
-                     os.path.abspath(__file__), "--bench-one", var,
-                     str(L), str(Z),
-                     str(nrep)],
+                    [
+                        sys.executable,
+                        os.path.abspath(__file__), "--bench-one", var,
+                        str(L),
+                        str(Z),
+                        str(nrep), "--mode", mode, "--log-level", log_level
+                    ],
                     env=env,
                     capture_output=True,
                     text=True,
@@ -282,6 +383,14 @@ def run_perf(shapes, variants, nrep=1, heads=None, sparsity=None, timeout=3600):
                 )
             except subprocess.TimeoutExpired:
                 print(f"  {var:<10} TIMEOUT/HANG")
+                continue
+            if not tabulate:
+                # run_once / profile: no timings to tabulate, so relay whatever
+                # the child produced instead of failing the PERF match.
+                status = "ok" if r.returncode == 0 else f"exit={r.returncode}"
+                print(f"  {var:<10} {status}")
+                for line in (r.stdout if r.returncode == 0 else r.stdout + r.stderr).splitlines():
+                    print(f"    {line}")
                 continue
             m = re.search(r"PERF \S+ L=\d+ Z=\d+ fwd=(\S+) fwd_sd=(\S+) bwd=(\S+) bwd_sd=(\S+)", r.stdout)
             if not m:
@@ -313,13 +422,19 @@ def main():
     ap.add_argument("--heads", type=int, default=None, help="num heads H (perf; default 2)")
     ap.add_argument("--sparsity", type=float, default=None,
                     help="jagged density knob (0.95 = D102650040); omit for uniform-dense")
+    ap.add_argument("--mode", choices=("bench", "run_once", "profile"), default="bench",
+                    help="per-variant work: time fwd/bwd (default), run one backward, or profile one backward")
+    ap.add_argument("--log-level", default="WARNING",
+                    help="Python logging level for progress messages (e.g. INFO for per-stage traces)")
     # hidden per-variant subprocess entry: --bench-one <variant> <L> <Z> <nrep>
     ap.add_argument("--bench-one", nargs=4, default=None, help=argparse.SUPPRESS, metavar=("VARIANT", "L", "Z", "NREP"))
     args = ap.parse_args()
 
+    logging.basicConfig(level=args.log_level.upper(), format="%(levelname)s %(name)s: %(message)s")
+
     if args.bench_one:
         var, L, Z, nrep = args.bench_one
-        _bench_one(var, int(L), int(Z), int(nrep))
+        _bench_one(var, int(L), int(Z), int(nrep), mode=args.mode)
         return
 
     Z = args.batch if args.batch is not None else 2
@@ -334,7 +449,8 @@ def main():
         run_accuracy(shapes)
     if do_perf:
         variants = [v.strip() for v in args.variants.split(",") if v.strip()]
-        run_perf(shapes, variants, nrep=args.nrep, heads=args.heads, sparsity=args.sparsity)
+        run_perf(shapes, variants, nrep=args.nrep, heads=args.heads, sparsity=args.sparsity, mode=args.mode,
+                 log_level=args.log_level)
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -99,7 +99,10 @@ def get_fwd_persistent_configs() -> List[triton.Config]:
         for qk_wait in [False]  # True, False]
         for slice_mask in [True]  # , False]
     ]
-    return configs
+    # Profiling/CI mode: compile a single representative forward config.  The
+    # backward benchmark only needs forward to construct its autograd graph;
+    # autotuning all forward candidates otherwise dominates setup time.
+    return configs[:1] if os.environ.get("HSTU_SELF_PIN") == "1" else configs
 
 
 def prune_configs_by_hdim(configs, named_args, **kwargs):
@@ -2396,7 +2399,7 @@ def _hstu_bwd_host_descriptor_pre_hook(nargs):
 
 
 def get_hstu_bwd_configs() -> List[triton.Config]:
-    return [
+    configs = [
         triton.Config(
             {
                 "BLOCK_M1": 128,
@@ -2445,6 +2448,7 @@ def get_hstu_bwd_configs() -> List[triton.Config]:
         # HSTU_SELF_PIN=1 -> one config (fast compile for tritonbench --mode bwd).
         for er in ([1] if os.environ.get("HSTU_SELF_PIN") == "1" else [1, 2])
     ]
+    return configs[:1] if os.environ.get("HSTU_SELF_PIN") == "1" else configs
 
 
 @triton.autotune(configs=get_hstu_bwd_configs(), key=["AUTOTUNE_MAX_SEQ_LEN", "HEAD_DIM"])

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -34,6 +34,9 @@ from stubs import (
     triton_autotune,
 )
 from stubs import acc_dq
+from triton.language.extra.cuda.inline_ptx_lib import (  # @manual=//triton:triton
+    _fma_f32x2, tanh_approx_fp32,
+)
 from triton.language.extra.libdevice import fast_dividef  # @manual=//triton:triton
 from triton.language.extra.subtile_ops import _split_n_2D  # @manual=//triton:triton
 
@@ -63,12 +66,15 @@ class HSTUAutoWSConfig:
     dq_reduce: bool = False  # bwd dq via TMA reduce-add (vs in-loop RMW)
     dq_reuse: bool = False  # FA-style TMEM reuse for the dq-reduce bwd
     dq_iters: int = 1  # dq TMA-reduce column subtiles
+    dkdv_subtile: int = 1  # dK/dV output-store column subtiles
     warps: int = 8  # num_warps for the autoWS config
     bn: int = 128  # fwd DP BLOCK_N
     bwd_bm: int = 64  # bwd autoWS BLOCK_M
     bwd_bn: int = 64  # bwd autoWS BLOCK_N
     bwd_stages: int = 1  # bwd autoWS num_stages
     sp: bool = False  # bwd SEQUENCE_PARALLEL
+    clc: bool = False  # bwd CLC-persistent flattened tile loop
+    clc_smem_algo: int = 1  # CLC outer-loop SMEM allocation algorithm
     pin: bool = False  # pin autotune to one config (fast compile)
 
     @classmethod
@@ -82,12 +88,15 @@ class HSTUAutoWSConfig:
             dq_reduce=g("HSTU_SELF_DQ_REDUCE") == "1",
             dq_reuse=g("HSTU_SELF_DQ_REUSE", "0") == "1",
             dq_iters=int(g("HSTU_SELF_DQ_ITERS", "1")),
+            dkdv_subtile=int(g("HSTU_SELF_BWD_DKDV_SUBTILE", "1")),
             warps=int(g("HSTU_SELF_AUTOWS_WARPS", "8")),
             bn=int(g("HSTU_SELF_AUTOWS_BN", "128")),
             bwd_bm=int(g("HSTU_SELF_AUTOWS_BWD_BM", "64")),
             bwd_bn=int(g("HSTU_SELF_AUTOWS_BWD_BN", "64")),
             bwd_stages=int(g("HSTU_SELF_AUTOWS_BWD_STAGES", "1")),
             sp=g("HSTU_SELF_AUTOWS_SP") == "1",
+            clc=g("HSTU_SELF_AUTOWS_CLC") == "1",
+            clc_smem_algo=int(g("HSTU_SELF_AUTOWS_CLC_SMEM_ALGO", "1")),
             pin=g("HSTU_SELF_PIN") == "1",
         )
 
@@ -116,6 +125,7 @@ def _reload_autotune_configs() -> None:
     for name, gen in (
         ("_hstu_attn_fwd", _get_fw_configs),
         ("_hstu_attn_bwd", _get_bw_configs),
+        ("_hstu_attn_bwd_clc", _get_bw_configs),
     ):
         kern = globals().get(name)
         if kern is None:
@@ -599,7 +609,9 @@ def _get_bw_configs() -> List[triton.Config]:
                 },
                 num_stages=_ns,
                 num_warps=_w,
+                maxRegAutoWS=192,
                 pre_hook=_bwd_pre_hook,
+                generate_subtiled_region=_AUTOWS_CFG.dkdv_subtile > 1,
             )
         ]
     # HSTU_SELF_PIN=1 shrinks the bwd autotune to one config so tritonbench
@@ -610,10 +622,30 @@ def _get_bw_configs() -> List[triton.Config]:
 
 
 @triton.jit
+def _fma_f32(a, b, c):
+    """a * b + c, packed two-wide where the hardware supports it.
+
+    _fma_f32x2 emits `fma.rn.f32x2`, which ptxas rejects below sm_100 with
+    "Feature 'fma.f32x2' requires .target sm_100 or higher". The backward
+    activation runs on Hopper too, so the packed form has to be guarded; the
+    scalar expression computes the same value and only gives up the
+    vectorization. cuda_capability_geq is a constexpr_function, so the branch is
+    folded at specialization time and costs nothing at runtime.
+    """
+    if tl.target_info.cuda_capability_geq(10, 0):
+        out = _fma_f32x2(a, b, c)
+    else:
+        out = a * b + c
+    return out
+
+
+@triton.jit
 def backward_activation(qk_trans, alpha, scale, valid_mask_trans, k):
     qk_trans = qk_trans * alpha
-    sig_trans = fast_dividef(1.0, 1.0 + tl.exp(-qk_trans))
-    silu_trans = qk_trans * sig_trans * scale
+    half_qk = qk_trans * 0.5
+    one_plus_tanh = _fma_f32(tanh_approx_fp32(half_qk), 1.0, 1.0)
+    sig_trans = one_plus_tanh * 0.5
+    silu_trans = half_qk * one_plus_tanh * scale
     act_qk_trans = tl.where(valid_mask_trans, silu_trans, 0)
     act_qk_trans = act_qk_trans.to(k.dtype)
     return qk_trans, sig_trans, act_qk_trans
@@ -882,7 +914,8 @@ def _hstu_attn_fwd_subtile(  # noqa: C901
 @triton.jit
 def _hstu_attn_bwd_one_block_0(  # noqa C901
     start_m,
-    offs_n,
+    start_n,
+    desc_row_q,
     offs_m,
     q_ptrs_trans,
     dq_ptrs_trans,
@@ -911,14 +944,13 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     max_attn_len,
     contextual_seq_len,
     n_targets,
-    max_ids,
-    pos_offs_n,
     HAS_NUM_TARGETS: tl.constexpr,
     HAS_MAX_ATTN_LEN: tl.constexpr,
     HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
     ATTN_SCALE_TYPE: tl.constexpr,
     ALLOW_TF32: tl.constexpr,
     BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
     ATOMIC_ADD: tl.constexpr,
     ENABLE_TMA: tl.constexpr,
     BLOCK_D_Q: tl.constexpr,
@@ -928,6 +960,18 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     DQ_REUSE: tl.constexpr = False,
 ):
     offs_m = offs_m + start_m
+    # Keep the integer KV-index/mask chain inside the warp-specialized loop.
+    # Building it in the enclosing scope makes AutoWS transfer the 128x128 i32
+    # value through a 64 KiB shared-memory channel.
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    max_ids, pos_offs_n = backward_off_common_preprocess(
+        seq_len_q,
+        contextual_seq_len,
+        n_targets,
+        offs_n,
+        HAS_CONTEXTUAL_SEQ_LEN,
+        HAS_NUM_TARGETS,
+    )
     mask_m = offs_m < seq_len_q
     if ATTN_SCALE_TYPE == "scalar":
         scale = tl.load(attn_scale).to(tl.float32)
@@ -936,7 +980,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
         scale = tl.load(attn_scale + offs_m, mask=mask_m).to(tl.float32)
     # recompute qk and silu
     if ENABLE_TMA:
-        q = device_desc_q.load([start_m, (off_h * stride_qh).to(tl.int32)])
+        q = device_desc_q.load([(desc_row_q + start_m).to(tl.int32), (off_h * stride_qh).to(tl.int32)])
         q_trans = tl.trans(q)
     else:
         q_trans = tl.load(
@@ -964,7 +1008,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     qk_trans, sig_trans, act_qk_trans = backward_activation(qk_trans, alpha, scale, valid_mask_trans, k)
     # compute dv
     if ENABLE_TMA:
-        do = device_desc_do.load([start_m, (off_h * stride_doh).to(tl.int32)])
+        do = device_desc_do.load([(desc_row_q + start_m).to(tl.int32), (off_h * stride_doh).to(tl.int32)])
     else:
         do = tl.load(
             do_ptrs + start_m * stride_dom,
@@ -1028,7 +1072,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
         dqs = _split_n_2D(dq, DQ_ITERS)
         for _s in tl.static_range(DQ_ITERS):
             device_desc_dq.store(
-                [start_m, (off_h * stride_dqh + _s * dq_slice_size).to(tl.int32)],
+                [(desc_row_q + start_m).to(tl.int32), (off_h * stride_dqh + _s * dq_slice_size).to(tl.int32)],
                 dqs[_s],
                 store_reduce="add",
             )
@@ -1630,6 +1674,8 @@ def _hstu_attn_fwd(  # noqa C901
 @triton.jit
 def _hstu_attn_bwd_one_col_block(  # noqa C901
     start_n,
+    desc_row_q,
+    desc_row_kv,
     seq_len_q,
     seq_len_kv,
     Q,
@@ -1686,6 +1732,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     DQ_REDUCE: tl.constexpr = False,
     DQ_ITERS: tl.constexpr = 1,
     DQ_REUSE: tl.constexpr = False,
+    DKDV_SUBTILE: tl.constexpr = 1,
 ):
     offs_m = tl.arange(0, BLOCK_M)
     offs_qk_d = tl.arange(0, BLOCK_D_Q)
@@ -1698,8 +1745,8 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     if ENABLE_TMA:
         q_ptrs_trans = None
         do_ptrs = None
-        k = device_desc_k.load([start_n, (off_h * stride_kh).to(tl.int32)])
-        v = device_desc_v.load([start_n, (off_h * stride_vh).to(tl.int32)])
+        k = device_desc_k.load([(desc_row_kv + start_n).to(tl.int32), (off_h * stride_kh).to(tl.int32)])
+        v = device_desc_v.load([(desc_row_kv + start_n).to(tl.int32), (off_h * stride_vh).to(tl.int32)])
     else:
         mask_n = offs_n < seq_len_kv
         q_ptrs_trans = Q + (offs_m[None, :] * stride_qm + offs_qk_d[:, None])
@@ -1709,14 +1756,6 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
         k = tl.load(k_ptrs, mask=mask_n[:, None], other=0.0)
         v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0)
     n_targets = target_common_preprocess(off_z, num_targets, HAS_NUM_TARGETS)
-    max_ids, pos_offs_n = backward_off_common_preprocess(
-        seq_len_q,
-        contextual_seq_len,
-        n_targets,
-        offs_n,
-        HAS_CONTEXTUAL_SEQ_LEN,
-        HAS_NUM_TARGETS,
-    )
     if HAS_CONTEXTUAL_SEQ_LEN:
         low = 0
         high = contextual_seq_len
@@ -1724,7 +1763,8 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             start_m = tl.multiple_of(start_m, BLOCK_M)
             dk, dv = _hstu_attn_bwd_one_block_0(
                 start_m=start_m,
-                offs_n=offs_n,
+                start_n=start_n,
+                desc_row_q=desc_row_q,
                 offs_m=offs_m,
                 q_ptrs_trans=q_ptrs_trans,
                 dq_ptrs_trans=dq_ptrs_trans,
@@ -1753,14 +1793,13 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 max_attn_len=max_attn_len,
                 contextual_seq_len=contextual_seq_len,
                 n_targets=n_targets,
-                max_ids=max_ids,
-                pos_offs_n=pos_offs_n,
                 HAS_NUM_TARGETS=HAS_NUM_TARGETS,
                 HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
                 HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
                 ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
                 ALLOW_TF32=ALLOW_TF32,
                 BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
                 ATOMIC_ADD=ATOMIC_ADD,
                 ENABLE_TMA=ENABLE_TMA,
                 BLOCK_D_Q=BLOCK_D_Q,
@@ -1805,7 +1844,8 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
         start_m = tl.multiple_of(start_m, BLOCK_M)
         dk, dv = _hstu_attn_bwd_one_block_0(
             start_m=start_m,
-            offs_n=offs_n,
+            start_n=start_n,
+            desc_row_q=desc_row_q,
             offs_m=offs_m,
             q_ptrs_trans=q_ptrs_trans,
             dq_ptrs_trans=dq_ptrs_trans,
@@ -1834,14 +1874,13 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             max_attn_len=max_attn_len,
             contextual_seq_len=contextual_seq_len,
             n_targets=n_targets,
-            max_ids=max_ids,
-            pos_offs_n=pos_offs_n,
             HAS_NUM_TARGETS=HAS_NUM_TARGETS,
             HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
             HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
             ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
             ALLOW_TF32=ALLOW_TF32,
             BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
             ATOMIC_ADD=ATOMIC_ADD,
             ENABLE_TMA=ENABLE_TMA,
             BLOCK_D_Q=BLOCK_D_Q,
@@ -1853,8 +1892,20 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     # write-back
     dk = dk * alpha
     if ENABLE_TMA:
-        device_desc_dv.store([start_n, (off_h * stride_dvh).to(tl.int32)], dv.to(k.dtype))
-        device_desc_dk.store([start_n, (off_h * stride_dkh).to(tl.int32)], dk.to(k.dtype))
+        dv_slices = _split_n_2D(dv, DKDV_SUBTILE)
+        dv_slice_size: tl.constexpr = BLOCK_D_V // DKDV_SUBTILE
+        for slice_id in tl.static_range(DKDV_SUBTILE):
+            device_desc_dv.store(
+                [(desc_row_kv + start_n).to(tl.int32), (off_h * stride_dvh + slice_id * dv_slice_size).to(tl.int32)],
+                dv_slices[slice_id].to(k.dtype),
+            )
+        dk_slices = _split_n_2D(dk, DKDV_SUBTILE)
+        dk_slice_size: tl.constexpr = BLOCK_D_Q // DKDV_SUBTILE
+        for slice_id in tl.static_range(DKDV_SUBTILE):
+            device_desc_dk.store(
+                [(desc_row_kv + start_n).to(tl.int32), (off_h * stride_dkh + slice_id * dk_slice_size).to(tl.int32)],
+                dk_slices[slice_id].to(k.dtype),
+            )
     else:
         dv_ptrs = DV + (offs_n[:, None] * stride_dvn + offs_v_d[None, :])
         dk_ptrs = DK + (offs_n[:, None] * stride_dkn + offs_qk_d[None, :])
@@ -1928,6 +1979,7 @@ def _hstu_attn_bwd(  # noqa C901
     DQ_REDUCE: tl.constexpr = False,
     DQ_ITERS: tl.constexpr = 1,
     DQ_REUSE: tl.constexpr = False,
+    DKDV_SUBTILE: tl.constexpr = 1,
 ):
     off_hz = tl.program_id(0)
     off_z = off_hz // H
@@ -2041,6 +2093,8 @@ def _hstu_attn_bwd(  # noqa C901
             return
         _hstu_attn_bwd_one_col_block(
             start_n=start_n,
+            desc_row_q=0,
+            desc_row_kv=0,
             seq_len_q=seq_len_q,
             seq_len_kv=seq_len_kv,
             Q=Q,
@@ -2097,11 +2151,14 @@ def _hstu_attn_bwd(  # noqa C901
             DQ_REDUCE=DQ_REDUCE,
             DQ_ITERS=DQ_ITERS,
             DQ_REUSE=DQ_REUSE,
+            DKDV_SUBTILE=DKDV_SUBTILE,
         )
     else:
         for start_n in range(0, seq_len_kv, BLOCK_N):
             _hstu_attn_bwd_one_col_block(
                 start_n=start_n,
+                desc_row_q=0,
+                desc_row_kv=0,
                 seq_len_q=seq_len_q,
                 seq_len_kv=seq_len_kv,
                 Q=Q,
@@ -2158,7 +2215,202 @@ def _hstu_attn_bwd(  # noqa C901
                 DQ_REDUCE=DQ_REDUCE,
                 DQ_ITERS=DQ_ITERS,
                 DQ_REUSE=DQ_REUSE,
+                DKDV_SUBTILE=DKDV_SUBTILE,
             )
+
+
+@triton_autotune(
+    configs=_get_bw_configs(),
+    key=["AUTOTUNE_Z", "H", "AUTOTUNE_MAX_SEQ_LEN", "DimQ", "DimV"],
+)
+@triton.jit
+def _hstu_attn_bwd_clc(  # noqa C901
+    Q,
+    K,
+    V,
+    sort_by_length_indices,
+    seq_offsets,
+    seq_offsets_q,
+    DOut,
+    DQ,
+    DK,
+    DV,
+    TILE_IDS,
+    LOCK,
+    stride_qm,
+    stride_qh,
+    stride_kn,
+    stride_kh,
+    stride_vn,
+    stride_vh,
+    stride_dom,
+    stride_doh,
+    stride_dqm,
+    stride_dqh,
+    stride_dkn,
+    stride_dkh,
+    stride_dvn,
+    stride_dvh,
+    alpha,
+    attn_scale,
+    Z,
+    AUTOTUNE_Z,
+    H,
+    max_q_len,
+    AUTOTUNE_MAX_SEQ_LEN,
+    DimQ,
+    DimV,
+    num_targets,
+    max_attn_len,
+    contextual_seq_len,
+    HAS_NUM_TARGETS: tl.constexpr,
+    HAS_MAX_ATTN_LEN: tl.constexpr,
+    HAS_CONTEXTUAL_SEQ_LEN: tl.constexpr,
+    ATTN_SCALE_TYPE: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    BLOCK_D_Q: tl.constexpr,
+    BLOCK_D_V: tl.constexpr,
+    SEQUENCE_PARALLEL: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    UNROLL: tl.constexpr,
+    HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
+    ENABLE_TMA: tl.constexpr,
+    AUTOWS: tl.constexpr,
+    DQ_REDUCE: tl.constexpr,
+    DQ_ITERS: tl.constexpr,
+    DQ_REUSE: tl.constexpr,
+    DKDV_SUBTILE: tl.constexpr,
+    CLC_SMEM_ALGO: tl.constexpr,
+):
+    tl.static_assert(ENABLE_TMA)
+    tl.static_assert(DQ_REDUCE)
+    tl.static_assert(not SEQUENCE_PARALLEL)
+    tl.static_assert(not HAS_SORT_BY_LENGTH_INDICES)
+
+    total_kv = tl.load(seq_offsets + Z).to(tl.int64)
+    total_q = tl.load(seq_offsets_q + Z).to(tl.int64)
+    desc_q = tl.make_tensor_descriptor(Q, shape=[total_q, H * DimQ], strides=[H * DimQ, 1],
+                                       block_shape=[BLOCK_M, BLOCK_D_Q])
+    desc_k = tl.make_tensor_descriptor(K, shape=[total_kv, H * DimQ], strides=[H * DimQ, 1],
+                                       block_shape=[BLOCK_N, BLOCK_D_Q])
+    desc_v = tl.make_tensor_descriptor(V, shape=[total_kv, H * DimV], strides=[H * DimV, 1],
+                                       block_shape=[BLOCK_N, BLOCK_D_V])
+    desc_do = tl.make_tensor_descriptor(DOut, shape=[total_q, H * DimV], strides=[H * DimV, 1],
+                                        block_shape=[BLOCK_M, BLOCK_D_V])
+    desc_dq = tl.make_tensor_descriptor(
+        DQ,
+        shape=[total_q, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_M, BLOCK_D_Q // DQ_ITERS],
+    )
+    desc_dk = tl.make_tensor_descriptor(
+        DK,
+        shape=[total_kv, H * DimQ],
+        strides=[H * DimQ, 1],
+        block_shape=[BLOCK_N, BLOCK_D_Q // DKDV_SUBTILE],
+    )
+    desc_dv = tl.make_tensor_descriptor(
+        DV,
+        shape=[total_kv, H * DimV],
+        strides=[H * DimV, 1],
+        block_shape=[BLOCK_N, BLOCK_D_V // DKDV_SUBTILE],
+    )
+
+    num_n_tiles = tl.cdiv(max_q_len, BLOCK_N)
+    sched = tl.clc_tile_scheduler()
+    while tl.condition(
+            sched.is_valid(),
+            warp_specialize=AUTOWS,
+            merge_epilogue_to_computation=DQ_REDUCE,
+            tmem_alloc_algo=2,
+            smem_alloc_algo=CLC_SMEM_ALGO,
+    ):
+        tile_id = tl.load(TILE_IDS + sched.tile_id[0])
+        off_hz = tile_id // num_n_tiles
+        start_n = (tile_id % num_n_tiles) * BLOCK_N
+        off_z = off_hz // H
+        off_h = (off_hz % H).to(tl.int64)
+
+        seq_start_kv = tl.load(seq_offsets + off_z).to(tl.int64)
+        seq_end_kv = tl.load(seq_offsets + off_z + 1)
+        seq_len_kv = (seq_end_kv - seq_start_kv).to(tl.int32)
+        seq_start_q = tl.load(seq_offsets_q + off_z).to(tl.int64)
+        seq_end_q = tl.load(seq_offsets_q + off_z + 1)
+        seq_len_q = (seq_end_q - seq_start_q).to(tl.int32)
+
+        q_base = Q + seq_start_q * stride_qm
+        k_base = K + seq_start_kv * stride_kn
+        v_base = V + seq_start_kv * stride_vn
+        do_base = DOut + seq_start_q * stride_dom
+        dq_base = DQ + seq_start_q * stride_dqm
+        dk_base = DK + seq_start_kv * stride_dkn
+        dv_base = DV + seq_start_kv * stride_dvn
+
+        if tl.constexpr(True):
+            _hstu_attn_bwd_one_col_block(
+                start_n=start_n,
+                desc_row_q=seq_start_q,
+                desc_row_kv=seq_start_kv,
+                seq_len_q=seq_len_q,
+                seq_len_kv=seq_len_kv,
+                Q=q_base,
+                K=k_base,
+                V=v_base,
+                DOut=do_base,
+                DQ=dq_base,
+                DK=dk_base,
+                DV=dv_base,
+                device_desc_q=desc_q,
+                device_desc_k=desc_k,
+                device_desc_v=desc_v,
+                device_desc_do=desc_do,
+                device_desc_dk=desc_dk,
+                device_desc_dv=desc_dv,
+                device_desc_dq=desc_dq,
+                LOCK=LOCK,
+                off_h=off_h,
+                off_z=off_z,
+                stride_qh=stride_qh,
+                stride_kh=stride_kh,
+                stride_vh=stride_vh,
+                stride_doh=stride_doh,
+                stride_dkh=stride_dkh,
+                stride_dvh=stride_dvh,
+                stride_qm=stride_qm,
+                stride_kn=stride_kn,
+                stride_vn=stride_vn,
+                stride_dom=stride_dom,
+                stride_dqm=stride_dqm,
+                stride_dqh=stride_dqh,
+                stride_dkn=stride_dkn,
+                stride_dvn=stride_dvn,
+                alpha=alpha,
+                attn_scale=attn_scale,
+                max_q_len=max_q_len,
+                seq_start_q=seq_start_q,
+                num_targets=num_targets,
+                max_attn_len=max_attn_len,
+                contextual_seq_len=contextual_seq_len,
+                HAS_NUM_TARGETS=HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN=HAS_MAX_ATTN_LEN,
+                HAS_CONTEXTUAL_SEQ_LEN=HAS_CONTEXTUAL_SEQ_LEN,
+                ATTN_SCALE_TYPE=ATTN_SCALE_TYPE,
+                ALLOW_TF32=ALLOW_TF32,
+                BLOCK_D_Q=BLOCK_D_Q,
+                BLOCK_D_V=BLOCK_D_V,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                UNROLL=UNROLL,
+                ATOMIC_ADD=False,
+                ENABLE_TMA=True,
+                AUTOWS=False,
+                DQ_REDUCE=DQ_REDUCE,
+                DQ_ITERS=DQ_ITERS,
+                DQ_REUSE=DQ_REUSE,
+                DKDV_SUBTILE=DKDV_SUBTILE,
+            )
+        sched = sched.advance()
 
 
 def triton_hstu_attention_fwd(
@@ -2286,10 +2538,51 @@ def triton_hstu_attention_bwd(
         attn_scale_type = "scalar"
     else:
         attn_scale_type = "dynamic"
-    grid = lambda meta: (  # noqa E731
-        Z * H,
-        (triton.cdiv(max_seq_len, meta["BLOCK_N"]) if meta["SEQUENCE_PARALLEL"] else 1),
-    )
+    # Only the CLC descriptors are built at dK/dV subtile width, so subtiling
+    # off the CLC path would store tiles narrower than the descriptor block.
+    assert _AUTOWS_CFG.dkdv_subtile == 1 or _AUTOWS_CFG.clc, (
+        "dkdv_subtile > 1 requires the CLC backward (HSTU_SELF_AUTOWS_CLC=1)")
+    clc_kwargs = {}
+    if _AUTOWS_CFG.clc:
+        assert enable_tma and _AUTOWS_CFG.autows and _AUTOWS_CFG.dq_reduce
+        assert sort_by_length_indices is None
+        # Compact the rectangular max-length grid to valid jagged tiles. Empty
+        # tail tiles cannot enter the partitioned body: their divergent inner
+        # loop trip counts break cross-partition barrier cadence.
+        #
+        # num_n_tiles is the radix of the tile_id encoding below, and the kernel
+        # decodes with tl.cdiv(max_q_len, BLOCK_N). Both sides must use the same
+        # (length, block) pair or tile_id // and % yield different (off_hz,
+        # start_n) pairs, so use max_q_len here too -- it is also the bound that
+        # matches seq_offsets_q, which blocks_per_seq is derived from. BLOCK_N
+        # agrees because the CLC path asserts _AUTOWS_CFG.autows above, and
+        # _get_bw_configs() then pins the single config to BLOCK_N = bwd_bn.
+        block_n = _AUTOWS_CFG.bwd_bn
+        num_n_tiles = triton.cdiv(max_q_len, block_n)
+        seq_lens = seq_offsets_q[1:] - seq_offsets_q[:-1]
+        blocks_per_seq = torch.div(seq_lens + block_n - 1, block_n, rounding_mode="floor")
+        counts = blocks_per_seq.repeat_interleave(H)
+        tile_count = int(counts.sum().item())
+        tile_starts = torch.cumsum(counts, dim=0) - counts
+        compact_ids = torch.arange(tile_count, device=q.device, dtype=torch.int64)
+        off_hz = torch.repeat_interleave(torch.arange(Z * H, device=q.device, dtype=torch.int64), counts)
+        local_n = compact_ids - torch.repeat_interleave(tile_starts, counts)
+        tile_ids = (off_hz * num_n_tiles + local_n).to(torch.int32)
+        # 1D by construction: the CLC tile scheduler hands out a linear tile id
+        # that indexes the compacted TILE_IDS list, which then decodes to
+        # (off_hz, start_n) in the kernel. The compacted list is ragged across
+        # heads/batches, so the (Z * H, n_tiles) rectangle the non-CLC path
+        # launches cannot express it without re-introducing the empty tiles.
+        grid = lambda meta: (  # noqa E731
+            tile_count, )
+        bwd_kernel = _hstu_attn_bwd_clc
+        clc_kwargs = {"TILE_IDS": tile_ids, "CLC_SMEM_ALGO": _AUTOWS_CFG.clc_smem_algo}
+    else:
+        grid = lambda meta: (  # noqa E731
+            Z * H,
+            (triton.cdiv(max_seq_len, meta["BLOCK_N"]) if meta["SEQUENCE_PARALLEL"] else 1),
+        )
+        bwd_kernel = _hstu_attn_bwd
     # The minimum size of BLOCK_M used in `_get_bw_configs`.
     # TODO (linjianma): avoid hardcoding the value.
     MIN_BLOCK_M = 16
@@ -2302,7 +2595,7 @@ def triton_hstu_attention_bwd(
     HAS_NUM_TARGETS = num_targets is not None
     HAS_MAX_ATTN_LEN = max_attn_len != 0
     HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
-    _hstu_attn_bwd[grid](
+    bwd_kernel[grid](
         Q=q,
         K=k,
         V=v,
@@ -2353,6 +2646,8 @@ def triton_hstu_attention_bwd(
         DQ_REDUCE=_AUTOWS_CFG.dq_reduce,
         DQ_ITERS=_AUTOWS_CFG.dq_iters,
         DQ_REUSE=_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse,
+        DKDV_SUBTILE=_AUTOWS_CFG.dkdv_subtile,
+        **clc_kwargs,
     )
 
     return dq, dk, dv

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -69,6 +69,7 @@ _DQREDUCE_CFG = dict(
     dq_iters=4,
     pin=True,
 )
+_CLC_CFG = dict(_DQREDUCE_CFG, clc=True, bwd_stages=2, clc_smem_algo=2)
 # Manual data-partition fwd: split BLOCK_M=256 into two 128-row halves
 # sharing one K/V load, warp-specialized (load + 2 MMA groups).
 _MANUAL_DP_CFG = dict(autows=True, manual_dp=True, dp=2, warps=4, pin=True)
@@ -78,7 +79,10 @@ _COMPILER_DP2_CFG = dict(autows=True, dp=2, warps=4, pin=True)
 
 # The dq-reduce / fadp / compiler-dp2 cases re-invoke this file as a subprocess;
 # select the config (before the kernel import below) from argv.
-if "--run-dqreduce" in sys.argv:
+if "--run-clc" in sys.argv:
+    _C.set_config(**_CLC_CFG)
+    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
+elif "--run-dqreduce" in sys.argv:
     _C.set_config(**_DQREDUCE_CFG)
     os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 elif "--run-fadp" in sys.argv:
@@ -235,6 +239,23 @@ def test_self_attention_bwd_autows_dqreduce(L, Z):
     assert r.returncode == 0, (f"dq-reduce autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}")
 
 
+@pytest.mark.parametrize("L,Z", [(256, 2)])
+def test_self_attention_bwd_autows_clc(L, Z):
+    """CLC-persistent AutoWS bwd matches the same torch/TLX reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-clc", str(L), str(Z)],
+        env=dict(os.environ),
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (f"CLC autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}")
+
+
 @pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell GPU")
 def test_self_attention_fwd_autows_fadp(L, Z):
@@ -294,9 +315,10 @@ if __name__ == "__main__":
     # Subprocess entry point for the dq-reduce config. _DQREDUCE_CFG was applied
     # via set_config() at the top of this file (argv --run-dqreduce) before the
     # kernel import, so the dq-reduce constexprs / autotune config are baked on.
-    if len(sys.argv) >= 4 and sys.argv[1] == "--run-dqreduce":
+    if len(sys.argv) >= 4 and sys.argv[1] in ("--run-dqreduce", "--run-clc"):
         _L, _Z = int(sys.argv[2]), int(sys.argv[3])
         assert bool(A._AUTOWS_CFG.dq_reduce and A._AUTOWS_CFG.dq_reuse), "dq-reduce reuse flag not baked on"
+        assert A._AUTOWS_CFG.clc == (sys.argv[1] == "--run-clc")
         (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(_L, _Z)
         rls = {n: _rel_l2(g_, w) for n, g_, w in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv))}
         print(f"REL_L2 dq/dk/dv = {rls['dq']:.2e} / {rls['dk']:.2e} / {rls['dv']:.2e} "
@@ -334,4 +356,4 @@ if __name__ == "__main__":
         print("OK")
         sys.exit(0)
     sys.exit("usage: test_self_attention_autows.py "
-             "--run-dqreduce|--run-fadp|--run-fwd L Z")
+             "--run-dqreduce|--run-clc|--run-fadp|--run-fwd L Z")


### PR DESCRIPTION
Summary:

This change adds the reproducible AutoWS HSTU self-attention CLC backward kernel and the benchmark/correctness plumbing needed to compare it with the BM64/BN128 TLX implementation. It includes persistent tile scheduling, dQ reduction/reuse controls, subtiled dK/dV epilogue plumbing, packed SiLU backward math, and CLC autotune refresh support. The configuration intentionally keeps dK/dV subtiling opt-in until the compiler store-wait support later in the stack is available.

Reviewed By: njriasan

Differential Revision: D114610707


