### PR TITLE
[tlx][ci] increase timeout for tlx tests

### DIFF
--- a/.ci/tritonbench/fbtriton_skip_tests.yaml
+++ b/.ci/tritonbench/fbtriton_skip_tests.yaml
@@ -90,19 +90,17 @@ fp8_attention:
 gather_gemv:
   report: true
   disabled_devices:
-    - hip
+   - hip
+# TODO: jagged_softmax will CPU OOM and cancel the entire workflow
 jagged_softmax:
   report: true
-  disabled_devices:
-    - hip
 jagged_mean:
   report: true
   disabled_devices:
     - hip
+# TODO: jagged_sum will CPU OOM and cancel the entire workflow
 jagged_sum:
   report: true
-  disabled_devices:
-    - hip
 # TODO: embedding, flash_attention will segfault on hip
 embedding:
   report: true

--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -94,7 +94,7 @@ jobs:
     env:
       CONDA_ENV: meta-triton
       SETUP_SCRIPT: /workspace/setup_instance.sh
-    timeout-minutes: 30
+    timeout-minutes: 120
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -92,7 +92,7 @@ jobs:
     env:
       CONDA_ENV: meta-triton
       SETUP_SCRIPT: /workspace/setup_instance.sh
-    timeout-minutes: 30
+    timeout-minutes: 120
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -86,7 +86,7 @@ jobs:
       CONDA_ENV: pytorch
       UV_VENV_DIR: /workspace/uv_venvs
       SETUP_SCRIPT: /workspace/setup_instance.sh
-    timeout-minutes: 30
+    timeout-minutes: 120
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Also, increase the reliability of Tritonbench CI by skipping high CPU memory requirement ones like jagged_softmax and jagged_sum.