### PR TITLE
[store-wait] Cover idx3 FA backward store-wait rotation end to end (#3287)

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
+++ b/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
@@ -1,0 +1,503 @@
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [4, 1, 8], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 1, 0]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 1]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 1, 0], [0, 2, 0], [16, 0, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [0, 16, 0], [1, 0, 0], [2, 0, 0]], warp = [[4, 0, 0], [8, 0, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 32], [0, 1], [0, 2], [16, 0], [32, 0]], lane = [[0, 4], [0, 8], [0, 16], [1, 0], [2, 0]], warp = [[4, 0], [8, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#loc = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1113:1)
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+#loc60 = loc("desc_q"(#loc))
+#loc61 = loc("desc_q.shape.0"(#loc))
+#loc62 = loc("desc_q.shape.1"(#loc))
+#loc63 = loc("desc_q.stride.0"(#loc))
+#loc64 = loc("desc_q.stride.1"(#loc))
+#loc65 = loc("desc_k"(#loc))
+#loc66 = loc("desc_k.shape.0"(#loc))
+#loc67 = loc("desc_k.shape.1"(#loc))
+#loc68 = loc("desc_k.stride.0"(#loc))
+#loc69 = loc("desc_k.stride.1"(#loc))
+#loc70 = loc("desc_v"(#loc))
+#loc71 = loc("desc_v.shape.0"(#loc))
+#loc72 = loc("desc_v.shape.1"(#loc))
+#loc73 = loc("desc_v.stride.0"(#loc))
+#loc74 = loc("desc_v.stride.1"(#loc))
+#loc75 = loc("sm_scale"(#loc))
+#loc76 = loc("desc_do"(#loc))
+#loc77 = loc("desc_do.shape.0"(#loc))
+#loc78 = loc("desc_do.shape.1"(#loc))
+#loc79 = loc("desc_do.stride.0"(#loc))
+#loc80 = loc("desc_do.stride.1"(#loc))
+#loc81 = loc("desc_dq"(#loc))
+#loc82 = loc("desc_dq.shape.0"(#loc))
+#loc83 = loc("desc_dq.shape.1"(#loc))
+#loc84 = loc("desc_dq.stride.0"(#loc))
+#loc85 = loc("desc_dq.stride.1"(#loc))
+#loc86 = loc("desc_dk"(#loc))
+#loc87 = loc("desc_dk.shape.0"(#loc))
+#loc88 = loc("desc_dk.shape.1"(#loc))
+#loc89 = loc("desc_dk.stride.0"(#loc))
+#loc90 = loc("desc_dk.stride.1"(#loc))
+#loc91 = loc("desc_dv"(#loc))
+#loc92 = loc("desc_dv.shape.0"(#loc))
+#loc93 = loc("desc_dv.shape.1"(#loc))
+#loc94 = loc("desc_dv.stride.0"(#loc))
+#loc95 = loc("desc_dv.stride.1"(#loc))
+#loc96 = loc("desc_m"(#loc))
+#loc97 = loc("desc_m.shape.0"(#loc))
+#loc98 = loc("desc_m.stride.0"(#loc))
+#loc99 = loc("desc_delta"(#loc))
+#loc100 = loc("desc_delta.shape.0"(#loc))
+#loc101 = loc("desc_delta.stride.0"(#loc))
+#loc102 = loc("stride_z"(#loc))
+#loc103 = loc("stride_h"(#loc))
+#loc104 = loc("stride_tok"(#loc))
+#loc105 = loc("BATCH"(#loc))
+#loc106 = loc("H"(#loc))
+#loc107 = loc("N_CTX"(#loc))
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd(%desc_q: !tt.tensordesc<64x128xf16, #shared> loc("desc_q"(#loc)), %desc_q.shape.0: i32 loc("desc_q.shape.0"(#loc)), %desc_q.shape.1: i32 loc("desc_q.shape.1"(#loc)), %desc_q.stride.0: i64 loc("desc_q.stride.0"(#loc)), %desc_q.stride.1: i64 loc("desc_q.stride.1"(#loc)), %desc_k: !tt.tensordesc<128x128xf16, #shared> loc("desc_k"(#loc)), %desc_k.shape.0: i32 loc("desc_k.shape.0"(#loc)), %desc_k.shape.1: i32 loc("desc_k.shape.1"(#loc)), %desc_k.stride.0: i64 loc("desc_k.stride.0"(#loc)), %desc_k.stride.1: i64 loc("desc_k.stride.1"(#loc)), %desc_v: !tt.tensordesc<128x128xf16, #shared> loc("desc_v"(#loc)), %desc_v.shape.0: i32 loc("desc_v.shape.0"(#loc)), %desc_v.shape.1: i32 loc("desc_v.shape.1"(#loc)), %desc_v.stride.0: i64 loc("desc_v.stride.0"(#loc)), %desc_v.stride.1: i64 loc("desc_v.stride.1"(#loc)), %sm_scale: f32 loc("sm_scale"(#loc)), %desc_do: !tt.tensordesc<64x128xf16, #shared> loc("desc_do"(#loc)), %desc_do.shape.0: i32 loc("desc_do.shape.0"(#loc)), %desc_do.shape.1: i32 loc("desc_do.shape.1"(#loc)), %desc_do.stride.0: i64 loc("desc_do.stride.0"(#loc)), %desc_do.stride.1: i64 loc("desc_do.stride.1"(#loc)), %desc_dq: !tt.tensordesc<64x32xf32, #shared1> loc("desc_dq"(#loc)), %desc_dq.shape.0: i32 loc("desc_dq.shape.0"(#loc)), %desc_dq.shape.1: i32 loc("desc_dq.shape.1"(#loc)), %desc_dq.stride.0: i64 loc("desc_dq.stride.0"(#loc)), %desc_dq.stride.1: i64 loc("desc_dq.stride.1"(#loc)), %desc_dk: !tt.tensordesc<128x64xf16, #shared> loc("desc_dk"(#loc)), %desc_dk.shape.0: i32 loc("desc_dk.shape.0"(#loc)), %desc_dk.shape.1: i32 loc("desc_dk.shape.1"(#loc)), %desc_dk.stride.0: i64 loc("desc_dk.stride.0"(#loc)), %desc_dk.stride.1: i64 loc("desc_dk.stride.1"(#loc)), %desc_dv: !tt.tensordesc<128x64xf16, #shared> loc("desc_dv"(#loc)), %desc_dv.shape.0: i32 loc("desc_dv.shape.0"(#loc)), %desc_dv.shape.1: i32 loc("desc_dv.shape.1"(#loc)), %desc_dv.stride.0: i64 loc("desc_dv.stride.0"(#loc)), %desc_dv.stride.1: i64 loc("desc_dv.stride.1"(#loc)), %desc_m: !tt.tensordesc<64xf32, #shared2> loc("desc_m"(#loc)), %desc_m.shape.0: i32 loc("desc_m.shape.0"(#loc)), %desc_m.stride.0: i64 loc("desc_m.stride.0"(#loc)), %desc_delta: !tt.tensordesc<64xf32, #shared2> loc("desc_delta"(#loc)), %desc_delta.shape.0: i32 loc("desc_delta.shape.0"(#loc)), %desc_delta.stride.0: i64 loc("desc_delta.stride.0"(#loc)), %stride_z: i32 {tt.divisibility = 16 : i32} loc("stride_z"(#loc)), %stride_h: i32 {tt.divisibility = 16 : i32} loc("stride_h"(#loc)), %stride_tok: i32 {tt.divisibility = 16 : i32} loc("stride_tok"(#loc)), %BATCH: i32 loc("BATCH"(#loc)), %H: i32 {tt.divisibility = 16 : i32} loc("H"(#loc)), %N_CTX: i32 {tt.divisibility = 16 : i32} loc("N_CTX"(#loc))) attributes {noinline = false} {
+    %false = arith.constant {async_task_id = array<i32: 1>} false loc(#loc1)
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<64x32xf32, #blocked> loc(#loc163)
+    %c32_i32 = arith.constant {async_task_id = array<i32: 0>} 32 : i32 loc(#loc163)
+    %c96_i32 = arith.constant {async_task_id = array<i32: 0>} 96 : i32 loc(#loc163)
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32 loc(#loc164)
+    %c128_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 128 : i32 loc(#loc109)
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32 loc(#loc109)
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 64 : i32 loc(#loc109)
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true loc(#loc1)
+    %cst_0 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #linear> loc(#loc1)
+    %bhid = tt.get_program_id z {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc110)
+    %pid = tt.get_program_id x {async_task_id = array<i32: 2, 3>} : i32 loc(#loc111)
+    %off_chz = arith.muli %bhid, %N_CTX {async_task_id = array<i32: 2>} : i32 loc(#loc165)
+    %off_chz_1 = arith.extsi %off_chz {async_task_id = array<i32: 2>} : i32 to i64 loc(#loc166)
+    %off_bh = arith.remsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc167)
+    %off_bh_2 = arith.muli %stride_h, %off_bh {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc168)
+    %off_bh_3 = arith.divsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc169)
+    %off_bh_4 = arith.muli %stride_z, %off_bh_3 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc170)
+    %off_bh_5 = arith.addi %off_bh_2, %off_bh_4 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc168)
+    %off_bh_6 = arith.extsi %off_bh_5 {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc171)
+    %off_bh_7 = arith.extsi %stride_tok {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc172)
+    %off_bh_8 = arith.divsi %off_bh_6, %off_bh_7 {async_task_id = array<i32: 0, 2, 3>} : i64 loc(#loc172)
+    %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 2, 3>} : i32 loc(#loc173)
+    %k = arith.extsi %start_n {async_task_id = array<i32: 2, 3>} : i32 to i64 loc(#loc174)
+    %k_9 = arith.addi %off_bh_8, %k {async_task_id = array<i32: 2, 3>} : i64 loc(#loc174)
+    %k_10 = arith.trunci %k_9 {async_task_id = array<i32: 2, 3>} : i64 to i32 loc(#loc175)
+    %k_11 = tt.descriptor_load %desc_k[%k_10, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1> loc(#loc176)
+    %k_12 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc176)
+    ttg.local_store %k_11, %k_12 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc176)
+    %v = tt.descriptor_load %desc_v[%k_10, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1> loc(#loc177)
+    %v_13 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc177)
+    ttg.local_store %v, %v_13 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc177)
+    %num_steps = arith.divsi %N_CTX, %c64_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc178)
+    %qkT, %qkT_14 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>} : () -> (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc186)
+    %dpT, %dpT_15 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>} : () -> (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc187)
+    %dv, %dv_16 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc188)
+    %dk, %dk_17 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc189)
+    %q = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc190)
+    %m = ttg.local_alloc : () -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc191)
+    %do = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc192)
+    %ppT = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc193)
+    %Di = ttg.local_alloc : () -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc194)
+    %dsT_0 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc195)
+    %dsT_1 = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc196)
+    %dq, %dq_18 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1>} : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc197)
+    %dk_19 = ttng.tmem_store %cst_0, %dk[%dk_17], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc189)
+    %dv_20 = ttng.tmem_store %cst_0, %dv[%dv_16], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc188)
+    %curr_m:7 = scf.for %blk_idx = %c0_i32 to %num_steps step %c1_i32 iter_args(%curr_m_35 = %c0_i32, %dv_36 = %false, %qkT_37 = %qkT_14, %dpT_38 = %dpT_15, %dv_39 = %dv_20, %dk_40 = %dk_19, %dq_41 = %dq_18) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %q_42 = arith.extsi %curr_m_35 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 to i64 loc(#loc199)
+      %q_43 = arith.addi %off_bh_8, %q_42 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 loc(#loc199)
+      %q_44 = arith.trunci %q_43 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32 loc(#loc200)
+      %q_45 = tt.descriptor_load %desc_q[%q_44, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1> loc(#loc190)
+      ttg.local_store %q_45, %q {async_task_id = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<64x128xf16, #blocked1> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc190)
+      %qT = ttg.memdesc_trans %q {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared3, #smem, mutable> loc(#loc201)
+      %offs_m_start = arith.addi %off_chz_1, %q_42 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 loc(#loc202)
+      %m_46 = arith.trunci %offs_m_start {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i32 loc(#loc203)
+      %m_47 = tt.descriptor_load %desc_m[%m_46] {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64xf32, #shared2> -> tensor<64xf32, #blocked2> loc(#loc191)
+      ttg.local_store %m_47, %m {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc191)
+      %qkT_48 = ttng.tc_gen5_mma %k_12, %qT, %qkT[%qkT_37], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc186)
+      %m_49 = ttg.local_load %m {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<64xf32, #shared2, #smem, mutable> -> tensor<64xf32, #blocked2> loc(#loc191)
+      %pT = ttg.convert_layout %m_49 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc204)
+      %pT_50 = ttg.convert_layout %m_47 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc204)
+      %pT_51 = tt.expand_dims %pT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc205)
+      %pT_52 = tt.expand_dims %pT_50 {async_task_id = array<i32: 2>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc205)
+      %pT_53 = tt.broadcast %pT_51 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x64xf32, #linear1> -> tensor<128x64xf32, #linear1> loc(#loc204)
+      %qkT_54, %qkT_55 = ttng.tmem_load %qkT[%qkT_48] {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear1> loc(#loc186)
+      %pT_56 = arith.subf %qkT_54, %pT_53 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> loc(#loc204)
+      %pT_57 = math.exp2 %pT_56 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> loc(#loc206)
+      %do_58 = tt.descriptor_load %desc_do[%q_44, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1> loc(#loc192)
+      ttg.local_store %do_58, %do {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64x128xf16, #blocked1> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc192)
+      %ppT_59 = arith.truncf %pT_57 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc193)
+      %dv_60 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} true loc(#loc188)
+      ttng.tmem_store %ppT_59, %ppT, %dv_60 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc188)
+      %dpT_61 = ttg.memdesc_trans %do {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared3, #smem, mutable> loc(#loc207)
+      %dpT_62 = ttng.tc_gen5_mma %v_13, %dpT_61, %dpT[%dpT_38], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc187)
+      %Di_63 = tt.descriptor_load %desc_delta[%m_46] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64xf32, #shared2> -> tensor<64xf32, #blocked2> loc(#loc194)
+      ttg.local_store %Di_63, %Di {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc194)
+      %dv_64 = ttng.tc_gen5_mma %ppT, %do, %dv[%dv_39], %dv_36, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc188)
+      %Di_65 = ttg.local_load %Di {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64xf32, #shared2, #smem, mutable> -> tensor<64xf32, #blocked2> loc(#loc194)
+      %dsT = ttg.convert_layout %Di_65 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc208)
+      %dsT_66 = ttg.convert_layout %Di_63 {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc208)
+      %dsT_67 = tt.expand_dims %dsT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc209)
+      %dsT_68 = tt.expand_dims %dsT_66 {async_task_id = array<i32: 2>, axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc209)
+      %dsT_69 = tt.broadcast %dsT_67 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<1x64xf32, #linear1> -> tensor<128x64xf32, #linear1> loc(#loc208)
+      %dpT_70, %dpT_71 = ttng.tmem_load %dpT[%dpT_62] {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear1> loc(#loc187)
+      %dsT_72 = arith.subf %dpT_70, %dsT_69 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> loc(#loc208)
+      %dsT_73 = arith.mulf %pT_57, %dsT_72 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> loc(#loc210)
+      %dsT_74 = arith.truncf %dsT_73 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc211)
+      ttg.local_store %dsT_74, %dsT_0 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc211)
+      %dk_75 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} true loc(#loc189)
+      ttng.tmem_store %dsT_74, %dsT_1, %dk_75 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc189)
+      %dk_76 = ttng.tc_gen5_mma %dsT_1, %q, %dk[%dk_40], %dv_36, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,tmem,1,5\22, \22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc189)
+      %dq_77 = ttg.memdesc_trans %dsT_0 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared3, #smem, mutable> loc(#loc212)
+      %dq_78 = ttng.tc_gen5_mma %dq_77, %k_12, %dq[%dq_41], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,11\22]}"} : !ttg.memdesc<64x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> loc(#loc197)
+      %dq_79, %dq_80 = ttng.tmem_load %dq[%dq_78] {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear2> loc(#loc197)
+      %dqs = tt.reshape %dq_79 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #linear2> -> tensor<64x2x64xf32, #linear3> loc(#loc220)
+      %dqs_81 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x64xf32, #linear3> -> tensor<64x64x2xf32, #linear4> loc(#loc220)
+      %dqs_82 = ttg.convert_layout %dqs_81 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64x2xf32, #linear4> -> tensor<64x64x2xf32, #linear5> loc(#loc220)
+      %dqs_83, %dqs_84 = tt.split %dqs_82 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64x2xf32, #linear5> -> tensor<64x64xf32, #linear6> loc(#loc220)
+      %dqs_85 = tt.reshape %dqs_83 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64xf32, #linear6> -> tensor<64x2x32xf32, #blocked3> loc(#loc224)
+      %dqs_86 = tt.trans %dqs_85 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #blocked3> -> tensor<64x32x2xf32, #blocked4> loc(#loc224)
+      %dqs_87, %dqs_88 = tt.split %dqs_86 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32x2xf32, #blocked4> -> tensor<64x32xf32, #blocked> loc(#loc224)
+      %dqs_89 = tt.reshape %dqs_84 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64xf32, #linear6> -> tensor<64x2x32xf32, #blocked3> loc(#loc225)
+      %dqs_90 = tt.trans %dqs_89 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #blocked3> -> tensor<64x32x2xf32, #blocked4> loc(#loc225)
+      %dqs_91, %dqs_92 = tt.split %dqs_90 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32x2xf32, #blocked4> -> tensor<64x32xf32, #blocked> loc(#loc225)
+      %dqN = arith.mulf %dqs_87, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN, %desc_dq_reduce_staging {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %12 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c0_i32] %desc_dq_reduce_staging {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %12   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_93 = arith.mulf %dqs_88, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_94 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_93, %desc_dq_reduce_staging_94 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %13 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c32_i32] %desc_dq_reduce_staging_94 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %13   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_95 = arith.mulf %dqs_91, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_96 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_95, %desc_dq_reduce_staging_96 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %14 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c64_i32] %desc_dq_reduce_staging_96 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %14   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_97 = arith.mulf %dqs_92, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_98 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_97, %desc_dq_reduce_staging_98 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %15 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c96_i32] %desc_dq_reduce_staging_98 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %15   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %curr_m_99 = arith.addi %curr_m_35, %c64_i32 {async_task_id = array<i32: 0, 2>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32 loc(#loc216)
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_99, %true, %qkT_55, %dpT_71, %dv_64, %dk_76, %dq_80 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token loc(#loc164)
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue_to_computation = true, tt.scheduled_max_stage = 1 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 202000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32} loc(#loc219)
+    %dv_21, %dv_22 = ttng.tmem_load %dv[%curr_m#4] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear> loc(#loc188)
+    %dk_23, %dk_24 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear> loc(#loc189)
+    %dvs = tt.reshape %dv_21 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear7> loc(#loc217)
+    %dvs_25 = tt.trans %dvs {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear7> -> tensor<128x64x2xf32, #linear8> loc(#loc217)
+    %dvs_26, %dvs_27 = tt.split %dvs_25 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #linear8> -> tensor<128x64xf32, #linear1> loc(#loc217)
+    %0 = arith.truncf %dvs_26 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc157)
+    %1 = ttg.convert_layout %0 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc157)
+    %desc_dv_staging = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    ttg.local_store %1, %desc_dv_staging {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    %2 = ttng.async_tma_copy_local_to_global %desc_dv[%k_10, %c0_i32] %desc_dv_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc158)
+    ttng.async_tma_store_token_wait %2   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc158)
+    %3 = arith.truncf %dvs_27 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc157)
+    %4 = ttg.convert_layout %3 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc157)
+    %desc_dv_staging_28 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    ttg.local_store %4, %desc_dv_staging_28 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    %5 = ttng.async_tma_copy_local_to_global %desc_dv[%k_10, %c64_i32] %desc_dv_staging_28 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc158)
+    ttng.async_tma_store_token_wait %5   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc158)
+    %dks = tt.reshape %dk_23 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear7> loc(#loc218)
+    %dks_29 = tt.trans %dks {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear7> -> tensor<128x64x2xf32, #linear8> loc(#loc218)
+    %dks_30, %dks_31 = tt.split %dks_29 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #linear8> -> tensor<128x64xf32, #linear1> loc(#loc218)
+    %dkN = tt.splat %sm_scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x64xf32, #linear1> loc(#loc184)
+    %dkN_32 = arith.mulf %dks_30, %dkN {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> loc(#loc184)
+    %6 = arith.truncf %dkN_32 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc161)
+    %7 = ttg.convert_layout %6 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc161)
+    %desc_dk_staging = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    ttg.local_store %7, %desc_dk_staging {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    %8 = ttng.async_tma_copy_local_to_global %desc_dk[%k_10, %c0_i32] %desc_dk_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc162)
+    ttng.async_tma_store_token_wait %8   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc162)
+    %dkN_33 = arith.mulf %dks_31, %dkN {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> loc(#loc184)
+    %9 = arith.truncf %dkN_33 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc161)
+    %10 = ttg.convert_layout %9 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc161)
+    %desc_dk_staging_34 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    ttg.local_store %10, %desc_dk_staging_34 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    %11 = ttng.async_tma_copy_local_to_global %desc_dk[%k_10, %c64_i32] %desc_dk_staging_34 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc162)
+    ttng.async_tma_store_token_wait %11   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc162)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc(unknown)
+#loc2 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1061:14)
+#loc3 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1148:5)
+#loc4 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":790:9)
+#loc5 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1145:12)
+#loc6 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1146:11)
+#loc7 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1049:16)
+#loc8 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1049:15)
+#loc9 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:28)
+#loc10 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:16)
+#loc11 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:52)
+#loc12 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:40)
+#loc13 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:15)
+#loc14 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:14)
+#loc15 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1055:15)
+#loc16 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:23)
+#loc17 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:22)
+#loc18 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:9)
+#loc19 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1059:9)
+#loc20 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1060:17)
+#loc21 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":707:15)
+#loc22 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":799:30)
+#loc23 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":719:15)
+#loc24 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":721:15)
+#loc25 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":733:15)
+#loc26 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:9)
+#loc27 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":705:9)
+#loc28 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":715:10)
+#loc29 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":717:11)
+#loc30 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":720:14)
+#loc31 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":727:11)
+#loc32 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":734:14)
+#loc33 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:23)
+#loc34 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:22)
+#loc35 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":703:10)
+#loc36 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":704:20)
+#loc37 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":705:22)
+#loc38 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:23)
+#loc39 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:29)
+#loc40 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:10)
+#loc41 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":719:25)
+#loc42 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:17)
+#loc43 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:23)
+#loc44 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:11)
+#loc45 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":734:21)
+#loc46 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":10:18)
+#loc47 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":738:11)
+#loc48 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":11:16)
+#loc49 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":11:53)
+#loc50 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":741:15)
+#loc51 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":742:9)
+#loc52 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":743:5)
+#loc53 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1093:11)
+#loc54 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1099:13)
+#loc55 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1097:9)
+#loc56 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1102:11)
+#loc57 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1104:15)
+#loc58 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1107:13)
+#loc59 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1105:9)
+#loc108 = loc(callsite(#loc2 at #loc3))
+#loc109 = loc(callsite(#loc1 at #loc3))
+#loc110 = loc("bhid"(#loc5))
+#loc111 = loc("pid"(#loc6))
+#loc112 = loc("off_chz"(#loc7))
+#loc113 = loc("off_chz"(#loc8))
+#loc114 = loc("off_bh"(#loc9))
+#loc115 = loc("off_bh"(#loc10))
+#loc116 = loc("off_bh"(#loc11))
+#loc117 = loc("off_bh"(#loc12))
+#loc118 = loc("off_bh"(#loc13))
+#loc119 = loc("off_bh"(#loc14))
+#loc120 = loc("start_n"(#loc15))
+#loc121 = loc("k"(#loc16))
+#loc122 = loc("k"(#loc17))
+#loc123 = loc("k"(#loc18))
+#loc124 = loc("v"(#loc19))
+#loc125 = loc("num_steps"(#loc20))
+#loc126 = loc("qkT"(#loc21))
+#loc127 = loc("dpT"(#loc23))
+#loc128 = loc("dv"(#loc24))
+#loc129 = loc("dk"(#loc25))
+#loc130 = loc("q"(#loc26))
+#loc131 = loc("m"(#loc27))
+#loc132 = loc("do"(#loc28))
+#loc133 = loc("ppT"(#loc29))
+#loc134 = loc("Di"(#loc30))
+#loc135 = loc("dsT_0"(#loc31))
+#loc136 = loc("dsT_1"(#loc31))
+#loc137 = loc("dq"(#loc32))
+#loc138 = loc("dk"(#loc4))
+#loc139 = loc("q"(#loc33))
+#loc140 = loc("q"(#loc34))
+#loc141 = loc("qT"(#loc35))
+#loc142 = loc("offs_m_start"(#loc36))
+#loc143 = loc("m"(#loc37))
+#loc144 = loc("pT"(#loc38))
+#loc145 = loc("pT"(#loc39))
+#loc146 = loc("pT"(#loc40))
+#loc147 = loc("dpT"(#loc41))
+#loc148 = loc("dsT"(#loc42))
+#loc149 = loc("dsT"(#loc43))
+#loc150 = loc("dsT"(#loc44))
+#loc151 = loc("dsT"(#loc31))
+#loc152 = loc("dq"(#loc45))
+#loc153 = loc("dqs"(#loc47))
+#loc154 = loc("dqN"(#loc50))
+#loc155 = loc("curr_m"(#loc52))
+#loc156 = loc("dvs"(#loc53))
+#loc157 = loc(callsite(#loc54 at #loc3))
+#loc158 = loc(callsite(#loc55 at #loc3))
+#loc159 = loc("dks"(#loc56))
+#loc160 = loc("dkN"(#loc57))
+#loc161 = loc(callsite(#loc58 at #loc3))
+#loc162 = loc(callsite(#loc59 at #loc3))
+#loc163 = loc(callsite(#loc1 at #loc108))
+#loc164 = loc(callsite(#loc4 at #loc108))
+#loc165 = loc(callsite(#loc112 at #loc3))
+#loc166 = loc(callsite(#loc113 at #loc3))
+#loc167 = loc(callsite(#loc114 at #loc3))
+#loc168 = loc(callsite(#loc115 at #loc3))
+#loc169 = loc(callsite(#loc116 at #loc3))
+#loc170 = loc(callsite(#loc117 at #loc3))
+#loc171 = loc(callsite(#loc118 at #loc3))
+#loc172 = loc(callsite(#loc119 at #loc3))
+#loc173 = loc(callsite(#loc120 at #loc3))
+#loc174 = loc(callsite(#loc121 at #loc3))
+#loc175 = loc(callsite(#loc122 at #loc3))
+#loc176 = loc(callsite(#loc123 at #loc3))
+#loc177 = loc(callsite(#loc124 at #loc3))
+#loc178 = loc(callsite(#loc125 at #loc3))
+#loc179 = loc(callsite(#loc22 at #loc108))
+#loc180 = loc("dv"(#loc138))
+#loc181 = loc(callsite(#loc156 at #loc3))
+#loc182 = loc("desc_dv_staging"(#loc158))
+#loc183 = loc(callsite(#loc159 at #loc3))
+#loc184 = loc(callsite(#loc160 at #loc3))
+#loc185 = loc("desc_dk_staging"(#loc162))
+#loc186 = loc(callsite(#loc126 at #loc179))
+#loc187 = loc(callsite(#loc127 at #loc179))
+#loc188 = loc(callsite(#loc128 at #loc179))
+#loc189 = loc(callsite(#loc129 at #loc179))
+#loc190 = loc(callsite(#loc130 at #loc179))
+#loc191 = loc(callsite(#loc131 at #loc179))
+#loc192 = loc(callsite(#loc132 at #loc179))
+#loc193 = loc(callsite(#loc133 at #loc179))
+#loc194 = loc(callsite(#loc134 at #loc179))
+#loc195 = loc(callsite(#loc135 at #loc179))
+#loc196 = loc(callsite(#loc136 at #loc179))
+#loc197 = loc(callsite(#loc137 at #loc179))
+#loc198 = loc("curr_m"(#loc180))
+#loc199 = loc(callsite(#loc139 at #loc179))
+#loc200 = loc(callsite(#loc140 at #loc179))
+#loc201 = loc(callsite(#loc141 at #loc179))
+#loc202 = loc(callsite(#loc142 at #loc179))
+#loc203 = loc(callsite(#loc143 at #loc179))
+#loc204 = loc(callsite(#loc144 at #loc179))
+#loc205 = loc(callsite(#loc145 at #loc179))
+#loc206 = loc(callsite(#loc146 at #loc179))
+#loc207 = loc(callsite(#loc147 at #loc179))
+#loc208 = loc(callsite(#loc148 at #loc179))
+#loc209 = loc(callsite(#loc149 at #loc179))
+#loc210 = loc(callsite(#loc150 at #loc179))
+#loc211 = loc(callsite(#loc151 at #loc179))
+#loc212 = loc(callsite(#loc152 at #loc179))
+#loc213 = loc(callsite(#loc153 at #loc179))
+#loc214 = loc(callsite(#loc154 at #loc179))
+#loc215 = loc(callsite(#loc51 at #loc179))
+#loc216 = loc(callsite(#loc155 at #loc179))
+#loc217 = loc(callsite(#loc46 at #loc181))
+#loc218 = loc(callsite(#loc46 at #loc183))
+#loc219 = loc(callsite(#loc198 at #loc108))
+#loc220 = loc(callsite(#loc46 at #loc213))
+#loc221 = loc(callsite(#loc48 at #loc213))
+#loc222 = loc(callsite(#loc49 at #loc213))
+#loc223 = loc("desc_dq_reduce_staging"(#loc215))
+#loc224 = loc(callsite(#loc46 at #loc221))
+#loc225 = loc(callsite(#loc46 at #loc222))
+
+
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=PLANNER
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=ANNOTATE
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --nvgpu-test-tma-store-token-wait-reorder --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=REORDER
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --nvgpu-test-tma-store-token-wait-reorder --nvgpu-tma-store-token-wait-lowering --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=LOWER
+
+// Generated from FA backward config idx 3 immediately after
+// doBufferAllocation: BLOCK_M1=64, EPILOGUE_SUBTILE=2, DQ_SUBTILE=4,
+// BWD_DOT_ATTRS=_BWD_DOT_ATTRS_BM64_TMEM.
+//
+// The budget comes from tt.smem_budget on the loop, not from the RUN-line
+// option; the two are kept in sync only for readability. It is 202000 rather
+// than the shipped 200000 because the point of this fixture is the dV
+// two-copy store-wait ring: at 200000 the effective budget is 195676 (2 KiB of
+// auxiliary SMEM) and Phase 3.7's dV bump lands at 197632, so the planner
+// reverts dV to one copy and there is no rotation left to check. dK must still
+// miss the bump for the asymmetry below to hold, so do not raise this further.
+// Whether the shipped 200000 config should still fit a two-copy dV is tracked
+// separately (T284939236).
+
+// PLANNER-LABEL: tt.func public @_attn_bwd
+// PLANNER-COUNT-4: %desc_dq_reduce_staging{{.*}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = [[DQ:[0-9]+]] : i32, buffer.tmaStaging = 2 : i32}
+// PLANNER-COUNT-2: %desc_dv_staging{{.*}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = [[DV:[0-9]+]] : i32, buffer.tmaStaging = 1 : i32}
+// PLANNER-COUNT-2: %desc_dk_staging{{.*}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = [[DK:[0-9]+]] : i32, buffer.tmaStaging = 1 : i32}
+
+// Only dQ is inside the merged computation loop. Its four token waits inherit
+// the two-copy ring and the stable wait_group(1) lowering contract.
+// ANNOTATE-LABEL: tt.func public @_attn_bwd
+// ANNOTATE-COUNT-4: ttng.async_tma_store_token_wait {{.*}}can_rotate_by_buffer_count = 2 : i32
+// ANNOTATE-NOT: planned_pending_count
+
+// Reordering materializes the two wraparound waits, keeps the two
+// same-iteration token waits at their future slot writers, and adds one drain.
+// REORDER-LABEL: tt.func public @_attn_bwd
+// REORDER-COUNT-2: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// REORDER-COUNT-2: ttng.async_tma_store_token_wait {{.*}}planned_pending_count = 1 : i32
+// REORDER: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+
+// Final lowering matches the one-CTA TLX topology: dQ rotates two staging
+// slots with wait_group(1); dV/dK use wait_group(0) at their overwrite and
+// drain points because idx 3 has one effective straight-line staging view.
+// LOWER-LABEL: tt.func public @_attn_bwd
+// Input descriptor loads must still land in their shared-memory buffers before
+// the corresponding consumers run. nvws.descriptor_load names the destination
+// buffer directly, so the load and its store are one op here rather than the
+// tt.descriptor_load + ttg.local_store pair this fixture was captured with.
+// LOWER: nvws.descriptor_load %desc_q{{.*}} %q
+// LOWER: nvws.descriptor_load %desc_do{{.*}} %do
+
+// dQ loads its accumulator, then rotates four reductions over two staging
+// slots. Every wait_group(1) is immediately before the next staging writer;
+// the loop is followed by a wait_group(0) drain.
+// LOWER: ttng.tmem_load %dq
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ0:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ0]]
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ1:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ1]]
+// LOWER: ttng.async_tma_store_wait {pendings = 1 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ2:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ2]]
+// LOWER: ttng.async_tma_store_wait {pendings = 1 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ3:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ3]]
+// LOWER: scf.yield
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+
+// The straight-line epilogue loads dV and dK before staging either output.
+// dV's final drain is delayed across dK preparation to the first dK writer.
+// LOWER-NEXT: {{.*}} = ttng.tmem_load %dv
+// LOWER-NEXT: {{.*}} = ttng.tmem_load %dk
+// LOWER: ttg.local_store {{.*}}, %[[DV0:desc_dv_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dv{{.*}} %[[DV0]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DV1:desc_dv_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dv{{.*}} %[[DV1]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DK0:desc_dk_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dk{{.*}} %[[DK0]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DK1:desc_dk_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dk{{.*}} %[[DK1]]
+// LOWER-NEXT: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NOT: ttng.async_tma_store_token_wait

--- a/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
@@ -7,6 +7,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: triple_buffer
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-SAME: can_rotate_by_buffer_count = 3
+// CHECK-NOT: planned_pending_count
   tt.func public @triple_buffer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -31,6 +32,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: single_buffer
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-SAME: can_rotate_by_buffer_count = 1
+// CHECK-NOT: planned_pending_count
   tt.func public @single_buffer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
@@ -10,8 +10,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
       %i: i32) {
     %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
-    // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
-    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    // Explicit planner metadata takes precedence over reconstructing program
+    // order after software-pipeline schedule serialization.
+    // CHECK: ttng.async_tma_store_wait {pendings = 2 : i32}
+    ttng.async_tma_store_token_wait %tok {planned_pending_count = 2 : i32} : !ttg.async.token
     tt.return
   }
 }

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -11,7 +11,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @single_buffer_k1(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -32,6 +32,201 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// A dQ-style four-subtile loop rotates over two staging slots. The wait for
+// store 0 must use store 2 as its reuse point, not store 0 merely because both
+// write equivalent slot-0 memdescs. Same-iteration rotation is also reflected
+// in block order for merged epilogue loops that are not later pipelined.
+// CHECK-LABEL: k2_four_stores_use_nearest_future_writer
+// CHECK: scf.for
+// CHECK-NEXT: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// CHECK: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[BUF0:[^ ]+]]
+// CHECK: %[[TOK2:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF0]]
+// CHECK: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK1]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[BUF1:[^ ]+]]
+// CHECK: %[[TOK3:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF1]]
+// CHECK: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+  tt.func public @k2_four_stores_use_nearest_future_writer(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index, %i: i32, %x: f32) {
+    scf.for %iv = %lb to %ub step %step {
+      ttg.local_store %src, %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x1 = arith.addf %x, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok1 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x2 = arith.addf %x1, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok2 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x3 = arith.addf %x2, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok3 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok3 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+    } {"tt.merge_epilogue_to_computation", "tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// TMA wait_group is queue-wide. The final wait for dV can move across
+// independent dK preparation and stop at dK's staging-buffer write.
+// CHECK-LABEL: straight_line_wait_before_next_staging_buffer
+// CHECK: %[[DVTOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[DVTOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[DKBUF:[^ ]+]]
+// CHECK: %[[DKTOK:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[DKBUF]]
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[DKTOK]]
+  tt.func public @straight_line_wait_before_next_staging_buffer(
+      %dv_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %dk_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %dv_src: tensor<128x64xf16>, %dk_src: tensor<128x64xf16>,
+      %dv_buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %dk_buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %x: f32) {
+    ttg.local_store %dv_src, %dv_buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %dv_tok = ttng.async_tma_copy_local_to_global %dv_desc[%i, %i] %dv_buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %dv_tok : !ttg.async.token
+    %y = arith.addf %x, %x : f32
+    ttg.local_store %dk_src, %dk_buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %dk_tok = ttng.async_tma_copy_local_to_global %dk_desc[%i, %i] %dk_buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %dk_tok : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// A straight-line epilogue can overlap independent work with the first TMA
+// store.  Delay its wait until immediately before the staging view is reused,
+// while preserving the wait after the final store as a drain.
+// CHECK-LABEL: straight_line_wait_before_staging_reuse
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: ttg.local_store
+// CHECK: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK1]]
+  tt.func public @straight_line_wait_before_staging_reuse(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src0: tensor<128x64xf16>, %src1: tensor<128x64xf16>,
+      %buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %x: f32) {
+    ttg.local_store %src0, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+    %y = arith.addf %x, %x : f32
+    ttg.local_store %src1, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Do not extend a queue-wide wait across a later TMA launch while looking for
+// the first store's staging-buffer reuse point.
+// CHECK-LABEL: straight_line_wait_does_not_cross_next_tma_launch
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttg.local_store
+  tt.func public @straight_line_wait_does_not_cross_next_tma_launch(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %i: i32) {
+    %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+    %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttg.local_store %src, %buf0 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Dynamic views of the same allocation may alias. Stop at the first such
+// writer instead of relying on structural equality and moving past it.
+// CHECK-LABEL: straight_line_dynamic_views_may_alias
+// CHECK: %[[TOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[SLOT1:.*]]
+  tt.func public @straight_line_dynamic_views_may_alias(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %multi: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %j: i32) {
+    %slot0 = ttg.memdesc_index %multi[%i] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %slot1 = ttg.memdesc_index %multi[%j] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %slot0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    ttg.local_store %src, %slot1 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %src, %slot0 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Two distinct memdesc block arguments are not provably disjoint; both may be
+// views of one allocation. Stop at the scratch write instead of treating the
+// arguments as separate allocations and moving the wait past it. Unlike
+// straight_line_dynamic_views_may_alias, the two buffers share no base value,
+// so only the allocation-based disjointness rule can block the move.
+// CHECK-LABEL: straight_line_distinct_memdesc_args_may_alias
+// CHECK: %[[TOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[SCRATCH:.*]]
+  tt.func public @straight_line_distinct_memdesc_args_may_alias(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %scratch: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32) {
+    ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    ttg.local_store %src, %scratch : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Double-buffered (K=2). One TMA copy at stage 1. Counting 2 copies forward
 // wraps twice to the copy at stage 1 + 2*numStages = stage 3 (with numStages=1
 // per wrap). Wait lands at stage 3.
@@ -41,7 +236,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 3 : i32
   tt.func public @double_buffer_k2(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -94,7 +289,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @no_schedule_creates_basic(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -125,7 +320,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 1 : i32
   tt.func public @cross_partition_memdesc_index(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %multibuf: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>,
@@ -157,7 +352,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @wraparound_considers_barrier_before_producer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -186,12 +381,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 2 : i32
 // CHECK: ttng.wait_barrier
 // CHECK: ttng.async_tma_copy_local_to_global
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 3 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 3 : i32
   tt.func public @k3_two_stores_wraparound_uses_first_wait(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -228,22 +423,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 12 : i32, loop.stage = 0 : i32}
+// CHECK-SAME: loop.cluster = 12 : i32, loop.stage = 0 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 6 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 9 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 10 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 4 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 4 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 13 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 14 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 8 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 8 : i32, loop.stage = 1 : i32
   tt.func public @k3_four_stores_all_waits_wraparound(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -289,7 +484,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
   tt.func public @loop_carried_token_with_dead_iter_arg(

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
@@ -12,7 +12,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_reduce {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @single_buffer_reduce_token_k1(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -1,6 +1,7 @@
 #include "CodePartitionUtility.h"
 #include "WarpSpecializationPipeline.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
@@ -193,6 +194,7 @@ struct NVGPUWSTMAStoreLoweringPass
 
 static constexpr const char *kCanRotateByBufferCount =
     "can_rotate_by_buffer_count";
+static constexpr const char *kPlannedPendingCount = "planned_pending_count";
 
 static bool isTMAStoreLikeOp(Operation *op) {
   return isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp>(op);
@@ -299,17 +301,75 @@ static bool sameMemDescValue(Value lhs, Value rhs) {
   return true;
 }
 
+static Value findMemDescBase(Value value) {
+  while (Operation *def = value.getDefiningOp()) {
+    if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+             ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+             ttg::MemDescReshapeOp>(def))
+      break;
+    value = def->getOperand(0);
+  }
+  return value;
+}
+
+// Only a distinct local allocation proves two memory descriptors cannot
+// overlap. A block argument does not: two memdesc arguments of the same
+// function, or two loop iter args, may both be views of one allocation.
+// Treating them as distinct would let memDescMayAlias answer "no alias" for
+// buffers that do alias, which is the unsafe direction for the wait-motion
+// checks below.
+static bool isKnownMemDescBase(Value value) {
+  return value.getDefiningOp<ttg::LocalAllocOp>() != nullptr;
+}
+
+static bool memDescMayAlias(Value lhs, Value rhs) {
+  Value lhsBase = findMemDescBase(lhs);
+  Value rhsBase = findMemDescBase(rhs);
+  if (lhsBase == rhsBase)
+    return true;
+  return !(isKnownMemDescBase(lhsBase) && isKnownMemDescBase(rhsBase));
+}
+
+static bool mayWriteOrFreeMemDesc(Operation *op, Value buffer) {
+  auto effectsOp = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectsOp)
+    return !isMemoryEffectFree(op);
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  effectsOp.getEffects(effects);
+  for (const auto &effect : effects) {
+    if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
+      continue;
+    if (isa<SideEffects::DefaultResource>(effect.getResource()))
+      return true;
+    if (effect.getResource() == ttg::SharedMemory::get() &&
+        (!effect.getValue() || memDescMayAlias(effect.getValue(), buffer)))
+      return true;
+  }
+  return false;
+}
+
 static Operation *
-findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer,
+findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer, Operation *before,
                             const tt::CoarseSchedule &schedule) {
+  Operation *beforeInBody = forOp.getBody()->findAncestorOpInBlock(*before);
+  if (!beforeInBody)
+    return nullptr;
+
+  Operation *writer = nullptr;
   for (auto &op : forOp.getBody()->without_terminator()) {
+    if (&op == beforeInBody)
+      break;
     auto localStore = dyn_cast<ttg::LocalStoreOp>(&op);
     if (!localStore || !schedule.count(&op))
       continue;
-    if (sameMemDescValue(localStore.getDst(), buffer))
-      return &op;
+    if (!memDescMayAlias(localStore.getDst(), buffer))
+      continue;
+    // The last potentially-aliasing writer must be the exact staging view.
+    // Otherwise we cannot identify the overwrite point safely.
+    writer = sameMemDescValue(localStore.getDst(), buffer) ? &op : nullptr;
   }
-  return nullptr;
+  return writer;
 }
 
 void doAnnotateTMAStoreWaits(triton::FuncOp funcOp) {
@@ -366,12 +426,14 @@ void doValidateTMAStoreAnnotations(triton::FuncOp funcOp) {
       auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
       if (!tmaOp) {
         waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->removeAttr(kPlannedPendingCount);
         return;
       }
 
       auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
       if (!allocOp) {
         waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->removeAttr(kPlannedPendingCount);
         return;
       }
     });
@@ -425,6 +487,77 @@ findScheduledWaitBarrierBetween(Operation *producer, Operation *insertionTarget,
 // logs (see the LDBG sites below); there is no failure mode, so this returns
 // void rather than a LogicalResult.
 void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
+  DominanceInfo dominance(funcOp);
+  auto operandsDominate = [&](Operation *op, Operation *target) {
+    return llvm::all_of(op->getOperands(), [&](Value operand) {
+      return dominance.dominates(operand, target);
+    });
+  };
+
+  // Straight-line epilogues are not software-pipelined, but can still overlap
+  // a TMA store with independent work.  Delay a token wait until immediately
+  // before the next write to a TMA staging view. A wait_group applies to the
+  // warp's TMA store queue, not to one descriptor or SMEM allocation, so the
+  // final wait for one output can overlap independent setup for the next
+  // output and land immediately before that output starts reusing the queue.
+  // This is deliberately limited to direct tokens and staging writers in the
+  // same block. The final use remains a drain.
+  SmallVector<ttng::TMAStoreTokenWaitOp> straightLineWaits;
+  funcOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
+    if (!waitOp->getParentOfType<scf::ForOp>())
+      straightLineWaits.push_back(waitOp);
+  });
+  for (ttng::TMAStoreTokenWaitOp waitOp : straightLineWaits) {
+    Operation *tmaStore = waitOp.getToken().getDefiningOp();
+    if (!tmaStore || !isTMAStoreLikeOp(tmaStore) ||
+        tmaStore->getBlock() != waitOp->getBlock())
+      continue;
+
+    Value buffer = getTMAStoreSource(tmaStore);
+    for (auto it = std::next(waitOp->getIterator()),
+              end = waitOp->getBlock()->end();
+         it != end; ++it) {
+      auto localStore = dyn_cast<ttg::LocalStoreOp>(&*it);
+      if (!localStore) {
+        if (isa<ttg::LocalAllocOp>(&*it))
+          continue;
+        if (isTMAStoreLikeOp(&*it) || mayWriteOrFreeMemDesc(&*it, buffer))
+          break;
+        continue;
+      }
+
+      bool writesTMAStaging = sameMemDescValue(localStore.getDst(), buffer);
+      if (!writesTMAStaging) {
+        for (auto next = std::next(localStore->getIterator()); next != end;
+             ++next) {
+          if (isTMAStoreLikeOp(&*next)) {
+            writesTMAStaging = sameMemDescValue(localStore.getDst(),
+                                                getTMAStoreSource(&*next));
+            break;
+          }
+          if (auto nextStore = dyn_cast<ttg::LocalStoreOp>(&*next)) {
+            if (memDescMayAlias(nextStore.getDst(), localStore.getDst()))
+              break;
+            continue;
+          }
+          if (isa<ttg::LocalAllocOp>(&*next))
+            continue;
+          if (mayWriteOrFreeMemDesc(&*next, localStore.getDst()))
+            break;
+        }
+      }
+      if (!writesTMAStaging) {
+        if (memDescMayAlias(localStore.getDst(), buffer))
+          break;
+        continue;
+      }
+      if (!operandsDominate(waitOp, localStore))
+        break;
+      waitOp->moveBefore(localStore);
+      break;
+    }
+  }
+
   funcOp.walk([&](scf::ForOp forOp) {
     bool hasNestedFor = false;
     forOp.getBody()->walk([&](scf::ForOp) { hasNestedFor = true; });
@@ -473,11 +606,15 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
     }
 
     bool changed = false;
+    bool needsFinalQueueDrain = false;
+    SmallVector<Attribute> finalDrainTaskIds;
     for (auto waitOp : waits) {
+      bool erasedWait = false;
       auto attr = waitOp->getAttrOfType<IntegerAttr>(kCanRotateByBufferCount);
       if (!attr)
         continue;
       int k = attr.getInt();
+      waitOp->removeAttr(kPlannedPendingCount);
 
       // Find the defining TMA store op.
       Value buffer;
@@ -528,9 +665,9 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
 
         Value targetBuffer = getTMAStoreSource(targetTMAStore);
         Operation *targetWriter =
-            targetBuffer
-                ? findLocalStoreWritingBuffer(forOp, targetBuffer, schedule)
-                : nullptr;
+            targetBuffer ? findLocalStoreWritingBuffer(forOp, targetBuffer,
+                                                       targetTMAStore, schedule)
+                         : nullptr;
         if (targetWriter) {
           insertionTarget = targetWriter;
         } else {
@@ -550,14 +687,65 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
           insertionTarget = waitBarrier;
         }
 
-        // Split the cluster at the insertion target: ops before it remain
-        // in the original cluster, the target and subsequent ops stay in
-        // the returned cluster.
+        // A same-iteration reuse does not need software-pipeline expansion to
+        // realize the rotation. Keep the block order consistent with the
+        // coarse schedule so loops that are deliberately not pipelined (for
+        // example a merged FA backward epilogue) still place the wait after
+        // the target writer's dependency slice and immediately before the
+        // staging write. Cross-iteration targets remain schedule-only because
+        // their token must be carried through the pipeline boundary.
+        auto targetIt = schedule.find(targetTMAStore);
+        bool sameIteration =
+            targetIt != schedule.end() && targetStage == targetIt->second.first;
+        if (targetWriter && sameIteration &&
+            !operandsDominate(waitOp, targetWriter)) {
+          LDBG("TMA store wait operands do not dominate the target writer for "
+               "loop at "
+               << forOp.getLoc() << "; leaving TMA store wait unchanged");
+          continue;
+        }
+
+        // Split the cluster at the insertion target only after all safety
+        // checks pass, so a rejected move leaves the schedule untouched.
         auto targetCluster =
             schedule.splitClusterBefore(insertionTarget, forOp);
-        // Insert a new cluster for our wait between the split halves.
         auto waitCluster = schedule.clusters.newBefore(targetCluster);
-        schedule.insert(waitOp, targetStage, waitCluster);
+
+        if (targetWriter && sameIteration) {
+          schedule.insert(waitOp, targetStage, waitCluster);
+          waitOp->moveBefore(targetWriter);
+        } else if (targetWriter && !sameIteration &&
+                   forOp->hasAttr("tt.merge_epilogue_to_computation") &&
+                   waitOp.getBarriers().empty() &&
+                   waitOp.getBarrierPreds().empty() &&
+                   waitOp.getNvwsTokens().empty() &&
+                   waitOp.getNvwsTokenIndices().empty()) {
+          // Merged epilogue loops are intentionally not expanded by the GPU
+          // pipeliner. Materialize a wraparound token wait as the equivalent
+          // queue-wide wait_group before the next iteration's staging writer,
+          // then add one queue drain after the loop. This is the concrete
+          // prologue/steady-state/epilogue protocol used by TLX.
+          int pendings = k - 1;
+          OpBuilder builder(targetWriter);
+          auto queueWait =
+              ttng::TMAStoreWaitOp::create(builder, waitOp.getLoc(), pendings);
+          Attribute taskIds = waitOp->getAttr("async_task_id");
+          if (taskIds)
+            queueWait->setAttr("async_task_id", taskIds);
+          if (!llvm::is_contained(finalDrainTaskIds, taskIds))
+            finalDrainTaskIds.push_back(taskIds);
+          // Read the target's stage before erasing the wait: schedule.erase
+          // removes an entry from a MapVector, which shifts the remaining
+          // elements and invalidates targetIt.
+          int targetOwnStage = targetIt->second.first;
+          schedule.erase(waitOp);
+          schedule.insert(queueWait, targetOwnStage, waitCluster);
+          waitOp.erase();
+          erasedWait = true;
+          needsFinalQueueDrain = true;
+        } else {
+          schedule.insert(waitOp, targetStage, waitCluster);
+        }
       } else {
         // Target not found; leave the schedule unchanged for this wait.
         LDBG("no reorder target found for TMA store wait in loop at "
@@ -565,12 +753,27 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
         continue;
       }
 
-      waitOp->removeAttr(kCanRotateByBufferCount);
+      if (!erasedWait) {
+        waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->setAttr(
+            kPlannedPendingCount,
+            IntegerAttr::get(IntegerType::get(funcOp.getContext(), 32), k - 1));
+      }
       changed = true;
     }
 
     if (changed)
       schedule.serialize(forOp);
+
+    if (needsFinalQueueDrain) {
+      OpBuilder builder(forOp);
+      builder.setInsertionPointAfter(forOp);
+      for (Attribute taskIds : finalDrainTaskIds) {
+        auto drain = ttng::TMAStoreWaitOp::create(builder, forOp.getLoc(), 0);
+        if (taskIds)
+          drain->setAttr("async_task_id", taskIds);
+      }
+    }
   });
 }
 
@@ -795,6 +998,9 @@ computePendingsFromToken(Value token, ttng::TMAStoreTokenWaitOp waitOp,
 // pendings = number of TMA store-like ops issued after the token's defining
 // store and before this wait, in program execution order.
 static int computePendings(ttng::TMAStoreTokenWaitOp waitOp) {
+  if (auto planned = waitOp->getAttrOfType<IntegerAttr>(kPlannedPendingCount))
+    return planned.getInt();
+
   ConditionContext context = getConditionContext(waitOp);
   if (std::optional<int> count =
           computePendingsFromToken(waitOp.getToken(), waitOp, context))

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -102,12 +102,35 @@ into a reinterpret view of the host alloc (see
 [CodePartition: Realizing `allocation.reuseTarget`](#code-partition-realizing-allocationreuetarget)
 below).
 
-### Phase 4.5: Epilogue Group Copy Increase
+### Phase 3.7: Epilogue Group Copy Increase
 
 Each fused P2_Other group (including TMA staging groups) is treated as
 an epilogue group. `increaseFusedEpilogueCopies` iteratively bumps
 `numCopies` from the current value up to `numBuffers`, accepting each
 bump as long as `computeTotalSmem ≤ smemBudget`.
+
+This reservation runs before the general Phase 4 P0/P1 copy increase. TMA
+store/reduce staging is on the output critical path and must get first claim on
+the discretionary budget; otherwise small operand buffers can consume the last
+few KiB before a high-value staging ring (for example FA-bwd dQ) is considered.
+
+TMA-fed operands of a compiler data-partitioned MMA loop with
+`tt.disallow_acc_multi_buffer` are not discretionary: before Phase 3.7, the
+planner pins them to the configured pipeline depth. Their acquire/release
+schedule assumes that depth, and shortening the ring can overwrite an operand
+while a partitioned, pipelined MMA still consumes it.
+Phase 3.7 therefore reserves output staging only from the budget remaining
+after these operand correctness floors. Ordinary single-group MMA operands and
+TMA-fed metadata used only by elementwise computation remain discretionary, so
+FA-backward dQ/dK/dV staging stays prioritized over their extra copies.
+
+Groups whose members all reuse another allocation (`isAllocated=false`) are
+bumped only when every Phase 3.6 host has enough physical capacity for the
+enlarged ring (`stagingSize × copies ≤ hostSize × hostCopies`). Their apparent
+cost in `computeTotalSmem` is zero, so omitting this capacity check makes an
+increase look free even when reuse realization must reject the alias and
+materialize a separate allocation, which can make the final physical layout
+exceed the planner budget.
 
 #### `K | S` cap for same-partition (wait_group-drained) staging
 
@@ -127,7 +150,7 @@ are *correct* — depends on the channel's producer/consumer topology:
   `desc_o`): the slot/phase come from a continuous `accumCnt` producer/consumer
   mbarrier rotation and tolerate **any** K.
 
-Phase 4.5 therefore detects same-partition staging via
+Phase 3.7 therefore detects same-partition staging via
 `getAsyncTaskIds(ch->getSrcOp()) == getAsyncTaskIds(ch->getDstOp())` and, for
 those groups, only accepts a `tryCopies` that divides S (others are skipped).
 This is a **defensive backstop**: in all shipped configs `num_stages = 2` and
@@ -197,13 +220,21 @@ then looks at the SMEM buffer used by that store:
 1. Get the `LocalAllocOp` that produces the buffer.
 2. Read the `buffer.copy` attribute (set earlier by the memory planner),
    which records how many physical copies of this buffer exist.
-3. If `buffer.copy = K`, set `can_rotate_by_buffer_count = K`
-   on the wait op.
+3. If `buffer.copy = K`, set `can_rotate_by_buffer_count = K` on the wait op.
 
 The attribute means: "K buffer copies exist, so this wait can be delayed
 until the K-th subsequent TMA store to the same buffer — at that point
 the buffer slot is about to be overwritten and the earlier store must
 have finished reading."
+
+After the reorder is successfully realized, the pass records
+`planned_pending_count = K - 1` as stable lowering metadata for the equivalent
+`cp.async.bulk.wait_group(K-1)` protocol. Delaying this metadata prevents a
+failed or skipped rotation from changing the original wait semantics.
+Software-pipeline schedule serialization can move token waits through clusters
+without retaining enough linear IR context to reconstruct K reliably; final
+wait lowering therefore uses this explicit count when present and falls back
+to program-order counting for unplanned waits.
 
 ### Token Tracing
 
@@ -229,6 +260,24 @@ and reordering that might invalidate assumptions.
 This pass runs **after** `scheduleLoops` has assigned pipeline stages and
 clusters to every op. It uses the SWP `CoarseSchedule` to move waits
 forward in the linearized pipeline order.
+
+Straight-line epilogues use the same reuse-point rule without a coarse
+schedule. A direct-token wait moves to immediately before the next
+`local_store` that feeds any TMA store in the block. TMA `wait_group` is
+queue-wide rather than descriptor- or allocation-specific, so the final wait
+for one output (for example dV) may cross independent preparation for the next
+output (dK) and stop at dK's staging write. The last wait in the block remains
+the final drain.
+
+Merged epilogue loops (`tt.merge_epilogue_to_computation`) serialize the
+same-iteration part of the coarse schedule directly into block order: the pass
+selects the nearest matching writer before the chosen future TMA operation, so
+a two-slot dQ ring maps store 0's wait to store 2 rather than the earlier
+equivalent slot-0 writer. These loops are intentionally not expanded by the GPU
+pipeliner. Barrier-free wraparound token waits are therefore materialized as
+queue-wide `wait_group(K-1)` operations before the next iteration's staging
+writers, followed by one `wait_group(0)` drain after the loop. Ordinary
+software-pipelined loops retain their loop-carried token schedule.
 
 ### Algorithm
 


### PR DESCRIPTION
Summary:

This is the end-to-end regression fixture for the idx3 FA backward epilogue shape assembled by the preceding planner, subtiling, interleaving, and store-wait diffs. It verifies that planner-selected staging depths flow through slot rotation to the final TMA store/reduce waits and that both co-consumed operands retain the expected copy counts. Keeping the integration coverage separate makes failures attributable while still checking the complete pipeline.

Reviewed By: njriasan

Differential Revision: D114610706


