### PR TITLE
Support column-major operands in the TLX Blackwell GEMM template

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -138,6 +138,55 @@ class TestTLXTemplates(TestCase):
             pass  # Both TMA and tl.store paths are valid
 
     @unittest.skipIf(
+        not has_datacenter_blackwell_tma_device(),
+        "Need Blackwell with device-side TMA support in Triton",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("layout", ("a_col", "b_col", "both_col"))
+    def test_tlx_matmul_ws_column_major(self, layout: str):
+        """A column-major operand goes through the transposed TMA descriptor path.
+
+        A column-major (M, K) operand has strides (1, M), so its .T is a row-major
+        (K, M) view of the same memory. The template describes that view, loads the
+        flipped tile shape, and recovers the MMA operand with tlx.local_trans -- no
+        contiguous copy. tlx_mode=force makes the TLX template the only choice, so a
+        layout it cannot handle fails here rather than quietly losing autotune.
+        """
+
+        def mm(a, b):
+            return torch.mm(a, b)
+
+        # Saturated (Rule 7) so the heuristic picks SPLIT_K=1: a split-K config would
+        # trip the separate reduce-k launch bug, which has nothing to do with layout.
+        M, K, N = 4096, 2048, 4096
+        dtype = torch.bfloat16
+        a = torch.randn((M, K), dtype=dtype, device=GPU_TYPE)
+        b = torch.randn((K, N), dtype=dtype, device=GPU_TYPE)
+        if layout in ("a_col", "both_col"):
+            a = a.t().contiguous().t()
+        if layout in ("b_col", "both_col"):
+            b = b.t().contiguous().t()
+
+        with config.patch({
+                "triton.tlx_mode": "force",
+                "force_disable_caches": True,
+                "enable_caching_generated_triton_templates": False,
+        }):
+            c_actual, code = run_and_get_code(torch.compile(mm), a, b)
+            c_expected = mm(a, b)
+
+        torch.testing.assert_close(c_actual, c_expected, atol=0.01, rtol=0.01)
+
+        # Both layout branches are constexpr and so both appear in the emitted source;
+        # the compiled-in flag is what says which one Triton folded to.
+        code_str = "\n".join(code)
+        self.assertIn("triton_tem_fused_tlx_mm", code_str)
+        if layout in ("a_col", "both_col"):
+            self.assertIn("A_ROW_MAJOR : tl.constexpr = False", code_str)
+        if layout in ("b_col", "both_col"):
+            self.assertIn("B_ROW_MAJOR : tl.constexpr = False", code_str)
+
+    @unittest.skipIf(
         not is_gfx950(),
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )

--- a/third_party/tlx/language/tlx/inductor/blackwell_gemm_ws.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/blackwell_gemm_ws.py.jinja
@@ -10,26 +10,56 @@
 
     dsize: tl.constexpr = 2
 
-    desc_a = tl.make_tensor_descriptor(
-        A,
-        shape=[M, K],
-        strides=[stride_am, 1],
-        block_shape=[BLOCK_M_SPLIT, BLOCK_K],
-    )
+    # A column-major (M, K) operand has strides (1, M), so its .T is a row-major
+    # (K, M) view of the same memory: the descriptor, the SMEM tile and the TMA
+    # offsets all flip, and the MMA operand is recovered with a metadata-only
+    # tlx.local_trans. No copy is needed. Mirrors tutorials/blackwell_gemm_ws.py.
+    if A_ROW_MAJOR:
+        desc_a = tl.make_tensor_descriptor(
+            A,
+            shape=[M, K],
+            strides=[stride_am, 1],
+            block_shape=[BLOCK_M_SPLIT, BLOCK_K],
+        )
+    else:
+        desc_a = tl.make_tensor_descriptor(
+            A,
+            shape=[K, M],
+            strides=[stride_ak, 1],
+            block_shape=[BLOCK_K, BLOCK_M_SPLIT],
+        )
 
-    desc_b = tl.make_tensor_descriptor(
-        B,
-        shape=[K, N],
-        strides=[stride_bk, 1],
-        block_shape=[BLOCK_K, BLOCK_N // NUM_CTAS],
-    )
+    if B_ROW_MAJOR:
+        desc_b = tl.make_tensor_descriptor(
+            B,
+            shape=[K, N],
+            strides=[stride_bk, 1],
+            block_shape=[BLOCK_K, BLOCK_N // NUM_CTAS],
+        )
+    else:
+        desc_b = tl.make_tensor_descriptor(
+            B,
+            shape=[N, K],
+            strides=[stride_bn, 1],
+            block_shape=[BLOCK_N // NUM_CTAS, BLOCK_K],
+        )
 
-    buffers_A = tlx.local_alloc(
-        (BLOCK_M_SPLIT, BLOCK_K),
-        A.dtype.element_ty,
-        NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
-    )
-    buffers_B = tlx.local_alloc((BLOCK_K, BLOCK_N // NUM_CTAS), A.dtype.element_ty, NUM_SMEM_BUFFERS)
+    if A_ROW_MAJOR:
+        buffers_A = tlx.local_alloc(
+            (BLOCK_M_SPLIT, BLOCK_K),
+            A.dtype.element_ty,
+            NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
+        )
+    else:
+        buffers_A = tlx.local_alloc(
+            (BLOCK_K, BLOCK_M_SPLIT),
+            A.dtype.element_ty,
+            NUM_SMEM_BUFFERS * NUM_MMA_GROUPS,
+        )
+    if B_ROW_MAJOR:
+        buffers_B = tlx.local_alloc((BLOCK_K, BLOCK_N // NUM_CTAS), A.dtype.element_ty, NUM_SMEM_BUFFERS)
+    else:
+        buffers_B = tlx.local_alloc((BLOCK_N // NUM_CTAS, BLOCK_K), A.dtype.element_ty, NUM_SMEM_BUFFERS)
     tmem_buffers = tlx.local_alloc(
         (BLOCK_M_SPLIT, BLOCK_N),
         tl.float32,
@@ -352,9 +382,12 @@
                             tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                             tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+                        # Transpose the SMEM views back if the inputs were column-major
+                        a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+                        b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
                         tlx.async_dot(
-                            buffers_A[a_buf],
-                            buffers_B[buf],
+                            a_operand,
+                            b_operand,
                             tmem_buffers[acc_buf],
                             use_acc=False,
                             mBarriers=[A_smem_empty_bars[a_buf]],
@@ -378,9 +411,11 @@
                                 tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                                 tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+                            a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+                            b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
                             tlx.async_dot(
-                                buffers_A[a_buf],
-                                buffers_B[buf],
+                                a_operand,
+                                b_operand,
                                 tmem_buffers[acc_buf],
                                 use_acc=True,
                                 mBarriers=[A_smem_empty_bars[a_buf]],
@@ -417,9 +452,12 @@
                         tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                         tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+                    # Transpose the SMEM views back if the inputs were column-major
+                    a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+                    b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
                     tlx.async_dot(
-                        buffers_A[a_buf],
-                        buffers_B[buf],
+                        a_operand,
+                        b_operand,
                         tmem_buffers[acc_buf],
                         use_acc=False,
                         mBarriers=[A_smem_empty_bars[a_buf]],
@@ -443,9 +481,11 @@
                             tlx.barrier_arrive(cta_bars[a_buf], arrive_count=1, remote_cta_rank=0)
                             tlx.barrier_wait(cta_bars[a_buf], phase=phase, pred=pred_cta0)
 
+                        a_operand = tlx.local_trans(buffers_A[a_buf]) if not A_ROW_MAJOR else buffers_A[a_buf]
+                        b_operand = tlx.local_trans(buffers_B[buf]) if not B_ROW_MAJOR else buffers_B[buf]
                         tlx.async_dot(
-                            buffers_A[a_buf],
-                            buffers_B[buf],
+                            a_operand,
+                            b_operand,
                             tmem_buffers[acc_buf],
                             use_acc=True,
                             mBarriers=[A_smem_empty_bars[a_buf]],
@@ -513,14 +553,22 @@
                         tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
                         offs_am = pid_m * BLOCK_M
                         tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
-                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
-                                                  eviction_policy="evict_last")
+                        if A_ROW_MAJOR:
+                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
+                                                      eviction_policy="evict_last")
+                        else:
+                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_k, offs_am], A_smem_full_bars[a_buf],
+                                                      eviction_policy="evict_last")
 
                         last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
                         tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
                         tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
-                        tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
-                                                  eviction_policy="evict_last")
+                        if B_ROW_MAJOR:
+                            tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
+                                                      eviction_policy="evict_last")
+                        else:
+                            tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_bn, offs_k], B_smem_full_bars[buf],
+                                                      eviction_policy="evict_last")
 
                         for group_id in tl.static_range(1, NUM_MMA_GROUPS):
                             a_buf = group_id * NUM_SMEM_BUFFERS + buf
@@ -530,8 +578,12 @@
                             offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
 
                             tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
-                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
-                                                      eviction_policy="evict_last")
+                            if A_ROW_MAJOR:
+                                tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
+                                                          eviction_policy="evict_last")
+                            else:
+                                tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_k, offs_am2], A_smem_full_bars[a_buf],
+                                                          eviction_policy="evict_last")
 
                         smem_accum_cnt += 1
 {% else %}
@@ -548,14 +600,22 @@
                     tlx.barrier_wait(A_smem_empty_bars[a_buf], phase ^ 1)
                     offs_am = pid_m * BLOCK_M
                     tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
-                    tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
-                                              eviction_policy="evict_last")
+                    if A_ROW_MAJOR:
+                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am, offs_k], A_smem_full_bars[a_buf],
+                                                  eviction_policy="evict_last")
+                    else:
+                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_k, offs_am], A_smem_full_bars[a_buf],
+                                                  eviction_policy="evict_last")
 
                     last_a_buf = (NUM_MMA_GROUPS - 1) * NUM_SMEM_BUFFERS + buf
                     tlx.barrier_wait(A_smem_empty_bars[last_a_buf], phase ^ 1)
                     tlx.barrier_expect_bytes(B_smem_full_bars[buf], expected_bytes)
