### PR TITLE
[TritonGPU] Predicate conditional TMEM read-modify-write chains

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -44,6 +44,25 @@ using TMEMTokenLoadOp = HasToken<ttng::TMEMLoadOp>;
 using TMEMTokenStoreOp = HasToken<ttng::TMEMStoreOp>;
 using TMEMTokenAllocOp = HasToken<ttng::TMEMAllocOp>;
 
+// Helper: return true if the value is a constant boolean with the expected
+// value.
+static bool isConstBool(Value v, bool expected) {
+  if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto attr = dyn_cast<BoolAttr>(cst.getValueAttr()))
+      return attr.getValue() == expected;
+  }
+  return false;
+}
+
+// A scalar condition used by a tensor-shaped consumer is represented as a
+// splat. Recover the scalar it was built from, so a predicate stays scalar and
+// remains traceable to the reduction that produced it.
+static Value extractScalarOrigin(Value v) {
+  if (auto splat = v.getDefiningOp<tt::SplatOp>())
+    return splat.getSrc();
+  return v;
+}
+
 class CombineTMEMStoreAndSelect : public OpRewritePattern<ttng::TMEMStoreOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -72,6 +91,10 @@ public:
       return failure();
     }
     Value pred = select.getCondition();
+    // Keep the TMEM store predicate scalar so data partitioning can trace and
+    // slice the reduction that produced it, and so it can later become the
+    // condition of an scf.if.
+    pred = extractScalarOrigin(pred);
     // In case the false operand is overwriting, we need to negate the predicate
     // (owerwrite when select would be false)
     if (valueFromTMEM == kTrue) {
@@ -98,6 +121,155 @@ public:
     if (!load.getResult().use_empty())
       return failure();
     rewriter.replaceAllUsesWith(load.getToken(), load.getDep());
+    return success();
+  }
+};
+
+// Materialize a predicated read-modify-write as control flow after software
+// pipelining and warp specialization. Before this point the eager SSA select
+// is useful: data partitioning can slice it into one predicate and one TMEM
+// accumulator per consumer task. Once the tasks exist, retaining a predicated
+// store alone is insufficient because the TMEM load and arithmetic feeding it
+// would still execute eagerly.
+class MaterializeConditionalTMEMStore
+    : public OpRewritePattern<ttng::TMEMStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  static bool isSameIndexedView(Value lhs, Value rhs) {
+    if (lhs == rhs)
+      return true;
+    auto lhsIndex = lhs.getDefiningOp<ttg::MemDescIndexOp>();
+    auto rhsIndex = rhs.getDefiningOp<ttg::MemDescIndexOp>();
+    return lhsIndex && rhsIndex && lhsIndex.getSrc() == rhsIndex.getSrc() &&
+           lhsIndex.getIndex() == rhsIndex.getIndex();
+  }
+
+  LogicalResult matchAndRewrite(ttng::TMEMStoreOp store,
+                                PatternRewriter &rewriter) const override {
+    if (isConstBool(store.getPred(), true) ||
+        isConstBool(store.getPred(), false))
+      return failure();
+
+    Block *block = store->getBlock();
+    ttng::TMEMLoadOp load;
+    if (store.getDep()) {
+      load = store.getDep().getDefiningOp<TMEMTokenLoadOp>();
+    } else {
+      // Code specialization has already converted the TMEM token edge into
+      // barriers. Recover the accumulator load from the pure expression tree
+      // feeding the store. There can be other TMEM loads in that tree (alpha,
+      // for example), so match the same indexed accumulator view precisely.
+      SmallVector<Value> worklist = {store.getSrc()};
+      DenseSet<Value> seen;
+      while (!worklist.empty()) {
+        Value value = worklist.pop_back_val();
+        if (!seen.insert(value).second)
+          continue;
+        Operation *def = value.getDefiningOp();
+        if (!def || def->getBlock() != block)
+          continue;
+        if (auto candidate = dyn_cast<ttng::TMEMLoadOp>(def)) {
+          if (isSameIndexedView(candidate.getSrc(), store.getDst())) {
+            if (load && load != candidate)
+              return failure();
+            load = candidate;
+          }
+          continue;
+        }
+        if (!isPure(def))
+          continue;
+        llvm::append_range(worklist, def->getOperands());
+      }
+    }
+    if (!load || load->getBlock() != block ||
+        !isSameIndexedView(load.getSrc(), store.getDst()))
+      return failure();
+
+    // Find the pure expression path from the TMEM load to the value being
+    // stored. Values independent of the load (for example alpha) remain
+    // outside the branch and are captured by it.
+    DenseSet<Value> dependsOnLoad;
+    DenseSet<Operation *> toMove;
+    dependsOnLoad.insert(load.getResult());
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (Operation &op : *block) {
+        if (&op == store.getOperation() || &op == load.getOperation() ||
+            !isPure(&op) || toMove.contains(&op))
+          continue;
+        if (llvm::any_of(op.getOperands(), [&](Value operand) {
+              return dependsOnLoad.contains(operand);
+            })) {
+          toMove.insert(&op);
+          for (Value result : op.getResults())
+            dependsOnLoad.insert(result);
+          changed = true;
+        }
+      }
+    }
+    if (!dependsOnLoad.contains(store.getSrc()))
+      return failure();
+
+    // Moving an op into the branch is only legal when all of its users move
+    // with it (apart from the root store).
+    for (Operation *op : toMove) {
+      for (Operation *user : op->getUsers()) {
+        if (user != store.getOperation() && !toMove.contains(user))
+          return failure();
+      }
+    }
+    for (Operation *user : load.getResult().getUsers()) {
+      if (!toMove.contains(user))
+        return failure();
+    }
+    // The load is sunk into the then region, so its token result must not be
+    // observed from the outer block either -- an ordering consumer left behind
+    // would no longer be dominated by its def. The store is expected (it is
+    // moved in with the load); anything else means someone else is sequencing
+    // against this load and we must not move it.
+    if (load.getToken()) {
+      for (Operation *user : load.getToken().getUsers()) {
+        if (user != store.getOperation() && !toMove.contains(user))
+          return failure();
+      }
+    }
+
+    bool threadsToken = static_cast<bool>(store.getDep());
+    if (!threadsToken && store.getToken() && !store.getToken().use_empty())
+      return failure();
+    Value incomingToken = load.getDep();
+    Value condition = store.getPred();
+    Location loc = store.getLoc();
+    // Insert at the store, after all values independent of the accumulator
+    // load (notably the alpha channel) have been produced. The accumulator
+    // load and its dependent arithmetic are then sunk into the branch.
+    rewriter.setInsertionPoint(store);
+    SmallVector<Type> resultTypes;
+    if (threadsToken)
+      resultTypes.push_back(rewriter.getType<AsyncTokenType>());
+    auto ifOp = scf::IfOp::create(rewriter, loc, resultTypes, condition,
+                                  /*withElseRegion=*/true);
+
+    auto thenYield = cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
+    rewriter.setInsertionPoint(thenYield);
+    rewriter.moveOpBefore(load, thenYield);
+    for (Operation &op : llvm::make_early_inc_range(*block)) {
+      if (toMove.contains(&op))
+        rewriter.moveOpBefore(&op, thenYield);
+    }
+    rewriter.modifyOpInPlace(store, [&] {
+      store.getPredMutable().assign(
+          arith::ConstantIntOp::create(rewriter, loc, 1, 1));
+    });
+    rewriter.moveOpBefore(store, thenYield);
+    if (threadsToken) {
+      auto elseYield = cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
+      elseYield.getResultsMutable().assign(incomingToken);
+      rewriter.replaceAllUsesWith(store.getToken(), ifOp.getResult(0));
+      thenYield.getResultsMutable().assign(store.getToken());
+    }
     return success();
   }
 };
