### PR TITLE
[AMD] Vectorize unordered reductions across register groups

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -686,18 +686,21 @@ private:
       return result;
     };
 
+    // Unordered reductions may combine all register groups that contribute to
+    // the same output element.  Keeping the groups separate forces each
+    // vectorized group to be reduced to a scalar before the partial results
+    // are combined, which introduces one horizontal vector reduction per
+    // group.  Merge them first so vector packing stays live across the whole
+    // in-thread reduction and is unpacked only once.
+    std::map<SmallVector<unsigned>, SmallVector<int>> mergedRegGroups;
     for (auto &[groupKey, group] : regGroups) {
-      auto reduced = reduceGroup(group);
       auto key = groupKey;
       key[axis] = 0;
-      bool isFirst = accs.find(key) == accs.end();
-      if (isFirst) {
-        accs[key] = std::move(reduced);
-        indices[key] = srcIndices[group.front()];
-      } else {
-        accumulate(op.getLoc(), rewriter, op.getCombineOp(), accs[key],
-                   reduced);
-      }
+      llvm::append_range(mergedRegGroups[key], group);
+    }
+    for (auto &[key, group] : mergedRegGroups) {
+      accs[key] = reduceGroup(group);
+      indices[key] = srcIndices[group.front()];
     }
   }
 

--- a/test/Conversion/amd/reduce_tree_vectorize.mlir
+++ b/test/Conversion/amd/reduce_tree_vectorize.mlir
@@ -122,3 +122,44 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// Register bit 0 is separated from bits 2--4 by a lane bit, forming eight
+// two-value register groups along the reduction axis. Since both warp bits
+// also move that axis, this exercises the multi-group reduction path.
+#multi_group = #ttg.linear<{register = [[1, 0], [4, 0], [8, 0], [16, 0]], lane = [[2, 0], [32, 0], [64, 0], [0, 1], [0, 2], [0, 4]], warp = [[128, 0], [256, 0]], block = []}>
+#rows = #ttg.slice<{dim = 0, parent = #multi_group}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // Unordered reductions may merge all eight groups before vectorization:
+  // 16 register values become eight packed pairs and one seven-node vector
+  // tree, followed by a single horizontal scalar add.
+  // GFX950-LABEL: reduce_multi_register_groups_unordered
+  // GFX950-COUNT-7: llvm.fadd {{.*}} : vector<2xf32>
+  // GFX950-NOT: llvm.fadd {{.*}} : vector<2xf32>
+  // GFX950: llvm.extractelement
+  // GFX950: llvm.extractelement
+  // GFX950: llvm.fadd {{.*}} : f32
+  tt.func public @reduce_multi_register_groups_unordered(%arg0: tensor<512x8xf32, #multi_group>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32, reduction_ordering = "unordered"}> ({
+    ^bb0(%a: f32, %b: f32):
+      %sum = arith.addf %a, %b : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<512x8xf32, #multi_group>) -> tensor<8xf32, #rows>
+    tt.return
+  }
+
+  // Explicitly ordered reductions continue to reduce each register group
+  // independently and therefore do not use packed vector combines.
+  // GFX950-LABEL: reduce_multi_register_groups_inner_tree
+  // GFX950-NOT: vector<2xf32>
+  // GFX950: llvm.return
+  tt.func public @reduce_multi_register_groups_inner_tree(%arg0: tensor<512x8xf32, #multi_group>) {
+    %0 = "tt.reduce"(%arg0) <{axis = 0 : i32, reduction_ordering = "inner_tree"}> ({
+    ^bb0(%a: f32, %b: f32):
+      %sum = arith.addf %a, %b : f32
+      tt.reduce.return %sum : f32
+    }) : (tensor<512x8xf32, #multi_group>) -> tensor<8xf32, #rows>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Summary

- merge register groups that contribute to the same output element before lowering unordered reductions
- keep packed vector operations live across the full in-thread reduction and unpack only once
- preserve the existing per-group lowering for reductions with an explicit `inner_tree`
- add multi-group inter-warp coverage for both lowering paths

## Details

The previous lowering reduced each register group independently before combining their scalar partial results. For unordered reductions, this change first groups all registers that contribute to the same output element and then builds one reduction tree. This allows vector combines to span register-group boundaries and avoids repeated horizontal reduction and unpacking.

This can change floating-point association, so it is deliberately restricted to reductions marked `unordered`. Reductions with an explicit `inner_tree` retain the existing association order.

The new gfx950 lit test uses eight two-value register groups in an inter-warp layout. It verifies that the unordered path emits one packed seven-node `vector<2xf32>` tree followed by a single horizontal scalar add, while the `inner_tree` path does not use the cross-group vector combines.

This compiler optimization was split from #2892 so its semantics and coverage can be reviewed independently.

## Testing

- `make -j8`
- `lit -v test/Conversion/amd/reduce_tree_vectorize.mlir test/Conversion/reduce_inner_tree_to_llvm.mlir`