### PR TITLE
[AutoWS] Share cooperative load staging through memdesc views

### DIFF
--- a/test/Hopper/TwoCTA/transform_2cta_loads.mlir
+++ b/test/Hopper/TwoCTA/transform_2cta_loads.mlir
@@ -96,6 +96,104 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
 
 // -----
 
+// Test: A single full V descriptor load split between two 2-CTA PV MMAs must
+// become one cooperative half-width load and two zero-copy shared-memory
+// views. This avoids two TMA loads without staging V through registers.
+// CHECK-LABEL: @fa_split_v_load
+// CHECK-SAME: %[[DESC:.*]]: !tt.tensordesc<128x64xbf16>
+// CHECK: %[[V:.*]] = tt.descriptor_load %[[DESC]]{{.*}}two_cta_b{{.*}} : !tt.tensordesc<128x64xbf16>
+// CHECK: %[[FULL:.*]] = ttg.local_alloc %[[V]] : {{.*}} -> !ttg.memdesc<128x64xbf16
+// CHECK: %[[V0:.*]] = ttg.memdesc_subslice %[[FULL]][0, 0] : {{.*}} -> !ttg.memdesc<64x64xbf16, {{.*}}, {{.*}}, 128x64>
+// CHECK: %[[V1:.*]] = ttg.memdesc_subslice %[[FULL]][64, 0] : {{.*}} -> !ttg.memdesc<64x64xbf16, {{.*}}, {{.*}}, 128x64>
+// CHECK-NOT: tt.split
+// CHECK: ttng.tc_gen5_mma %{{.*}}, %[[V0]], {{.*}} {two_ctas}
+// CHECK: ttng.tc_gen5_mma %{{.*}}, %[[V1]], {{.*}} {two_ctas}
+
+#v_blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#v_reshape = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#v_trans = #ttg.blocked<{sizePerThread = [1, 8, 1], threadsPerWarp = [2, 16, 1], warpsPerCTA = [4, 1, 1], order = [1, 0, 2]}>
+#v_leaf = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [8, 0], [16, 0], [32, 0]], lane = [[0, 8], [0, 16], [0, 32], [0, 64], [1, 0]], warp = [[2, 0], [4, 0]], block = []}>
+#v_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#v_smem = #ttg.shared_memory
+#v_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fa_split_v_load(
+      %v_desc: !tt.tensordesc<128x128xbf16>,
+      %a0: !ttg.memdesc<256x64xbf16, #v_shared, #v_smem>,
+      %a1: !ttg.memdesc<256x64xbf16, #v_shared, #v_smem>,
+      %acc0: !ttg.memdesc<256x128xf32, #v_tmem, #ttng.tensor_memory, mutable>,
+      %acc1: !ttg.memdesc<256x128xf32, #v_tmem, #ttng.tensor_memory, mutable>,
+      %token0: !ttg.async.token,
+      %token1: !ttg.async.token) attributes {noinline = false} {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+
+    %v = tt.descriptor_load %v_desc[%c0_i32, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #v_blocked>
+    %v_reshape_value = tt.reshape %v : tensor<128x128xbf16, #v_blocked> -> tensor<2x64x128xbf16, #v_reshape>
+    %v_trans_value = tt.trans %v_reshape_value {order = array<i32: 1, 2, 0>} : tensor<2x64x128xbf16, #v_reshape> -> tensor<64x128x2xbf16, #v_trans>
+    %v0, %v1 = tt.split %v_trans_value : tensor<64x128x2xbf16, #v_trans> -> tensor<64x128xbf16, #v_leaf>
+    %v0_smem = ttg.local_alloc %v0 : (tensor<64x128xbf16, #v_leaf>) -> !ttg.memdesc<64x128xbf16, #v_shared, #v_smem>
+    %v1_smem = ttg.local_alloc %v1 : (tensor<64x128xbf16, #v_leaf>) -> !ttg.memdesc<64x128xbf16, #v_shared, #v_smem>
+
+    %mma0 = ttng.tc_gen5_mma %a0, %v0_smem, %acc0[%token0], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #v_shared, #v_smem>, !ttg.memdesc<64x128xbf16, #v_shared, #v_smem>, !ttg.memdesc<256x128xf32, #v_tmem, #ttng.tensor_memory, mutable>
+    %mma1 = ttng.tc_gen5_mma %a1, %v1_smem, %acc1[%token1], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #v_shared, #v_smem>, !ttg.memdesc<64x128xbf16, #v_shared, #v_smem>, !ttg.memdesc<256x128xf32, #v_tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Test: the same split chain, but the descriptor argument also feeds a second,
+// unrelated descriptor_load. With no MakeTensorDescOp to clone, the transform
+// retypes the argument in place, so firing here would silently hand the other
+// load a half-width descriptor and make it address the wrong tile. The pass
+// must bail and leave the split chain intact.
+// CHECK-LABEL: @fa_split_v_load_shared_desc
+// CHECK-SAME: %[[DESC:.*]]: !tt.tensordesc<128x128xbf16>
+// CHECK: tt.split
+// CHECK-NOT: ttg.memdesc_subslice
+
+#v2_blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#v2_reshape = #ttg.blocked<{sizePerThread = [1, 1, 8], threadsPerWarp = [1, 2, 16], warpsPerCTA = [1, 4, 1], order = [2, 1, 0]}>
+#v2_trans = #ttg.blocked<{sizePerThread = [1, 8, 1], threadsPerWarp = [2, 16, 1], warpsPerCTA = [4, 1, 1], order = [1, 0, 2]}>
+#v2_leaf = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [8, 0], [16, 0], [32, 0]], lane = [[0, 8], [0, 16], [0, 32], [0, 64], [1, 0]], warp = [[2, 0], [4, 0]], block = []}>
+#v2_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#v2_smem = #ttg.shared_memory
+#v2_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @fa_split_v_load_shared_desc(
+      %v_desc: !tt.tensordesc<128x128xbf16>,
+      %a0: !ttg.memdesc<256x64xbf16, #v2_shared, #v2_smem>,
+      %a1: !ttg.memdesc<256x64xbf16, #v2_shared, #v2_smem>,
+      %acc0: !ttg.memdesc<256x128xf32, #v2_tmem, #ttng.tensor_memory, mutable>,
+      %acc1: !ttg.memdesc<256x128xf32, #v2_tmem, #ttng.tensor_memory, mutable>,
+      %token0: !ttg.async.token,
+      %token1: !ttg.async.token) attributes {noinline = false} {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c128_i32 = arith.constant 128 : i32
+
+    %v = tt.descriptor_load %v_desc[%c0_i32, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #v2_blocked>
+    %v_reshape_value = tt.reshape %v : tensor<128x128xbf16, #v2_blocked> -> tensor<2x64x128xbf16, #v2_reshape>
+    %v_trans_value = tt.trans %v_reshape_value {order = array<i32: 1, 2, 0>} : tensor<2x64x128xbf16, #v2_reshape> -> tensor<64x128x2xbf16, #v2_trans>
+    %v0, %v1 = tt.split %v_trans_value : tensor<64x128x2xbf16, #v2_trans> -> tensor<64x128xbf16, #v2_leaf>
+    %v0_smem = ttg.local_alloc %v0 : (tensor<64x128xbf16, #v2_leaf>) -> !ttg.memdesc<64x128xbf16, #v2_shared, #v2_smem>
+    %v1_smem = ttg.local_alloc %v1 : (tensor<64x128xbf16, #v2_leaf>) -> !ttg.memdesc<64x128xbf16, #v2_shared, #v2_smem>
+
+    // Second consumer of the same descriptor.
+    %v_other = tt.descriptor_load %v_desc[%c128_i32, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #v2_blocked>
+    %v_other_smem = ttg.local_alloc %v_other : (tensor<128x128xbf16, #v2_blocked>) -> !ttg.memdesc<128x128xbf16, #v2_shared, #v2_smem>
+
+    %mma0 = ttng.tc_gen5_mma %a0, %v0_smem, %acc0[%token0], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #v2_shared, #v2_smem>, !ttg.memdesc<64x128xbf16, #v2_shared, #v2_smem>, !ttg.memdesc<256x128xf32, #v2_tmem, #ttng.tensor_memory, mutable>
+    %mma1 = ttng.tc_gen5_mma %a1, %v1_smem, %acc1[%token1], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #v2_shared, #v2_smem>, !ttg.memdesc<64x128xbf16, #v2_shared, #v2_smem>, !ttg.memdesc<256x128xf32, #v2_tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 // Test: Host-side TMA descriptor (function argument) with 2-CTA.
 // The pass should update the argument's TensorDescType to half-width and
 // transform the load, same as device-side but without cloning MakeTensorDescOp.

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -207,7 +207,12 @@ struct Transform2CTALoads
 
     LDBG("Found " << twoCTAMMAOps.size() << " 2-CTA MMA ops to transform");
 
+    DenseSet<Operation *> splitTransformedMMAs;
     for (auto mma : twoCTAMMAOps) {
+      if (splitTransformedMMAs.contains(mma))
+        continue;
+      if (succeeded(transformSplitBLoad(mma, splitTransformedMMAs)))
+        continue;
       if (failed(transformBLoad(mma)))
         LDBG("Skipped MMA at " << mma.getLoc()
                                << " (B not from descriptor load)");
@@ -235,6 +240,174 @@ struct Transform2CTALoads
                             UnitAttr::get(moduleOp.getContext()));
       });
     }
+  }
+
+  // A source-level split of one KxN V tile normally becomes
+  //
+  //   descriptor_load -> reshape -> trans -> split -> local_alloc x2
+  //
+  // before this pass. Transforming either leaf independently would retain a
+  // register-mediated shared-to-shared copy. Instead, make the cooperative
+  // descriptor load half-width once, allocate its complete 2Kx(N/2) tile in
+  // shared memory, and feed the two MMAs with zero-copy Kx(N/2) subslices.
+  LogicalResult transformSplitBLoad(ttng::TCGen5MMAOp mma,
+                                    DenseSet<Operation *> &transformedMMAs) {
+    auto localAlloc = mma.getB().getDefiningOp<ttg::LocalAllocOp>();
+    if (!localAlloc)
+      return failure();
+    auto split = localAlloc.getSrc().getDefiningOp<tt::SplitOp>();
+    if (!split || !split.getOutLHS().hasOneUse() ||
+        !split.getOutRHS().hasOneUse())
+      return failure();
+
+    auto lhsAlloc =
+        dyn_cast<ttg::LocalAllocOp>(*split.getOutLHS().getUsers().begin());
+    auto rhsAlloc =
+        dyn_cast<ttg::LocalAllocOp>(*split.getOutRHS().getUsers().begin());
+    if (!lhsAlloc || !rhsAlloc || !lhsAlloc.getResult().hasOneUse() ||
+        !rhsAlloc.getResult().hasOneUse())
+      return failure();
+    auto lhsMMA =
+        dyn_cast<ttng::TCGen5MMAOp>(*lhsAlloc.getResult().getUsers().begin());
+    auto rhsMMA =
+        dyn_cast<ttng::TCGen5MMAOp>(*rhsAlloc.getResult().getUsers().begin());
+    if (!lhsMMA || !rhsMMA || !lhsMMA.getTwoCtas() || !rhsMMA.getTwoCtas() ||
+        lhsMMA.getB() != lhsAlloc.getResult() ||
+        rhsMMA.getB() != rhsAlloc.getResult())
+      return failure();
+
+    auto trans = split.getSrc().getDefiningOp<tt::TransOp>();
+    if (!trans || trans.getOrder().size() != 3 || trans.getOrder()[0] != 1 ||
+        trans.getOrder()[1] != 2 || trans.getOrder()[2] != 0)
+      return failure();
+    auto reshape = trans.getSrc().getDefiningOp<tt::ReshapeOp>();
+    if (!reshape)
+      return failure();
+    auto descLoad = reshape.getSrc().getDefiningOp<tt::DescriptorLoadOp>();
+    if (!descLoad)
+      return failure();
+
+    auto descType = originalDescTypes.lookup(descLoad.getDesc());
+    auto loadType = dyn_cast<RankedTensorType>(descLoad.getType());
+    auto lhsType = dyn_cast<ttg::MemDescType>(lhsAlloc.getType());
+    auto rhsType = dyn_cast<ttg::MemDescType>(rhsAlloc.getType());
+    if (!descType || !loadType || !lhsType || !rhsType ||
+        loadType.getRank() != 2 || lhsType != rhsType)
+      return failure();
+
+    constexpr unsigned splitDim = 1;
+    auto blockShape = descType.getBlockType().getShape();
+    auto loadShape = loadType.getShape();
+    auto leafShape = lhsType.getShape();
+    if (blockShape.size() != 2 || blockShape[splitDim] % 2 != 0 ||
+        loadShape.size() != 2 || leafShape.size() != 2 ||
+        loadShape[0] != 2 * leafShape[0] || loadShape[1] != leafShape[1])
+      return failure();
+
+    int64_t halfN = blockShape[splitDim] / 2;
+    if (halfN < 16)
+      return failure();
+    SmallVector<int64_t> newBlockShape(blockShape.begin(), blockShape.end());
+    newBlockShape[splitDim] = halfN;
+
+    MLIRContext *ctx = mma.getContext();
+    auto elemType = descType.getElementType();
+    auto sharedLayout =
+        shrinkSwizzleForShape(descType.getSharedLayout(), newBlockShape);
+    auto newDescType =
+        tt::TensorDescType::get(newBlockShape, elemType, sharedLayout);
+
+    Value newDesc;
+    auto makeDesc = descLoad.getDesc().getDefiningOp<tt::MakeTensorDescOp>();
+    if (makeDesc) {
+      OpBuilder descBuilder(makeDesc);
+      IRMapping mapper;
+      auto *clonedOp = descBuilder.clone(*makeDesc.getOperation(), mapper);
+      auto newMakeDesc = cast<tt::MakeTensorDescOp>(clonedOp);
+      newMakeDesc.getResult().setType(newDescType);
+      newDesc = newMakeDesc.getResult();
+    } else {
+      auto descVal = descLoad.getDesc();
+      // The makeDesc path above clones before retyping. Here there is nothing
+      // to clone -- the descriptor is typically a func argument -- so the type
+      // is mutated in place, which is only sound if this load is its sole
+      // consumer. Otherwise an unrelated descriptor_load sharing the value
+      // would silently inherit the half-width type and address the wrong tile.
+      if (!descVal.hasOneUse())
+        return failure();
+      descVal.setType(newDescType);
+      newDesc = descVal;
+      if (auto funcOp = descLoad->getParentOfType<triton::FuncOp>()) {
+        auto &entryBlock = funcOp.getBlocks().front();
+        SmallVector<Type> argTys(entryBlock.getArgumentTypes());
+        funcOp.setFunctionType(FunctionType::get(
+            ctx, argTys, funcOp.getFunctionType().getResults()));
+      }
+    }
+
+    OpBuilder builder(descLoad);
+    Location loc = descLoad.getLoc();
+    auto i32Ty = builder.getI32Type();
+    Value ctaRank = nvgpu::ClusterCTAIdOp::create(builder, loc, i32Ty);
+    Value two = arith::ConstantIntOp::create(builder, loc, 2, 32);
+    Value ctaMod2 = arith::RemSIOp::create(builder, loc, ctaRank, two);
+    Value halfNVal = arith::ConstantIntOp::create(builder, loc, halfN, 32);
+    Value offset = arith::MulIOp::create(builder, loc, ctaMod2, halfNVal);
+    SmallVector<Value> newIndices(descLoad.getIndices());
+    newIndices[splitDim] =
+        arith::AddIOp::create(builder, loc, newIndices[splitDim], offset);
+
+    auto origEncoding = cast<ttg::BlockedEncodingAttr>(loadType.getEncoding());
+    auto newEncoding =
+        getCompatibleEncoding(origEncoding, newBlockShape, splitDim, ctx);
+    auto halfResultType =
+        RankedTensorType::get(newBlockShape, elemType, newEncoding);
+    auto newDescLoad = tt::DescriptorLoadOp::create(
+        builder, loc, halfResultType, newDesc, newIndices);
+    newDescLoad->setAttr("two_cta_b", builder.getUnitAttr());
+
+    builder.setInsertionPoint(lhsAlloc);
+    auto fullMemDescEncoding =
+        shrinkSwizzleForShape(lhsType.getEncoding(), newBlockShape);
+    auto fullMemDescType = ttg::MemDescType::get(
+        newBlockShape, elemType, fullMemDescEncoding, lhsType.getMemorySpace(),
+        lhsType.getMutableMemory());
+    auto fullAlloc = ttg::LocalAllocOp::create(
+        builder, lhsAlloc.getLoc(), fullMemDescType, newDescLoad.getResult());
+
+    SmallVector<int64_t> slicedShape(newBlockShape.begin(),
+                                     newBlockShape.end());
+    slicedShape[0] /= 2;
+    auto slicedType = ttg::MemDescType::get(
+        slicedShape, elemType, fullMemDescEncoding, lhsType.getMemorySpace(),
+        lhsType.getMutableMemory(), newBlockShape);
+    SmallVector<int32_t> lhsOffsets = {0, 0};
+    SmallVector<int32_t> rhsOffsets = {static_cast<int32_t>(slicedShape[0]), 0};
+    Value lhsSlice = ttg::MemDescSubsliceOp::create(
+        builder, lhsAlloc.getLoc(), slicedType, fullAlloc, lhsOffsets);
+    Value rhsSlice = ttg::MemDescSubsliceOp::create(
+        builder, rhsAlloc.getLoc(), slicedType, fullAlloc, rhsOffsets);
+    lhsAlloc.getResult().replaceAllUsesWith(lhsSlice);
+    rhsAlloc.getResult().replaceAllUsesWith(rhsSlice);
+    lhsAlloc.erase();
+    rhsAlloc.erase();
+
+    if (split->use_empty())
+      split.erase();
+    if (trans->use_empty())
+      trans.erase();
+    if (reshape->use_empty())
+      reshape.erase();
+    if (descLoad->use_empty())
+      descLoad.erase();
+    if (makeDesc && makeDesc->use_empty())
+      makeDesc.erase();
+
+    transformedMMAs.insert(lhsMMA);
+    transformedMMAs.insert(rhsMMA);
+    LDBG("Transformed split B load for 2-CTA MMAs at "
+         << lhsMMA.getLoc() << " and " << rhsMMA.getLoc());
+    return success();
   }
 
   LogicalResult transformBLoad(ttng::TCGen5MMAOp mma) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -3719,42 +3719,50 @@ Operation *getSameLevelOp(Operation *p, Operation *c) {
 };
 
 // When the consumer is a local_alloc loading from shared memory to registers,
-// look ahead for the actual consumers, usually dot ops, that can directly
-// use shared memory. The local_alloc will be removed later.
+// look ahead for the actual consumers, usually dot ops, that can directly use
+// shared memory. Address-only memdesc views are not consumers: follow them to
+// their transitive users so the channel's release is placed after the last
+// operation that reads the buffer. The local_alloc will be removed later.
 SmallVector<Operation *> getActualConsumers(Operation *consumerOp) {
-  // TransOp is not a real consumer. It caculates the shared memory
-  // address for the real consumer. Continue to find its transitive users
-  // recursively. Return all transitive users;
-  auto goThroughTrans = [&](Operation *user) -> DenseSet<Operation *> {
+  // Keep this in sync with WSCodePartition.cpp's isMemDescView: every
+  // address-only memdesc view must be followed, or the release lands after the
+  // view instead of the real reader and the buffer is recycled early (a
+  // shared-buffer WAR race). tt::TransOp is the tensor-level analogue.
+  auto isView = [](Operation *op) {
+    return isa<tt::TransOp, ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+               ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+               ttg::MemDescReshapeOp>(op);
+  };
+  auto goThroughViews = [&](Operation *user) -> DenseSet<Operation *> {
     DenseSet<Operation *> users;
     DenseSet<Operation *> visited;
-    SmallVector<Operation *> transUsers;
-    transUsers.push_back(user);
-    while (!transUsers.empty()) {
-      auto transUser = transUsers.pop_back_val();
-      visited.insert(transUser);
-      if (isa<tt::TransOp, ttg::MemDescTransOp>(transUser)) {
-        for (auto transitiveUser : transUser->getUsers()) {
+    SmallVector<Operation *> viewUsers;
+    viewUsers.push_back(user);
+    while (!viewUsers.empty()) {
+      auto viewUser = viewUsers.pop_back_val();
+      if (!visited.insert(viewUser).second)
+        continue;
+      if (isView(viewUser)) {
+        for (auto transitiveUser : viewUser->getUsers()) {
           if (!visited.count(transitiveUser))
-            transUsers.push_back(transitiveUser);
+            viewUsers.push_back(transitiveUser);
         }
       } else {
-        users.insert(transUser);
+        users.insert(viewUser);
       }
     }
     return users;
   };
-  if (isa<ttg::MemDescTransOp>(consumerOp)) {
-    auto users = goThroughTrans(consumerOp);
+  if (isView(consumerOp)) {
+    auto users = goThroughViews(consumerOp);
     return SmallVector<Operation *>(users.begin(), users.end());
   }
   if (isa<ttg::LocalAllocOp>(consumerOp)) {
     DenseSet<Operation *> users;
     for (auto user : consumerOp->getUsers()) {
-      if (isa<tt::TransOp, ttg::MemDescTransOp>(user)) {
-        auto transUsers = goThroughTrans(user);
-        for (auto *tUsr : transUsers)
-          users.insert(tUsr);
+      if (isView(user)) {
+        auto viewUsers = goThroughViews(user);
+        users.insert(viewUsers.begin(), viewUsers.end());
       } else {
         users.insert(user);
       }


### PR DESCRIPTION
Summary:
Loading one full [BLOCK_N, HEAD_DIM] V tile and splitting it for two PV MMAs produced a TMA load task -> correction task local_load/reshape/split/local_store -> MMA task round trip, and CTA1 could consume V without the clustered TMA completion wait. Transform2CTALoads now recognizes the exact descriptor_load -> reshape -> trans -> split -> local_alloc x2 chain and emits one cooperative [BLOCK_N, HEAD_DIM / 2] descriptor load into a single shared allocation, replacing the register leaves with two memdesc_subslice views consumed directly by the PV MMAs. Code partitioning treated each address-only subslice as the TMA channel consumer and released the shared buffer before either MMA, so getActualConsumers now follows address-only MemDescIndexOp, MemDescSubsliceOp, MemDescReinterpretOp and MemDescTransOp chains to their real consumers, as it already did for tensor transposes.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 188b67e47 on the MetaMain2 fork.

Depends on D114254019

Reviewed By: njriasan

Differential Revision: D116999806


