### PR TITLE
[triton][beta] Skip TMEM barriers for warp-local hazards (#3277)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h
@@ -4,6 +4,8 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LinearLayout.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <cstdint>
 #include <functional>
@@ -31,6 +33,18 @@ FailureOr<TMemLdStEncodingInfo>
 computeTMemLdStEncodingInfo(RankedTensorType regTy, gpu::MemDescType memTy,
                             int maxnreg,
                             std::function<InFlightDiagnostic()> emitError = {});
+
+// Return the complete per-message footprint, including vectorization beyond
+// the base instruction atom.
+FailureOr<LinearLayout>
+getTMemLdStMessageLayout(MLIRContext *ctx, TMemAccessAtom atom, bool unpacked,
+                         int numRegsPerMessage);
+
+// Return the physical tensor-memory word addresses touched by each warp when
+// lowering a tmem_load or tmem_store with these types.
+FailureOr<SmallVector<DenseSet<uint32_t>>>
+getTMemLdStWarpAddresses(RankedTensorType regTy, gpu::MemDescType memTy,
+                         int maxnreg, uint32_t baseAddress = 0);
 
 // Check whether a tmem_load with register layout `regTy` reading from `memTy`
 // can be supported with a fused reduction along the N dimension. This is the

--- a/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.cpp
@@ -2,6 +2,7 @@
 
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/DenseSet.h"
 
 #include <algorithm>
 #include <tuple>
@@ -321,6 +322,105 @@ computeTMemLdStEncodingInfo(RankedTensorType regTy, MemDescType memTy,
   bool isScales = isa<TensorMemoryScalesEncodingAttr>(memTy.getEncoding());
   int bitwidth = memTy.getElementTypeBitWidth();
   return lowerTMemLdSt(cvt, maxnreg, bitwidth, isScales, emitError);
+}
+
+FailureOr<LinearLayout>
+getTMemLdStMessageLayout(MLIRContext *ctx, TMemAccessAtom atom, bool unpacked,
+                         int numRegsPerMessage) {
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kCol = StringAttr::get(ctx, "col");
+  LinearLayout atomLayout =
+      getTileLayout(ctx, atom, unpacked, /*withWarp=*/false);
+  int32_t atomRegs = atomLayout.getInDimSize(kReg);
+  if (numRegsPerMessage % atomRegs != 0)
+    return failure();
+  return atomLayout * LinearLayout::identity1D(numRegsPerMessage / atomRegs,
+                                                kReg, kCol);
+}
+
+FailureOr<SmallVector<DenseSet<uint32_t>>>
+getTMemLdStWarpAddresses(RankedTensorType regTy, MemDescType memTy,
+                         int maxnreg, uint32_t baseAddress) {
+  auto info = computeTMemLdStEncodingInfo(regTy, memTy, maxnreg);
+  if (failed(info))
+    return failure();
+
+  auto *ctx = regTy.getContext();
+  auto kReg = StringAttr::get(ctx, "register");
+  auto kLane = StringAttr::get(ctx, "lane");
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kRow = StringAttr::get(ctx, "row");
+  auto kCol = StringAttr::get(ctx, "col");
+  const LinearLayout &reps = info->reps;
+  if (!reps.hasInDim(kReg) || !reps.hasInDim(kLane) || !reps.hasInDim(kWarp))
+    return failure();
+
+  auto getRowCol = [&](const auto &outputs) {
+    std::optional<uint32_t> row;
+    std::optional<uint32_t> col;
+    for (auto [name, value] : outputs) {
+      if (name == kRow)
+        row = value;
+      else if (name == kCol)
+        col = value;
+    }
+    return std::make_pair(row, col);
+  };
+  auto encode = [](uint32_t row, uint32_t col) {
+    assert(col < (1u << 16) && "TMEM column offset must fit in 16 bits");
+    return (row << 16) | col;
+  };
+
+  auto messageLayout = getTMemLdStMessageLayout(
+      ctx, info->atom, info->unpacked, info->numRegsPerMessage);
+  if (failed(messageLayout))
+    return failure();
+
+  SmallVector<uint32_t> messageOffsets;
+  for (int32_t messageReg = 0;
+       messageReg < messageLayout->getInDimSize(kReg); ++messageReg) {
+    for (int32_t lane = 0; lane < messageLayout->getInDimSize(kLane); ++lane) {
+      auto [row, col] = getRowCol(
+          messageLayout->apply({{kReg, messageReg}, {kLane, lane}}));
+      if (!row || !col)
+        return failure();
+      messageOffsets.push_back(encode(*row, *col));
+    }
+  }
+
+  SmallVector<DenseSet<uint32_t>> addressesByWarp;
+  addressesByWarp.resize(reps.getInDimSize(kWarp));
+  for (int32_t warp = 0; warp < reps.getInDimSize(kWarp); ++warp) {
+    // Keep this warp-base calculation synchronized with lowerTMemLdSt.
+    uint32_t warpOffset = (warp & 3) << (5 + 16);
+    if (reps.getInDimSize(kWarp) > 4) {
+      auto [row, col] =
+          getRowCol(reps.apply({{kReg, 0}, {kLane, 0}, {kWarp, warp}}));
+      if (!row || !col)
+        return failure();
+      warpOffset += encode(*row, *col);
+    }
+
+    DenseSet<uint32_t> addresses;
+    for (int32_t reg = 0; reg < reps.getInDimSize(kReg);
+         reg += info->numRegsPerMessage) {
+      auto [messageRow, messageCol] =
+          getRowCol(reps.apply({{kReg, reg}, {kLane, 0}, {kWarp, 0}}));
+      if (!messageRow || !messageCol)
+        return failure();
+      uint32_t messageOffset = encode(*messageRow, *messageCol);
+
+      for (uint32_t inMessageOffset : messageOffsets) {
+        uint32_t address =
+            baseAddress + warpOffset + messageOffset + inMessageOffset;
+        addresses.insert(address);
+        if (info->secondHalfOffset)
+          addresses.insert(address + *info->secondHalfOffset);
+      }
+    }
+    addressesByWarp[warp] = std::move(addresses);
+  }
+  return addressesByWarp;
 }
 
 bool supportsTMemLoadReduce(RankedTensorType regTy, MemDescType memTy,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -2,6 +2,7 @@
 #include "triton/Analysis/Membar.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/TensorMemoryUtils.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -11,6 +12,7 @@
 #include "llvm/ADT/DenseSet.h"
 
 #include <limits>
+#include <optional>
 
 namespace mlir {
 namespace triton {
@@ -52,8 +54,152 @@ static TMemAccessKind getTMemAccessKind(Operation *op) {
   return TMemAccessKind::None;
 }
 
+struct TMemAccessInfo {
+  Region *warpScope;
+  SmallVector<DenseSet<uint32_t>> addressesByWarp;
+};
+
+static Region *getWarpScope(Operation *op) {
+  for (Region *region = op->getParentRegion(); region;) {
+    Operation *parent = region->getParentOp();
+    if (isa_and_nonnull<ttg::WarpSpecializeOp,
+                        ttg::WarpSpecializePartitionsOp>(parent))
+      return region;
+    region = parent ? parent->getParentRegion() : nullptr;
+  }
+  return nullptr;
+}
+
+// Resolve a tensor-memory descriptor to one statically known address. Control
+// flow merges are deliberately not unified here: if an access can name more
+// than one allocation, keep the CTA barrier.
+static std::optional<uint32_t> getTMemBaseAddress(Value value) {
+  DenseSet<Value> seen;
+  uint32_t offset = 0;
+  while (seen.insert(value).second) {
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(
+          arg.getOwner()->getParentOp());
+      if (!partitions)
+        return std::nullopt;
+      value = partitions.getExplicitCaptures()[arg.getArgNumber()];
+      continue;
+    }
+
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp)
+      return std::nullopt;
+    if (auto alloc = dyn_cast<TMEMAllocOp>(defOp)) {
+      auto col = alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
+      auto row = alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
+      if (!col || !row)
+        return std::nullopt;
+      return offset + static_cast<uint32_t>(col.getInt()) +
+             (static_cast<uint32_t>(row.getInt()) << 16);
+    }
+    if (auto slice = dyn_cast<TMEMSubSliceOp>(defOp)) {
+      offset += getTMemSubSliceOffset(slice.getSrc().getType(), slice.getN());
+      value = slice.getSrc();
+      continue;
+    }
+    if (auto reinterpret = dyn_cast<ttg::MemDescReinterpretOp>(defOp)) {
+      value = reinterpret.getSrc();
+      continue;
+    }
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+struct PerWarpTMemOpInfo {
+  RankedTensorType regType;
+  ttg::MemDescType memDescType;
+  Value memDesc;
+};
+
+// These operations lower to one tcgen05.ld/st instruction stream per warp.
+// MMA and copy operations use an elected issuer or multicast and are excluded.
+static std::optional<PerWarpTMemOpInfo> getPerWarpTMemOpInfo(Operation *op) {
+  if (auto load = dyn_cast<TMEMLoadOp>(op))
+    return PerWarpTMemOpInfo{load.getType(), load.getSrc().getType(),
+                             load.getSrc()};
+  if (auto store = dyn_cast<TMEMStoreOp>(op))
+    return PerWarpTMemOpInfo{store.getSrc().getType(), store.getDst().getType(),
+                             store.getDst()};
+  if (auto alloc = dyn_cast<TMEMAllocOp>(op)) {
+    if (alloc.getSrc())
+      return PerWarpTMemOpInfo{alloc.getSrc().getType(), alloc.getType(),
+                               alloc.getResult()};
+  }
+  return std::nullopt;
+}
+
+static std::optional<TMemAccessInfo> getTMemAccessInfo(Operation *op) {
+  auto accessOp = getPerWarpTMemOpInfo(op);
+  std::optional<int> numWarps = ttg::maybeLookupNumWarps(op);
+  if (!accessOp || !numWarps)
+    return std::nullopt;
+
+  std::optional<uint32_t> baseAddress = getTMemBaseAddress(accessOp->memDesc);
+  if (!baseAddress)
+    return std::nullopt;
+
+  auto addressesByWarp = getTMemLdStWarpAddresses(
+      accessOp->regType, accessOp->memDescType, getContextualMaxNReg(op),
+      *baseAddress);
+  if (failed(addressesByWarp) || addressesByWarp->size() != *numWarps)
+    return std::nullopt;
+
+  TMemAccessInfo access{getWarpScope(op), std::move(*addressesByWarp)};
+  if (llvm::any_of(access.addressesByWarp,
+                   [](const auto &addresses) { return addresses.empty(); }))
+    return std::nullopt;
+  return access;
+}
+
+using TMemAccessCache = DenseMap<Operation *, std::optional<TMemAccessInfo>>;
+
+static void cacheTMemAccessInfo(Operation *op, TMemAccessCache &cache) {
+  auto [it, inserted] = cache.try_emplace(op);
+  if (inserted)
+    it->second = getTMemAccessInfo(op);
+}
+
+static bool isWarpLocalHazard(Operation *lhs, Operation *rhs,
+                              TMemAccessCache &cache) {
+  cacheTMemAccessInfo(lhs, cache);
+  cacheTMemAccessInfo(rhs, cache);
+  const std::optional<TMemAccessInfo> &lhsAccess = cache.find(lhs)->second;
+  const std::optional<TMemAccessInfo> &rhsAccess = cache.find(rhs)->second;
+  if (!lhsAccess || !rhsAccess ||
+      lhsAccess->warpScope != rhsAccess->warpScope ||
+      lhsAccess->addressesByWarp.size() != rhsAccess->addressesByWarp.size())
+    return false;
+
+  for (auto [lhsWarp, lhsAddresses] :
+       llvm::enumerate(lhsAccess->addressesByWarp)) {
+    for (auto [rhsWarp, rhsAddresses] :
+         llvm::enumerate(rhsAccess->addressesByWarp)) {
+      if (lhsWarp == rhsWarp)
+        continue;
+      const auto &smaller = lhsAddresses.size() < rhsAddresses.size()
+                                ? lhsAddresses
+                                : rhsAddresses;
+      const auto &larger = lhsAddresses.size() < rhsAddresses.size()
+                               ? rhsAddresses
+                               : lhsAddresses;
+      if (llvm::any_of(smaller, [&](uint32_t address) {
+            return larger.contains(address);
+          }))
+        return false;
+    }
+  }
+  return true;
+}
+
 static bool filterFn(Operation *lhs, Operation *rhs, bool /*lhsIsRead*/,
-                     bool /*rhsIsRead*/, Allocation * /*allocation*/) {
+                     bool /*rhsIsRead*/, Allocation * /*allocation*/,
+                     TMemAccessCache &cache) {
   TMemAccessKind lhsKind = getTMemAccessKind(lhs);
   TMemAccessKind rhsKind = getTMemAccessKind(rhs);
 
@@ -72,6 +218,12 @@ static bool filterFn(Operation *lhs, Operation *rhs, bool /*lhsIsRead*/,
       lhsKind == TMemAccessKind::Load && rhsKind == TMemAccessKind::MMA;
   bool storeToMma =
       lhsKind == TMemAccessKind::Store && rhsKind == TMemAccessKind::MMA;
+
+  // A hazard between two per-warp accesses needs no CTA rendezvous when every
+  // physical address is owned by the same warp at both endpoints. Program
+  // order plus the tcgen05.wait::{ld,st} emitted by lowering is sufficient.
+  if ((war || raw || waw) && isWarpLocalHazard(lhs, rhs, cache))
+    return true;
 
   bool requiresBarrier = war || raw || waw || loadToMma || storeToMma;
   return !requiresBarrier;
@@ -353,8 +505,13 @@ struct TMemBarrierInsertionPass
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     ModuleAllocation allocation(mod);
+    TMemAccessCache cache;
+    MembarFilterFn filter = [&](Operation *lhs, Operation *rhs, bool lhsIsRead,
+                                bool rhsIsRead, Allocation *allocation) {
+      return filterFn(lhs, rhs, lhsIsRead, rhsIsRead, allocation, cache);
+    };
     ModuleMembarOrFenceAnalysis<TMemBarrierAnalysis> analysis(&allocation,
-                                                              filterFn);
+                                                              filter);
     analysis.run();
   }
 };

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -6,6 +6,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -82,13 +83,29 @@ static bool isTensorMemory(Value value) {
          isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace());
 }
 
-static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
+// Offset of a view relative to the root allocation, in physical TMEM
+// coordinates (rows, 32-bit columns).
+struct TMemViewOffset {
+  int64_t row = 0;
+  int64_t col = 0;
+  bool known = true;
+};
+
+// A root allocation reached from a view, together with the view's offset
+// within it. Two views of one allocation can be physically disjoint, so the
+// offset is what lets the interval model tell them apart.
+struct RootAlloc {
+  TMEMAllocOp alloc;
+  TMemViewOffset offset;
+};
+
+static void appendRootAllocs(Value value, SmallVectorImpl<RootAlloc> &allocs,
                              bool &unknown) {
   DenseSet<Value> seen;
-  SmallVector<Value> worklist{value};
+  SmallVector<std::pair<Value, TMemViewOffset>> worklist{{value, {}}};
 
   while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
+    auto [current, offset] = worklist.pop_back_val();
     if (!seen.insert(current).second)
       continue;
 
@@ -108,25 +125,27 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
               std::distance(branch->getSuccessors().begin(), it);
           SuccessorOperands args = branch.getSuccessorOperands(successorIndex);
           worklist.push_back(
-              args.getForwardedOperands()[arg.getArgNumber() -
-                                          args.getProducedOperandCount()]);
+              {args.getForwardedOperands()[arg.getArgNumber() -
+                                           args.getProducedOperandCount()],
+               offset});
         }
         continue;
       }
 
       if (auto ws = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-        worklist.push_back(ws.getExplicitCaptures()[arg.getArgNumber()]);
+        worklist.push_back(
+            {ws.getExplicitCaptures()[arg.getArgNumber()], offset});
       } else if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
         unsigned idx = arg.getArgNumber() - 1;