-                    tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
-                                              eviction_policy="evict_last")
+                    if B_ROW_MAJOR:
+                        tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_k, offs_bn], B_smem_full_bars[buf],
+                                                  eviction_policy="evict_last")
+                    else:
+                        tlx.async_descriptor_load(desc_b, buffers_B[buf], [offs_bn, offs_k], B_smem_full_bars[buf],
+                                                  eviction_policy="evict_last")
 
                     for group_id in tl.static_range(1, NUM_MMA_GROUPS):
                         a_buf = group_id * NUM_SMEM_BUFFERS + buf
@@ -565,8 +625,12 @@
                         offs_am2 = offs_am + group_id * BLOCK_M_SPLIT
 
                         tlx.barrier_expect_bytes(A_smem_full_bars[a_buf], dsize * BLOCK_M_SPLIT * BLOCK_K)
-                        tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
-                                                  eviction_policy="evict_last")
+                        if A_ROW_MAJOR:
+                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_am2, offs_k], A_smem_full_bars[a_buf],
+                                                      eviction_policy="evict_last")
+                        else:
+                            tlx.async_descriptor_load(desc_a, buffers_A[a_buf], [offs_k, offs_am2], A_smem_full_bars[a_buf],
+                                                      eviction_policy="evict_last")
 
                     smem_accum_cnt += 1
 {% endif %}

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -21,6 +21,7 @@ them without importing torch._inductor.
 import dataclasses
 import logging
 import os