@@ -433,16 +605,6 @@ public:
   }
 };
 
-// Helper: return true if the value is a constant boolean with the expected
-// value.
-static bool isConstBool(Value v, bool expected) {
-  if (auto cst = v.getDefiningOp<arith::ConstantOp>()) {
-    if (auto attr = dyn_cast<BoolAttr>(cst.getValueAttr()))
-      return attr.getValue() == expected;
-  }
-  return false;
-}
-
 // Helper to detect if the use of an alloc fully overwrites it.
 struct AllocUse {
   Operation *useOp;
@@ -678,7 +840,8 @@ struct HoistTMEMAlloc
                  SinkTMEMLoad, RemoveUnusedTMEMLoad>(&getContext());
     if (postPipeline) {
       patterns.add<CombineTMEMStoreAndAlloc, HoistTMEMAllocOutOfIf,
-                   TMEMLoadForwarding>(&getContext());
+                   MaterializeConditionalTMEMStore, TMEMLoadForwarding>(
+          &getContext());
     }
     scf::ForOp::getCanonicalizationPatterns(patterns, &getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {

--- a/test/TritonGPU/hoist-tmem-alloc.mlir
+++ b/test/TritonGPU/hoist-tmem-alloc.mlir
@@ -44,6 +44,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// A post-specialization, tokenless predicated TMEM read-modify-write must
+// become real control flow. Otherwise the accumulator load and multiply still
+// execute when the store predicate is false.
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // POST-PIPELINE-LABEL: @materialize_tokenless_conditional_tmem_update
+  // POST-PIPELINE: scf.if %[[PRED:.*]] {
+  // POST-PIPELINE-NEXT: %[[ACC:.*]] = ttng.tmem_load
+  // POST-PIPELINE-NEXT: %[[SCALED:.*]] = arith.mulf %[[ACC]],
+  // POST-PIPELINE-NEXT: ttng.tmem_store %[[SCALED]],
+  // POST-PIPELINE-NEXT: }
+  tt.func public @materialize_tokenless_conditional_tmem_update(
+      %mem: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %pred: i1,
+      %alpha: tensor<128x128xf32, #blocked>) {
+    %acc = ttng.tmem_load %mem : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %scaled = arith.mulf %acc, %alpha : tensor<128x128xf32, #blocked>
+    ttng.tmem_store %scaled, %mem, %pred : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>


### PR DESCRIPTION
Summary:
Keep the TMEM store predicate scalar by looking through the tt.splat a scalar condition acquires when it feeds a tensor select, so data partitioning can trace and slice the reduction that produced it and it can later become an scf.if condition. Materialize the predicated read-modify-write as control flow in the post-pipeline HoistTMEMAlloc invocation: a predicated store alone still left the accumulator TMEM load and rescale arithmetic executing eagerly on every iteration. Values independent of the load stay outside the branch and are captured by it.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 1f524e776 on the MetaMain2 fork.

Depends on D114254019

Reviewed By: njriasan

Differential Revision: D116999775


