### PR TITLE
[triton][beta] Annotate subtiled AutoWS barrier endpoints (#3279)

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_code_partition_subtiled_region.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_subtiled_region.mlir
@@ -1,9 +1,8 @@
 // RUN: triton-opt %s --nvgpu-test-ws-code-partition="num-buffers=1" | FileCheck %s
-// XFAIL: *
 
 // Test: Code partition with SubtiledRegionOps for epilogue subtiling.
 // Regression test for B-11-F1 / T273485415.
-// Inline consumer-side subtiled NVWS tokens must carry WSBarrier destination
+// Inline subtiled NVWS tokens must carry task IDs and WSBarrier destination
 // metadata so WSBarrierAnalysis can inject channel graph metadata.
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
@@ -20,8 +19,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
   // CHECK: partition0
   // CHECK:   ttng.subtiled_region
   // CHECK:     nvws.producer_acquire
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-SAME: dstTask = 2 : i32
   // CHECK:     ttg.local_store
   // CHECK:     nvws.producer_commit
+  // CHECK-SAME: channelGraph = array<i32: 2>
+  // CHECK-SAME: dstTask = 2 : i32
   //
   // Partition 1 (store): SubtiledRegionOp with inline consumer ops
   // CHECK: partition1

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_inside_outside.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_inside_outside.mlir
@@ -28,16 +28,16 @@
 // (the +0 folds in), guarded by exactly one wait/arrive on the dstTask=2 barrier.
 // CHECK:      %[[LHS:.*]], %[[RHS:.*]] = tt.split
 // CHECK:      arith.truncf %[[LHS]] {async_task_id = array<i32: 0>}
-// CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+// CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
 // CHECK:      ttg.local_store
-// CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+// CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
 //
 // tile 1 is outRHS at the DISTINCT slot accumCnt+1.
 // CHECK:      arith.addi %[[CNT:.*]], %c1_i64 {async_task_id = array<i32: 0>}
 // CHECK:      arith.truncf %[[RHS]] {async_task_id = array<i32: 0>}
-// CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+// CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
 // CHECK:      ttg.local_store
-// CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+// CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
 //
 // Epilogue-store consumer (async_task_id 2). The first column's consumer reads
 // slot accumCnt+0 (= tile 0 = outLHS); the second column's consumer reads the

--- a/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_barrier.mlir
+++ b/test/Hopper/WarpSpecialization/ws_subtiled_region_per_tile_barrier.mlir
@@ -40,17 +40,17 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
   // CHECK:      %[[MOD:[0-9]+]] = arith.subi %[[CNT]], %[[MUL]] {async_task_id = array<i32: 0>}
   // CHECK:      %[[IDX:[0-9]+]] = arith.trunci %[[MOD]] {async_task_id = array<i32: 0>} : i64 to i32
   // CHECK:      ttg.memdesc_index %{{[0-9]+}}[%[[IDX]]] {async_task_id = array<i32: 0>} : !ttg.memdesc<3x128x64xf16
-  // CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+  // CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
   // CHECK:      ttg.local_store
-  // CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+  // CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
   //
   // The second subtile (tileIdx 1) flattens to `addi accumCnt, %c1_i64`, giving a
   // DISTINCT barrier generation -- the property the buggy shared-index version
   // lacked (it deadlocked).
   // CHECK:      arith.addi %[[CNT]], %c1_i64 {async_task_id = array<i32: 0>}
-  // CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+  // CHECK:      ttng.wait_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
   // CHECK:      ttg.local_store
-  // CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {dstTask = 2 : i32}
+  // CHECK:      ttng.arrive_barrier {{.*}}WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32
   tt.func public @matmul_kernel_tma_persistent_ws(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<128x64xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x64xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: i32 {tt.divisibility = 16 : i32}, %arg16: i32 {tt.divisibility = 16 : i32}, %arg17: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %false = arith.constant false
     %true = arith.constant true

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -4018,9 +4018,8 @@ void insertAsyncComm(
               tileBuilder.setInsertionPoint(annotTarget);
               Value tileBufIdx = producerSubtiled.addSharedArg(bufferIdx);
               Value tilePhase = producerSubtiled.addSharedArg(phase);
-              ttnvws::ProducerAcquireOp::create(
-                  tileBuilder, annotTarget->getLoc(), perTileTok, tileBufIdx,
-                  tilePhase,
+              tileBuilder.createWithAsyncTaskIds<ttnvws::ProducerAcquireOp>(
+                  annotTarget->getLoc(), perTileTok, tileBufIdx, tilePhase,
                   WSBarrierAttr::forDstTask(funcOp.getContext(), token.first)
                       .build(funcOp.getContext()));
               LDBG("create inline per-tile ProducerAcquire in SubtiledRegionOp "
@@ -4038,9 +4037,8 @@ void insertAsyncComm(
               tileBufIdx = producerSubtiled.addSharedArg(bufferIdx);
               tilePhase = producerSubtiled.addSharedArg(phase);
             }
-            ttnvws::ProducerAcquireOp::create(
-                tileBuilder, annotTarget->getLoc(), tileToken, tileBufIdx,
-                tilePhase,
+            tileBuilder.createWithAsyncTaskIds<ttnvws::ProducerAcquireOp>(
+                annotTarget->getLoc(), tileToken, tileBufIdx, tilePhase,
                 WSBarrierAttr::forDstTask(funcOp.getContext(), token.first)
                     .build(funcOp.getContext()));
             LDBG("create inline ProducerAcquire in SubtiledRegionOp "
@@ -4212,8 +4210,8 @@ void insertAsyncComm(
               OpBuilderWithAsyncTaskIds tileBuilder(annotTarget);
               tileBuilder.setInsertionPointAfter(annotTarget);
               Value tileBufIdx = commitSubtiled.addSharedArg(bufferIdx);
-              ttnvws::ProducerCommitOp::create(
-                  tileBuilder, annotTarget->getLoc(), perTileTok, tileBufIdx,
+              tileBuilder.createWithAsyncTaskIds<ttnvws::ProducerCommitOp>(
+                  annotTarget->getLoc(), perTileTok, tileBufIdx,
                   WSBarrierAttr::forDstTask(funcOp.getContext(), token.first)
                       .build(funcOp.getContext()));
               emittedSubtiledPerTileProducer.insert(
@@ -4232,8 +4230,8 @@ void insertAsyncComm(
             } else {
               tileBufIdx = commitSubtiled.addSharedArg(bufferIdx);
             }
-            ttnvws::ProducerCommitOp::create(
-                tileBuilder, annotTarget->getLoc(), tileToken, tileBufIdx,
+            tileBuilder.createWithAsyncTaskIds<ttnvws::ProducerCommitOp>(
+                annotTarget->getLoc(), tileToken, tileBufIdx,
                 WSBarrierAttr::forDstTask(funcOp.getContext(), token.first)
                     .build(funcOp.getContext()));
             LDBG("create inline ProducerCommit in SubtiledRegionOp "
@@ -4360,8 +4358,11 @@ void insertAsyncComm(
             tileBufIdx = subtiled.addSharedArg(bufferIdx);
             tilePhase = subtiled.addSharedArg(phase);
           }
-          ttnvws::ConsumerWaitOp::create(tileBuilder, insertTarget->getLoc(),
-                                         tileToken, tileBufIdx, tilePhase);
+          tileBuilder.createWithAsyncTaskIds<ttnvws::ConsumerWaitOp>(
+              insertTarget->getLoc(), tileToken, tileBufIdx, tilePhase,
+              WSBarrierAttr::forDstTask(funcOp.getContext(),
+                                        masterChannel->relation.first)
+                  .build(funcOp.getContext()));
           LDBG("create inline ConsumerWait in SubtiledRegionOp "
                << masterChannel->uniqID << " ");
         } else {
@@ -4463,8 +4464,11 @@ void insertAsyncComm(
           } else {
             tileBufIdx = subtiled.addSharedArg(bufferIdx);
           }
-          ttnvws::ConsumerReleaseOp::create(tileBuilder, insertTarget->getLoc(),
-                                            tileToken, tileBufIdx);
+          tileBuilder.createWithAsyncTaskIds<ttnvws::ConsumerReleaseOp>(
+              insertTarget->getLoc(), tileToken, tileBufIdx,
+              WSBarrierAttr::forDstTask(funcOp.getContext(),
+                                        masterChannel->relation.first)
+                  .build(funcOp.getContext()));
           LDBG("create inline ConsumerRelease in SubtiledRegionOp "
                << masterChannel->uniqID << " ");
         } else {


### PR DESCRIPTION
Summary:

Preserve async task IDs and destination metadata on inline subtiled producer and consumer token endpoints so WSBarrier graph and ordered-region injection can annotate them. This change was authored with Claude.

Reviewed By: manman-ren

Differential Revision: D117407821