+from collections.abc import Sequence
 from typing import Any, Generator
 
 log = logging.getLogger(__name__)
@@ -807,68 +808,29 @@ class BlackwellGemmWSConfigMixin(TMATemplateConfigMixin):
             check_tmem=False,
         )
 
-    def adjust_kernel_inputs(
-        self,
-        kernel_inputs: KernelInputs,
-        op_name: str,
-    ) -> KernelInputs:
-        """
-        Adjust kernel inputs for TLX template.
+    @staticmethod
+    def _row_major_kwargs(kernel_inputs: KernelInputs) -> dict[str, bool]:
+        """A_ROW_MAJOR/B_ROW_MAJOR, spelled exactly as TMATemplateConfigMixin does."""
+        mat1, mat2 = kernel_inputs.mat1mat2()
+        return {
+            "A_ROW_MAJOR": not mat1.layout.is_transposed(),
+            "B_ROW_MAJOR": not mat2.layout.is_transposed(),
+        }
 
-        TLX Blackwell GEMM template requires both A and B to be row-major
-        (stride[-1] == 1). If either is column-major, make it contiguous to
-        convert to row-major layout.
-
-        Note: Unlike triton_blackwell_ws_persistent_device_tma_mm.py.jinja which uses
-        A_ROW_MAJOR/B_ROW_MAJOR flags to handle column-major inputs via transposed TMA
-        descriptor + .T after load, the TLX template cannot easily support this approach
-        because:
-        1. tlx.async_dot operates directly on SMEM buffers with fixed shapes
-        2. Loading column-major data with transposed descriptor yields transposed layout
-           in SMEM
-        3. There's no simple transpose before async_dot (unlike tl.dot which accepts .T)
-
-        Making A/B contiguous here matches the standalone TLX kernel behavior
-        (a.contiguous(), b.contiguous() in tritonbench wrapper) and ensures correct
-        results with minimal template changes.
-        """
-        from torch._inductor.ir import ExternKernel
-
-        assert isinstance(kernel_inputs, MMKernelInputs), "Expect MMKernelInputs"
+    @staticmethod
+    def _has_unsupported_layout(kernel_inputs: KernelInputs) -> bool:
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            return False
 
         strides = kernel_inputs.strides_hinted()
-        nodes = list(kernel_inputs.nodes())
-        mat1_idx = kernel_inputs._mat1_idx
-        mat2_idx = kernel_inputs._mat2_idx
-        changed = False
 