-        worklist.push_back(forOp.getYieldedValues()[idx]);
-        worklist.push_back(forOp.getInits()[idx]);
+        worklist.push_back({forOp.getYieldedValues()[idx], offset});
+        worklist.push_back({forOp.getInits()[idx], offset});
       } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
         unsigned idx = arg.getArgNumber();
         if (arg.getParentRegion() == &whileOp.getAfter()) {
-          worklist.push_back(whileOp.getConditionOp().getArgs()[idx]);
+          worklist.push_back({whileOp.getConditionOp().getArgs()[idx], offset});
         } else {
-          worklist.push_back(whileOp.getYieldedValues()[idx]);
-          worklist.push_back(whileOp.getInits()[idx]);
+          worklist.push_back({whileOp.getYieldedValues()[idx], offset});
+          worklist.push_back({whileOp.getInits()[idx], offset});
         }
       } else {
         unknown = true;
@@ -141,23 +160,55 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
     }
 
     unsigned resultIndex = cast<OpResult>(current).getResultNumber();
+    // The view ops that carry an offset must be matched before the generic
+    // MemDescViewTrait branch below, which would otherwise shadow them and
+    // discard the offset.
     if (auto alloc = dyn_cast<TMEMAllocOp>(defOp)) {
-      allocs.push_back(alloc);
-    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
-      worklist.push_back(defOp->getOperand(0));
+      allocs.push_back({alloc, offset});
+    } else if (auto index = dyn_cast<ttg::MemDescIndexOp>(defOp)) {
+      // Multi-buffered views advance the base pointer by one buffer's worth of
+      // 32-bit columns, matching MemDescIndexOpConversion.
+      APInt indexValue;
+      TMemViewOffset next = offset;
+      if (matchPattern(index.getIndex(), m_ConstantInt(&indexValue)))
+        next.col += indexValue.getSExtValue() *
+                    getTmemAllocSizes(index.getType()).numCols;
+      else
+        next.known = false;
+      worklist.push_back({index.getSrc(), next});
     } else if (auto slice = dyn_cast<TMEMSubSliceOp>(defOp)) {
-      worklist.push_back(slice.getSrc());
+      // getTMemSubSliceOffset packs the column offset in the low 16 bits and
+      // the row offset in the high 16 bits, as TMEMSubSliceOpConversion does.
+      // This tree's tmem_subslice predates upstream's (offset, dim) form: it
+      // carries a single $N and can only slice the inner (column) dimension,
+      // which is exactly upstream's dim=1 default.
+      uint32_t packed =
+          getTMemSubSliceOffset(slice.getSrc().getType(), slice.getN());
+      TMemViewOffset next = offset;
+      next.col += packed & 0xffff;
+      next.row += packed >> 16;
+      worklist.push_back({slice.getSrc(), next});
+    } else if (isa<ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+                   ttg::MemDescReshapeOp>(defOp)) {
+      // Pure reinterpretations do not move the base pointer.
+      worklist.push_back({defOp->getOperand(0), offset});
+    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
+      // Keep walking to the root, but do not pretend the offset is known.
+      TMemViewOffset next = offset;
+      next.known = false;
+      worklist.push_back({defOp->getOperand(0), next});
     } else if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-      worklist.push_back(selectOp.getTrueValue());
