### PR TITLE
[AutoWS] Serialize data-partitioned forward correction chains

### DIFF
--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -19,12 +19,22 @@ inline constexpr StringLiteral kDataPartitionFactorAttrName =
 // and, optionally, the channels the operands travel through, e.g.
 //   {"stage": "0", "order": "2", "channels": ["opndD,tmem,1,0"]}
 // The names below are the single source of truth for everyone who reads or
-// writes that annotation (ScheduleLoops, AssignLatencies, WSMemoryPlanner).
+// writes that annotation (ScheduleLoops, AssignLatencies, WSMemoryPlanner,
+// WSDataPartition).
 inline constexpr StringLiteral kAutoWSAnnotationAttrName = "tt.autows";
 inline constexpr StringLiteral kAutoWSStageKey = "stage";
 inline constexpr StringLiteral kAutoWSOrderKey = "order";
 inline constexpr StringLiteral kAutoWSChannelsKey = "channels";
 inline constexpr StringLiteral kAutoWSOperandDTag = "opndD";
+
+// Each entry of the "channels" array is a comma-separated string laid out as
+//   operand,memory,copies,bufferId[,extra]
+// e.g. "opndA,tmem,1,2,64" or "opndD,tmem,1,7". Readers split on ',' and index
+// the buffer id positionally, so the layout is recorded here next to the keys
+// rather than as a bare literal at each parse site.
+inline constexpr unsigned kAutoWSChannelBufferIdField = 3;
+inline constexpr unsigned kAutoWSChannelMinFields = 4;
+inline constexpr unsigned kAutoWSChannelMaxFields = 5;
 
 enum class AutoWSLoopAttrPropagation {
   NotForwarded,

--- a/test/Hopper/WarpSpecialization/blackwell_ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_ws_data_partition.mlir
@@ -58,7 +58,19 @@ module attributes {ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i
         %v_j_load_18 = ttg.local_alloc %v_j_load : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
         %permute = ttg.local_alloc %k_j_load : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
         %permute_19 = ttg.memdesc_trans %permute {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared2, #smem> -> !ttg.memdesc<128x128xbf16, #shared3, #smem>
-        // CHECK-COUNT-2: ttng.tc_gen5_mma
+        // Data partition 0 must complete its qK/correction/PV chain before
+        // data partition 1 begins. Interleaving the two independent correction
+        // chains doubles their live ranges and spills both accumulator halves.
+        // CHECK: ttng.tc_gen5_mma
+        // CHECK: ttng.tmem_load
+        // CHECK: ttng.tmem_load
+        // CHECK: ttng.tmem_store
+        // CHECK: ttng.tc_gen5_mma
+        // CHECK: ttng.tc_gen5_mma
+        // CHECK: ttng.tmem_load
+        // CHECK: ttng.tmem_load
+        // CHECK: ttng.tmem_store
+        // CHECK: ttng.tc_gen5_mma
         %qk_20 = ttng.tc_gen5_mma %q_i_load_5, %permute_19, %qk[%qk_16], %false, %true : !ttg.memdesc<256x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xbf16, #shared3, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
         %qk_21, %qk_22 = ttng.tmem_load %qk[%qk_20] : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #blocked>
         %amax = "tt.reduce"(%qk_21) <{axis = 1 : i32}> ({
@@ -98,7 +110,6 @@ module attributes {ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i
         %v_13 = arith.truncf %v_10 : tensor<256x128xf32, #blocked> to tensor<256x128xbf16, #blocked>
         %acc_33 = ttng.tmem_alloc %v_13 : (tensor<256x128xbf16, #blocked>) -> !ttg.memdesc<256x128xbf16, #tmem1, #ttng.tensor_memory>
         %acc_34 = ttng.tmem_store %inline_triton_result_3_32, %acc[%acc_27], %true : tensor<256x128xf32, #blocked> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
-        // CHECK-COUNT-2: ttng.tc_gen5_mma
         %acc_35 = ttng.tc_gen5_mma %acc_33, %v_j_load_18, %acc[%acc_34], %true, %true : !ttg.memdesc<256x128xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
         %v_14 = arith.mulf %arg8, %v_12 : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
         %v_3 = arith.addf %v_14, %l_ij : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -18,18 +18,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %2 = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
       %3 = tt.splat %arg1 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<64x256x!tt.ptr<f16>, #blocked1>
       %4:2 = scf.for %arg7 = %c0_i32 to %arg4 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+        // The shared B load and both sliced A loads are emitted first (they
+        // carry no partition id, or B is shared by both), then each partition's
+        // alloc+dot chain in turn.  Bind everything by SSA value so the pairing
+        // -- each dot consumes its own A slice and the one shared B -- is still
+        // checked even though the ops are no longer adjacent.
+        // CHECK: %[[#GB:]] = tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>
         // CHECK: %[[#GA1:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
         // CHECK: %[[#GA2:]] = tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
-        // After reordering, B load is moved right after A loads:
-        // CHECK: %[[#GB:]] = tt.load {{.*}} : tensor<64x256x!tt.ptr<f16>
         %8 = tt.load %2 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
+        // CHECK: %[[#LB:]] = ttg.local_alloc %[[#GB]]
         // CHECK: %[[#LA1:]] = ttg.local_alloc %[[#GA1]]
-        // CHECK: %[[#LA2:]] = ttg.local_alloc %[[#GA2]]
         %9 = ttg.local_alloc %8 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
         %10 = tt.load %3 {async_task_id = array<i32: 0>} : tensor<64x256x!tt.ptr<f16>, #blocked1>
-        // CHECK: %[[#LB:]] = ttg.local_alloc %[[#GB]]
         %11 = ttg.local_alloc %10 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
         // CHECK: %[[#C1:]] = ttng.warp_group_dot %[[#LA1]], %[[#LB]], {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
+        // CHECK: %[[#LA2:]] = ttg.local_alloc %[[#GA2]]
         // CHECK: %[[#C2:]] = ttng.warp_group_dot %[[#LA2]], %[[#LB]], {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
         %12 = ttng.warp_group_dot %9, %11, %arg8 {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
         %13 = arith.addi %arg9, %c64_i32 {async_task_id = array<i32: 0>} : i32
@@ -74,17 +78,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %5 = ttng.reinterpret_tensor_descriptor %arg6 {async_task_id = array<i32: 0>} : !tt.ptr<i8> to !tt.tensordesc<128x128xbf16>
     %6 = ttng.reinterpret_tensor_descriptor %arg6 {async_task_id = array<i32: 0>} : !tt.ptr<i8> to !tt.tensordesc<128x128xbf16>
     %7 = ttng.reinterpret_tensor_descriptor %arg6 {async_task_id = array<i32: 0>} : !tt.ptr<i8> to !tt.tensordesc<128x128xbf16>
-    // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
-    // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
+    // CHECK: tt.descriptor_load {{.*}} -> tensor<128x128xbf16
     %8 = tt.descriptor_load %4[%0, %1] {async_task_id = array<i32: 0>} : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #blocked1>
     %9 = ttg.local_alloc %8 {async_task_id = array<i32: 1, 2>} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
-    // CHECK: tt.descriptor_load {{.*}} -> tensor<128x128xbf16
     %10 = tt.descriptor_load %5[%1, %1] {async_task_id = array<i32: 0>} : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #blocked1>
     %11 = ttg.local_alloc %10 {async_task_id = array<i32: 1, 2>} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
-    // After reordering, second dot's loads are also moved before first dot:
+    // Each partition now runs its whole chain -- both sliced loads, the first
+    // dot, the transpose and the second dot -- before the other partition
+    // starts, instead of hoisting all four sliced loads ahead of both dots.
     // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
     // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
-    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x128xbf16, {{.*}} * !ttg.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
     // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x128xbf16, {{.*}} * !ttg.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
      %12 = ttng.warp_group_dot %9, %11, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem> * !ttg.memdesc<128x128xbf16, #shared, #smem> -> tensor<128x128xf32, #mma>
     %13 = arith.truncf %12 {async_task_id = array<i32: 1, 2>} : tensor<128x128xf32, #mma> to tensor<128x128xbf16, #mma>
@@ -93,6 +96,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %16 = ttg.local_alloc %15 {async_task_id = array<i32: 1, 2>} : (tensor<128x128xbf16, #blocked1>) -> !ttg.memdesc<128x128xbf16, #shared, #smem>
     %17 = ttg.memdesc_trans %16 {async_task_id = array<i32: 1, 2>, order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared1, #smem>
     // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<128x64xbf16, {{.*}} * !ttg.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
+    // Second partition's chain.
+    // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
+    // CHECK: tt.descriptor_load {{.*}} -> tensor<64x128xbf16
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x128xbf16, {{.*}} * !ttg.memdesc<128x128xbf16, {{.*}} -> tensor<64x128xf32, {{.*}}
     // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<128x64xbf16, {{.*}} * !ttg.memdesc<64x128xbf16, {{.*}} -> tensor<128x128xf32, {{.*}}
     %18 = ttng.warp_group_dot %17, %14, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x128xbf16, #shared1, #smem> * !ttg.memdesc<128x128xbf16, #shared, #smem> -> tensor<128x128xf32, #mma>
     %19 = ttg.convert_layout %18 {async_task_id = array<i32: 1, 2>} : tensor<128x128xf32, #mma> -> tensor<128x128xf32, #blocked>
@@ -106,10 +113,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// Test that loads are reordered by first-use position after data partitioning.
-// B's descriptor_load appears before A's, but A's local_alloc appears before
-// B's. After partitioning, loads should be reordered to A0, A1, B because
-// A's partitioned local_allocs (the first uses of A0/A1) precede B's.
+// Test how loads are ordered after data partitioning. B's descriptor_load
+// appears before A's, but A's local_alloc appears before B's. The first-use
+// reorder would put A0, A1, B; the per-partition grouping that runs after it
+// takes precedence, and since B is shared by both partitions (no
+// tt.data_partition_id) it sorts ahead of the two sliced A loads. Each
+// partition's alloc+dot chain then follows in turn.
 // CHECK-LABEL: @reorder_loads_to_first_use
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
@@ -131,10 +140,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
         // A's local_alloc comes before B's local_alloc.
         %9 = ttg.local_alloc %8 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
         %11 = ttg.local_alloc %10 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
-        // After reordering, A loads (split) should appear before B load:
-        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
-        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
+        // Shared B first, then the two sliced A loads, then each partition's
+        // alloc+dot chain.
         // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16
+        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
+        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
         // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
         // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
         %12 = ttng.warp_group_dot %9, %11, %arg8 {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
@@ -170,13 +180,14 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %1 = tt.get_num_programs x {async_task_id = array<i32: 0, 1, 2>} : i32
     scf.for %arg6 = %0 to %arg3 step %1  : i32 {
       %4:2 = scf.for %arg7 = %c0_i32 to %arg4 step %c1_i32 iter_args(%arg8 = %cst, %arg9 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+        // B is not partitioned (partition is along M dim), so it sorts ahead of
+        // the two sliced A loads:
+        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16
         // Two descriptor_load ops should be created from slicing A:
         // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
         // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
         %8 = tt.descriptor_load %desc_a[%0, %arg9] {async_task_id = array<i32: 0>} : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16, #blocked>
         %9 = ttg.local_alloc %8 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-        // B is not partitioned (partition is along M dim):
-        // CHECK: tt.descriptor_load {{.*}} : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16
         %10 = tt.descriptor_load %desc_b[%arg9, %0] {async_task_id = array<i32: 0>} : !tt.tensordesc<64x256xf16> -> tensor<64x256xf16, #blocked1>
         %11 = ttg.local_alloc %10 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
         // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
@@ -187,8 +198,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %5 = arith.truncf %4#0 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
       %6 = ttg.convert_layout %5 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
       %7 = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
-      // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
-      // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+      // The printed layout alias depends on first-use order, which the
+      // per-partition grouping changes; match either numbering.
+      // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, {{#blocked[0-9]*}}>
+      // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, {{#blocked[0-9]*}}>
       tt.store %7, %6 {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
     } {tt.data_partition_factor = 2 : i32}
     tt.return
@@ -210,35 +223,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   tt.func public @test_split_join_reshape_trans_partition(%arg0: !tt.ptr<f16>, %arg1: tensor<64x256xf16, #blocked1>, %arg2: !tt.ptr<f16>) {
     %cst = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>
     %ptr = tt.splat %arg0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<64x128x!tt.ptr<f16>, #blockedT>
-    // CHECK: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>,
+    // Each partition's whole chain is emitted before the other's, so the ops
+    // appear once per partition in program order rather than pairwise.
     // CHECK: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>,
     %ld = tt.load %ptr {async_task_id = array<i32: 0>} : tensor<64x128x!tt.ptr<f16>, #blockedT>
     // CHECK: tt.trans {{.*}} : tensor<64x64xf16,
-    // CHECK: tt.trans {{.*}} : tensor<64x64xf16,
     %t0 = tt.trans %ld {async_task_id = array<i32: 0>, order = array<i32: 1, 0>} : tensor<64x128xf16, #blockedT> -> tensor<128x64xf16, #blocked>
-    // CHECK: tt.reshape {{.*}} : tensor<64x64xf16,
     // CHECK: tt.reshape {{.*}} : tensor<64x64xf16,
     %r0 = tt.reshape %t0 allow_reorder {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked> -> tensor<128x64x1xf16, #blocked2>
     // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
-    // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
     %r1 = tt.reshape %r0 allow_reorder {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x1xf16, #blocked2> -> tensor<128x64xf16, #blocked>
-    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
     // CHECK: tt.join {{.*}} : tensor<64x64xf16,
     %0 = tt.join %r1, %r1 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64xf16, #blocked> -> tensor<128x64x2xf16, #blocked2>
     // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
-    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
     %1:2 = tt.split %0 {async_task_id = array<i32: 0, 1, 2>} : tensor<128x64x2xf16, #blocked2> -> tensor<128x64xf16, #blocked>
-    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
     // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
     %2 = ttg.local_alloc %1#0 {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %3 = ttg.local_alloc %arg1 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
-    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
     // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
     %4 = ttng.warp_group_dot %2, %3, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
     %5 = arith.truncf %4 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
     %6 = ttg.convert_layout %5 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
     %7 = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
+    // The second partition repeats the same chain.
+    // CHECK: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>,
+    // CHECK: tt.trans {{.*}} : tensor<64x64xf16,
+    // CHECK: tt.reshape {{.*}} : tensor<64x64xf16,
+    // CHECK: tt.reshape {{.*}} : tensor<64x64x1xf16,
+    // CHECK: tt.join {{.*}} : tensor<64x64xf16,
+    // CHECK: tt.split {{.*}} : tensor<64x64x2xf16,
+    // CHECK: ttg.local_alloc {{.*}} : (tensor<64x64xf16,
+    // CHECK: ttng.warp_group_dot {{.*}} : !ttg.memdesc<64x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<64x256xf32, #mma>
     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
     tt.store %7, %6 {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
     tt.return
@@ -267,12 +283,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %ld = tt.load %ptr {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked>
     %a = ttg.local_alloc %ld {async_task_id = array<i32: 1, 2>} : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
     %b = ttg.local_alloc %arg1 {async_task_id = array<i32: 1, 2>} : (tensor<64x256xf16, #blocked1>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
-    // CHECK: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32, #mma>
+    // Per-partition grouping: dot, map_elementwise and store for one partition,
+    // then the same chain for the other.
     // CHECK: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32, #mma>
     %dot = ttng.warp_group_dot %a, %b, %cst {async_task_id = array<i32: 1, 2>, inputPrecision = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x256xf16, #shared, #smem> -> tensor<128x256xf32, #mma>
     %mask = tt.splat %mask_val {async_task_id = array<i32: 1, 2>} : i32 -> tensor<128x256xi32, #mma>
-    // CHECK: "tt.map_elementwise"
-    // CHECK: : (tensor<64x256xf32, #mma>, tensor<64x256xi32, #mma>) -> tensor<64x256xf32, #mma>
     // CHECK: "tt.map_elementwise"
     // CHECK: : (tensor<64x256xf32, #mma>, tensor<64x256xi32, #mma>) -> tensor<64x256xf32, #mma>
     %result = "tt.map_elementwise"(%dot, %mask) <{pack = 1 : i32}> ({
@@ -285,6 +300,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %cvt = ttg.convert_layout %trunc {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
     %st_ptr = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
+    // CHECK: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32, #mma>
+    // CHECK: "tt.map_elementwise"
+    // CHECK: : (tensor<64x256xf32, #mma>, tensor<64x256xi32, #mma>) -> tensor<64x256xf32, #mma>
     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>,
     tt.store %st_ptr, %cvt {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
     tt.return

--- a/test/Hopper/WarpSpecialization/ws_data_partition_dot_k_no_atomic.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_dot_k_no_atomic.mlir
@@ -5,10 +5,8 @@
 // deterministically and choose the legal N-dimension direction here.
 
 // CHECK-LABEL: @dot_k_operand_without_atomic_store
-// CHECK: ttng.warp_group_dot
-// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
-// CHECK-SAME: !ttg.memdesc<64x128xf16, #shared, #smem>
-// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// Each partition's whole chain (both dots plus its store) is emitted before the
+// other partition's, instead of pairing the two partitions' dots by shape.
 // CHECK: ttng.warp_group_dot
 // CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
 // CHECK-SAME: !ttg.memdesc<64x128xf16, #shared, #smem>
@@ -16,6 +14,11 @@
 // CHECK: ttng.warp_group_dot
 // CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
 // CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x128xf32, #mma>
+// CHECK: tt.store
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<64x128xf16, #shared, #smem>
 // CHECK-SAME: -> tensor<128x128xf32, #mma>
 // CHECK: ttng.warp_group_dot
 // CHECK-SAME: !ttg.memdesc<128x128xf16, #shared, #smem>

--- a/test/Hopper/WarpSpecialization/ws_data_partition_scaled_memdesc_reshape_reproducer.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_scaled_memdesc_reshape_reproducer.mlir
@@ -10,15 +10,18 @@
 // CHECK-SAME: !ttg.memdesc<128x256xf32
 // CHECK: tt.descriptor_load {{.*}}!tt.tensordesc<128x128xf8E4M3FN
 // CHECK: tt.descriptor_load {{.*}}!tt.tensordesc<1x1x1x2x256xui8
-// CHECK: ttng.tmem_alloc
-// CHECK-SAME: tensor<128x4xi8
-// CHECK-SAME: !ttg.memdesc<128x4xi8
+// Each partition's scale alloc stays with its own MMA: after data
+// partitioning the clones are grouped per partition (DP0 chain, then DP1)
+// instead of hoisting both scale allocs ahead of both MMAs.
 // CHECK: ttng.tmem_alloc
 // CHECK-SAME: tensor<128x4xi8
 // CHECK-SAME: !ttg.memdesc<128x4xi8
 // CHECK: ttng.tc_gen5_mma_scaled
 // CHECK-SAME: !ttg.memdesc<128x128xf8E4M3FN
 // CHECK-SAME: !ttg.memdesc<128x256xf32
+// CHECK-SAME: !ttg.memdesc<128x4xi8
+// CHECK: ttng.tmem_alloc
+// CHECK-SAME: tensor<128x4xi8
 // CHECK-SAME: !ttg.memdesc<128x4xi8
 // CHECK: ttng.tc_gen5_mma_scaled
 // CHECK-SAME: !ttg.memdesc<128x128xf8E4M3FN

--- a/test/Hopper/WarpSpecialization/ws_data_partition_shared_const_layout.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_shared_const_layout.mlir
@@ -21,14 +21,18 @@
 // The shared 0.0 constant stays in the original (sliced) #linear layout.
 // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #linear>
 // Each partition's tmem_store gets its own *local* convert to the
-// TMEM-compatible #linear1 layout, sourced from the original constant.
-// CHECK: ttg.convert_layout %[[CST]] : tensor<128x64xf32, #linear> -> tensor<128x64xf32, #linear1>
-// CHECK: ttng.tmem_store
-// CHECK: ttg.convert_layout %[[CST]] : tensor<128x64xf32, #linear> -> tensor<128x64xf32, #linear1>
-// CHECK: ttng.tmem_store
+// TMEM-compatible #linear1 layout, sourced from the original constant. The
+// converts carry no tt.data_partition_id, so serializeDataPartitionedOps sorts
+// both of them ahead of the partitioned stores instead of leaving each next to
+// its consumer; bind them by SSA value so each store still uses its own.
+// CHECK: %[[CVT0:.*]] = ttg.convert_layout %[[CST]] : tensor<128x64xf32, #linear> -> tensor<128x64xf32, #linear1>
+// CHECK: %[[CVT1:.*]] = ttg.convert_layout %[[CST]] : tensor<128x64xf32, #linear> -> tensor<128x64xf32, #linear1>
 // Both partitioned subf ops consume the constant in the ORIGINAL #linear layout
-// (not the tmem-compatible #linear1), so operand/result encodings agree.
+// (not the tmem-compatible #linear1), so operand/result encodings agree. Each
+// partition's store/epilogue pair still stays together.
+// CHECK: ttng.tmem_store %[[CVT0]]
 // CHECK: arith.subf %[[CST]], %{{.*}} : tensor<128x64xf32, #linear>
+// CHECK: ttng.tmem_store %[[CVT1]]
 // CHECK: arith.subf %[[CST]], %{{.*}} : tensor<128x64xf32, #linear>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_data_partition_single_task_dot.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition_single_task_dot.mlir
@@ -5,18 +5,22 @@
 // unrelated dot with a single consumer task id should not be sliced merely
 // because another dot in the same function needs partitioning.
 
+// The unpartitioned dot now precedes the sliced pair: serializeDataPartitionedOps
+// groups each partition's chain, and an op with no tt.data_partition_id sorts
+// ahead of the partitioned ones. What matters here is still that it is emitted
+// once, unsliced, at its full 128x256 shape.
 // CHECK-LABEL: @single_task_dot_not_partitioned
+// CHECK: ttng.warp_group_dot
+// CHECK-SAME: {async_task_id = array<i32: 1>
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK-SAME: !ttg.memdesc<64x256xf16, #shared, #smem>
+// CHECK-SAME: -> tensor<128x256xf32, #mma>
 // CHECK: ttng.warp_group_dot
 // CHECK-SAME: {async_task_id = array<i32: 1>
 // CHECK-SAME: -> tensor<64x256xf32, #mma>
 // CHECK: ttng.warp_group_dot
 // CHECK-SAME: {async_task_id = array<i32: 2>
 // CHECK-SAME: -> tensor<64x256xf32, #mma>
-// CHECK: ttng.warp_group_dot
-// CHECK-SAME: {async_task_id = array<i32: 1>
-// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
-// CHECK-SAME: !ttg.memdesc<64x256xf16, #shared, #smem>
-// CHECK-SAME: -> tensor<128x256xf32, #mma>
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
+++ b/test/Hopper/WarpSpecialization/ws_while_loop_autows.mlir
@@ -312,9 +312,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // DATAPART-LABEL: @while_data_partition
-  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+  // Each partition's sliced load stays with its own dot (load, dot, load, dot):
+  // serializeDataPartitionedOps groups the clones per partition instead of
+  // interleaving both loads ahead of both dots.
   // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
   // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
+  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
   // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
   tt.func public @while_data_partition(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %out: !tt.ptr<f32>, %arg2: i32) {
     %true = arith.constant {async_task_id = array<i32: 0, 1, 2>} true
@@ -353,8 +356,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
   // DATAPART-LABEL: @while_descriptor_data_partition
   // DATAPART: scf.while
-  // DATAPART: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
+  // The second slice's offset advance is still materialized, now hoisted ahead
+  // of both sliced descriptor loads rather than sitting between them.
   // DATAPART: arith.addi %{{.*}}, %{{.*}} : i32
+  // DATAPART: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
   // DATAPART: tt.descriptor_load {{.*}} : !tt.tensordesc<64x64xf16> -> tensor<64x64xf16
   // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
   // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
@@ -450,13 +455,15 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // registers; the data-partition mechanics are identical for tc_gen5_mma.)
   // DATAPART-LABEL: @while_clc_data_partition
   // DATAPART: scf.while
-  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
-  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
-  // The two consumer warp groups each get an M/2 = 64 slice of the accumulator.
-  // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
-  // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
-  // The CLC advance (loop-carried valid producer, task 0) is left intact.
+  // The CLC advance (loop-carried valid producer, task 0) is left intact. It
+  // carries no partition id, so it now precedes the per-partition chains.
   // DATAPART: ttng.clc_advance
+  // The two consumer warp groups each get an M/2 = 64 slice of the accumulator,
+  // each slice's load emitted with its own dot.
+  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+  // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
+  // DATAPART: tt.load {{.*}} : tensor<64x64x!tt.ptr<f16>
+  // DATAPART: ttng.warp_group_dot {{.*}} -> tensor<64x256xf32
   tt.func public @while_clc_data_partition(%arg0: !tt.ptr<f16>, %arg1: !tt.ptr<f16>, %out: !tt.ptr<f32>) {
     %true = arith.constant {async_task_id = array<i32: 0, 1, 2>} true
     %acc_init = arith.constant {async_task_id = array<i32: 1, 2>} dense<0.000000e+00> : tensor<128x256xf32, #mma>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -3,10 +3,13 @@
 #include "mlir/Transforms/RegionUtils.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <optional>
 
@@ -21,6 +24,57 @@ namespace mlir {
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 static const char *kDataPartitionAttrName = "tt.data_partition_factor";
+static const char *kDataPartitionIdAttrName = "tt.data_partition_id";
+
+static void remapAutoWSBufferIds(Operation *op, unsigned partition,
+                                 unsigned numPartitions) {
+  auto attr = op->getAttrOfType<StringAttr>(kAutoWSAnnotationAttrName);
+  if (!attr)
+    return;
+  auto parsed = llvm::json::parse(attr.getValue());
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    return;
+  }
+  auto *object = parsed->getAsObject();
+  auto *channels = object ? object->getArray(kAutoWSChannelsKey) : nullptr;
+  if (!channels)
+    return;
+
+  bool changed = false;
+  for (llvm::json::Value &channel : *channels) {
+    auto channelString = channel.getAsString();
+    if (!channelString)
+      continue;
+    SmallVector<StringRef, 5> fields;
+    StringRef(*channelString).split(fields, ',');
+    if (fields.size() != kAutoWSChannelMinFields &&
+        fields.size() != kAutoWSChannelMaxFields)
+      continue;
+    unsigned oldId;
+    if (fields[kAutoWSChannelBufferIdField].getAsInteger(10, oldId))
+      continue;
+    SmallVector<std::string, 5> remappedFields;
+    remappedFields.reserve(fields.size());
+    for (auto [index, field] : llvm::enumerate(fields)) {
+      if (index == kAutoWSChannelBufferIdField)
+        remappedFields.push_back(
+            std::to_string(oldId * numPartitions + partition));
+      else
+        remappedFields.push_back(field.str());
+    }
+    channel = llvm::join(remappedFields, ",");
+    changed = true;
+  }
+  if (!changed)
+    return;
+
+  std::string serialized;
+  llvm::raw_string_ostream stream(serialized);
+  stream << *parsed;
+  op->setAttr(kAutoWSAnnotationAttrName,
+              StringAttr::get(op->getContext(), stream.str()));
+}
 
 static bool containsAll(const SmallVector<AsyncTaskId> &superset,
                         const SmallVector<AsyncTaskId> &subset) {
@@ -1273,6 +1327,9 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     builder.setInsertionPoint(op);
     auto newOp = builder.clone(*op, mappings);
     setAsyncTaskIds(newOp, sliceTaskIds);
+    newOp->setAttr(kDataPartitionIdAttrName, builder.getI32IntegerAttr(offset));
+    if (numOfPartitions > 1 && isDotOrMMAv5Op(newOp))
+      remapAutoWSBufferIds(newOp, offset, numOfPartitions);
     if (numOfPartitions > 1 && isa<LocalAllocOp, ttng::TMEMAllocOp>(newOp)) {
       newOp->setLoc(appendToNameLoc(
           newOp->getLoc(), "_" + std::to_string(offset), op->getContext()));
@@ -2020,6 +2077,14 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     llvm_unreachable("unsupported op type");
   }
 
+  // Some slicing paths construct the replacement explicitly rather than via
+  // cloneAndSetResultType (notably TMEM loads, transposes, and ranges).  Mark
+  // every replacement uniformly so the post-slice scheduler can serialize
+  // the complete partition chain instead of hoisting unmarked TMEM loads from
+  // both partitions together.
+  if (newOp != op)
+    newOp->setAttr(kDataPartitionIdAttrName, builder.getI32IntegerAttr(offset));
+
   LLVM_DEBUG({
     LDBG("resulting");
     newOp->dump();
@@ -2261,6 +2326,117 @@ static void reorderLoadsToFirstUse(triton::FuncOp &funcOp) {
   });
 }
 
+// Recursive slicing inserts each clone beside its source operation.  With two
+// data partitions this leaves independent chains interleaved operation by
+// operation, extending the live ranges of both partitions.  In FA forward the
+// correction task then holds both BM256 accumulator halves live and ptxas
+// spills them.  Group the clones by partition while the graph is still purely
+// data-partitioned, before scheduling and channel construction capture any
+// operation identities.  This matches TLX's complete DP0-then-DP1 execution.
+static void serializeDataPartitionedOps(triton::FuncOp &funcOp) {
+  funcOp.walk([&](Block *block) {
+    // Do not move a region-owning control-flow operation relative to values
+    // used only inside its nested regions: those captures are not explicit
+    // SSA operands of the parent op.  The profitable FA correction block has
+    // only straight-line tensor operations (tt.reduce regions are explicit
+    // dataflow ops), while entry/outer blocks contain scf control flow.
+    if (llvm::any_of(*block, [](Operation &op) {
+          return isa<LoopLikeOpInterface, scf::IfOp>(&op);
+        }))
+      return;
+
+    DenseMap<Operation *, unsigned> originalOrder;
+    DenseMap<Operation *, int64_t> partitionId;
+    unsigned index = 0;
+    for (Operation &op : *block) {
+      originalOrder[&op] = index++;
+      if (auto id = op.getAttrOfType<IntegerAttr>(kDataPartitionIdAttrName))
+        partitionId[&op] = id.getInt();
+    }
+
+    DenseSet<int64_t> ids;
+    for (auto [op, id] : partitionId)
+      ids.insert(id);
+    if (ids.size() < 2)
+      return;
+
+    // Auxiliary layout conversions are sometimes built explicitly instead of
+    // through cloneAndSetResultType.  Infer their partition from a unique
+    // marked operand so users move with their producer.
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (Operation &blockOp : *block) {
+        Operation *op = &blockOp;
+        if (partitionId.count(op) || op->hasTrait<OpTrait::IsTerminator>())
+          continue;
+        std::optional<int64_t> inferred;
+        bool conflicting = false;
+        for (Value operand : op->getOperands()) {
+          Operation *def = operand.getDefiningOp();
+          auto it = def ? partitionId.find(def) : partitionId.end();
+          if (it == partitionId.end())
+            continue;
+          if (inferred && *inferred != it->second) {
+            conflicting = true;
+            break;
+          }
+          inferred = it->second;
+        }
+        if (inferred && !conflicting) {
+          partitionId[op] = *inferred;
+          changed = true;
+        }
+      }
+    }
+
+    // Rebuild the whole block, not just marked operations.  Region-bearing
+    // operations such as tt.reduce and shared scalar/layout adapters can be
+    // definitions or users of a marked value.  Keeping them in the
+    // topological schedule guarantees SSA dominance while the partition id is
+    // still the primary ordering key whenever dependencies permit it.
+    SmallVector<Operation *> candidates;
+    for (Operation &op : *block) {
+      if (!op.hasTrait<OpTrait::IsTerminator>())
+        candidates.push_back(&op);
+    }
+    DenseSet<Operation *> candidateSet(candidates.begin(), candidates.end());
+    DenseSet<Operation *> emitted;
+    SmallVector<Operation *> ordered;
+    ordered.reserve(candidates.size());
+    while (ordered.size() != candidates.size()) {
+      Operation *best = nullptr;
+      auto key = [&](Operation *op) {
+        int64_t id = partitionId.count(op) ? partitionId.lookup(op) : -1;
+        return std::pair(id, originalOrder.lookup(op));
+      };
+      for (Operation *candidate : candidates) {
+        if (emitted.contains(candidate))
+          continue;
+        bool ready = llvm::all_of(candidate->getOperands(), [&](Value operand) {
+          Operation *def = operand.getDefiningOp();
+          return !def || !candidateSet.contains(def) || emitted.contains(def);
+        });
+        if (ready && (!best || key(candidate) < key(best)))
+          best = candidate;
+      }
+      assert(best && "cycle while serializing data-partition operations");
+      emitted.insert(best);
+      ordered.push_back(best);
+    }
+
+    Operation *anchor = candidates.back()->getNextNode();
+    for (Operation *op : ordered) {
+      if (anchor)
+        op->moveBefore(anchor);
+      else
+        op->moveBefore(block, block->end());
+    }
+  });
+
+  funcOp.walk([&](Operation *op) { op->removeAttr(kDataPartitionIdAttrName); });
+}
+
 bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups) {
   DataPartitionScheme partitionScheme;
   partitionScheme.numPartitions = numConsumerGroups;
@@ -2340,6 +2516,8 @@ bool doDataPartition(triton::FuncOp &funcOp, unsigned numConsumerGroups) {
     LDBG("final cleanup failed");
     return false;
   }
+
+  serializeDataPartitionedOps(funcOp);
 
   // Make sure original ops are not used
   LLVM_DEBUG({


### PR DESCRIPTION
Summary:
Recursive data-partition slicing inserted every clone beside its source, so the output was ordered by original operation rather than by data partition and both accumulator halves stayed live at once in the one-warp correction task. Mark sliced replacements with a temporary DP id and topologically rebuild straight-line blocks with that id as the primary ordering key, so one partition, DP0, completes its correction chain before DP1 begins. Explicitly constructed replacements such as TMEM loads are tagged too; blocks containing scf.if or loop regions are left untouched because nested captures are not explicit parent operands.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 97da3a99b on the MetaMain2 fork.

Depends on D114254019

Reviewed By: njriasan

Differential Revision: D116999607