-        # Check A's layout from strides
-        # Column-major A has stride pattern [1, M] where inner dim stride is not 1
-        a_strides = strides[mat1_idx]
-        is_a_col_major = a_strides[-2] == 1 and a_strides[-1] != 1
-        if is_a_col_major:
-            mat_a_contiguous = ExternKernel.require_contiguous(nodes[mat1_idx])
-            nodes[mat1_idx] = mat_a_contiguous
-            changed = True
+        def is_dense_2d(s: Sequence[int]) -> bool:
+            return s[-1] == 1 or s[-2] == 1
 
-        # Check B's layout from strides
-        # Column-major B has stride pattern [1, N] where first stride is 1
-        b_strides = strides[mat2_idx]
-        is_b_col_major = b_strides[-2] == 1 and b_strides[-1] != 1
-        if is_b_col_major:
-            mat_b_contiguous = ExternKernel.require_contiguous(nodes[mat2_idx])
-            nodes[mat2_idx] = mat_b_contiguous
-            changed = True
-
-        if changed:
-            return MMKernelInputs(
-                nodes,
-                kernel_inputs.output_layout(),
-                mat1_idx=mat1_idx,
-                mat2_idx=mat2_idx,
-            )
-
-        return kernel_inputs
+        return not (
+            is_dense_2d(strides[kernel_inputs._mat1_idx])
+            and is_dense_2d(strides[kernel_inputs._mat2_idx])
+        )
 
     def _get_template_configs_impl(
         self,
@@ -923,6 +885,10 @@ class BlackwellGemmWSConfigMixin(TMATemplateConfigMixin):
                 "num_stages": 1,
                 "num_warps": 4,
                 "NUM_SMS": num_sms,
+                # This config is hand-built rather than routed through
+                # TMATemplateConfigMixin, so it has to carry the layout flags itself;
+                # the autotuning pool below picks them up from super().
+                **self._row_major_kwargs(kernel_inputs),
             }
 
             # Check NUM_CTAS=2 compatibility
@@ -1455,8 +1421,16 @@ class BlackwellGemmWSConfigHeuristic(BlackwellGemmWSConfigMixin, CUDAConfigHeuri
 
     def should_run(self, inputs: KernelInputs) -> bool:
         """
-        Override to allow TLX templates to run without max_autotune when tlx_mode is set.
+        Override to allow TLX templates to run without max_autotune when tlx_mode is set,
+        and to decline operands the template's TMA descriptors cannot describe.
+
+        Both descriptor forms in the template hardcode a unit innermost stride, so an
+        operand that is neither row- nor column-major has no valid form and is declined
+        rather than described with a stride it does not have.
         """
+        if self._has_unsupported_layout(inputs):
+            log.debug("TLX blackwell_gemm_ws declined: operand is neither row- nor column-major")
+            return False
         if config.triton.tlx_mode in ("allow", "force"):
             return True
         return super().should_run(inputs)


### PR DESCRIPTION
Summary:
A GEMM with a column-major A or B could not use `blackwell_gemm_ws`: the candidate                                                                                                                                
failed to compile with `NameError('A is not defined')` inside                                                                                                                                                     
`tl.make_tensor_descriptor`, taking the whole `torch.compile` down with it. This                                                                                                                                  
adds the transposed-descriptor path the template was always missing, so those
shapes run with no copy, and narrows the layout gate to what the template really
cannot express.

- **root cause**: `adjust_kernel_inputs` swapped a column-major operand for
  `ExternKernel.require_contiguous(...)`, but only the *choice* sees the adjusted
  nodes -- `tuned_mm` passes the originals to `autotune_select_algorithm`, so the
  copy has no users, gets dead-code-eliminated into `V.graph.removed_buffers`, and
  `def_kernel` then silently drops the operand from the kernel signature. The
  rendered kernel also carried contiguous strides for non-contiguous data, so
  binding the pointer alone would have given wrong numerics rather than a crash.
- **fix**: a column-major `(M, K)` operand has strides `(1, M)`, so its `.T` is a
  row-major `(K, M)` view of the same memory. The descriptor, the SMEM tile shape
  and the TMA offsets flip, and the MMA operand is recovered with a metadata-only
  `tlx.local_trans`. No copy, no extra SMEM. This is the same handling
  `tutorials/blackwell_gemm_ws.py` already had and both non-TLX Inductor TMA
  templates use; only the Inductor port had dropped it, leaving `A_ROW_MAJOR` /
  `B_ROW_MAJOR` plumbed to the kernel with nothing reading them.
- **layout flags**: the hand-built heuristic config never carried
  `A_ROW_MAJOR`/`B_ROW_MAJOR` (only the autotuning pool picked them up from
  `TMATemplateConfigMixin`), so `tlx_mode=force` had no such constexpr at all.
  Added via `_row_major_kwargs`, spelled exactly as the mixin does.
- **scope**: Blackwell WS GEMM only. The gfx950 warp-pipe heuristics have their own
  `adjust_kernel_inputs` and a different MRO, untouched.

Reviewed By: htyu

Differential Revision: D117294713