-      worklist.push_back(selectOp.getFalseValue());
+      worklist.push_back({selectOp.getTrueValue(), offset});
+      worklist.push_back({selectOp.getFalseValue(), offset});
     } else if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-      worklist.push_back(ifOp.thenYield().getOperand(resultIndex));
-      worklist.push_back(ifOp.elseYield().getOperand(resultIndex));
+      worklist.push_back({ifOp.thenYield().getOperand(resultIndex), offset});
+      worklist.push_back({ifOp.elseYield().getOperand(resultIndex), offset});
     } else if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
-      worklist.push_back(forOp.getYieldedValues()[resultIndex]);
-      worklist.push_back(forOp.getInits()[resultIndex]);
+      worklist.push_back({forOp.getYieldedValues()[resultIndex], offset});
+      worklist.push_back({forOp.getInits()[resultIndex], offset});
     } else if (auto whileOp = dyn_cast<scf::WhileOp>(defOp)) {
-      worklist.push_back(whileOp.getConditionOp().getArgs()[resultIndex]);
+      worklist.push_back(
+          {whileOp.getConditionOp().getArgs()[resultIndex], offset});
     } else {
       unknown = true;
     }
@@ -165,46 +216,54 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
 }
 
 static SmallVector<AllocationSlice> getTMemSlices(Value value) {
-  SmallVector<TMEMAllocOp> allocs;
+  SmallVector<RootAlloc> allocs;
   bool unknown = false;
   appendRootAllocs(value, allocs, unknown);
 
   SmallVector<AllocationSlice> slices;
-  if (unknown || allocs.empty()) {
+  auto everything = [&]() -> SmallVector<AllocationSlice> {
+    slices.clear();
     slices.emplace_back(
         Interval<size_t>(0, std::numeric_limits<size_t>::max()));
     return slices;
-  }
+  };
 
-  for (TMEMAllocOp alloc : allocs) {
+  if (unknown || allocs.empty())
+    return everything();
+
+  // The accessed extent is the view's own footprint, not the whole allocation.
+  auto viewTy = dyn_cast<ttg::MemDescType>(value.getType());
+  if (!viewTy)
+    return everything();
+  TMemAllocation viewSize = getTmemAllocSizes(viewTy);
+
+  for (RootAlloc &root : allocs) {
     auto colAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
     auto rowAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
-    if (!colAttr || !rowAttr) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
+    if (!colAttr || !rowAttr)
+      return everything();
 
-    int64_t colOffset = colAttr.getInt();
-    int64_t rowOffset = rowAttr.getInt();
-    TMemAllocation allocSize = getTmemAllocSizes(alloc.getType());
+    TMemAllocation allocSize = getTmemAllocSizes(root.alloc.getType());
+    // Fall back to the whole allocation when the view offset is not statically
+    // known, so an unresolved view can never look narrower than it is.
+    bool useView = root.offset.known;
+    int64_t colOffset = colAttr.getInt() + (useView ? root.offset.col : 0);
+    int64_t rowOffset = rowAttr.getInt() + (useView ? root.offset.row : 0);
+    int64_t numRows = useView ? viewSize.numRows : allocSize.numRows;
+    int64_t numCols = useView ? viewSize.numCols : allocSize.numCols;
+
     if (rowOffset % kRowOffsetGranularity != 0 ||
-        allocSize.numRows % kAllocRowGranularity != 0) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        numRows % kAllocRowGranularity != 0)
+      return everything();
 
     int64_t rowGroup = rowOffset / kRowOffsetGranularity;
-    int64_t numRowGroups = allocSize.numRows / kAllocRowGranularity;
+    int64_t numRowGroups = numRows / kAllocRowGranularity;
     for (int64_t row = 0; row < numRowGroups; ++row) {
       size_t start = static_cast<size_t>(rowGroup + row) * kFlattenedRowStride +
                      static_cast<size_t>(colOffset);
-      slices.emplace_back(Interval<size_t>(start, start + allocSize.numCols));
+      slices.emplace_back(Interval<size_t>(start, start + numCols));
     }
   }
   return slices;

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -8,6 +8,7 @@
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
 #tmem128 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem64 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+#tmem128x64 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
@@ -328,6 +329,113 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.barrier local
     ttng.tmem_store %arg0, %0, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %arg1, %0 : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Two multi-buffered views of one allocation that land on different physical
+  // columns do not alias, so no barrier is needed between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Same allocation, same buffer index: the views do alias and the WAR still
+  // needs ordering.
+  // CHECK-LABEL: @ld_then_st_same_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_same_buffer(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A dynamic buffer index cannot prove disjointness: stay conservative.
+  // CHECK-LABEL: @ld_then_st_dynamic_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_dynamic_buffer(%arg0: tensor<128x128xf32, #blocked>, %idx: i32) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%idx] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // tmem_subslice offsets are honoured too: two column subslices of one
+  // allocation that do not overlap need no barrier between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %wr = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Overlapping subslices of one allocation still need the barrier.
+  // CHECK-LABEL: @ld_then_st_overlapping_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_overlapping_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %wr = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // memdesc_reinterpret does not move the base pointer, so the buffer offset
+  // underneath it still decides aliasing.
+  // CHECK-LABEL: @ld_then_st_reinterpret_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_reinterpret_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %v = ttg.memdesc_reinterpret %0 : !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %v[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %v[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
 }

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -4,6 +4,9 @@
 #shared_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared_copy = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked64 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 64], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
