### PR TITLE
[TLX] Keep V8 K-offset updates in warp pipeline stages

### DIFF
--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/v8_warp_pipeline/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/v8_warp_pipeline/matmul_kernel.py
@@ -119,9 +119,8 @@ def v8_warp_pipeline(
             b_left = tlx.local_load(smem_b_left[1], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[0], b_ptr, br_off + b_k)
             tlx.async_load_commit_group()
-
-        a_k += BLOCK_K * stride_ak
-        b_k += BLOCK_K * stride_bk
+            a_k += BLOCK_K * stride_ak
+            b_k += BLOCK_K * stride_bk
 
         # ──── Region 2 ────
         with tlx.warp_pipeline_stage("mfma", priority=0):
@@ -142,9 +141,10 @@ def v8_warp_pipeline(
             b_left = tlx.local_load(smem_b_left[0], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[1], b_ptr, br_off + b_k)
             tlx.async_load_commit_group()
-
-        a_k += BLOCK_K * stride_ak
-        b_k += BLOCK_K * stride_bk
+            # Keep the trailing scalar updates in the final stage. Otherwise
+            # WarpPipeliner creates an extra cluster containing only these adds.
+            a_k += BLOCK_K * stride_ak
+            b_k += BLOCK_K * stride_bk
 
     # ── Epilogue: drain the last two K iterations ──
     acc_left = tl.dot(a, b_left, acc_left)


### PR DESCRIPTION
Summary:
Move the loop-carried K-offset updates into their corresponding memory stages. Leaving the final updates outside warp_pipeline_stage creates an unnecessary trailing pipeline cluster containing only two scalar additions.

This also makes the V8 hot-loop schedule match V9 before V9 applies its grid-level PID mappings.

Reviewed By: htyu

Differential Revision: D117307820