+#blocked64_8 = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 2], order = [0, 1]}>
 #blocked_scales = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
 #tmem128 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
@@ -14,7 +17,6 @@
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @alloc_then_alloc
   // CHECK: ttng.tmem_alloc
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
   tt.func @alloc_then_alloc(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -24,7 +26,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_ld
   // CHECK: ttng.tmem_alloc
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_load
   tt.func @alloc_then_ld(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -34,7 +35,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_st
   // CHECK: ttng.tmem_alloc
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @alloc_then_st(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
@@ -62,7 +62,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_alloc
   // CHECK: ttng.tmem_load
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
   tt.func @ld_then_alloc(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -85,7 +84,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @ld_then_st
   // CHECK: ttng.tmem_load
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @ld_then_st(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
@@ -128,7 +126,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_ld
   // CHECK: ttng.tmem_store
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_load
   tt.func @st_then_ld(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
@@ -141,7 +138,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @st_then_st
   // CHECK: ttng.tmem_store
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @st_then_st(%arg0: tensor<128x128xf32, #blocked>) {
     %true = arith.constant true
@@ -259,7 +255,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: @ld_then_alloc_then_st_aliases_second_row
   // CHECK: ttng.tmem_load
   // CHECK-NEXT: ttng.tmem_alloc
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
   tt.func @ld_then_alloc_then_st_aliases_second_row(%arg0: tensor<64x128xf32, #linear64>) {
     %true = arith.constant true
@@ -273,7 +268,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
   // CHECK-LABEL: @alloc_then_alloc_partial_overlap
   // CHECK: ttng.tmem_alloc
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_alloc
   tt.func @alloc_then_alloc_partial_overlap(%arg0: tensor<128x128xf32, #blocked>) {
     %0 = ttng.tmem_alloc %arg0 {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : (tensor<128x128xf32, #blocked>) -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -403,11 +397,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
-  // Overlapping subslices of one allocation still need the barrier.
+  // Identical subslices do not need a CTA barrier when the same warp owns
+  // both accesses to every overlapping element.
   // CHECK-LABEL: @ld_then_st_overlapping_subslices
   // CHECK: ttng.tmem_load
-  // CHECK-NEXT: ttg.barrier local
   // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
   tt.func @ld_then_st_overlapping_subslices(%arg0: tensor<128x64xf32, #blocked>) {
     %true = arith.constant true
     %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
@@ -436,6 +431,153 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     %wr = ttg.memdesc_index %v[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+  // CHECK-LABEL: @ld_then_st_block_m64
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_block_m64(%arg0: tensor<64x128xf32, #linear64>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %1 = ttng.tmem_load %0 : !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear64>
+    ttng.tmem_store %arg0, %0, %true : tensor<64x128xf32, #linear64> -> !ttg.memdesc<64x128xf32, #tmem64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A proper-subset overlap is warp-local when each store warp only touches
+  // addresses read by the same load warp.
+  // CHECK-LABEL: @ld_then_st_same_warp_subset
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_same_warp_subset(
+      %arg0: tensor<128x64xf32, #blocked64>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable, 128x128>
+    ttg.barrier local
+    %2 = ttng.tmem_load %0 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %1, %true : tensor<128x64xf32, #blocked64> -> !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable, 128x128>
+    tt.return
+  }
+
+  // CHECK-LABEL: @ld_then_st_reinterpret
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_reinterpret(%arg0: tensor<128x128xf16, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable>
+    %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %2 = ttng.tmem_load %1 : !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf16, #blocked>
+    ttng.tmem_store %arg0, %1, %true : tensor<128x128xf16, #blocked> -> !ttg.memdesc<128x128xf16, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @unknown_argument_source
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @unknown_argument_source(
+      %arg0: tensor<128x128xf32, #blocked>,
+      %arg1: !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_load %arg1 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %arg1, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @mixed_loop_source
+  // CHECK: ttng.tmem_store
+  // CHECK: scf.for
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_load
+  tt.func @mixed_loop_source(%arg0: tensor<128x128xf32, #blocked>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %arg0, %0, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %2 = scf.for %arg1 = %c0 to %c1 step %c1 iter_args(%arg2 = %0) -> (!ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>) {
+      scf.yield %1 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    }
+    %3 = ttng.tmem_load %2 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @scale_stores_are_per_warp
+  // CHECK: ttng.tmem_store
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @scale_stores_are_per_warp(
+      %arg0: tensor<128x1xi8, #blocked_scales>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x1xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    ttng.tmem_store %arg0, %0, %true : tensor<128x1xi8, #blocked_scales> -> !ttg.memdesc<128x1xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %arg0, %0, %true : tensor<128x1xi8, #blocked_scales> -> !ttg.memdesc<128x1xi8, #tmem_scales, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: @multiple_warp_scope_writers
+  // CHECK: ttg.warp_specialize
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_load
+  tt.func @multiple_warp_scope_writers(
+      %arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.warp_specialize(%0, %arg0)
+    default {
+      ttng.tmem_store %arg0, %0, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>, %arg2: tensor<128x128xf32, #blocked>) num_warps(4) {
+      %true_0 = arith.constant true
+      ttng.tmem_store %arg2, %arg1, %true_0 : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>, tensor<128x128xf32, #blocked>) -> ()
+    %1 = ttng.tmem_load %0 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    tt.return
+  }
+
+  // CHECK-LABEL: @single_warp_scope_capture
+  // CHECK: partition0
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @single_warp_scope_capture(
+      %arg0: tensor<128x128xf32, #blocked>) {
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.warp_specialize(%0, %arg0)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%arg1: !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>, %arg2: tensor<128x128xf32, #blocked>) num_warps(4) {
+      %true = arith.constant true
+      %1 = ttng.tmem_load %arg1 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+      ttng.tmem_store %arg2, %arg1, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>, tensor<128x128xf32, #blocked>) -> ()
+    tt.return
+  }
+}
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // The full load gives warp 0 columns [0, 64), while the subslice store gives
+  // warp 4 columns [32, 64) in the same rows. Keep the CTA barrier because a
+  // different warp owns part of the overlapping region.
+  // CHECK-LABEL: @ld_then_st_cross_warp_overlap_8warps
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_cross_warp_overlap_8warps(
+      %arg0: tensor<128x64xf32, #blocked64_8>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable, 128x128>
+    ttg.barrier local
+    %2 = ttng.tmem_load %0 : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked8>
+    ttng.tmem_store %arg0, %1, %true : tensor<128x64xf32, #blocked64_8> -> !ttg.memdesc<128x64xf32, #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>, #ttng.tensor_memory, mutable, 128x128>
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -91,9 +91,9 @@ recognizes the `scf.while` outer loop (same doc).
 | `WarpSpecialization.cpp` | `NVGPUWarpSpecialization` | Top-level pipeline orchestration |
 | `SinkBroadcast.cpp` | `nvgpu-sink-broadcast` | Pre-partition peephole that sinks `tt.broadcast` producer chains to elementwise users |
 | `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes), including ordered-subset-carry `scf.while`. See [PartitionSchedulingMeta.md](PartitionSchedulingMeta.md); downstream dynamic/CLC validation is tracked in [WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md) |
-| `../../Analyze2CTADependencies.cpp` | `nvgpu-analyze-2cta-dependencies` | Classifies dependent 2-CTA MMA operand chains as collective contractions or peer gathers before AutoWS; see [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
-| `../../Plan2CTAExchange.cpp` | `nvgpu-plan-2cta-exchange` | Inserts an abstract peer-gather SSA dependency before AutoWS scheduling and memory planning |
-| `../../Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining to local stores and async peer stores completed on the existing AutoWS full barrier |
+| `Analyze2CTADependencies.cpp` | `nvgpu-analyze-2cta-dependencies` | Classifies dependent 2-CTA MMA operand chains as collective contractions or peer gathers before AutoWS; see [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
+| `Plan2CTAExchange.cpp` | `nvgpu-plan-2cta-exchange` | Inserts an abstract peer-gather SSA dependency before AutoWS scheduling and memory planning |
+| `Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining to local stores and async peer stores completed on the existing AutoWS full barrier |
 | (frontend) | `tl.range` / `tl.condition` → `tt.*` loop attrs | The user-facing AutoWS/pipelining annotations, their IR attributes and consumers, and what works on `scf.while` today: [AutoWSAnnotations.md](AutoWSAnnotations.md) |
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |
@@ -105,7 +105,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSBuffer.cpp` | `appendAccumCntsForOps` | Accumulation counter infrastructure for multi-buffer indexing |
 | `WSMemoryPlanner.cpp` | `doMemoryPlanner` | Plans SMEM and TMEM allocation (multi-buffering, liveness) |
 | `WSCodePartition.cpp` | `doCodePartition` | Creates channels, inserts async copies and barriers |
-| `Pipeliner/PartitionLoopPeeling.cpp` | `peelPartitionLoops` | After scheduled-load lowering, peels a partition-local first iteration when `iv < lb + step`, folding the masked prologue and unmasked remainder predicates |
+| `PartitionLoopPeeling.cpp` | `peelPartitionLoops` | After scheduled-load lowering, peels a partition-local first iteration when `iv < lb + step`, folding the masked prologue and unmasked remainder predicates |
 | `WSLowerMem.cpp` | `doConvertDescriptorLoadsToNVWS` / `optimizeTMALoads` | Converts `tt.descriptor_load` to buffered `nvws.descriptor_load` before buffer hoisting, then lowers it to async TMA copies after planning |
 | `WSSpecialize.cpp` | `specializeRegion` | Clones ops into `ttg.WarpSpecializeOp` regions |
 | `WSLowerToken.cpp` | `doTokenLowering` | Lowers `ProducerAcquireOp`/`ConsumerWaitOp` to hardware barriers |
@@ -114,6 +114,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSTMAStoreLowering.cpp` | `doValidateTMAStoreAnnotations` | Safety check: strip invalid annotations |
 | `WSTMAStoreLowering.cpp` | `doTMAStoreWaitReorder` | Reschedule TMA store waits using SWP CoarseSchedule |
 | `TMEMAlloc1D.cpp` | `TMEM1DAllocator` | 1D tensor memory allocation for cross-partition values |
+| `TMemBarrierInsertion.cpp` | `triton-nvidia-gpu-tmem-barrier-insertion` | Inserts CTA barriers for TMEM reuse and elides hazards proven warp-local; see [TMEMBarrierInsertion.md](TMEMBarrierInsertion.md) |
 | `CodePartitionUtility.cpp` | — | Channel data structures, operand D handling, barrier fusion, buffer management |
 | `Utility.cpp` | — | `AsyncTaskId` helpers, `OpBuilderWithAsyncTaskIds` |
 
@@ -126,7 +127,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `CodePartitionUtility.h` | `Channel`, `AllocChannel`, `TmemAllocChannel`, `ReuseGroup`, `ReuseConfig`, `CommChannel` |
 | `TMEMUtils.h` | `TMEM1DAllocator`, `sliceAndReinterpretMDTMEM`, `createTMEMDesc` |
 | `WSBarrierAnalysis.h` | `WSBarrierAttr`, `buildChannelGraph`, `buildWSBarrierOrderedRegionRanges`, `injectChannelGraph` — channel graph and ordered-region construction for barrier constraints |
-| `nvidia/hopper/include/Transforms/WSBarrierReorder.h` | `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations` — barrier reordering utilities consumed by `InterleaveTMem` |
+| `WSBarrierReorder.h` | `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations` — barrier reordering utilities consumed by `InterleaveTMem` |
 
 ## Glossary
 
@@ -158,6 +159,7 @@ recognizes the `scf.while` outer loop (same doc).
 - [Accumulation Counters](AccumulationCounters.md) — accumulation counter infrastructure for multi-buffering
 - [Operand D Handling](OperandDHandling.md) — MMA accumulator lifecycle through WS
 - [TMEM Allocation Heuristics](TMEMAllocationHeuristics.md) — TMEM memory planning algorithms
+- [TMEM Barrier Insertion](TMEMBarrierInsertion.md) — physical-address ownership rules for warp-local barrier elision
 - [SMEM Allocation Design](SmemAllocationDesign.md) — SMEM budget-aware allocation
 - [Memory Planner Search](MemoryPlannerSearch.md) — high-level guide to the TMEM/SMEM plan-space allocator (heuristics → search → post-pass, module seams, knobs)
 - [Barrier Fusion](BarrierFusion.md) — TMA fusion, tcgen05_commit combining

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMBarrierInsertion.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMBarrierInsertion.md
@@ -1,0 +1,73 @@
+# TMEM Barrier Insertion
+
+`triton-nvidia-gpu-tmem-barrier-insertion` orders accesses to aliased physical
+tensor memory. It normally inserts a CTA barrier for read-after-write,
+write-after-read, and write-after-write hazards. A CTA barrier is unnecessary
+when the hazard is entirely warp-local because program order and the
+`tcgen05.wait::{ld,st}` emitted by lowering already order each warp's accesses.
+
+## Warp-local safety rule
+
+For two candidate accesses, let `A[w]` and `B[w]` be the sets of physical TMEM
+words touched by warp `w`. The barrier can be omitted exactly when the accesses
+have the same warp scope and:
+
+```
+A[i] intersect B[j] is empty for every i != j
+```
+
+The regions owned by the same warp do not need to be identical. For example,
+`A[0] = [0, 64)` followed by `B[0] = [0, 32)` is safe if no other warp in `B`
+touches `[0, 64)`. It is unsafe if, for example, `B[4] = [32, 64)`, because
+warp 4 would overwrite words that warp 0 may still be reading.
+
+This rule also permits completely disjoint accesses. It does not require an
+overlap to justify removing a barrier; it only rejects cross-warp overlap.
+
+## Address model
+
+The analysis resolves each access to a statically known allocation address,
+including offsets introduced by `ttng.tmem_subslice` and transparent
+`ttg.memdesc_reinterpret` views. Captures into a warp-specialized partition are
+traced back to the captured descriptor.
+
+For each warp, it enumerates every physical word touched by every lowered TMEM
+message. The message footprint is the instruction atom composed with its
+register-vector repeat factor. This distinction matters when more than four
+warps split a tensor along columns: recording only the first atom would
+under-approximate the footprint and could miss a real cross-warp hazard.
+
+The pass keeps the CTA barrier conservatively when it cannot resolve the
+allocation, layout, warp count, or warp scope, and for MMA or TMEM-copy hazards
+whose execution model is not represented as one independent instruction stream
+per warp.
+
+## Examples
+
+With four warps split along rows, a full 128-column load followed by a
+64-column subslice store can be warp-local:
+
+```
+load warp 0:  rows [0, 32), columns [0, 128)
+store warp 0: rows [0, 32), columns [0, 64)
+```
+
+The store region is a proper subset of the same warp's load region and no
+different warp overlaps it.
+
+With eight warps split across rows and columns, the same shapes can require a
+CTA barrier:
+
+```
+full load warp 0:      rows [0, 32), columns [0, 64)
+subslice store warp 4: rows [0, 32), columns [32, 64)
+```
+
+The physical intersection is owned by different warps, so warp-local ordering
+is insufficient.
+
+## Tests
+
+`test/TritonNvidiaGPU/tmem_barrier_insertion.mlir` covers same-warp equal and
+proper-subset regions, the eight-warp cross-owner counterexample, descriptor
+reinterpretation, and conservative fallbacks.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -355,6 +355,12 @@ std::pair<SmallVector<Value>, SmallVector<Value>> lowerTMemLdSt(
   auto kRow = str_attr("row");
   bool isStore = !vals.empty();
 
+  auto messageLayout =
+      getTMemLdStMessageLayout(ctx, atom, unpacked, valsPerMessage);
+  assert(succeeded(messageLayout) &&
+         messageLayout->getInDimSize(kReg) == valsPerMessage &&
+         "invalid TMEM message footprint");
+
   tmemBase = b.ptrtoint(i32_ty, tmemBase);
 
   assert(to_vector(reps.getOutDimNames()) ==
@@ -367,7 +373,9 @@ std::pair<SmallVector<Value>, SmallVector<Value>> lowerTMemLdSt(
   };
 
   Value warpId = WarpIdOp::create(rewriter, loc);
-  // Map warpId to rows 32 and 64
+  // Keep this warp-base calculation synchronized with
+  // getTMemLdStWarpAddresses.
+  // Map warpId to rows 32 and 64.
   auto warpIdInGroup = b.and_(warpId, b.i32_val(3));
   tmemBase = b.add(tmemBase, b.shl(warpIdInGroup, b.i32_val(5 + 16)));
   // The block offset is already added to the tmemBase


### PR DESCRIPTION
Summary:

`TMemBarrierInsertion` inserts CTA-wide barriers for aliasing TMEM WAR, RAW, and WAW hazards. Those barriers are unnecessary when both endpoints are issued independently by each warp and every physical address is owned by the same warp at both endpoints.

This diff adds `getTMemLdStWarpAddresses`, which derives each warp's physical TMEM word offsets from the same instruction atom, repetition layout, warp offsets, and second-half offset used by load/store lowering. The barrier pass combines those offsets with the resolved allocation and subview base, then elides synchronization only when no address can be touched by different warps across the two operations.

The analysis is conservative about provenance and execution scope. It supports direct allocations, TMEM subslices, reinterpret views, and unambiguous warp-specialization captures. Control-flow merges, unknown block arguments, unsupported views, and accesses in different warp-specialization regions retain the CTA barrier. MMA and `tmem_copy` remain outside the per-warp path and keep their existing barriers.

Authored with Claude Code.

Reviewed By: manman-ren

Differential Revision: D117364686
