### PR TITLE
Align BM128 backward warp allocation (#3290)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -127,16 +127,21 @@ def TTNG_ClusterArriveOp : TTNG_Op<"cluster_arrive", []> {
 }
 
 def TTNG_TwoCTAPeerGatherOp : TTNG_Op<"two_cta_peer_gather", [
-    SameOperandsAndResultType,
     MemoryEffects<[MemRead<SharedMemory>, MemWrite<SharedMemory>]>
   ]> {
   let summary = "Abstract peer gather for a dependent 2-CTA MMA operand";
 
   let description = [{
     Represents the cross-CTA exchange needed to reconstruct a complete logical
-    tensor from two CTA-owned slices. This operation is inserted before warp
-    specialization so partition scheduling sees the dependency. A later pass
-    materializes DSMEM staging and synchronization.
+    tensor from two CTA-owned slices. This is an explicit operation, rather
+    than hidden transformation state, because its producer-consumer edge and
+    result lifetime must be visible to partition scheduling, channel creation,
+    and memory planning before the concrete DSMEM protocol can be selected.
+    A later pass materializes local/remote stores and synchronization.
+
+    `src` and `result` are rank-two tensors with the same element count and
+    element type. The result may have a different shape to represent the
+    physical layout consumed by the dependent MMA.
   }];
 
   let arguments = (ins
@@ -148,8 +153,33 @@ def TTNG_TwoCTAPeerGatherOp : TTNG_Op<"two_cta_peer_gather", [
 
   let assemblyFormat = [{
     $src `split_dim` `=` $splitDim `num_ctas` `=` $numCTAs attr-dict
-    `:` type($src)
+    `:` type($src) `->` type($result)
   }];
+  let hasVerifier = 1;
+}
+
+def TTNG_TwoCTAPeerRelayOp : TTNG_Op<"two_cta_peer_relay", [
+    MemoryEffects<[MemRead<SharedMemory>, MemWrite<SharedMemory>]>
+  ]> {
+  let summary = "Relay completion of a dependent 2-CTA peer gather";
+
+  let description = [{
+    Marks the shared-memory destination of a two-CTA peer gather for a
+    dedicated one-warp relay partition. AutoWS creates an independent channel
+    from the gather producer to this consumer. The post-WS materialization
+    pass redirects remote DSMEM completion to that channel and lowers this op
+    to publication on the MMA consumer channel. Keeping the relay as an
+    explicit operation makes that otherwise synchronization-only task visible
+    to partition allocation and prevents it from being folded into a compute
+    partition whose other warps do not participate.
+  }];
+
+  let arguments = (ins
+    Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src
+  );
+
+  let assemblyFormat = "$src attr-dict `:` type($src)";
+  let hasVerifier = 1;
 }
 
 def TTNG_ClusterWaitOp : TTNG_Op<"cluster_wait", []> {

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -1,3 +1,4 @@
+#include "lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionAttrs.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -30,6 +31,29 @@ static int32_t minRegistersForRegion(Region &region, bool instrumented,
   return instrumented || regionUsesAssertOrPrint(region)
              ? std::max(minRegisters, kMinRegistersForAssertOrPrint)
              : minRegisters;
+}
+
+// A module with exactly one AutoWS-generated WarpSpecializeOp can use direct
+// warp-ID dispatch. Require the AutoWS tag so manual TLX is not opted in
+// implicitly; TLX requests this lowering via async_tasks(exclusive=True).
+static void enableSingleWarpSpecializeForAutoWS(ModuleOp mod) {
+  if (mod->hasAttr(AttrSingleWarpSpecializeName))
+    return;
+
+  SmallVector<WarpSpecializeOp> wsOps;
+  mod.walk([&](WarpSpecializeOp op) { wsOps.push_back(op); });
+  if (wsOps.size() != 1)
+    return;
+
+  bool hasAutoWSTag = false;
+  wsOps.front()->walk([&](Operation *op) {
+    if (!op->hasAttr(kWarpSpecializeTagAttrName))
+      return WalkResult::advance();
+    hasAutoWSTag = true;
+    return WalkResult::interrupt();
+  });
+  if (hasAutoWSTag)
+    setHasSingleWarpSpecialize(mod, true);
 }
 
 // Given a `ttg.warp_specialize` with a certain number of existing warps, pad it
@@ -98,6 +122,7 @@ struct AllocateWarpGroups
   void runOnOperation() override {
     ModuleOp mod = getOperation();
     bool laterInstrumentation = instrumented.getValue();
+    enableSingleWarpSpecializeForAutoWS(mod);
 
     // First determine the maximum number of extra warps.
     int maxExtraWarps = 0;

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -17,6 +17,11 @@ using namespace triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 namespace tlx = mlir::triton::tlx;
 
+namespace {
+constexpr StringLiteral kComputationPartitionType = "computation";
+constexpr StringLiteral kReductionPartitionType = "reduction";
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // relayoutWarps
 //===----------------------------------------------------------------------===//
@@ -283,24 +288,54 @@ static LogicalResult optimizePartitionNumWarps(ModuleAxisInfoAnalysis &axisInfo,
   // With reduction=4 (TMEM floor), gemm=1, load=1, computation=8,
   // total = 14, within the 16 warp budget.
   //
-  // Note: the types array comes from the scheduler and may be longer than
-  // partitionNumWarps (the WarpSpecializeOp may have fewer regions). We scan
-  // the full types array to detect the BWD pattern, then apply the override
-  // to the last partition (which is computation in BWD).
+  // The types array comes from the scheduler and may be longer than
+  // partitionNumWarps: it also covers the default region, and empty partitions
+  // may have been removed. Rather than assume a fixed role position (dependent
+  // 2-CTA attention appends a one-warp relay partition after computation), look
+  // the role up per region and key the warp overrides off that.
+  //
+  // The lookup is positional, not a real role map: it assumes the surviving
+  // regions are the LAST partitionNumWarps.size() entries of partitionTypes,
+  // i.e. that any extra entries sit at the front. That holds for the default
+  // region, and today for removed-empty partitions, but it is an invariant of
+  // the scheduler's emission order rather than something checked here. If a
+  // partition were ever dropped from the middle or the end, every role label
+  // would shift and a warp override could land on the wrong partition. The
+  // !isTwoCTA guard below bounds the blast radius; a genuine role map keyed by
+  // region would remove the assumption.
+  std::optional<size_t> partitionTypeOffset;
+  if (partitionTypes.size() >= partitionNumWarps.size())
+    partitionTypeOffset = partitionTypes.size() - partitionNumWarps.size();
+  auto getPartitionType = [&](size_t partitionIdx) -> StringRef {
+    if (!partitionTypeOffset)
+      return {};
+    size_t typeIdx = partitionIdx + *partitionTypeOffset;
+    return typeIdx < partitionTypes.size() ? partitionTypes[typeIdx]
+                                           : StringRef();
+  };
+
   bool hasReduction = false;
   bool hasComputation = false;
+  ModuleOp mod = axisInfo.getModuleOp();
+  bool isTwoCTA = mod->hasAttr(ttng::AttrTwoCTAsName);
+  // The type list also includes the default region, which may carry the only
+  // reduction/computation role. Scan the complete list for pattern detection,
+  // but use getPartitionType() for per-specialized-region assignments.
   for (StringRef type : partitionTypes) {
-    if (type == "reduction")
+    if (type == kReductionPartitionType)
       hasReduction = true;
-    if (type == "computation")
+    if (type == kComputationPartitionType)
       hasComputation = true;
   }
 
   if (hasReduction && hasComputation && !partitionNumWarps.empty()) {
-    partitionNumWarps.back() = 8;
+    for (size_t idx = 0; idx < partitionNumWarps.size(); ++idx) {
+      StringRef type = getPartitionType(idx);
+      if (type == kComputationPartitionType && !isTwoCTA)
+        partitionNumWarps[idx] = 8;
+    }
   }
 
-  ModuleOp mod = axisInfo.getModuleOp();
   auto minRegAttr = mod->getAttrOfType<IntegerAttr>(AttrMinRegAutoWSName);
   auto maxRegAttr = mod->getAttrOfType<IntegerAttr>(AttrMaxRegAutoWSName);
   bool hasMax = !!maxRegAttr;

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -487,10 +487,46 @@ LogicalResult ClusterWaitOp::verify() {
   return success();
 }
 
+// -- TwoCTAPeerGatherOp --
+LogicalResult TwoCTAPeerGatherOp::verify() {
+  auto sourceType = dyn_cast<RankedTensorType>(getSrc().getType());
+  auto resultType = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!sourceType || !resultType || sourceType.getRank() != 2 ||
+      resultType.getRank() != 2)
+    return emitOpError("requires rank-two source and result tensors");
+  if (getNumCTAs() != 2)
+    return emitOpError("currently supports exactly two CTAs");
+  if (getSplitDim() < 0 || getSplitDim() >= sourceType.getRank())
+    return emitOpError("split_dim must name a source dimension");
+  if (sourceType.getShape()[getSplitDim()] % getNumCTAs() != 0)
+    return emitOpError("split dimension must be evenly divisible by num_ctas");
+  if (sourceType.getElementType() != resultType.getElementType() ||
+      sourceType.getNumElements() != resultType.getNumElements())
+    return emitOpError(
+        "source and result must preserve element type and element count");
+  return success();
+}
+
+// -- TwoCTAPeerRelayOp --
+LogicalResult TwoCTAPeerRelayOp::verify() {
+  auto type = getSrc().getType();
+  if (!isa<SharedMemorySpaceAttr>(type.getMemorySpace()))
+    return emitOpError("requires a shared-memory source");
+  return success();
+}
+
 static LogicalResult verifyClusterIsMultiCTA(Operation *op) {
   int numCTAs = triton::gpu::lookupNumCTAs(op);
+  // A two-CTA AutoWS kernel forms its pair through the module's cluster dims
+  // rather than ttg.num-ctas, so take the larger of the two: the op is legal
+  // whenever the launch actually has more than one CTA per cluster.
+  if (auto mod = op->getParentOfType<ModuleOp>()) {
+    auto dims = triton::gpu::TritonGPUDialect::getClusterDims(mod);
+    numCTAs = std::max(numCTAs, dims[0] * dims[1] * dims[2]);
+  }
   if (numCTAs <= 1)
-    return op->emitOpError("requires ttg.num-ctas > 1");
+    return op->emitOpError("requires more than one CTA per cluster, from "
+                           "either ttg.num-ctas or ttg.cluster-dim-{x,y,z}");
   return success();
 }
 

--- a/test/Conversion/allocate_warp_groups.mlir
+++ b/test/Conversion/allocate_warp_groups.mlir
@@ -7,6 +7,50 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 
 // -----
 
+// A single AutoWS-generated warp-specialize region enables direct warp-ID
+// dispatch. The tag is placed on an operation in the region, matching the IR
+// emitted by AutoWS.
+// CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.single-warp-specialize" = true, "ttg.total-num-warps" = 8 : i32} {
+// CHECK: tt.func @single_autows_region
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @single_autows_region() {
+  ttg.warp_specialize()
+  default {
+    %c0 = arith.constant {ttg.warp_specialize.tag = 0 : i32} 0 : i32
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+// A manual warp-specialize region has no AutoWS tag and must remain under the
+// frontend's explicit exclusive-task control.
+// CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 8 : i32} {
+// CHECK: tt.func @single_manual_region
+module attributes {"ttg.num-warps" = 4 : i32} {
+
+tt.func @single_manual_region() {
+  ttg.warp_specialize()
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(4) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
+
+}
+
+// -----
+
 // CHECK: module attributes {"ttg.num-warps" = 4 : i32, "ttg.total-num-warps" = 20 : i32}
 module attributes {"ttg.num-warps" = 4 : i32} {
 

--- a/test/Conversion/nvgpu_invalid.mlir
+++ b/test/Conversion/nvgpu_invalid.mlir
@@ -5,7 +5,7 @@
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   llvm.func @cluster_barrier_num_ctas_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
+    // expected-error @below {{requires more than one CTA per cluster}}
     ttng.cluster_barrier
     llvm.return
   }

--- a/test/Hopper/TwoCTA/analyze_2cta_dependencies_bwd_bm128_persistent.mlir
+++ b/test/Hopper/TwoCTA/analyze_2cta_dependencies_bwd_bm128_persistent.mlir
@@ -1,0 +1,61 @@
+// RUN: triton-opt %s --nvgpu-analyze-2cta-dependencies | FileCheck %s
+
+// Classification of dependent 2-CTA MMAs, reduced from the BM128 persistent
+// backward kernel to just the operand chains the pass inspects.
+//
+// The pass annotates a two_ctas MMA only when its A operand traces back to
+// another two_ctas MMA. It then splits on whether that chain contains a
+// rank-two transpose: a plain contraction stays collective, while the
+// transposed dQ-style operand needs a peer gather because the value is an MMA
+// result already distributed across the CTA pair and cannot be re-loaded.
+//
+// %root is not annotated: its A comes straight from a block argument.
+
+// CHECK-DAG: ttng.tc_gen5_mma {{.*}}ttng.two_cta_dependency = "collective_contraction"
+// CHECK-DAG: ttng.tc_gen5_mma {{.*}}ttng.two_cta_dependency = "collective_contraction"
+// CHECK-DAG: ttng.tc_gen5_mma {{.*}}ttng.two_cta_dependency = "requires_peer_gather"{{.*}}!ttg.memdesc<64x256xf16{{.*}}!ttg.memdesc<256x128xf16{{.*}}!ttg.memdesc<64x128xf32
+
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @two_cta_dependency_kinds(
+      %a: !ttg.memdesc<128x128xf16, #shared, #smem>,
+      %bT: !ttg.memdesc<128x128xf16, #shared1, #smem>,
+      %kt: !ttg.memdesc<256x128xf16, #shared, #smem>) attributes {noinline = false} {
+    %true = arith.constant true
+    %zero = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear1>
+    %zero_dq = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #linear>
+
+    // Root collective MMA. Its A operand is a block argument, so it is left
+    // unannotated and only serves as the producer the dependents trace back to.
+    %acc, %acc_tok = ttng.tmem_alloc %zero : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %root = ttng.tc_gen5_mma %a, %bT, %acc[%acc_tok], %true, %true {two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %rootv, %rootv_tok = ttng.tmem_load %acc[%root] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+    %p = arith.truncf %rootv : tensor<128x128xf32, #linear1> to tensor<128x128xf16, #linear1>
+    %p_smem = ttg.local_alloc %p : (tensor<128x128xf16, #linear1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+
+    // Two dependents whose A chain has no rank-two transpose.
+    %acc_dv, %acc_dv_tok = ttng.tmem_alloc %zero : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dv = ttng.tc_gen5_mma %p_smem, %bT, %acc_dv[%acc_dv_tok], %true, %true {two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    %acc_dk, %acc_dk_tok = ttng.tmem_alloc %zero : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dk = ttng.tc_gen5_mma %p_smem, %bT, %acc_dk[%acc_dk_tok], %true, %true {two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+
+    // dQ-style dependent: the A chain carries the rank-two transpose plus the
+    // reshape into TLX's physical [M/2, 2*N] operand layout.
+    %pT = tt.trans %p {order = array<i32: 1, 0>} : tensor<128x128xf16, #linear1> -> tensor<128x128xf16, #linear3>
+    %pT_packed = tt.reshape %pT : tensor<128x128xf16, #linear3> -> tensor<64x256xf16, #linear4>
+    %pT_smem = ttg.local_alloc %pT_packed : (tensor<64x256xf16, #linear4>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+    %acc_dq, %acc_dq_tok = ttng.tmem_alloc %zero_dq : (tensor<64x128xf32, #linear>) -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dq = ttng.tc_gen5_mma %pT_smem, %kt, %acc_dq[%acc_dq_tok], %true, %true {two_ctas} : !ttg.memdesc<64x256xf16, #shared, #smem>, !ttg.memdesc<256x128xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/analyze_2cta_dependencies_fwd_sliced_chain.mlir
+++ b/test/Hopper/TwoCTA/analyze_2cta_dependencies_fwd_sliced_chain.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-opt %s --nvgpu-analyze-2cta-dependencies | FileCheck %s --check-prefix=DEP
+
+// Full TTGIR captured immediately before NVGPUAnalyze2CTADependencies from
+// test_dot_2cta.py::test_tl_dot_2cta_sliced_dependent_chain: a 2-CTA qK MMA
+// whose result is statically subtiled by reshape -> rank-3 permute -> split and
+// fed to two serial 2-CTA PV MMAs.
+//
+// A rank-3 transpose here only exposes a size-two axis to tt.split; it does not
+// transpose the logical MMA operand across CTAs, so both dependent MMAs are
+// collective contractions. Classifying them as peer gathers instead makes
+// Plan2CTAExchange fail with "requires_peer_gather expects a transposed
+// local_alloc operand with a tensor source". Only the rank-2 matrix transpose
+// of the dQ path needs a peer gather.
+// DEP-COUNT-2: ttng.two_cta_dependency = "collective_contraction"
+// DEP-NOT: requires_peer_gather
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0], [128, 0, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1], [128, 0, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [128, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#loc = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":56:1)
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#loc17 = loc("q_ptr"(#loc))
+#loc18 = loc("k_ptr"(#loc))
+#loc19 = loc("v_ptr"(#loc))
+#loc20 = loc("o_ptr"(#loc))
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_tl_dot_2cta_sliced_dependent_chain_kernel(%q_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc("q_ptr"(#loc)), %k_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc("k_ptr"(#loc)), %v_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc("v_ptr"(#loc)), %o_ptr: !tt.ptr<bf16> {tt.divisibility = 16 : i32} loc("o_ptr"(#loc))) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf32, #linear> loc(#loc1)
+    %true = arith.constant true loc(#loc1)
+    %v1 = arith.constant 64 : i32 loc(#loc21)
+    %c0_i32 = arith.constant 0 : i32 loc(#loc1)
+    %c256_i32 = arith.constant 256 : i32 loc(#loc1)
+    %c128_i32 = arith.constant 128 : i32 loc(#loc1)
+    %c128_i64 = arith.constant 128 : i64 loc(#loc1)
+    %c1_i64 = arith.constant 1 : i64 loc(#loc1)
+    %q_desc = tt.make_tensor_descriptor %q_ptr, [%c256_i32, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<256x128xbf16> loc(#loc22)
+    %k_desc = tt.make_tensor_descriptor %k_ptr, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<128x128xbf16> loc(#loc23)
+    %v_desc = tt.make_tensor_descriptor %v_ptr, [%c128_i32, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<64x128xbf16> loc(#loc24)
+    %o_desc = tt.make_tensor_descriptor %o_ptr, [%c256_i32, %c128_i32], [%c128_i64, %c1_i64] : !tt.ptr<bf16>, !tt.tensordesc<256x128xbf16> loc(#loc25)
+    %q = tt.descriptor_load %q_desc[%c0_i32, %c0_i32] : !tt.tensordesc<256x128xbf16> -> tensor<256x128xbf16, #blocked> loc(#loc26)
+    %q_0 = ttg.local_alloc %q : (tensor<256x128xbf16, #blocked>) -> !ttg.memdesc<256x128xbf16, #shared, #smem> loc(#loc26)
+    %k = tt.descriptor_load %k_desc[%c0_i32, %c0_i32] : !tt.tensordesc<128x128xbf16> -> tensor<128x128xbf16, #blocked> loc(#loc27)
+    %v0 = tt.descriptor_load %v_desc[%c0_i32, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16, #blocked> loc(#loc28)
+    %v0_1 = ttg.local_alloc %v0 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem> loc(#loc28)
+    %v1_2 = tt.descriptor_load %v_desc[%v1, %c0_i32] : !tt.tensordesc<64x128xbf16> -> tensor<64x128xbf16, #blocked> loc(#loc21)
+    %v1_3 = ttg.local_alloc %v1_2 : (tensor<64x128xbf16, #blocked>) -> !ttg.memdesc<64x128xbf16, #shared, #smem> loc(#loc21)
+    %qk = ttg.local_alloc %k : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared, #smem> loc(#loc29)
+    %qk_4 = ttg.memdesc_trans %qk {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared1, #smem> loc(#loc29)
+    %qk_5, %qk_6 = ttng.tmem_alloc %cst : (tensor<256x128xf32, #linear>) -> (!ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc30)
+    %qk_7 = ttng.tc_gen5_mma %q_0, %qk_4, %qk_5[%qk_6], %true, %true {two_ctas} : !ttg.memdesc<256x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc30)
+    %qk_8, %qk_9 = ttng.tmem_load %qk_5[%qk_7] : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear> loc(#loc30)
+    %qk_10 = arith.truncf %qk_8 : tensor<256x128xf32, #linear> to tensor<256x128xbf16, #linear> loc(#loc30)
+    %0 = tt.reshape %qk_10 : tensor<256x128xbf16, #linear> -> tensor<256x2x64xbf16, #linear1> loc(#loc12)
+    %1 = tt.trans %0 {order = array<i32: 0, 2, 1>} : tensor<256x2x64xbf16, #linear1> -> tensor<256x64x2xbf16, #linear2> loc(#loc12)
+    %outLHS, %outRHS = tt.split %1 : tensor<256x64x2xbf16, #linear2> -> tensor<256x64xbf16, #linear3> loc(#loc12)
+    %2 = ttg.local_alloc %outLHS : (tensor<256x64xbf16, #linear3>) -> !ttg.memdesc<256x64xbf16, #shared, #smem> loc(#loc12)
+    %3 = ttg.local_alloc %outRHS : (tensor<256x64xbf16, #linear3>) -> !ttg.memdesc<256x64xbf16, #shared, #smem> loc(#loc12)
+    %acc, %acc_11 = ttng.tmem_alloc %cst : (tensor<256x128xf32, #linear>) -> (!ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc31)
+    %acc_12 = ttng.tc_gen5_mma %2, %v0_1, %acc[%acc_11], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #shared, #smem>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc31)
+    %acc_13, %acc_14 = ttng.tmem_load %acc[%acc_12] : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear> loc(#loc31)
+    %acc_15, %acc_16 = ttng.tmem_alloc %acc_13 : (tensor<256x128xf32, #linear>) -> (!ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc32)
+    %acc_17 = ttng.tc_gen5_mma %3, %v1_3, %acc_15[%acc_16], %true, %true {two_ctas} : !ttg.memdesc<256x64xbf16, #shared, #smem>, !ttg.memdesc<64x128xbf16, #shared, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc32)
+    %acc_18, %acc_19 = ttng.tmem_load %acc_15[%acc_17] : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #linear> loc(#loc32)
+    %4 = arith.truncf %acc_18 : tensor<256x128xf32, #linear> to tensor<256x128xbf16, #linear> loc(#loc15)
+    %5 = ttg.convert_layout %4 : tensor<256x128xbf16, #linear> -> tensor<256x128xbf16, #blocked> loc(#loc16)
+    tt.descriptor_store %o_desc[%c0_i32, %c0_i32], %5 : !tt.tensordesc<256x128xbf16>, tensor<256x128xbf16, #blocked> loc(#loc16)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc(unknown)
+#loc2 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":65:10)
+#loc3 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":57:14)
+#loc4 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":58:14)
+#loc5 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":59:14)
+#loc6 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":60:14)
+#loc7 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":62:9)
+#loc8 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":63:9)
+#loc9 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":64:10)
+#loc10 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":66:20)
+#loc11 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":66:10)
+#loc12 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":68:14)
+#loc13 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":70:11)
+#loc14 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":71:11)
+#loc15 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":72:26)
+#loc16 = loc("/home/mren/MetaMain2/triton-splits/python/test/unit/language/test_dot_2cta.py":72:5)
+#loc21 = loc("v1"(#loc2))
+#loc22 = loc("q_desc"(#loc3))
+#loc23 = loc("k_desc"(#loc4))
+#loc24 = loc("v_desc"(#loc5))
+#loc25 = loc("o_desc"(#loc6))
+#loc26 = loc("q"(#loc7))
+#loc27 = loc("k"(#loc8))
+#loc28 = loc("v0"(#loc9))
+#loc29 = loc("qk"(#loc10))
+#loc30 = loc("qk"(#loc11))
+#loc31 = loc("acc"(#loc13))
+#loc32 = loc("acc"(#loc14))
+
+
+

--- a/test/Hopper/TwoCTA/insert_2cta_sync_bwd_bm128_inner.mlir
+++ b/test/Hopper/TwoCTA/insert_2cta_sync_bwd_bm128_inner.mlir
@@ -1,0 +1,1051 @@
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64], [0, 32]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 1, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 0, 1]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [64, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0], [32, 0, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [64, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [32, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared3 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared4 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, twoCTAs = true>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 2, twoCTAs = true>
+#tmem3 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem4 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 88 : i32, ttg.min_reg_auto_ws = 88 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd(%desc_q: !tt.tensordesc<128x64xf16, #shared>, %desc_q.shape.0: i32, %desc_q.shape.1: i32, %desc_q.stride.0: i64, %desc_q.stride.1: i64, %desc_qt: !tt.tensordesc<64x128xf16, #shared>, %desc_qt.shape.0: i32, %desc_qt.shape.1: i32, %desc_qt.stride.0: i64, %desc_qt.stride.1: i64, %desc_k: !tt.tensordesc<128x128xf16, #shared>, %desc_k.shape.0: i32, %desc_k.shape.1: i32, %desc_k.stride.0: i64, %desc_k.stride.1: i64, %desc_kt: !tt.tensordesc<256x64xf16, #shared>, %desc_kt.shape.0: i32, %desc_kt.shape.1: i32, %desc_kt.stride.0: i64, %desc_kt.stride.1: i64, %desc_v: !tt.tensordesc<128x128xf16, #shared>, %desc_v.shape.0: i32, %desc_v.shape.1: i32, %desc_v.stride.0: i64, %desc_v.stride.1: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<128x64xf16, #shared>, %desc_do.shape.0: i32, %desc_do.shape.1: i32, %desc_do.stride.0: i64, %desc_do.stride.1: i64, %desc_dot: !tt.tensordesc<64x128xf16, #shared>, %desc_dot.shape.0: i32, %desc_dot.shape.1: i32, %desc_dot.stride.0: i64, %desc_dot.stride.1: i64, %desc_dq: !tt.tensordesc<128x16xf32, #shared1>, %desc_dq.shape.0: i32, %desc_dq.shape.1: i32, %desc_dq.stride.0: i64, %desc_dq.stride.1: i64, %desc_dk: !tt.tensordesc<128x64xf16, #shared>, %desc_dk.shape.0: i32, %desc_dk.shape.1: i32, %desc_dk.stride.0: i64, %desc_dk.stride.1: i64, %desc_dv: !tt.tensordesc<128x64xf16, #shared>, %desc_dv.shape.0: i32, %desc_dv.shape.1: i32, %desc_dv.stride.0: i64, %desc_dv.stride.1: i64, %desc_m: !tt.tensordesc<128xf32, #shared2>, %desc_m.shape.0: i32, %desc_m.stride.0: i64, %desc_delta: !tt.tensordesc<128xf32, #shared2>, %desc_delta.shape.0: i32, %desc_delta.stride.0: i64, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %0 = ub.poison : !ttg.async.token
+    %c256_i32 = arith.constant 256 : i32
+    %c7_i32 = arith.constant 7 : i32
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0>} 1 : i64
+    %c0_i64 = arith.constant {async_task_id = array<i32: 0>} 0 : i64
+    %true = arith.constant {async_task_id = array<i32: 0>} true
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0>} 64 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0>} 128 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0>} 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %1 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %2 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %3 = ttg.memdesc_index %1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %4 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %4, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %5 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %6 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %7 = ttg.memdesc_index %5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %7, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %8 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %8, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dq = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dq_0 = ttg.memdesc_index %dq[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dq_0, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_1 = ttg.memdesc_index %dsT_dq_0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_1, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_2 = ttg.memdesc_index %dsT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_2, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %Di = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %Di_3 = ttg.memdesc_index %Di[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %Di_3, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dpT_4 = ttg.memdesc_index %dpT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dpT_4, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_5 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dpT_6 = ttg.memdesc_index %dpT_5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dpT_6, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %ppT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %ppT_7 = ttg.memdesc_index %ppT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %ppT_7, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %do = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %do_8 = ttg.memdesc_index %do[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %do_8, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %do_9 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %do_10 = ttg.memdesc_index %do_9[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %do_10, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %m = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %m_11 = ttg.memdesc_index %m[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %m_11, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %q = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %q_12 = ttg.memdesc_index %q[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %q_12, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %q_13 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %q_14 = ttg.memdesc_index %q_13[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %q_14, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %qT_15 = ttg.memdesc_index %qT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %qT_15, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qT_16 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %qT_17 = ttg.memdesc_index %qT_16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %qT_17, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_18 = ttg.memdesc_index %dk[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_18, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_19 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_20 = ttg.memdesc_index %dk_19[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_20, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_21 = ttg.memdesc_index %dv[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_21, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_22 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_23 = ttg.memdesc_index %dv_22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_23, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_24 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dpT_25 = ttg.memdesc_index %dpT_24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dpT_25, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %qkT_26 = ttg.memdesc_index %qkT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %qkT_26, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %v = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %v_27 = ttg.memdesc_index %v[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %v_27, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %v_28 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %v_29 = ttg.memdesc_index %v_28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %v_29, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %kt = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %kt_30 = ttg.memdesc_index %kt[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %kt_30, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %kt_31 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %kt_32 = ttg.memdesc_index %kt_31[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %kt_32, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %k = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %k_33 = ttg.memdesc_index %k[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %k_33, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %k_34 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %k_35 = ttg.memdesc_index %k_34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %k_35, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT_36 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %qkT_37 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %qkT_38 = ttg.memdesc_index %qkT_36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %qkT_38, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT_39 = ttg.memdesc_index %qkT_37[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %qkT_39, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dpT_40 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dpT_41 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dpT_42 = ttg.memdesc_index %dpT_40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dpT_42, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_43 = ttg.memdesc_index %dpT_41[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dpT_43, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dv_44 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_45 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_46 = ttg.memdesc_index %dv_44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_46, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_47 = ttg.memdesc_index %dv_45[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_47, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dv_48 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_49 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_50 = ttg.memdesc_index %dv_48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_50, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_51 = ttg.memdesc_index %dv_49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_51, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dv_52 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_53 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dv_54 = ttg.memdesc_index %dv_52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_54, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_55 = ttg.memdesc_index %dv_53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dv_55, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dk_56 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_57 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_58 = ttg.memdesc_index %dk_56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_58, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_59 = ttg.memdesc_index %dk_57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_59, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dk_60 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_61 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_62 = ttg.memdesc_index %dk_60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_62, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_63 = ttg.memdesc_index %dk_61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_63, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dk_64 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_65 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dk_66 = ttg.memdesc_index %dk_64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_66, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_67 = ttg.memdesc_index %dk_65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dk_67, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %m_68 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %m_69 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %m_70 = ttg.memdesc_index %m_68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %m_70, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %m_71 = ttg.memdesc_index %m_69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %m_71, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %ppT_72 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %ppT_73 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %ppT_74 = ttg.memdesc_index %ppT_72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %ppT_74, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %ppT_75 = ttg.memdesc_index %ppT_73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %ppT_75, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %Di_76 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %Di_77 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %Di_78 = ttg.memdesc_index %Di_76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %Di_78, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %Di_79 = ttg.memdesc_index %Di_77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %Di_79, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dsT_80 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_81 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_82 = ttg.memdesc_index %dsT_80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_82, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_83 = ttg.memdesc_index %dsT_81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_83, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dsT_dq_1 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_dq_1_84 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_dq_1_85 = ttg.memdesc_index %dsT_dq_1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_dq_1_85, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_1_86 = ttg.memdesc_index %dsT_dq_1_84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_dq_1_86, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dsT_dq_0_87 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_88 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_89 = ttg.memdesc_index %dsT_dq_0_87[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_89, 2 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_90 = ttg.memdesc_index %dsT_dq_0_88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_90, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %dq_91 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dq_92 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>
+    %dq_93 = ttg.memdesc_index %dq_91[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dq_93, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dq_94 = ttg.memdesc_index %dq_92[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.init_barrier %dq_94, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttg.barrier local
+    %k_95 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+    %desc_dv_staging = ttg.memdesc_reinterpret %k_95 {allocation.shareGroup = 0 : i32, buffer.copy = 1 : i32, buffer.id = 26 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %kt_96 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 12 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+    %v_97 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+    %qkT_98 = ttng.tmem_alloc {allocation.shareGroup = 1 : i32, buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %dpT_99 = ttng.tmem_alloc {allocation.shareGroup = 4 : i32, buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %dv_100 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %dk_101 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32} : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %qT_102 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+    %desc_dk_staging = ttg.memdesc_reinterpret %qT_102 {allocation.shareGroup = 2 : i32, buffer.copy = 1 : i32, buffer.id = 28 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %q_103 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 15 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %m_104 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 16 : i32} : () -> !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>
+    %do_105 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 17 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %dpT_106 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+    %Di_107 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 19 : i32} : () -> !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>
+    %dsT_dq_1_108 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 20 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %dsT_dq_0_109 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+    %dk_110 = ttg.memdesc_index %dk_101[%c0_i32] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %dv_111 = ttg.memdesc_index %dv_100[%c0_i32] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %desc_dq_reduce_staging = ttg.local_alloc {allocation.shareGroup = 3 : i32, buffer.copy = 1 : i32, buffer.id = 22 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>
+    %dv_112 = ttg.memdesc_index %dv_100[%c0_i32] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %dk_113 = ttg.memdesc_index %dk_101[%c0_i32] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %desc_dv_staging_114 = ttg.memdesc_index %desc_dv_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dv_staging_115 = ttg.memdesc_index %desc_dv_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dv_staging_116 = ttg.memdesc_index %desc_dv_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dv_staging_117 = ttg.memdesc_index %desc_dv_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dk_staging_118 = ttg.memdesc_index %desc_dk_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dk_staging_119 = ttg.memdesc_index %desc_dk_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dk_staging_120 = ttg.memdesc_index %desc_dk_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %desc_dk_staging_121 = ttg.memdesc_index %desc_dk_staging[%c0_i32] : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.warp_specialize(%H, %stride_h, %stride_z, %stride_tok, %N_CTX, %dk_110, %dv_111, %dpT_99, %dq, %desc_dq_reduce_staging, %desc_dq, %k_34, %kt_31, %v_28, %qT_102, %qT_16, %k_95, %qkT_98, %qT, %qkT, %ppT, %dpT_106, %dpT_5, %v_97, %dpT, %dpT_24, %dv_100, %do_105, %do, %do_9, %dk_101, %q_103, %q, %q_13, %dsT, %dsT_dq_0_109, %kt_96, %dsT_dq_0, %dk, %dk_19, %dv, %dv_22, %v, %kt, %k, %desc_k, %desc_kt, %desc_v, %desc_qt, %desc_q, %m, %m_104, %desc_m, %desc_do, %desc_dot, %Di, %Di_107, %desc_delta, %dsT_dq_1_108, %1, %2, %5, %6, %qkT_36, %qkT_37, %dpT_40, %dpT_41, %dv_44, %dv_45, %dv_48, %dv_49, %dv_52, %dv_53, %dk_56, %dk_57, %dk_60, %dk_61, %dk_64, %dk_65, %m_68, %m_69, %ppT_72, %ppT_73, %Di_76, %Di_77, %dsT_80, %dsT_81, %dsT_dq_1, %dsT_dq_1_84, %dsT_dq_0_87, %dsT_dq_0_88, %dq_91, %dq_92) attributes {requestedRegisters = array<i32: 88, 88, 88, 40>, ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"]}
+    default {
+      %bhid = tt.get_program_id z {async_task_id = array<i32: 0>} : i32
+      %pid = tt.get_program_id x {async_task_id = array<i32: 0>} : i32
+      %off_bh = arith.remsi %bhid, %H {async_task_id = array<i32: 0>} : i32
+      %off_bh_178 = arith.muli %stride_h, %off_bh {async_task_id = array<i32: 0>} : i32
+      %off_bh_179 = arith.divsi %bhid, %H {async_task_id = array<i32: 0>} : i32
+      %off_bh_180 = arith.muli %stride_z, %off_bh_179 {async_task_id = array<i32: 0>} : i32
+      %off_bh_181 = arith.addi %off_bh_178, %off_bh_180 {async_task_id = array<i32: 0>} : i32
+      %off_bh_182 = arith.extsi %off_bh_181 {async_task_id = array<i32: 0>} : i32 to i64
+      %off_bh_183 = arith.extsi %stride_tok {async_task_id = array<i32: 0>} : i32 to i64
+      %off_bh_184 = arith.divsi %off_bh_182, %off_bh_183 {async_task_id = array<i32: 0>} : i64
+      %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 0>} : i32
+      %k_185 = arith.extsi %start_n {async_task_id = array<i32: 0>} : i32 to i64
+      %k_186 = arith.addi %off_bh_184, %k_185 {async_task_id = array<i32: 0>} : i64
+      %k_187 = arith.trunci %k_186 {async_task_id = array<i32: 0>} : i64 to i32
+      %num_steps = arith.divsi %N_CTX, %c128_i32 {async_task_id = array<i32: 0>} : i32
+      %curr_m = scf.for %curr_m_208 = %c0_i32 to %num_steps step %c1_i32 iter_args(%curr_m_209 = %c0_i64) -> (i64)  : i32 {
+        %m_210 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %m_211 = arith.trunci %m_210 {async_task_id = array<i32: 0>} : i64 to i1
+        %qkT_212 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %qkT_213 = arith.trunci %qkT_212 {async_task_id = array<i32: 0>} : i64 to i1
+        %dv_214 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %dv_215 = arith.trunci %dv_214 {async_task_id = array<i32: 0>} : i64 to i1
+        %m_216 = ttg.memdesc_index %m_104[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128xf32, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        %m_217 = ttg.memdesc_index %m[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %m_218 = arith.extui %m_211 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %m_217, %m_218, %true {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %m_219 = ttg.local_load %m_216 {async_task_id = array<i32: 0>} : !ttg.memdesc<128xf32, #shared2, #smem, mutable> -> tensor<128xf32, #blocked>
+        %m_220 = ttg.memdesc_index %m_69[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %m_220, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %pT = ttg.convert_layout %m_219 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %pT_221 = tt.expand_dims %pT {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %pT_222 = tt.broadcast %pT_221 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %qkT_223 = ttg.memdesc_index %qkT_98[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_224 = ttg.memdesc_index %qkT[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_225 = arith.extui %qkT_213 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %qkT_224, %qkT_225 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_226 = ttng.tmem_load %qkT_223 {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %qkT_227 = ttg.memdesc_index %qkT_37[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %qkT_227, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %pT_228 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %qkT_226, %pT_222 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %pT_229 = math.exp2 %pT_228 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear>
+        %ppT_230 = arith.truncf %pT_229 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %qkT_231 = ttng.tmem_subslice %qkT_98 {N = 0 : i32, async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+        %qkT_232 = ttg.memdesc_reinterpret %qkT_231 {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+        %ppT_233 = ttg.memdesc_index %qkT_232[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_234 = ttg.memdesc_index %qkT_37[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dv_235 = arith.extui %dv_215 : i1 to i32
+        ttng.wait_barrier %qkT_234, %dv_235 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {dstTask = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tmem_store %ppT_230, %ppT_233, %true {async_task_id = array<i32: 0>} : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %ppT_236 = ttg.memdesc_index %ppT_72[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %ppT_236, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_237 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %dpT_238 = arith.trunci %dpT_237 {async_task_id = array<i32: 0>} : i64 to i1
+        %Di_239 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %Di_240 = arith.trunci %Di_239 {async_task_id = array<i32: 0>} : i64 to i1
+        %Di_241 = ttg.memdesc_index %Di_107[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128xf32, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        %Di_242 = ttg.memdesc_index %Di[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %Di_243 = arith.extui %Di_240 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %Di_242, %Di_243, %true {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %Di_244 = ttg.local_load %Di_241 {async_task_id = array<i32: 0>} : !ttg.memdesc<128xf32, #shared2, #smem, mutable> -> tensor<128xf32, #blocked>
+        %Di_245 = ttg.memdesc_index %Di_77[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %Di_245, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_246 = ttg.convert_layout %Di_244 {async_task_id = array<i32: 0>} : tensor<128xf32, #blocked> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %dsT_247 = tt.expand_dims %dsT_246 {async_task_id = array<i32: 0>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %dsT_248 = tt.broadcast %dsT_247 {async_task_id = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %dpT_249 = ttg.memdesc_index %dpT_99[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_250 = ttg.memdesc_index %dpT_24[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_251 = arith.extui %dpT_238 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %dpT_250, %dpT_251 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_252 = ttng.tmem_load %dpT_249 {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %dpT_253 = ttg.memdesc_index %dpT_41[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dpT_253, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_254 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %dpT_252, %dsT_248 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %dsT_255 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {async_task_id = array<i32: 0>, constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %pT_229, %dsT_254 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %dsT_256 = arith.truncf %dsT_255 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %dpT_257 = ttng.tmem_subslice %dpT_99 {N = 0 : i32, async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+        %dpT_258 = ttg.memdesc_reinterpret %dpT_257 {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+        %dsT_259 = ttg.memdesc_index %dpT_258[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dk_260 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %dk_261 = arith.trunci %dk_260 {async_task_id = array<i32: 0>} : i64 to i1
+        %dsT_262 = ttg.memdesc_index %dsT[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dk_263 = arith.xori %dk_261, %true {async_task_id = array<i32: 0>} : i1
+        %dk_264 = arith.extui %dk_263 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %dsT_262, %dk_264 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tmem_store %dsT_256, %dsT_259, %true {async_task_id = array<i32: 0>} : tensor<128x128xf16, #linear> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dsT_265 = ttg.memdesc_index %dsT_80[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dsT_265, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_1_266 = ttg.memdesc_index %dsT_dq_1_108[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %dsT_dq = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %dsT_dq_267 = arith.trunci %dsT_dq {async_task_id = array<i32: 0>} : i64 to i1
+        %dsT_dq_1_268 = ttg.memdesc_index %dsT_dq_1_84[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_269 = arith.xori %dsT_dq_267, %true : i1
+        %dsT_dq_270 = arith.extui %dsT_dq_269 : i1 to i32
+        ttng.wait_barrier %dsT_dq_1_268, %dsT_dq_270 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_1_271 = ttg.memdesc_index %dsT_dq_1[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_0_272 = ttg.memdesc_index %dsT_dq_0_109[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %dsT_dq_273 = arith.andi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        %dsT_dq_274 = arith.trunci %dsT_dq_273 {async_task_id = array<i32: 0>} : i64 to i1
+        %dsT_dq_0_275 = ttg.memdesc_index %dsT_dq_0[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_276 = arith.xori %dsT_dq_274, %true {async_task_id = array<i32: 0>} : i1
+        %dsT_dq_277 = arith.extui %dsT_dq_276 {async_task_id = array<i32: 0>} : i1 to i32
+        ttng.wait_barrier %dsT_dq_0_275, %dsT_dq_277 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_278 = ttng.tmem_subslice %dsT_259 {N = 0 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+        %dsT_dq_279 = ttng.tmem_load %dsT_dq_278 : !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf16, #linear1>
+        %dsT_dq_280 = ttng.tmem_subslice %dsT_259 {N = 64 : i32} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable, 128x128>
+        %dsT_dq_281 = ttng.tmem_load %dsT_dq_280 : !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf16, #linear1>
+        %dsT_dq_282 = ttg.memdesc_subslice %dsT_dq_0_272[0, 0] : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+        %dsT_dq_283 = ttg.memdesc_subslice %dsT_dq_0_272[128, 0] : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+        ttng.barrier_expect %dsT_dq_1_271, 16384, %true : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_284 = nvg.cluster_id
+        %dsT_dq_285 = arith.cmpi eq, %dsT_dq_284, %c0_i32 : i32
+        scf.if %dsT_dq_285 {
+          ttg.local_store %dsT_dq_279, %dsT_dq_282 : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+          ttg.local_store %dsT_dq_281, %dsT_dq_1_266 : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          ttng.wait_barrier_named %c7_i32, %c256_i32 : i32, i32
+          ttng.fence_async_shared {bCluster = false}
+          ttg.async_remote_shmem_copy %dsT_dq_1_266, rank %c1_i32, %dsT_dq_282 barrier %dsT_dq_1_271 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64> barrier_ty !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        } else {
+          ttg.local_store %dsT_dq_281, %dsT_dq_283 : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64>
+          ttg.local_store %dsT_dq_279, %dsT_dq_1_266 : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          ttng.wait_barrier_named %c7_i32, %c256_i32 : i32, i32
+          ttng.fence_async_shared {bCluster = false}
+          ttg.async_remote_shmem_copy %dsT_dq_1_266, rank %c0_i32, %dsT_dq_283 barrier %dsT_dq_1_271 : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable, 256x64> barrier_ty !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        }
+        %dsT_dq_0_286 = ttg.memdesc_index %dsT_dq_0_87[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dsT_dq_0_286, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %accum_cnt = arith.addi %curr_m_209, %c1_i64 {async_task_id = array<i32: 0>} : i64
+        scf.yield {async_task_id = array<i32: 0>} %accum_cnt : i64
+      } {async_task_id = array<i32: 0>, tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+      %dv_188 = ttg.memdesc_index %dv[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dv_188, %c0_i32 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_189 = ttg.memdesc_index %dv_52[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dv_189, %c0_i32 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_190 = ttng.tmem_load %dv_112 {async_task_id = array<i32: 0>, tmem.end = array<i32: 6, 7>, tmem.start = array<i32: 8>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %dv_191 = ttg.memdesc_index %dv_53[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dv_191, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_192 = ttg.memdesc_index %dv_49[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dv_192, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %13 = ttg.memdesc_index %6[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %13, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_193 = ttg.memdesc_index %dk[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dk_193, %c0_i32 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, direction = "forward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_194 = ttg.memdesc_index %dk_64[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dk_194, %c0_i32 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_195 = ttng.tmem_load %dk_113 {async_task_id = array<i32: 0>, tmem.end = array<i32: 10, 11>, tmem.start = array<i32: 12>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %dk_196 = ttg.memdesc_index %dk_65[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dk_196, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_197 = ttg.memdesc_index %dk_61[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dk_197, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 2 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %14 = ttg.memdesc_index %2[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %14, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dvs = tt.reshape %dv_190 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear2>
+      %dvs_198 = tt.trans %dvs {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear2> -> tensor<128x64x2xf32, #linear3>
+      %dvs_199 = ttg.convert_layout %dvs_198 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #linear3> -> tensor<128x64x2xf32, #blocked1>
+      %dvs_200, %dvs_201 = tt.split %dvs_199 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #blocked1> -> tensor<128x64xf32, #blocked2>
+      %15 = arith.truncf %dvs_200 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+      ttg.local_store %15, %desc_dv_staging_114 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked2> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %16 = ttng.async_tma_copy_local_to_global %desc_dv[%k_187, %c0_i32] %desc_dv_staging_115 {async_task_id = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %16   {async_task_id = array<i32: 0>} : !ttg.async.token
+      %17 = arith.truncf %dvs_201 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+      ttg.local_store %17, %desc_dv_staging_116 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked2> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %18 = ttng.async_tma_copy_local_to_global %desc_dv[%k_187, %c64_i32] %desc_dv_staging_117 {async_task_id = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %18   {async_task_id = array<i32: 0>} : !ttg.async.token
+      %dks = tt.reshape %dk_195 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear2>
+      %dks_202 = tt.trans %dks {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear2> -> tensor<128x64x2xf32, #linear3>
+      %dks_203 = ttg.convert_layout %dks_202 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #linear3> -> tensor<128x64x2xf32, #blocked1>
+      %dks_204, %dks_205 = tt.split %dks_203 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #blocked1> -> tensor<128x64xf32, #blocked2>
+      %dkN = tt.splat %sm_scale {async_task_id = array<i32: 0>} : f32 -> tensor<128x64xf32, #blocked2>
+      %dkN_206 = arith.mulf %dks_204, %dkN {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+      %19 = arith.truncf %dkN_206 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+      ttg.local_store %19, %desc_dk_staging_118 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked2> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %20 = ttng.async_tma_copy_local_to_global %desc_dk[%k_187, %c0_i32] %desc_dk_staging_119 {async_task_id = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %20   {async_task_id = array<i32: 0>} : !ttg.async.token
+      %dkN_207 = arith.mulf %dks_205, %dkN {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+      %21 = arith.truncf %dkN_207 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+      ttg.local_store %21, %desc_dk_staging_120 {async_task_id = array<i32: 0>} : tensor<128x64xf16, #blocked2> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %22 = ttng.async_tma_copy_local_to_global %desc_dk[%k_187, %c64_i32] %desc_dk_staging_121 {async_task_id = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %22   {async_task_id = array<i32: 0>} : !ttg.async.token
+      ttg.warp_yield
+    }
+    partition0(%H_178: i32, %stride_h_179: i32, %stride_z_180: i32, %stride_tok_181: i32, %N_CTX_182: i32, %dk_183: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dv_184: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_185: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dq_186: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_dq_reduce_staging_187: !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>, %desc_dq_188: !tt.tensordesc<128x16xf32, #shared1>, %k_189: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_190: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_191: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qT_192: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %qT_193: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_194: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_195: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_196: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_197: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_198: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_199: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_200: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_201: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_202: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_203: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_204: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_205: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_206: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %do_207: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_208: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_209: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_210: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %q_211: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_212: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_213: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_214: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_215: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_216: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_217: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_218: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_219: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_220: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_221: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_222: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_k_223: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_224: !tt.tensordesc<256x64xf16, #shared>, %desc_v_225: !tt.tensordesc<128x128xf16, #shared>, %desc_qt_226: !tt.tensordesc<64x128xf16, #shared>, %desc_q_227: !tt.tensordesc<128x64xf16, #shared>, %m_228: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_229: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_m_230: !tt.tensordesc<128xf32, #shared2>, %desc_do_231: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_232: !tt.tensordesc<64x128xf16, #shared>, %Di_233: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_234: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_delta_235: !tt.tensordesc<128xf32, #shared2>, %dsT_dq_1_236: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg122: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_237: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_238: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_239: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_240: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_241: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_242: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_243: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_244: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_245: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_246: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_247: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_248: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_249: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_250: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_251: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_252: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_253: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_254: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_255: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_256: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_257: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_258: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_259: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_260: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_261: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_262: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_263: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_264: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_265: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_266: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>) num_warps(8) {
+      %c1_i64_267 = arith.constant {async_task_id = array<i32: 1>} 1 : i64
+      %curr_m = arith.constant {async_task_id = array<i32: 1>} 0 : i64
+      %c0_i32_268 = arith.constant {async_task_id = array<i32: 1>} 0 : i32
+      %cst = arith.constant {async_task_id = array<i32: 1>} dense<0.693147182> : tensor<128x16xf32, #blocked3>
+      %c16_i32 = arith.constant {async_task_id = array<i32: 1>} 16 : i32
+      %c32_i32 = arith.constant {async_task_id = array<i32: 1>} 32 : i32
+      %c48_i32 = arith.constant {async_task_id = array<i32: 1>} 48 : i32
+      %c1_i32_269 = arith.constant {async_task_id = array<i32: 1>} 1 : i32
+      %c2_i64 = arith.constant {async_task_id = array<i32: 1>} 2 : i64
+      %c128_i32_270 = arith.constant {async_task_id = array<i32: 1>} 128 : i32
+      %c2_i32 = arith.constant {async_task_id = array<i32: 1>} 2 : i32
+      %c64_i32_271 = arith.constant {async_task_id = array<i32: 1>} 64 : i32
+      %true_272 = arith.constant {async_task_id = array<i32: 1>} true
+      %cst_273 = arith.constant {async_task_id = array<i32: 1>} dense<0.000000e+00> : tensor<128x128xf32, #linear>
+      %bhid = tt.get_program_id z {async_task_id = array<i32: 1>} : i32
+      %pid = tt.get_program_id x {async_task_id = array<i32: 1>} : i32
+      %off_bh = arith.remsi %bhid, %H_178 {async_task_id = array<i32: 1>} : i32
+      %off_bh_274 = arith.muli %stride_h_179, %off_bh {async_task_id = array<i32: 1>} : i32
+      %off_bh_275 = arith.divsi %bhid, %H_178 {async_task_id = array<i32: 1>} : i32
+      %off_bh_276 = arith.muli %stride_z_180, %off_bh_275 {async_task_id = array<i32: 1>} : i32
+      %off_bh_277 = arith.addi %off_bh_274, %off_bh_276 {async_task_id = array<i32: 1>} : i32
+      %off_bh_278 = arith.extsi %off_bh_277 {async_task_id = array<i32: 1>} : i32 to i64
+      %off_bh_279 = arith.extsi %stride_tok_181 {async_task_id = array<i32: 1>} : i32 to i64
+      %off_bh_280 = arith.divsi %off_bh_278, %off_bh_279 {async_task_id = array<i32: 1>} : i64
+      %cluster_cta_rank = arith.remsi %pid, %c2_i32 {async_task_id = array<i32: 1>} : i32
+      %num_steps = arith.divsi %N_CTX_182, %c128_i32_270 {async_task_id = array<i32: 1>} : i32
+      %dq_row = arith.muli %cluster_cta_rank, %c64_i32_271 {async_task_id = array<i32: 1>} : i32
+      %dq_row_281 = arith.extsi %dq_row {async_task_id = array<i32: 1>} : i32 to i64
+      %13 = ttg.memdesc_index %arg123[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %13, %c1_i32_269 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_282 = ttg.memdesc_index %dk_252[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dk_282, %c1_i32_269 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tmem_store %cst_273, %dk_183, %true_272 {async_task_id = array<i32: 1>, tmem.end = array<i32: 12>, tmem.start = array<i32: 9, 11>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dk_283 = ttg.memdesc_index %dk_251[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dk_283, 1 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %14 = ttg.memdesc_index %arg125[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %14, %c1_i32_269 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_284 = ttg.memdesc_index %dv_246[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dv_284, %c1_i32_269 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tmem_store %cst_273, %dv_184, %true_272 {async_task_id = array<i32: 1>, tmem.end = array<i32: 8>, tmem.start = array<i32: 5, 7>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dv_285 = ttg.memdesc_index %dv_245[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.arrive_barrier %dv_285, 1 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %curr_m_286:2 = scf.for %curr_m_287 = %c0_i32_268 to %num_steps step %c1_i32_269 iter_args(%arg157 = %c0_i32_268, %curr_m_288 = %curr_m) -> (i32, i64)  : i32 {
+        %qt = arith.extsi %arg157 {async_task_id = array<i32: 1>} : i32 to i64
+        %qt_289 = arith.addi %off_bh_280, %qt {async_task_id = array<i32: 1>} : i64
+        %dq_290 = arith.andi %curr_m_288, %c1_i64_267 {async_task_id = array<i32: 1>} : i64
+        %dq_291 = arith.trunci %dq_290 {async_task_id = array<i32: 1>} : i64 to i1
+        %dpT_292 = ttng.tmem_subslice %dpT_185 {N = 0 : i32, async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_293 = ttg.memdesc_reinterpret %dpT_292 {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable>
+        %dq_294 = ttg.memdesc_index %dpT_293[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable>
+        %dq_295 = ttg.memdesc_index %dq_186[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_296 = arith.extui %dq_291 {async_task_id = array<i32: 1>} : i1 to i32
+        ttng.wait_barrier %dq_295, %dq_296 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, direction = "forward", dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_297 = ttng.tmem_load %dq_294 {async_task_id = array<i32: 1>} : !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear4>
+        %dq_298 = ttg.memdesc_index %dq_266[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dq_298, 1 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 2, 3, 4>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dqs = tt.reshape %dq_297 {async_task_id = array<i32: 1>} : tensor<64x128xf32, #linear4> -> tensor<128x2x32xf32, #linear5>
+        %dqs_299 = tt.trans %dqs {async_task_id = array<i32: 1>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear5> -> tensor<128x32x2xf32, #linear6>
+        %dqs_300 = ttg.convert_layout %dqs_299 {async_task_id = array<i32: 1>} : tensor<128x32x2xf32, #linear6> -> tensor<128x32x2xf32, #linear7>
+        %dqs_301, %dqs_302 = tt.split %dqs_300 {async_task_id = array<i32: 1>} : tensor<128x32x2xf32, #linear7> -> tensor<128x32xf32, #linear8>
+        %dqs_303 = tt.reshape %dqs_301 {async_task_id = array<i32: 1>} : tensor<128x32xf32, #linear8> -> tensor<128x2x16xf32, #blocked4>
+        %dqs_304 = tt.trans %dqs_303 {async_task_id = array<i32: 1>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked4> -> tensor<128x16x2xf32, #blocked5>
+        %dqs_305, %dqs_306 = tt.split %dqs_304 {async_task_id = array<i32: 1>} : tensor<128x16x2xf32, #blocked5> -> tensor<128x16xf32, #blocked3>
+        %dqs_307 = tt.reshape %dqs_302 {async_task_id = array<i32: 1>} : tensor<128x32xf32, #linear8> -> tensor<128x2x16xf32, #blocked4>
+        %dqs_308 = tt.trans %dqs_307 {async_task_id = array<i32: 1>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked4> -> tensor<128x16x2xf32, #blocked5>
+        %dqs_309, %dqs_310 = tt.split %dqs_308 {async_task_id = array<i32: 1>} : tensor<128x16x2xf32, #blocked5> -> tensor<128x16xf32, #blocked3>
+        %dq_row_311 = arith.addi %qt_289, %dq_row_281 {async_task_id = array<i32: 1>} : i64
+        %dq_row_312 = arith.muli %dq_row_311, %c2_i64 {async_task_id = array<i32: 1>} : i64
+        %dqN = arith.mulf %dqs_305, %cst {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3>
+        %15 = arith.trunci %dq_row_312 {async_task_id = array<i32: 1>} : i64 to i32
+        %desc_dq_reduce_staging_313 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        ttg.local_store %dqN, %desc_dq_reduce_staging_313 {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %desc_dq_reduce_staging_314 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %16 = ttng.async_tma_reduce add, %desc_dq_188[%15, %c0_i32_268] %desc_dq_reduce_staging_314 {async_task_id = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %16   {async_task_id = array<i32: 1>} : !ttg.async.token
+        %dqN_315 = arith.mulf %dqs_306, %cst {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3>
+        %desc_dq_reduce_staging_316 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        ttg.local_store %dqN_315, %desc_dq_reduce_staging_316 {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %desc_dq_reduce_staging_317 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %17 = ttng.async_tma_reduce add, %desc_dq_188[%15, %c16_i32] %desc_dq_reduce_staging_317 {async_task_id = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %17   {async_task_id = array<i32: 1>} : !ttg.async.token
+        %dqN_318 = arith.mulf %dqs_309, %cst {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3>
+        %desc_dq_reduce_staging_319 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        ttg.local_store %dqN_318, %desc_dq_reduce_staging_319 {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %desc_dq_reduce_staging_320 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %18 = ttng.async_tma_reduce add, %desc_dq_188[%15, %c32_i32] %desc_dq_reduce_staging_320 {async_task_id = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %18   {async_task_id = array<i32: 1>} : !ttg.async.token
+        %dqN_321 = arith.mulf %dqs_310, %cst {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3>
+        %desc_dq_reduce_staging_322 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        ttg.local_store %dqN_321, %desc_dq_reduce_staging_322 {async_task_id = array<i32: 1>} : tensor<128x16xf32, #blocked3> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %desc_dq_reduce_staging_323 = ttg.memdesc_index %desc_dq_reduce_staging_187[%c0_i32_268] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %19 = ttng.async_tma_reduce add, %desc_dq_188[%15, %c48_i32] %desc_dq_reduce_staging_323 {async_task_id = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %19   {async_task_id = array<i32: 1>} : !ttg.async.token
+        %curr_m_324 = arith.addi %arg157, %c128_i32_270 {async_task_id = array<i32: 1>} : i32
+        %accum_cnt = arith.addi %curr_m_288, %c1_i64_267 {async_task_id = array<i32: 1>} : i64
+        scf.yield {async_task_id = array<i32: 1>} %curr_m_324, %accum_cnt : i32, i64
+      } {async_task_id = array<i32: 1>, tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    }
+    partition1(%H_178: i32, %stride_h_179: i32, %stride_z_180: i32, %stride_tok_181: i32, %N_CTX_182: i32, %dk_183: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dv_184: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_185: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dq_186: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_dq_reduce_staging_187: !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>, %desc_dq_188: !tt.tensordesc<128x16xf32, #shared1>, %k_189: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_190: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_191: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qT_192: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %qT_193: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_194: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_195: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_196: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_197: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_198: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_199: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_200: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_201: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_202: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_203: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_204: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_205: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_206: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %do_207: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_208: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_209: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_210: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %q_211: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_212: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_213: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_214: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_215: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_216: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_217: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_218: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_219: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_220: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_221: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_222: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_k_223: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_224: !tt.tensordesc<256x64xf16, #shared>, %desc_v_225: !tt.tensordesc<128x128xf16, #shared>, %desc_qt_226: !tt.tensordesc<64x128xf16, #shared>, %desc_q_227: !tt.tensordesc<128x64xf16, #shared>, %m_228: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_229: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_m_230: !tt.tensordesc<128xf32, #shared2>, %desc_do_231: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_232: !tt.tensordesc<64x128xf16, #shared>, %Di_233: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_234: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_delta_235: !tt.tensordesc<128xf32, #shared2>, %dsT_dq_1_236: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg122: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_237: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_238: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_239: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_240: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_241: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_242: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_243: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_244: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_245: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_246: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_247: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_248: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_249: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_250: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_251: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_252: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_253: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_254: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_255: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_256: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_257: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_258: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_259: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_260: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_261: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_262: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_263: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_264: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_265: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_266: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>) num_warps(1) {
+      %13 = ub.poison : i1
+      %c1_i64_267 = arith.constant {async_task_id = array<i32: 2>} 1 : i64
+      %c0_i64_268 = arith.constant {async_task_id = array<i32: 2>} 0 : i64
+      %false = arith.constant {async_task_id = array<i32: 2>} false
+      %c1_i32_269 = arith.constant {async_task_id = array<i32: 2>} 1 : i32
+      %c128_i32_270 = arith.constant {async_task_id = array<i32: 2>} 128 : i32
+      %c0_i32_271 = arith.constant {async_task_id = array<i32: 2>} 0 : i32
+      %true_272 = arith.constant {async_task_id = array<i32: 2>} true
+      %num_steps = arith.divsi %N_CTX_182, %c128_i32_270 {async_task_id = array<i32: 2>} : i32
+      %k_273 = ttg.memdesc_index %k_189[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %k_273, %c0_i32_271, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %kt_274 = ttg.memdesc_index %kt_190[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %kt_274, %c0_i32_271, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %v_275 = ttg.memdesc_index %v_191[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %v_275, %c0_i32_271, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_276 = ttg.memdesc_index %dv_244[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dv_276, %c1_i32_269 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_277 = ttg.memdesc_index %dk_250[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dk_277, %c1_i32_269 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %curr_m = arith.cmpi sgt, %num_steps, %c0_i32_271 : i32
+      %qT_278 = ttg.memdesc_index %qT_192[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+      %qT_279 = ttg.memdesc_index %qT_193[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %qT_279, %c0_i32_271, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %qT_280 = ttg.memdesc_trans %qT_278 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>
+      %k_281 = ttg.memdesc_index %k_194[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %qkT_282 = ttg.memdesc_index %qkT_195[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %qT_283 = ttg.memdesc_index %qT_196[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %qkT_284 = ttg.memdesc_index %qkT_197[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %qkT_285 = ttg.memdesc_index %qkT_238[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %qkT_285, %c1_i32_269, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %ppT_286 = ttg.memdesc_index %ppT_198[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %ppT_286, %c1_i32_269, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {direction = "backward", dstTask = 2 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_mma %k_281, %qT_280, %qkT_282, %false, %curr_m, %qT_283[%true_272], %qkT_284[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dpT_287 = ttg.memdesc_index %dpT_199[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+      %dpT_288 = ttg.memdesc_index %dpT_200[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dpT_288, %c0_i32_271, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dpT_289 = ttg.memdesc_trans %dpT_287 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>
+      %v_290 = ttg.memdesc_index %v_201[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %dpT_291 = ttg.memdesc_index %dpT_185[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %dpT_292 = ttg.memdesc_index %dpT_202[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dpT_293 = ttg.memdesc_index %dpT_203[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dpT_294 = ttg.memdesc_index %dpT_240[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dpT_294, %c1_i32_269, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dq_295 = ttg.memdesc_index %dq_266[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %dq_295, %c1_i32_269, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_mma %v_290, %dpT_289, %dpT_291, %false, %curr_m, %dpT_292[%true_272], %dpT_293[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_296 = ttg.memdesc_index %dv_204[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %do_297 = ttg.memdesc_index %do_205[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %qkT_298 = ttng.tmem_subslice %qkT_195 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+      %qkT_299 = ttg.memdesc_reinterpret %qkT_298 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+      %ppT_300 = ttg.memdesc_index %qkT_299[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+      %do_301 = ttg.memdesc_index %do_206[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %do_302 = ttg.memdesc_index %do_207[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %do_302, %c0_i32_271, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %ppT_303 = ttg.memdesc_index %ppT_198[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %ppT_304 = ttg.memdesc_index %ppT_255[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %ppT_304, %c0_i32_271, %curr_m {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_mma %ppT_300, %do_297, %dv_296, %false, %curr_m, %do_301[%true_272], %ppT_303[%true_272] {async_task_id = array<i32: 2>, is_async, tmem.end = array<i32: 5>, tmem.start = array<i32: 6>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %curr_m_305 = arith.subi %num_steps, %c1_i32_269 : i32
+      %curr_m_306:3 = scf.for %curr_m_316 = %c0_i32_271 to %curr_m_305 step %c1_i32_269 iter_args(%arg157 = %false, %curr_m_317 = %c0_i64_268, %dq_318 = %false) -> (i1, i64, i1)  : i32 {
+        %accum_cnt = arith.addi %curr_m_317, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %qT_319 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %qT_320 = arith.trunci %qT_319 {async_task_id = array<i32: 2>} : i64 to i1
+        %qT_321 = ttg.memdesc_index %qT_192[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        %qT_322 = ttg.memdesc_index %qT_193[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qT_323 = arith.extui %qT_320 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %qT_322, %qT_323, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qT_324 = ttg.memdesc_trans %qT_321 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>
+        %q_325 = arith.andi %curr_m_317, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %q_326 = arith.trunci %q_325 {async_task_id = array<i32: 2>} : i64 to i1
+        %k_327 = ttg.memdesc_index %k_194[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %qkT_328 = ttg.memdesc_index %qkT_195[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qT_329 = ttg.memdesc_index %qT_196[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_330 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %qkT_331 = arith.trunci %qkT_330 {async_task_id = array<i32: 2>} : i64 to i1
+        %qkT_332 = ttg.memdesc_index %qkT_197[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_333 = ttg.memdesc_index %qkT_238[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_334 = arith.xori %qkT_331, %true_272 : i1
+        %qkT_335 = arith.extui %qkT_334 : i1 to i32
+        ttng.wait_barrier %qkT_333, %qkT_335, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dv_336 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dv_337 = arith.trunci %dv_336 {async_task_id = array<i32: 2>} : i64 to i1
+        %ppT_338 = ttg.memdesc_index %ppT_198[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qkT_339 = arith.xori %dv_337, %true_272 {async_task_id = array<i32: 2>} : i1
+        %qkT_340 = arith.extui %qkT_339 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %ppT_338, %qkT_340, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {direction = "backward", dstTask = 2 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %k_327, %qT_324, %qkT_328, %false, %true_272, %qT_329[%true_272], %qkT_332[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dk_341 = arith.andi %curr_m_317, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dk_342 = arith.trunci %dk_341 {async_task_id = array<i32: 2>} : i64 to i1
+        %dk_343 = ttg.memdesc_index %dk_208[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %q_344 = ttg.memdesc_index %q_209[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %dpT_345 = ttng.tmem_subslice %dpT_185 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+        %dpT_346 = ttg.memdesc_reinterpret %dpT_345 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+        %dsT_347 = ttg.memdesc_index %dpT_346[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %q_348 = ttg.memdesc_index %q_210[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_349 = ttg.memdesc_index %q_211[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_350 = arith.extui %q_326 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %q_349, %q_350, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_351 = ttg.memdesc_index %dsT_212[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_352 = ttg.memdesc_index %dsT_259[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dk_353 = arith.extui %dk_342 : i1 to i32
+        ttng.wait_barrier %dsT_352, %dk_353 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %dsT_347, %q_344, %dk_343, %arg157, %true_272, %q_348[%true_272], %dsT_351[%true_272] {async_task_id = array<i32: 2>, is_async, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.autows = "{\22stage\22: \221\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq = arith.andi %curr_m_317, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dsT_dq_354 = arith.trunci %dsT_dq {async_task_id = array<i32: 2>} : i64 to i1
+        %dsT_dq_0_355 = ttg.memdesc_index %dsT_dq_0_213[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %dsT_dq_0_356 = ttg.memdesc_index %dsT_dq_0_263[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_357 = arith.extui %dsT_dq_354 : i1 to i32
+        ttng.wait_barrier %dsT_dq_0_356, %dsT_dq_357 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_358 = ttg.memdesc_trans %dsT_dq_0_355 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared4, #smem, mutable>
+        %kt_359 = ttg.memdesc_index %kt_214[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %dpT_360 = ttng.tmem_subslice %dpT_185 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_361 = ttg.memdesc_reinterpret %dpT_360 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable>
+        %dq_362 = ttg.memdesc_index %dpT_361[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable>
+        %dsT_dq_0_363 = ttg.memdesc_index %dsT_dq_0_215[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_364 = ttg.memdesc_index %dq_186[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_365 = ttg.memdesc_index %dpT_240[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_366 = arith.extui %dq_318 : i1 to i32
+        ttng.wait_barrier %dpT_365, %dq_366 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %dsT_dq_358, %kt_359, %dq_362, %false, %true_272, %dsT_dq_0_363[%true_272], %dq_364[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared4, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_367 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %do_368 = arith.trunci %do_367 {async_task_id = array<i32: 2>} : i64 to i1
+        %dpT_369 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dpT_370 = arith.trunci %dpT_369 {async_task_id = array<i32: 2>} : i64 to i1
+        %dpT_371 = ttg.memdesc_index %dpT_199[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        %dpT_372 = ttg.memdesc_index %dpT_200[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_373 = arith.extui %dpT_370 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %dpT_372, %dpT_373, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_374 = ttg.memdesc_trans %dpT_371 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>
+        %v_375 = ttg.memdesc_index %v_201[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %dpT_376 = ttg.memdesc_index %dpT_185[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_377 = ttg.memdesc_index %dpT_202[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_378 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dpT_379 = arith.trunci %dpT_378 {async_task_id = array<i32: 2>} : i64 to i1
+        %dpT_380 = ttg.memdesc_index %dpT_203[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_381 = ttg.memdesc_index %dpT_240[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_382 = arith.xori %dpT_379, %true_272 : i1
+        %dpT_383 = arith.extui %dpT_382 : i1 to i32
+        ttng.wait_barrier %dpT_381, %dpT_383, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_384 = arith.andi %accum_cnt, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dq_385 = arith.trunci %dq_384 {async_task_id = array<i32: 2>} : i64 to i1
+        %dq_386 = ttg.memdesc_index %dq_266[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_387 = arith.xori %dq_385, %true_272 : i1
+        %dq_388 = arith.extui %dq_387 : i1 to i32
+        ttng.wait_barrier %dq_386, %dq_388, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %v_375, %dpT_374, %dpT_376, %false, %true_272, %dpT_377[%true_272], %dpT_380[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared4, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dv_389 = ttg.memdesc_index %dv_204[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %do_390 = ttg.memdesc_index %do_205[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %qkT_391 = ttng.tmem_subslice %qkT_195 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+        %qkT_392 = ttg.memdesc_reinterpret %qkT_391 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+        %ppT_393 = ttg.memdesc_index %qkT_392[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %do_394 = ttg.memdesc_index %do_206[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_395 = ttg.memdesc_index %do_207[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_396 = arith.extui %do_368 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %do_395, %do_396, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %ppT_397 = ttg.memdesc_index %ppT_198[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %ppT_398 = ttg.memdesc_index %ppT_255[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dv_399 = arith.extui %dv_337 : i1 to i32
+        ttng.wait_barrier %ppT_398, %dv_399, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %ppT_393, %do_390, %dv_389, %true_272, %true_272, %do_394[%true_272], %ppT_397[%true_272] {async_task_id = array<i32: 2>, is_async, tmem.end = array<i32: 5>, tmem.start = array<i32: 6>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        scf.yield %true_272, %accum_cnt, %dq_385 : i1, i64, i1
+      } {async_task_id = array<i32: 2>, tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+      %curr_m_307 = arith.cmpi sgt, %num_steps, %c0_i32_271 : i32
+      %curr_m_308:3 = scf.if %curr_m_307 -> (i1, i64, i1) {
+        %accum_cnt = arith.addi %curr_m_306#1, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %q_316 = arith.andi %curr_m_306#1, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %q_317 = arith.trunci %q_316 {async_task_id = array<i32: 2>} : i64 to i1
+        %dk_318 = arith.andi %curr_m_306#1, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dk_319 = arith.trunci %dk_318 {async_task_id = array<i32: 2>} : i64 to i1
+        %dk_320 = ttg.memdesc_index %dk_208[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %q_321 = ttg.memdesc_index %q_209[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %dpT_322 = ttng.tmem_subslice %dpT_185 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128>
+        %dpT_323 = ttg.memdesc_reinterpret %dpT_322 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf32, #tmem1, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable>
+        %dsT_324 = ttg.memdesc_index %dpT_323[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf16, #tmem2, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %q_325 = ttg.memdesc_index %q_210[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_326 = ttg.memdesc_index %q_211[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_327 = arith.extui %q_317 {async_task_id = array<i32: 2>} : i1 to i32
+        ttng.wait_barrier %q_326, %q_327, %true_272 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_328 = ttg.memdesc_index %dsT_212[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_329 = ttg.memdesc_index %dsT_259[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dk_330 = arith.extui %dk_319 : i1 to i32
+        ttng.wait_barrier %dsT_329, %dk_330 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %dsT_324, %q_321, %dk_320, %curr_m_306#0, %true_272, %q_325[%true_272], %dsT_328[%true_272] {async_task_id = array<i32: 2>, is_async, tmem.end = array<i32: 9>, tmem.start = array<i32: 10>, tt.autows = "{\22stage\22: \221\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq = arith.andi %curr_m_306#1, %c1_i64_267 {async_task_id = array<i32: 2>} : i64
+        %dsT_dq_331 = arith.trunci %dsT_dq {async_task_id = array<i32: 2>} : i64 to i1
+        %dsT_dq_0_332 = ttg.memdesc_index %dsT_dq_0_213[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %dsT_dq_0_333 = ttg.memdesc_index %dsT_dq_0_263[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_334 = arith.extui %dsT_dq_331 : i1 to i32
+        ttng.wait_barrier %dsT_dq_0_333, %dsT_dq_334 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_335 = ttg.memdesc_trans %dsT_dq_0_332 {async_task_id = array<i32: 2>, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared4, #smem, mutable>
+        %kt_336 = ttg.memdesc_index %kt_214[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %dpT_337 = ttng.tmem_subslice %dpT_185 {N = 0 : i32, async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_338 = ttg.memdesc_reinterpret %dpT_337 {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable>
+        %dq_339 = ttg.memdesc_index %dpT_338[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x64x128xf32, #tmem3, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable>
+        %dsT_dq_0_340 = ttg.memdesc_index %dsT_dq_0_215[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_341 = ttg.memdesc_index %dq_186[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_342 = ttg.memdesc_index %dpT_240[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dq_343 = arith.extui %curr_m_306#2 : i1 to i32
+        ttng.wait_barrier %dpT_342, %dq_343 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.tc_gen5_mma %dsT_dq_335, %kt_336, %dq_339, %false, %true_272, %dsT_dq_0_340[%true_272], %dq_341[%true_272] {async_task_id = array<i32: 2>, is_async, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared4, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem4, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        scf.yield %true_272, %accum_cnt, %13 : i1, i64, i1
+      } else {
+        scf.yield %curr_m_306#0, %curr_m_306#1, %curr_m_306#2 : i1, i64, i1
+      }
+      %dk_309 = ttg.memdesc_index %dk_216[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %dk_309 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dk_310 = ttg.memdesc_index %dk_217[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %dk_310 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_311 = ttg.memdesc_index %dv_218[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %dv_311 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %dv_312 = ttg.memdesc_index %dv_219[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %dv_312 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %v_313 = ttg.memdesc_index %v_220[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %v_313 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %kt_314 = ttg.memdesc_index %kt_221[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %kt_314 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %k_315 = ttg.memdesc_index %k_222[%c0_i32_271] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.tc_gen5_commit %k_315 {async_task_id = array<i32: 2>} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttg.warp_return
+    }
+    partition2(%H_178: i32, %stride_h_179: i32, %stride_z_180: i32, %stride_tok_181: i32, %N_CTX_182: i32, %dk_183: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dv_184: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_185: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dq_186: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_dq_reduce_staging_187: !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>, %desc_dq_188: !tt.tensordesc<128x16xf32, #shared1>, %k_189: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_190: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_191: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qT_192: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %qT_193: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_194: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_195: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_196: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_197: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_198: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_199: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_200: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_201: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_202: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_203: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_204: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_205: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_206: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %do_207: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_208: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_209: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_210: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %q_211: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_212: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_213: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_214: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_215: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_216: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_217: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_218: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_219: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_220: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_221: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_222: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_k_223: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_224: !tt.tensordesc<256x64xf16, #shared>, %desc_v_225: !tt.tensordesc<128x128xf16, #shared>, %desc_qt_226: !tt.tensordesc<64x128xf16, #shared>, %desc_q_227: !tt.tensordesc<128x64xf16, #shared>, %m_228: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_229: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_m_230: !tt.tensordesc<128xf32, #shared2>, %desc_do_231: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_232: !tt.tensordesc<64x128xf16, #shared>, %Di_233: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_234: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_delta_235: !tt.tensordesc<128xf32, #shared2>, %dsT_dq_1_236: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg122: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_237: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_238: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_239: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_240: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_241: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_242: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_243: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_244: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_245: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_246: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_247: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_248: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_249: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_250: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_251: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_252: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_253: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_254: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_255: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_256: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_257: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_258: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_259: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_260: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_261: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_262: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_263: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_264: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_265: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_266: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>) num_warps(1) {
+      %c1_i64_267 = arith.constant {async_task_id = array<i32: 3>} 1 : i64
+      %curr_m = arith.constant {async_task_id = array<i32: 3>} 0 : i64
+      %true_268 = arith.constant {async_task_id = array<i32: 3>} true
+      %c1_i32_269 = arith.constant {async_task_id = array<i32: 3>} 1 : i32
+      %c128_i32_270 = arith.constant {async_task_id = array<i32: 3>} 128 : i32
+      %c0_i32_271 = arith.constant {async_task_id = array<i32: 3>} 0 : i32
+      %c2_i32 = arith.constant {async_task_id = array<i32: 3>} 2 : i32
+      %c64_i32_272 = arith.constant {async_task_id = array<i32: 3>} 64 : i32
+      %bhid = tt.get_program_id z {async_task_id = array<i32: 3>} : i32
+      %pid = tt.get_program_id x {async_task_id = array<i32: 3>} : i32
+      %off_chz = arith.muli %bhid, %N_CTX_182 {async_task_id = array<i32: 3>} : i32
+      %off_chz_273 = arith.extsi %off_chz {async_task_id = array<i32: 3>} : i32 to i64
+      %off_bh = arith.remsi %bhid, %H_178 {async_task_id = array<i32: 3>} : i32
+      %off_bh_274 = arith.muli %stride_h_179, %off_bh {async_task_id = array<i32: 3>} : i32
+      %off_bh_275 = arith.divsi %bhid, %H_178 {async_task_id = array<i32: 3>} : i32
+      %off_bh_276 = arith.muli %stride_z_180, %off_bh_275 {async_task_id = array<i32: 3>} : i32
+      %off_bh_277 = arith.addi %off_bh_274, %off_bh_276 {async_task_id = array<i32: 3>} : i32
+      %off_bh_278 = arith.extsi %off_bh_277 {async_task_id = array<i32: 3>} : i32 to i64
+      %off_bh_279 = arith.extsi %stride_tok_181 {async_task_id = array<i32: 3>} : i32 to i64
+      %off_bh_280 = arith.divsi %off_bh_278, %off_bh_279 {async_task_id = array<i32: 3>} : i64
+      %start_n = arith.muli %pid, %c128_i32_270 {async_task_id = array<i32: 3>} : i32
+      %cluster_cta_rank = arith.remsi %pid, %c2_i32 {async_task_id = array<i32: 3>} : i32
+      %k_281 = arith.extsi %start_n {async_task_id = array<i32: 3>} : i32 to i64
+      %k_282 = arith.addi %off_bh_280, %k_281 {async_task_id = array<i32: 3>} : i64
+      %k_283 = arith.trunci %k_282 {async_task_id = array<i32: 3>} : i64 to i32
+      %k_284 = ttg.memdesc_index %k_222[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %k_284, %c1_i32_269 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %k_285 = ttg.memdesc_index %k_189[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.barrier_expect %k_285, 32768 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %k_286 = ttg.memdesc_index %k_194[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %desc_k_223[%k_283, %c0_i32_271] %k_286, %k_285, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %kt_start_n = arith.muli %cluster_cta_rank, %c128_i32_270 {async_task_id = array<i32: 3>} : i32
+      %kt_start_n_287 = arith.subi %start_n, %kt_start_n {async_task_id = array<i32: 3>} : i32
+      %kt_288 = arith.extsi %kt_start_n_287 {async_task_id = array<i32: 3>} : i32 to i64
+      %kt_289 = arith.addi %off_bh_280, %kt_288 {async_task_id = array<i32: 3>} : i64
+      %kt_290 = arith.trunci %kt_289 {async_task_id = array<i32: 3>} : i64 to i32
+      %kt_291 = nvg.cluster_id {async_task_id = array<i32: 3>}
+      %kt_292 = arith.remsi %kt_291, %c2_i32 {async_task_id = array<i32: 3>} : i32
+      %kt_293 = arith.muli %kt_292, %c64_i32_272 {async_task_id = array<i32: 3>} : i32
+      %kt_294 = ttg.memdesc_index %kt_221[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %kt_294, %c1_i32_269 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %kt_295 = ttg.memdesc_index %kt_190[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.barrier_expect %kt_295, 32768 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %kt_296 = ttg.memdesc_index %kt_214[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %desc_kt_224[%kt_290, %kt_293] %kt_296, %kt_295, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<256x64xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+      %v_297 = ttg.memdesc_index %v_220[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.wait_barrier %v_297, %c1_i32_269 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 0 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %v_298 = ttg.memdesc_index %v_191[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      ttng.barrier_expect %v_298, 32768 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+      %v_299 = ttg.memdesc_index %v_201[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %desc_v_225[%k_283, %c0_i32_271] %v_299, %v_298, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+      %num_steps = arith.divsi %N_CTX_182, %c128_i32_270 {async_task_id = array<i32: 3>} : i32
+      %curr_m_300:2 = scf.for %curr_m_301 = %c0_i32_271 to %num_steps step %c1_i32_269 iter_args(%arg157 = %c0_i32_271, %curr_m_302 = %curr_m) -> (i32, i64)  : i32 {
+        %qt = arith.extsi %arg157 {async_task_id = array<i32: 3>} : i32 to i64
+        %qt_303 = arith.addi %off_bh_280, %qt {async_task_id = array<i32: 3>} : i64
+        %qt_304 = arith.trunci %qt_303 {async_task_id = array<i32: 3>} : i64 to i32
+        %qt_305 = arith.addi %qt_304, %kt_293 {async_task_id = array<i32: 3>} : i32
+        %qT_306 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %qT_307 = arith.trunci %qT_306 {async_task_id = array<i32: 3>} : i64 to i1
+        %qT_308 = ttg.memdesc_index %qT_196[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qt_309 = arith.xori %qT_307, %true_268 {async_task_id = array<i32: 3>} : i1
+        %qt_310 = arith.extui %qt_309 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %qT_308, %qt_310 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qT_311 = ttg.memdesc_index %qT_193[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %qT_311, 16384 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %qT_312 = ttg.memdesc_index %qT_192[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_qt_226[%qt_305, %c0_i32_271] %qT_312, %qT_311, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        %q_313 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %q_314 = arith.trunci %q_313 {async_task_id = array<i32: 3>} : i64 to i1
+        %q_315 = ttg.memdesc_index %q_210[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_316 = arith.xori %q_314, %true_268 {async_task_id = array<i32: 3>} : i1
+        %q_317 = arith.extui %q_316 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %q_315, %q_317 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_318 = ttg.memdesc_index %q_211[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %q_318, 16384 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %q_319 = ttg.memdesc_index %q_209[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_q_227[%qt_304, %kt_293] %q_319, %q_318, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %offs_m_start = arith.addi %off_chz_273, %qt {async_task_id = array<i32: 3>} : i64
+        %m_320 = arith.trunci %offs_m_start {async_task_id = array<i32: 3>} : i64 to i32
+        %m_321 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %m_322 = arith.trunci %m_321 {async_task_id = array<i32: 3>} : i64 to i1
+        %m_323 = ttg.memdesc_index %m_254[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %m_324 = arith.xori %m_322, %true_268 : i1
+        %m_325 = arith.extui %m_324 : i1 to i32
+        ttng.wait_barrier %m_323, %m_325 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %m_326 = ttg.memdesc_index %m_228[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %m_326, 512 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %m_327 = ttg.memdesc_index %m_229[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128xf32, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_m_230[%m_320] %m_327, %m_326, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        %do_328 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %do_329 = arith.trunci %do_328 {async_task_id = array<i32: 3>} : i64 to i1
+        %do_330 = ttg.memdesc_index %do_206[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_331 = arith.xori %do_329, %true_268 {async_task_id = array<i32: 3>} : i1
+        %do_332 = arith.extui %do_331 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %do_330, %do_332 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_333 = ttg.memdesc_index %do_207[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %do_333, 16384 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %do_334 = ttg.memdesc_index %do_205[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_do_231[%qt_304, %kt_293] %do_334, %do_333, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+        %dpT_335 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %dpT_336 = arith.trunci %dpT_335 {async_task_id = array<i32: 3>} : i64 to i1
+        %dpT_337 = ttg.memdesc_index %dpT_202[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dot = arith.xori %dpT_336, %true_268 {async_task_id = array<i32: 3>} : i1
+        %dot_338 = arith.extui %dot {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %dpT_337, %dot_338 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_339 = ttg.memdesc_index %dpT_200[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %dpT_339, 16384 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dpT_340 = ttg.memdesc_index %dpT_199[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_dot_232[%qt_305, %c0_i32_271] %dpT_340, %dpT_339, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+        %Di_341 = arith.andi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        %Di_342 = arith.trunci %Di_341 {async_task_id = array<i32: 3>} : i64 to i1
+        %Di_343 = ttg.memdesc_index %Di_258[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %Di_344 = arith.xori %Di_342, %true_268 : i1
+        %Di_345 = arith.extui %Di_344 : i1 to i32
+        ttng.wait_barrier %Di_343, %Di_345 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %Di_346 = ttg.memdesc_index %Di_233[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.barrier_expect %Di_346, 512 {async_task_id = array<i32: 3>}, %true_268 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %Di_347 = ttg.memdesc_index %Di_234[%c0_i32_271] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128xf32, #shared2, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_delta_235[%m_320] %Di_347, %Di_346, %true_268 {async_task_id = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2>, !ttg.memdesc<1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared2, #smem, mutable>
+        %curr_m_348 = arith.addi %arg157, %c128_i32_270 {async_task_id = array<i32: 3>} : i32
+        %accum_cnt = arith.addi %curr_m_302, %c1_i64_267 {async_task_id = array<i32: 3>} : i64
+        scf.yield {async_task_id = array<i32: 3>} %curr_m_348, %accum_cnt : i32, i64
+      } {async_task_id = array<i32: 3>, tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    }
+    partition3(%H_178: i32, %stride_h_179: i32, %stride_z_180: i32, %stride_tok_181: i32, %N_CTX_182: i32, %dk_183: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dv_184: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_185: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dq_186: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_dq_reduce_staging_187: !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>, %desc_dq_188: !tt.tensordesc<128x16xf32, #shared1>, %k_189: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_190: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_191: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qT_192: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %qT_193: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_194: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_195: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_196: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_197: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_198: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_199: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_200: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_201: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_202: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_203: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_204: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_205: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_206: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %do_207: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_208: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_209: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_210: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %q_211: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_212: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_213: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_214: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_215: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_216: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_217: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_218: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_219: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %v_220: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %kt_221: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %k_222: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %desc_k_223: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_224: !tt.tensordesc<256x64xf16, #shared>, %desc_v_225: !tt.tensordesc<128x128xf16, #shared>, %desc_qt_226: !tt.tensordesc<64x128xf16, #shared>, %desc_q_227: !tt.tensordesc<128x64xf16, #shared>, %m_228: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_229: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_m_230: !tt.tensordesc<128xf32, #shared2>, %desc_do_231: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_232: !tt.tensordesc<64x128xf16, #shared>, %Di_233: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_234: !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, %desc_delta_235: !tt.tensordesc<128xf32, #shared2>, %dsT_dq_1_236: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg122: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_237: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %qkT_238: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_239: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dpT_240: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_241: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_242: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_243: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_244: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_245: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dv_246: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_247: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_248: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_249: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_250: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_251: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dk_252: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_253: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %m_254: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_255: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %ppT_256: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_257: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %Di_258: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_259: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_260: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_261: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_1_262: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_263: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dsT_dq_0_264: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_265: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, %dq_266: !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>) num_warps(1) {
+      %c1_i64_267 = arith.constant {async_task_id = array<i32: 4>} 1 : i64
+      %curr_m = arith.constant {async_task_id = array<i32: 4>} 0 : i64
+      %c1_i32_268 = arith.constant {async_task_id = array<i32: 4>} 1 : i32
+      %c128_i32_269 = arith.constant {async_task_id = array<i32: 4>} 128 : i32
+      %c0_i32_270 = arith.constant {async_task_id = array<i32: 4>} 0 : i32
+      %num_steps = arith.divsi %N_CTX_182, %c128_i32_269 {async_task_id = array<i32: 4>} : i32
+      %curr_m_271 = scf.for %curr_m_272 = %c0_i32_270 to %num_steps step %c1_i32_268 iter_args(%curr_m_273 = %curr_m) -> (i64)  : i32 {
+        %dsT_dq = arith.andi %curr_m_273, %c1_i64_267 {async_task_id = array<i32: 4>} : i64
+        %dsT_dq_274 = arith.trunci %dsT_dq {async_task_id = array<i32: 4>} : i64 to i1
+        %dsT_dq_1_275 = ttg.memdesc_index %dsT_dq_1_261[%c0_i32_270] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_276 = arith.extui %dsT_dq_274 : i1 to i32
+        ttng.wait_barrier %dsT_dq_1_275, %dsT_dq_276 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 3>, dstTask = 0 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.fence_async_shared {bCluster = false}
+        %dsT_dq_277 = ttg.memdesc_index %dsT_dq_0_263[%c0_i32_270] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dsT_dq_277, 1 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %dsT_dq_1_278 = ttg.memdesc_index %dsT_dq_1_262[%c0_i32_270] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        ttng.arrive_barrier %dsT_dq_1_278, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 3>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+        %accum_cnt = arith.addi %curr_m_273, %c1_i64_267 {async_task_id = array<i32: 4>} : i64
+        scf.yield {async_task_id = array<i32: 4>} %accum_cnt : i64
+      } {async_task_id = array<i32: 4>, tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    } : (i32, i32, i32, i32, i32, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>, !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<256x64xf16, #shared>, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, !tt.tensordesc<128xf32, #shared2>, !tt.tensordesc<128x64xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared2, #smem, mutable>, !tt.tensordesc<128xf32, #shared2>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared3, #smem, mutable>) -> ()
+    %dq_122 = ttg.memdesc_index %dq[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dq_122 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %k_123 = ttg.memdesc_index %k_34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %k_123 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %kt_124 = ttg.memdesc_index %kt_31[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %kt_124 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %v_125 = ttg.memdesc_index %v_28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %v_125 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qT_126 = ttg.memdesc_index %qT_16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %qT_126 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qT_127 = ttg.memdesc_index %qT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %qT_127 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT_128 = ttg.memdesc_index %qkT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %qkT_128 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %ppT_129 = ttg.memdesc_index %ppT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %ppT_129 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_130 = ttg.memdesc_index %dpT_5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dpT_130 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_131 = ttg.memdesc_index %dpT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dpT_131 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_132 = ttg.memdesc_index %dpT_24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dpT_132 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %do_133 = ttg.memdesc_index %do[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %do_133 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %do_134 = ttg.memdesc_index %do_9[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %do_134 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %q_135 = ttg.memdesc_index %q[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %q_135 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %q_136 = ttg.memdesc_index %q_13[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %q_136 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_137 = ttg.memdesc_index %dsT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_137 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_138 = ttg.memdesc_index %dsT_dq_0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_138 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_139 = ttg.memdesc_index %dk[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_139 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_140 = ttg.memdesc_index %dk_19[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_140 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_141 = ttg.memdesc_index %dv[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_141 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_142 = ttg.memdesc_index %dv_22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_142 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %v_143 = ttg.memdesc_index %v[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %v_143 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %kt_144 = ttg.memdesc_index %kt[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %kt_144 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %k_145 = ttg.memdesc_index %k[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %k_145 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %m_146 = ttg.memdesc_index %m[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %m_146 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %Di_147 = ttg.memdesc_index %Di[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %Di_147 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %9 = ttg.memdesc_index %1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %9 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %10 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %10 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %11 = ttg.memdesc_index %5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %11 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %12 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %12 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT_148 = ttg.memdesc_index %qkT_36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %qkT_148 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %qkT_149 = ttg.memdesc_index %qkT_37[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %qkT_149 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_150 = ttg.memdesc_index %dpT_40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dpT_150 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dpT_151 = ttg.memdesc_index %dpT_41[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dpT_151 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_152 = ttg.memdesc_index %dv_44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_152 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_153 = ttg.memdesc_index %dv_45[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_153 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_154 = ttg.memdesc_index %dv_48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_154 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_155 = ttg.memdesc_index %dv_49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_155 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_156 = ttg.memdesc_index %dv_52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_156 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dv_157 = ttg.memdesc_index %dv_53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dv_157 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_158 = ttg.memdesc_index %dk_56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_158 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_159 = ttg.memdesc_index %dk_57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_159 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_160 = ttg.memdesc_index %dk_60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_160 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_161 = ttg.memdesc_index %dk_61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_161 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_162 = ttg.memdesc_index %dk_64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_162 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dk_163 = ttg.memdesc_index %dk_65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dk_163 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %m_164 = ttg.memdesc_index %m_68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %m_164 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %m_165 = ttg.memdesc_index %m_69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %m_165 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %ppT_166 = ttg.memdesc_index %ppT_72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %ppT_166 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %ppT_167 = ttg.memdesc_index %ppT_73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %ppT_167 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %Di_168 = ttg.memdesc_index %Di_76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %Di_168 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %Di_169 = ttg.memdesc_index %Di_77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %Di_169 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_170 = ttg.memdesc_index %dsT_80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_170 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_171 = ttg.memdesc_index %dsT_81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_171 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_1_172 = ttg.memdesc_index %dsT_dq_1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_1_172 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_1_173 = ttg.memdesc_index %dsT_dq_1_84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_1_173 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_174 = ttg.memdesc_index %dsT_dq_0_87[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_174 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dsT_dq_0_175 = ttg.memdesc_index %dsT_dq_0_88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_175 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dq_176 = ttg.memdesc_index %dq_91[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dq_176 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    %dq_177 = ttg.memdesc_index %dq_92[%c0_i32] : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    ttng.inval_barrier %dq_177 : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
+    tt.return
+  }
+}
+
+// RUN: triton-opt %s --nvgpu-insert-2cta-sync | FileCheck %s
+
+// The full input is the BM128 2-CTA backward TTGIR immediately before
+// NVGPUInsert2CTASync. Inner-loop specialization leaves each partition MMA
+// outside an scf.for even though the WarpSpecializeOp itself is loop-nested.
+// CHECK-LABEL: tt.func public @_attn_bwd
+// CHECK: ttng.init_barrier {{.*}}, 2
+// CHECK: ttg.warp_specialize(
+// CHECK-NOT: ttng.init_barrier
+// CHECK: tt.return

--- a/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm128_persistent.mlir
+++ b/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm128_persistent.mlir
@@ -1,0 +1,1317 @@
+// RUN: triton-opt %s --nvgpu-materialize-2cta-exchange | FileCheck %s --check-prefix=SHAPE
+// RUN: triton-opt %s --nvgpu-materialize-2cta-exchange | FileCheck %s --check-prefix=CLEAN
+
+// Full TTGIR captured immediately before NVGPUMaterialize2CTAExchange from
+// the non-causal persistent BM128 2-CTA configuration after AutoWS and
+// software pipelining.
+// SHAPE-DAG: ttg.memdesc_subslice {{.*}}[0, 0]
+// SHAPE-DAG: ttg.memdesc_subslice {{.*}}[128, 0]
+// SHAPE-DAG: ttg.local_store {{.*}} tensor<128x64xf16
+// SHAPE-DAG: ttg.async_remote_shmem_copy
+// Warp-specialize uses IDs 0-6 after padding; the relay takes the next slot.
+// SHAPE-DAG: %[[BAR:.+]] = arith.constant 7 : i32
+// SHAPE-DAG: ttng.wait_barrier_named %[[BAR]],
+// SHAPE-DAG: ttng.fence_async_shared
+// SHAPE-DAG: ttng.tmem_subslice {{.*}} {N = 0 : i32
+// SHAPE-DAG: ttng.tmem_subslice {{.*}} {N = 64 : i32
+// SHAPE-COUNT-2: ttng.tmem_load
+// CLEAN-NOT: ttng.two_cta_peer_gather
+// CLEAN-NOT: ttng.two_cta_peer_relay
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [0, 1, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [0, 0, 1]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 16, 0], [0, 1, 0], [0, 2, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 32], [0, 16], [0, 1], [0, 2], [32, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1, 0], [0, 0, 16], [0, 0, 1], [0, 0, 2], [32, 0, 0]], lane = [[0, 0, 4], [0, 0, 8], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [32, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear10 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear11 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear12 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear13 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear14 = #ttg.linear<{register = [[128, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear15 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear16 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear17 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear18 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear19 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared5 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+#tmem3 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, twoCTAs = true>
+#tmem4 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 2, twoCTAs = true>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.tensordesc<128x64xf16, #shared>, %desc_q.shape.0: i32, %desc_q.shape.1: i32, %desc_q.stride.0: i64, %desc_q.stride.1: i64, %desc_qt: !tt.tensordesc<64x128xf16, #shared>, %desc_qt.shape.0: i32, %desc_qt.shape.1: i32, %desc_qt.stride.0: i64, %desc_qt.stride.1: i64, %desc_k: !tt.tensordesc<128x128xf16, #shared>, %desc_k.shape.0: i32, %desc_k.shape.1: i32, %desc_k.stride.0: i64, %desc_k.stride.1: i64, %desc_kt: !tt.tensordesc<256x64xf16, #shared>, %desc_kt.shape.0: i32, %desc_kt.shape.1: i32, %desc_kt.stride.0: i64, %desc_kt.stride.1: i64, %desc_v: !tt.tensordesc<128x128xf16, #shared>, %desc_v.shape.0: i32, %desc_v.shape.1: i32, %desc_v.stride.0: i64, %desc_v.stride.1: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<128x64xf16, #shared>, %desc_do.shape.0: i32, %desc_do.shape.1: i32, %desc_do.stride.0: i64, %desc_do.stride.1: i64, %desc_dot: !tt.tensordesc<64x128xf16, #shared>, %desc_dot.shape.0: i32, %desc_dot.shape.1: i32, %desc_dot.stride.0: i64, %desc_dot.stride.1: i64, %desc_dq: !tt.tensordesc<64x16xf32, #shared1>, %desc_dq.shape.0: i32, %desc_dq.shape.1: i32, %desc_dq.stride.0: i64, %desc_dq.stride.1: i64, %desc_dk: !tt.tensordesc<128x16xf16, #shared2>, %desc_dk.shape.0: i32, %desc_dk.shape.1: i32, %desc_dk.stride.0: i64, %desc_dk.stride.1: i64, %desc_dv: !tt.tensordesc<128x16xf16, #shared2>, %desc_dv.shape.0: i32, %desc_dv.shape.1: i32, %desc_dv.stride.0: i64, %desc_dv.stride.1: i64, %desc_m: !tt.tensordesc<128xf32, #shared3>, %desc_m.shape.0: i32, %desc_m.stride.0: i64, %desc_delta: !tt.tensordesc<128xf32, #shared3>, %desc_delta.shape.0: i32, %desc_delta.stride.0: i64, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c1_i64 = arith.constant {async_task_id = array<i32: 0>} 1 : i64
+    %c0_i64 = arith.constant {async_task_id = array<i32: 0>} 0 : i64
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<64x16xf32, #blocked>
+    %c2_i32 = arith.constant {async_task_id = array<i32: 0>} 2 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 0>} 128 : i32
+    %c127_i32 = arith.constant {async_task_id = array<i32: 0>} 127 : i32
+    %c16_i32 = arith.constant {async_task_id = array<i32: 0>} 16 : i32
+    %c32_i32 = arith.constant {async_task_id = array<i32: 0>} 32 : i32
+    %c48_i32 = arith.constant {async_task_id = array<i32: 0>} 48 : i32
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0>} 64 : i32
+    %c80_i32 = arith.constant {async_task_id = array<i32: 0>} 80 : i32
+    %c96_i32 = arith.constant {async_task_id = array<i32: 0>} 96 : i32
+    %c112_i32 = arith.constant {async_task_id = array<i32: 0>} 112 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %dq = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dq_0 = ttg.memdesc_index %dq[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dq_0, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_1 = ttg.memdesc_index %dsT_dq_0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_1, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_2 = ttg.memdesc_index %dsT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_2, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %Di = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %Di_3 = ttg.memdesc_index %Di[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %Di_3, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dpT_4 = ttg.memdesc_index %dpT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dpT_4, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_5 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dpT_6 = ttg.memdesc_index %dpT_5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dpT_6, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_7 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dpT_8 = ttg.memdesc_index %dpT_7[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dpT_8, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %ppT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %ppT_9 = ttg.memdesc_index %ppT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %ppT_9, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %do = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %do_10 = ttg.memdesc_index %do[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %do_10, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %do_11 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %do_12 = ttg.memdesc_index %do_11[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %do_12, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qkT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %qkT_13 = ttg.memdesc_index %qkT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qkT_13, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %m = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %m_14 = ttg.memdesc_index %m[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %m_14, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>
+    %qT_15 = ttg.memdesc_index %qT[%c0_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qT_15, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_16 = ttg.memdesc_index %qT[%c1_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qT_16, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_17 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>
+    %qT_18 = ttg.memdesc_index %qT_17[%c0_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qT_18, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_19 = ttg.memdesc_index %qT_17[%c1_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qT_19, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %q = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %q_20 = ttg.memdesc_index %q[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %q_20, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %q_21 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %q_22 = ttg.memdesc_index %q_21[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %q_22, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dk = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dk_23 = ttg.memdesc_index %dk[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dk_23, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dv_24 = ttg.memdesc_index %dv[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dv_24, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %v = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %v_25 = ttg.memdesc_index %v[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %v_25, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %v_26 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %v_27 = ttg.memdesc_index %v_26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %v_27, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %kt = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %kt_28 = ttg.memdesc_index %kt[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %kt_28, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %kt_29 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %kt_30 = ttg.memdesc_index %kt_29[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %kt_30, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %k = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %k_31 = ttg.memdesc_index %k[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %k_31, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %k_32 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %k_33 = ttg.memdesc_index %k_32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %k_33, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv_34 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dv_35 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dv_36 = ttg.memdesc_index %dv_34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dv_36, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv_37 = ttg.memdesc_index %dv_35[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dv_37, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dk_38 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dk_39 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dk_40 = ttg.memdesc_index %dk_38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dk_40, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dk_41 = ttg.memdesc_index %dk_39[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dk_41, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %m_42 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %m_43 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %m_44 = ttg.memdesc_index %m_42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %m_44, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %m_45 = ttg.memdesc_index %m_43[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %m_45, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %qkT_46 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %qkT_47 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %qkT_48 = ttg.memdesc_index %qkT_46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qkT_48, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qkT_49 = ttg.memdesc_index %qkT_47[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %qkT_49, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %ppT_50 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %ppT_51 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %ppT_52 = ttg.memdesc_index %ppT_50[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %ppT_52, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %ppT_53 = ttg.memdesc_index %ppT_51[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %ppT_53, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dpT_54 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dpT_55 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dpT_56 = ttg.memdesc_index %dpT_54[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dpT_56, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_57 = ttg.memdesc_index %dpT_55[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dpT_57, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %Di_58 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %Di_59 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %Di_60 = ttg.memdesc_index %Di_58[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %Di_60, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %Di_61 = ttg.memdesc_index %Di_59[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %Di_61, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dsT_62 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_63 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_64 = ttg.memdesc_index %dsT_62[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_64, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_65 = ttg.memdesc_index %dsT_63[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_65, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dsT_dq_1 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_dq_1_66 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_dq_1_67 = ttg.memdesc_index %dsT_dq_1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_dq_1_67, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_1_68 = ttg.memdesc_index %dsT_dq_1_66[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_dq_1_68, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dsT_dq_0_69 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_70 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_71 = ttg.memdesc_index %dsT_dq_0_69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_71, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_72 = ttg.memdesc_index %dsT_dq_0_70[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dsT_dq_0_72, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %dq_73 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dq_74 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+    %dq_75 = ttg.memdesc_index %dq_73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dq_75, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dq_76 = ttg.memdesc_index %dq_74[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.init_barrier %dq_76, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttg.barrier local
+    %k_77 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+    %kt_78 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 12 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+    %v_79 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+    %dv_80, %dv_81 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %dk_82, %dk_83 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %q_84 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 14 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %qT_85 = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>
+    %m_86 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 16 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+    %qkT_87, %qkT_88 = ttng.tmem_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %do_89 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 17 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %dpT_90 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+    %dpT_91, %dpT_92 = ttng.tmem_alloc {allocation.shareGroup = 3 : i32, buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %Di_93 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 19 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+    %dsT_dq_1_94 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 20 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+    %dsT_dq_0_95 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+    %desc_dq_reduce_staging = ttg.local_alloc {allocation.shareGroup = 2 : i32, buffer.copy = 1 : i32, buffer.id = 22 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable>
+    %desc_dv_staging = ttg.local_alloc {allocation.shareGroup = 1 : i32, buffer.copy = 1 : i32, buffer.id = 30 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+    %desc_dk_staging = ttg.local_alloc {allocation.shareGroup = 4 : i32, buffer.copy = 1 : i32, buffer.id = 38 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+    ttg.warp_specialize(%N_CTX, %BATCH, %H, %k_32, %kt_29, %v_26, %qT_85, %qT_17, %k_77, %qkT_87, %qT, %qkT, %ppT, %dpT_90, %dpT_7, %v_79, %dpT_91, %dpT_5, %dpT, %dv_80, %do_89, %do, %do_11, %dk_82, %q_84, %q, %q_21, %dsT, %dsT_dq_0_95, %kt_78, %dsT_dq_0, %dq, %dk, %dv, %v, %kt, %k, %dsT_dq_1_94, %stride_tok, %stride_h, %stride_z, %desc_k, %desc_kt, %desc_v, %desc_q, %desc_qt, %m, %m_86, %desc_m, %desc_do, %desc_dot, %Di, %Di_93, %desc_delta, %sm_scale, %desc_dv_staging, %desc_dv, %desc_dk_staging, %desc_dk, %dv_34, %dv_35, %dk_38, %dk_39, %m_42, %m_43, %qkT_46, %qkT_47, %ppT_50, %ppT_51, %dpT_54, %dpT_55, %Di_58, %Di_59, %dsT_62, %dsT_63, %dsT_dq_1, %dsT_dq_1_66, %dsT_dq_0_69, %dsT_dq_0_70, %dq_73, %dq_74) attributes {requestedRegisters = array<i32: 24, 24, 24, 192>, ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"]}
+    default {
+      %n_tile_num = arith.addi %N_CTX, %c127_i32 {async_task_id = array<i32: 0>} : i32
+      %n_tile_num_144 = arith.divsi %n_tile_num, %c128_i32 {async_task_id = array<i32: 0>} : i32
+      %cluster_rank = tt.get_program_id x {async_task_id = array<i32: 0>} : i32
+      %cluster_rank_145 = arith.remsi %cluster_rank, %c2_i32 {async_task_id = array<i32: 0>} : i32
+      %prog_id = arith.divsi %cluster_rank, %c2_i32 {async_task_id = array<i32: 0>} : i32
+      %num_progs = tt.get_num_programs x {async_task_id = array<i32: 0>} : i32
+      %num_progs_146 = arith.divsi %num_progs, %c2_i32 {async_task_id = array<i32: 0>} : i32
+      %scheduled_n_tiles = arith.divsi %n_tile_num_144, %c2_i32 {async_task_id = array<i32: 0>} : i32
+      %total_tiles = arith.muli %scheduled_n_tiles, %BATCH {async_task_id = array<i32: 0>} : i32
+      %total_tiles_147 = arith.muli %total_tiles, %H {async_task_id = array<i32: 0>} : i32
+      %tiles_per_sm = arith.divsi %total_tiles_147, %num_progs_146 {async_task_id = array<i32: 0>} : i32
+      %0 = arith.remsi %total_tiles_147, %num_progs_146 {async_task_id = array<i32: 0>} : i32
+      %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 0>} : i32
+      %2 = scf.if %1 -> (i32) {
+        %tiles_per_sm_149 = arith.addi %tiles_per_sm, %c1_i32 {async_task_id = array<i32: 0>} : i32
+        scf.yield {async_task_id = array<i32: 0>} %tiles_per_sm_149 : i32
+      } else {
+        scf.yield {async_task_id = array<i32: 0>} %tiles_per_sm : i32
+      } {async_task_id = array<i32: 0>}
+      %off_bh = arith.extsi %stride_tok {async_task_id = array<i32: 0>} : i32 to i64
+      %num_steps = arith.divsi %N_CTX, %c128_i32 {async_task_id = array<i32: 0>} : i32
+      %dq_row = arith.muli %cluster_rank_145, %c64_i32 {async_task_id = array<i32: 0>} : i32
+      %dq_row_148 = arith.extsi %dq_row {async_task_id = array<i32: 0>} : i32 to i64
+      %tile_idx:2 = scf.for %tile_idx_149 = %c0_i32 to %2 step %c1_i32 iter_args(%prog_id_150 = %prog_id, %tile_idx_151 = %c0_i64) -> (i32, i64)  : i32 {
+        %bhid = arith.divsi %prog_id_150, %scheduled_n_tiles {async_task_id = array<i32: 0>} : i32
+        %off_bh_152 = arith.remsi %bhid, %H {async_task_id = array<i32: 0>} : i32
+        %off_bh_153 = arith.muli %stride_h, %off_bh_152 {async_task_id = array<i32: 0>} : i32
+        %off_bh_154 = arith.divsi %bhid, %H {async_task_id = array<i32: 0>} : i32
+        %off_bh_155 = arith.muli %stride_z, %off_bh_154 {async_task_id = array<i32: 0>} : i32
+        %off_bh_156 = arith.addi %off_bh_153, %off_bh_155 {async_task_id = array<i32: 0>} : i32
+        %off_bh_157 = arith.extsi %off_bh_156 {async_task_id = array<i32: 0>} : i32 to i64
+        %off_bh_158 = arith.divsi %off_bh_157, %off_bh {async_task_id = array<i32: 0>} : i64
+        %curr_m:2 = scf.for %curr_m_160 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg67 = %c0_i32, %tile_idx_161 = %tile_idx_151) -> (i32, i64)  : i32 {
+          %q_162 = arith.extsi %arg67 {async_task_id = array<i32: 0>} : i32 to i64
+          %q_163 = arith.addi %off_bh_158, %q_162 {async_task_id = array<i32: 0>} : i64
+          %dq_164 = arith.andi %tile_idx_161, %c1_i64 {async_task_id = array<i32: 0>} : i64
+          %dq_165 = arith.trunci %dq_164 {async_task_id = array<i32: 0>} : i64 to i1
+          %dpT_166 = ttng.tmem_subslice %dpT_91 {N = 0 : i32, async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %dpT_167 = ttg.memdesc_reinterpret %dpT_166 {async_task_id = array<i32: 0>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+          %dq_168 = ttg.memdesc_index %dpT_167[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+          %dq_169 = ttg.memdesc_index %dq[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_170 = arith.extui %dq_165 {async_task_id = array<i32: 0>} : i1 to i32
+          ttng.wait_barrier %dq_169, %dq_170 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_171, %dq_172 = ttng.tmem_load %dq_168[] {async_task_id = array<i32: 0>} : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear>
+          %dq_173 = ttg.memdesc_index %dq_74[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dq_173, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dqs = tt.reshape %dq_171 {async_task_id = array<i32: 0>} : tensor<64x128xf32, #linear> -> tensor<64x2x64xf32, #linear1>
+          %dqs_174 = tt.trans %dqs {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x64xf32, #linear1> -> tensor<64x64x2xf32, #linear2>
+          %dqs_175 = ttg.convert_layout %dqs_174 {async_task_id = array<i32: 0>} : tensor<64x64x2xf32, #linear2> -> tensor<64x64x2xf32, #linear3>
+          %dqs_176, %dqs_177 = tt.split %dqs_175 {async_task_id = array<i32: 0>} : tensor<64x64x2xf32, #linear3> -> tensor<64x64xf32, #linear4>
+          %dqs_178 = tt.reshape %dqs_176 {async_task_id = array<i32: 0>} : tensor<64x64xf32, #linear4> -> tensor<64x2x32xf32, #linear5>
+          %dqs_179 = tt.trans %dqs_178 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #linear5> -> tensor<64x32x2xf32, #linear6>
+          %dqs_180, %dqs_181 = tt.split %dqs_179 {async_task_id = array<i32: 0>} : tensor<64x32x2xf32, #linear6> -> tensor<64x32xf32, #linear7>
+          %dqs_182 = tt.reshape %dqs_180 {async_task_id = array<i32: 0>} : tensor<64x32xf32, #linear7> -> tensor<64x2x16xf32, #blocked1>
+          %dqs_183 = tt.trans %dqs_182 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked1> -> tensor<64x16x2xf32, #blocked2>
+          %dqs_184, %dqs_185 = tt.split %dqs_183 {async_task_id = array<i32: 0>} : tensor<64x16x2xf32, #blocked2> -> tensor<64x16xf32, #blocked>
+          %dqs_186 = tt.reshape %dqs_181 {async_task_id = array<i32: 0>} : tensor<64x32xf32, #linear7> -> tensor<64x2x16xf32, #blocked1>
+          %dqs_187 = tt.trans %dqs_186 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked1> -> tensor<64x16x2xf32, #blocked2>
+          %dqs_188, %dqs_189 = tt.split %dqs_187 {async_task_id = array<i32: 0>} : tensor<64x16x2xf32, #blocked2> -> tensor<64x16xf32, #blocked>
+          %dqs_190 = tt.reshape %dqs_177 {async_task_id = array<i32: 0>} : tensor<64x64xf32, #linear4> -> tensor<64x2x32xf32, #linear5>
+          %dqs_191 = tt.trans %dqs_190 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #linear5> -> tensor<64x32x2xf32, #linear6>
+          %dqs_192, %dqs_193 = tt.split %dqs_191 {async_task_id = array<i32: 0>} : tensor<64x32x2xf32, #linear6> -> tensor<64x32xf32, #linear7>
+          %dqs_194 = tt.reshape %dqs_192 {async_task_id = array<i32: 0>} : tensor<64x32xf32, #linear7> -> tensor<64x2x16xf32, #blocked1>
+          %dqs_195 = tt.trans %dqs_194 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked1> -> tensor<64x16x2xf32, #blocked2>
+          %dqs_196, %dqs_197 = tt.split %dqs_195 {async_task_id = array<i32: 0>} : tensor<64x16x2xf32, #blocked2> -> tensor<64x16xf32, #blocked>
+          %dqs_198 = tt.reshape %dqs_193 {async_task_id = array<i32: 0>} : tensor<64x32xf32, #linear7> -> tensor<64x2x16xf32, #blocked1>
+          %dqs_199 = tt.trans %dqs_198 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked1> -> tensor<64x16x2xf32, #blocked2>
+          %dqs_200, %dqs_201 = tt.split %dqs_199 {async_task_id = array<i32: 0>} : tensor<64x16x2xf32, #blocked2> -> tensor<64x16xf32, #blocked>
+          %dq_row_202 = arith.addi %q_163, %dq_row_148 {async_task_id = array<i32: 0>} : i64
+          %dqN = arith.mulf %dqs_184, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %3 = arith.trunci %dq_row_202 {async_task_id = array<i32: 0>} : i64 to i32
+          %desc_dq_reduce_staging_203 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN, %desc_dq_reduce_staging_203 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_204 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %4 = ttng.async_tma_reduce add, %desc_dq[%3, %c0_i32] %desc_dq_reduce_staging_204 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %4   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_205 = arith.mulf %dqs_185, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_206 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_205, %desc_dq_reduce_staging_206 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_207 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %5 = ttng.async_tma_reduce add, %desc_dq[%3, %c16_i32] %desc_dq_reduce_staging_207 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %5   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_208 = arith.mulf %dqs_188, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_209 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_208, %desc_dq_reduce_staging_209 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_210 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %6 = ttng.async_tma_reduce add, %desc_dq[%3, %c32_i32] %desc_dq_reduce_staging_210 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %6   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_211 = arith.mulf %dqs_189, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_212 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_211, %desc_dq_reduce_staging_212 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_213 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %7 = ttng.async_tma_reduce add, %desc_dq[%3, %c48_i32] %desc_dq_reduce_staging_213 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %7   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_214 = arith.mulf %dqs_196, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_215 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_214, %desc_dq_reduce_staging_215 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_216 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %8 = ttng.async_tma_reduce add, %desc_dq[%3, %c64_i32] %desc_dq_reduce_staging_216 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %8   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_217 = arith.mulf %dqs_197, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_218 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_217, %desc_dq_reduce_staging_218 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_219 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %9 = ttng.async_tma_reduce add, %desc_dq[%3, %c80_i32] %desc_dq_reduce_staging_219 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %9   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_220 = arith.mulf %dqs_200, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_221 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_220, %desc_dq_reduce_staging_221 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_222 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %10 = ttng.async_tma_reduce add, %desc_dq[%3, %c96_i32] %desc_dq_reduce_staging_222 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %10   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %dqN_223 = arith.mulf %dqs_201, %cst {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked>
+          %desc_dq_reduce_staging_224 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          ttg.local_store %dqN_223, %desc_dq_reduce_staging_224 {async_task_id = array<i32: 0>} : tensor<64x16xf32, #blocked> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %desc_dq_reduce_staging_225 = ttg.memdesc_index %desc_dq_reduce_staging[%c0_i32] {async_task_id = array<i32: 0>} : !ttg.memdesc<1x64x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<64x16xf32, #shared1, #smem, mutable>
+          %11 = ttng.async_tma_reduce add, %desc_dq[%3, %c112_i32] %desc_dq_reduce_staging_225 {async_task_id = array<i32: 0>} : !tt.tensordesc<64x16xf32, #shared1>, !ttg.memdesc<64x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %11   {async_task_id = array<i32: 0>} : !ttg.async.token
+          %curr_m_226 = arith.addi %arg67, %c128_i32 {async_task_id = array<i32: 0>} : i32
+          %accum_cnt = arith.addi %tile_idx_161, %c1_i64 {async_task_id = array<i32: 0>} : i64
+          scf.yield {async_task_id = array<i32: 0>} %curr_m_226, %accum_cnt : i32, i64
+        } {async_task_id = array<i32: 0>, tt.warp_specialize}
+        %tile_idx_159 = arith.addi %prog_id_150, %num_progs_146 {async_task_id = array<i32: 0>} : i32
+        scf.yield {async_task_id = array<i32: 0>} %tile_idx_159, %curr_m#1 : i32, i64
+      } {async_task_id = array<i32: 0>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_yield
+    }
+    partition0(%N_CTX_144: i32, %BATCH_145: i32, %H_146: i32, %k_147: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_148: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_149: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qT_150: !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>, %qT_151: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %k_152: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_153: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_154: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %qkT_155: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_156: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_157: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_158: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_159: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_160: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_161: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_162: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_163: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_164: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_165: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %do_166: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_167: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_168: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_169: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %q_170: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_171: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_172: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_173: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_174: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_175: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_176: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_177: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_178: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_179: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %k_180: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_181: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %stride_tok_182: i32, %stride_h_183: i32, %stride_z_184: i32, %desc_k_185: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_186: !tt.tensordesc<256x64xf16, #shared>, %desc_v_187: !tt.tensordesc<128x128xf16, #shared>, %desc_q_188: !tt.tensordesc<128x64xf16, #shared>, %desc_qt_189: !tt.tensordesc<64x128xf16, #shared>, %m_190: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_191: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_m_192: !tt.tensordesc<128xf32, #shared3>, %desc_do_193: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_194: !tt.tensordesc<64x128xf16, #shared>, %Di_195: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_196: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_delta_197: !tt.tensordesc<128xf32, #shared3>, %sm_scale_198: f32, %desc_dv_staging_199: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dv_200: !tt.tensordesc<128x16xf16, #shared2>, %desc_dk_staging_201: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dk_202: !tt.tensordesc<128x16xf16, #shared2>, %dv_203: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_204: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_205: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_206: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_207: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_208: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_209: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_210: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_211: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_212: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_213: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_214: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_215: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_216: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_217: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_218: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_219: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_220: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_221: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_222: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_223: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_224: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(1) {
+      %c2_i64 = arith.constant {async_task_id = array<i32: 1>} 2 : i64
+      %c1_i64_225 = arith.constant {async_task_id = array<i32: 1>} 1 : i64
+      %c0_i64_226 = arith.constant {async_task_id = array<i32: 1>} 0 : i64
+      %true = arith.constant {async_task_id = array<i32: 1>} true
+      %n_tile_num = arith.constant {async_task_id = array<i32: 1>} 127 : i32
+      %c128_i32_227 = arith.constant {async_task_id = array<i32: 1>} 128 : i32
+      %kt_228 = arith.constant {async_task_id = array<i32: 1>} 2 : i32
+      %c1_i32_229 = arith.constant {async_task_id = array<i32: 1>} 1 : i32
+      %c0_i32_230 = arith.constant {async_task_id = array<i32: 1>} 0 : i32
+      %false = arith.constant {async_task_id = array<i32: 1>} false
+      %n_tile_num_231 = arith.addi %N_CTX_144, %n_tile_num {async_task_id = array<i32: 1>} : i32
+      %n_tile_num_232 = arith.divsi %n_tile_num_231, %c128_i32_227 {async_task_id = array<i32: 1>} : i32
+      %cluster_rank = tt.get_program_id x {async_task_id = array<i32: 1>} : i32
+      %prog_id = arith.divsi %cluster_rank, %kt_228 {async_task_id = array<i32: 1>} : i32
+      %num_progs = tt.get_num_programs x {async_task_id = array<i32: 1>} : i32
+      %num_progs_233 = arith.divsi %num_progs, %kt_228 {async_task_id = array<i32: 1>} : i32
+      %scheduled_n_tiles = arith.divsi %n_tile_num_232, %kt_228 {async_task_id = array<i32: 1>} : i32
+      %total_tiles = arith.muli %scheduled_n_tiles, %BATCH_145 {async_task_id = array<i32: 1>} : i32
+      %total_tiles_234 = arith.muli %total_tiles, %H_146 {async_task_id = array<i32: 1>} : i32
+      %tiles_per_sm = arith.divsi %total_tiles_234, %num_progs_233 {async_task_id = array<i32: 1>} : i32
+      %0 = arith.remsi %total_tiles_234, %num_progs_233 {async_task_id = array<i32: 1>} : i32
+      %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 1>} : i32
+      %2 = scf.if %1 -> (i32) {
+        %tiles_per_sm_235 = arith.addi %tiles_per_sm, %c1_i32_229 {async_task_id = array<i32: 1>} : i32
+        scf.yield {async_task_id = array<i32: 1>} %tiles_per_sm_235 : i32
+      } else {
+        scf.yield {async_task_id = array<i32: 1>} %tiles_per_sm : i32
+      } {async_task_id = array<i32: 1>}
+      %num_steps = arith.divsi %N_CTX_144, %c128_i32_227 {async_task_id = array<i32: 1>} : i32
+      %tile_idx:2 = scf.for %tile_idx_235 = %c0_i32_230 to %2 step %c1_i32_229 iter_args(%tile_idx_236 = %c0_i64_226, %tile_idx_237 = %c0_i64_226) -> (i64, i64)  : i32 {
+        %curr_m = arith.andi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        %curr_m_238 = arith.trunci %curr_m {async_task_id = array<i32: 1>} : i64 to i1
+        %curr_m_239 = arith.andi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        %curr_m_240 = arith.trunci %curr_m_239 {async_task_id = array<i32: 1>} : i64 to i1
+        %curr_m_241 = arith.andi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        %curr_m_242 = arith.trunci %curr_m_241 {async_task_id = array<i32: 1>} : i64 to i1
+        %k_243 = ttg.memdesc_index %k_147[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %k_244 = arith.extui %curr_m_238 {async_task_id = array<i32: 1>} : i1 to i32
+        ttng.wait_barrier %k_243, %k_244, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_245 = ttg.memdesc_index %kt_148[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_246 = arith.extui %curr_m_240 {async_task_id = array<i32: 1>} : i1 to i32
+        ttng.wait_barrier %kt_245, %kt_246, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_247 = ttg.memdesc_index %v_149[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_248 = arith.extui %curr_m_242 {async_task_id = array<i32: 1>} : i1 to i32
+        ttng.wait_barrier %v_247, %v_248, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %curr_m_249 = arith.andi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        %curr_m_250 = arith.trunci %curr_m_249 {async_task_id = array<i32: 1>} : i64 to i1
+        %dv_251 = ttg.memdesc_index %dv_204[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dv_252 = arith.xori %curr_m_250, %true : i1
+        %dv_253 = arith.extui %dv_252 : i1 to i32
+        ttng.wait_barrier %dv_251, %dv_253 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %curr_m_254 = arith.andi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        %curr_m_255 = arith.trunci %curr_m_254 {async_task_id = array<i32: 1>} : i64 to i1
+        %dk_256 = ttg.memdesc_index %dk_206[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dk_257 = arith.xori %curr_m_255, %true : i1
+        %dk_258 = arith.extui %dk_257 : i1 to i32
+        ttng.wait_barrier %dk_256, %dk_258 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %curr_m_259:2 = scf.for %curr_m_265 = %c0_i32_230 to %num_steps step %c1_i32_229 iter_args(%arg148 = %false, %tile_idx_266 = %tile_idx_237) -> (i1, i64)  : i32 {
+          %q_267 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %q_268 = arith.trunci %q_267 {async_task_id = array<i32: 1>} : i64 to i1
+          %qT_269 = arith.divui %tile_idx_266, %c2_i64 {async_task_id = array<i32: 1>} : i64
+          %qT_270 = arith.muli %qT_269, %c2_i64 {async_task_id = array<i32: 1>} : i64
+          %qT_271 = arith.subi %tile_idx_266, %qT_270 {async_task_id = array<i32: 1>} : i64
+          %qT_272 = arith.trunci %qT_271 {async_task_id = array<i32: 1>} : i64 to i32
+          %qT_273 = arith.andi %qT_269, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %qT_274 = arith.trunci %qT_273 {async_task_id = array<i32: 1>} : i64 to i1
+          %qT_275 = arith.divui %tile_idx_266, %c2_i64 {async_task_id = array<i32: 1>} : i64
+          %qT_276 = arith.muli %qT_275, %c2_i64 {async_task_id = array<i32: 1>} : i64
+          %qT_277 = arith.subi %tile_idx_266, %qT_276 {async_task_id = array<i32: 1>} : i64
+          %qT_278 = arith.trunci %qT_277 {async_task_id = array<i32: 1>} : i64 to i32
+          %qT_279 = ttg.memdesc_index %qT_150[%qT_278] {async_task_id = array<i32: 1>} : !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %qT_280 = ttg.memdesc_index %qT_151[%qT_272] {async_task_id = array<i32: 1>} : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qT_281 = arith.extui %qT_274 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %qT_280, %qT_281, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qT_282 = ttg.memdesc_trans %qT_279 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+          %k_283 = ttg.memdesc_index %k_152[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %qkT_284 = ttg.memdesc_index %qkT_153[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %qT_285 = ttg.memdesc_index %qT_154[%qT_272] {async_task_id = array<i32: 1>} : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_286 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %qkT_287 = arith.trunci %qkT_286 {async_task_id = array<i32: 1>} : i64 to i1
+          %qkT_288 = ttg.memdesc_index %qkT_155[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_289 = ttg.memdesc_index %qkT_210[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_290 = arith.xori %qkT_287, %true : i1
+          %qkT_291 = arith.extui %qkT_290 : i1 to i32
+          ttng.wait_barrier %qkT_289, %qkT_291 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dv_292 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dv_293 = arith.trunci %dv_292 {async_task_id = array<i32: 1>} : i64 to i1
+          %ppT_294 = ttg.memdesc_index %ppT_156[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_295 = arith.xori %dv_293, %true {async_task_id = array<i32: 1>} : i1
+          %qkT_296 = arith.extui %qkT_295 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %ppT_294, %qkT_296 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {direction = "backward", dstTask = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_297 = ttng.tc_gen5_mma %k_283, %qT_282, %qkT_284[], %false, %true, %qT_285[%true], %qkT_288[%true] {async_task_id = array<i32: 1>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_298 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %do_299 = arith.trunci %do_298 {async_task_id = array<i32: 1>} : i64 to i1
+          %dpT_300 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dpT_301 = arith.trunci %dpT_300 {async_task_id = array<i32: 1>} : i64 to i1
+          %dpT_302 = ttg.memdesc_index %dpT_157[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %dpT_303 = ttg.memdesc_index %dpT_158[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_304 = arith.extui %dpT_301 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %dpT_303, %dpT_304, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_305 = ttg.memdesc_trans %dpT_302 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+          %v_306 = ttg.memdesc_index %v_159[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %dpT_307 = ttg.memdesc_index %dpT_160[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %dpT_308 = ttg.memdesc_index %dpT_161[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_309 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dpT_310 = arith.trunci %dpT_309 {async_task_id = array<i32: 1>} : i64 to i1
+          %dpT_311 = ttg.memdesc_index %dpT_162[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_312 = ttg.memdesc_index %dpT_214[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_313 = arith.xori %dpT_310, %true : i1
+          %dpT_314 = arith.extui %dpT_313 : i1 to i32
+          ttng.wait_barrier %dpT_312, %dpT_314 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_315 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dq_316 = arith.trunci %dq_315 {async_task_id = array<i32: 1>} : i64 to i1
+          %dq_317 = ttg.memdesc_index %dq_224[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_318 = arith.xori %dq_316, %true : i1
+          %dq_319 = arith.extui %dq_318 : i1 to i32
+          ttng.wait_barrier %dq_317, %dq_319 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_320 = ttng.tc_gen5_mma %v_306, %dpT_305, %dpT_307[], %false, %true, %dpT_308[%true], %dpT_311[%true] {async_task_id = array<i32: 1>, is_async, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dv_321 = ttg.memdesc_index %dv_163[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %do_322 = ttg.memdesc_index %do_164[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %qkT_323 = ttng.tmem_subslice %qkT_153 {N = 0 : i32, async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %qkT_324 = ttg.memdesc_reinterpret %qkT_323 {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %ppT_325 = ttg.memdesc_index %qkT_324[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %do_326 = ttg.memdesc_index %do_165[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_327 = ttg.memdesc_index %do_166[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_328 = arith.extui %do_299 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %do_327, %do_328, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %ppT_329 = ttg.memdesc_index %ppT_156[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %ppT_330 = ttg.memdesc_index %ppT_211[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dv_331 = arith.extui %dv_293 : i1 to i32
+          ttng.wait_barrier %ppT_330, %dv_331 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dv_332 = ttng.tc_gen5_mma %ppT_325, %do_322, %dv_321[], %arg148, %true, %do_326[%true], %ppT_329[%true] {async_task_id = array<i32: 1>, is_async, tmem.start = array<i32: 3>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dk_333 = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dk_334 = arith.trunci %dk_333 {async_task_id = array<i32: 1>} : i64 to i1
+          %dk_335 = ttg.memdesc_index %dk_167[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %q_336 = ttg.memdesc_index %q_168[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dpT_337 = ttng.tmem_subslice %dpT_160 {N = 0 : i32, async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %dpT_338 = ttg.memdesc_reinterpret %dpT_337 {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %dsT_339 = ttg.memdesc_index %dpT_338[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %q_340 = ttg.memdesc_index %q_169[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %q_341 = ttg.memdesc_index %q_170[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %q_342 = arith.extui %q_268 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %q_341, %q_342, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_343 = ttg.memdesc_index %dsT_171[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_344 = ttg.memdesc_index %dsT_217[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dk_345 = arith.extui %dk_334 : i1 to i32
+          ttng.wait_barrier %dsT_344, %dk_345 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dk_346 = ttng.tc_gen5_mma %dsT_339, %q_336, %dk_335[], %arg148, %true, %q_340[%true], %dsT_343[%true] {async_task_id = array<i32: 1>, is_async, tmem.start = array<i32: 4>, tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq = arith.andi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          %dsT_dq_347 = arith.trunci %dsT_dq {async_task_id = array<i32: 1>} : i64 to i1
+          %dsT_dq_0_348 = ttg.memdesc_index %dsT_dq_0_172[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dsT_dq_0_349 = ttg.memdesc_index %dsT_dq_0_221[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_350 = arith.extui %dsT_dq_347 : i1 to i32
+          ttng.wait_barrier %dsT_dq_0_349, %dsT_dq_350 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_351 = ttg.memdesc_trans %dsT_dq_0_348 {async_task_id = array<i32: 1>, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>
+          %kt_352 = ttg.memdesc_index %kt_173[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dpT_353 = ttng.tmem_subslice %dpT_160 {N = 0 : i32, async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %dpT_354 = ttg.memdesc_reinterpret %dpT_353 {async_task_id = array<i32: 1>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+          %dq_355 = ttg.memdesc_index %dpT_354[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+          %dsT_dq_0_356 = ttg.memdesc_index %dsT_dq_0_174[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_357 = ttg.memdesc_index %dq_175[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_358 = ttg.memdesc_index %dpT_214[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_359 = arith.extui %dq_316 : i1 to i32
+          ttng.wait_barrier %dpT_358, %dq_359 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dq_360 = ttng.tc_gen5_mma %dsT_dq_351, %kt_352, %dq_355[], %false, %true, %dsT_dq_0_356[%true], %dq_357[%true] {async_task_id = array<i32: 1>, is_async, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %accum_cnt_361 = arith.addi %tile_idx_266, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+          scf.yield {async_task_id = array<i32: 1>} %true, %accum_cnt_361 : i1, i64
+        } {async_task_id = array<i32: 1>, tt.warp_specialize}
+        %dk_260 = ttg.memdesc_index %dk_176[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tc_gen5_commit %dk_260 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dv_261 = ttg.memdesc_index %dv_177[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tc_gen5_commit %dv_261 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_262 = ttg.memdesc_index %v_178[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tc_gen5_commit %v_262 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_263 = ttg.memdesc_index %kt_179[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tc_gen5_commit %kt_263 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %k_264 = ttg.memdesc_index %k_180[%c0_i32_230] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tc_gen5_commit %k_264 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %accum_cnt = arith.addi %tile_idx_236, %c1_i64_225 {async_task_id = array<i32: 1>} : i64
+        scf.yield {async_task_id = array<i32: 1>} %accum_cnt, %curr_m_259#1 : i64, i64
+      } {async_task_id = array<i32: 1>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    }
+    partition1(%N_CTX_144: i32, %BATCH_145: i32, %H_146: i32, %k_147: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_148: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_149: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qT_150: !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>, %qT_151: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %k_152: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_153: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_154: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %qkT_155: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_156: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_157: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_158: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_159: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_160: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_161: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_162: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_163: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_164: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_165: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %do_166: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_167: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_168: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_169: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %q_170: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_171: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_172: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_173: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_174: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_175: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_176: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_177: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_178: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_179: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %k_180: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_181: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %stride_tok_182: i32, %stride_h_183: i32, %stride_z_184: i32, %desc_k_185: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_186: !tt.tensordesc<256x64xf16, #shared>, %desc_v_187: !tt.tensordesc<128x128xf16, #shared>, %desc_q_188: !tt.tensordesc<128x64xf16, #shared>, %desc_qt_189: !tt.tensordesc<64x128xf16, #shared>, %m_190: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_191: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_m_192: !tt.tensordesc<128xf32, #shared3>, %desc_do_193: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_194: !tt.tensordesc<64x128xf16, #shared>, %Di_195: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_196: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_delta_197: !tt.tensordesc<128xf32, #shared3>, %sm_scale_198: f32, %desc_dv_staging_199: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dv_200: !tt.tensordesc<128x16xf16, #shared2>, %desc_dk_staging_201: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dk_202: !tt.tensordesc<128x16xf16, #shared2>, %dv_203: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_204: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_205: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_206: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_207: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_208: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_209: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_210: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_211: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_212: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_213: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_214: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_215: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_216: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_217: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_218: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_219: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_220: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_221: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_222: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_223: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_224: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(1) {
+      %c1_i64_225 = arith.constant {async_task_id = array<i32: 2>} 1 : i64
+      %c0_i64_226 = arith.constant {async_task_id = array<i32: 2>} 0 : i64
+      %n_tile_num = arith.constant {async_task_id = array<i32: 2>} 127 : i32
+      %c128_i32_227 = arith.constant {async_task_id = array<i32: 2>} 128 : i32
+      %kt_228 = arith.constant {async_task_id = array<i32: 2>} 2 : i32
+      %c1_i32_229 = arith.constant {async_task_id = array<i32: 2>} 1 : i32
+      %c0_i32_230 = arith.constant {async_task_id = array<i32: 2>} 0 : i32
+      %n_tile_num_231 = arith.addi %N_CTX_144, %n_tile_num {async_task_id = array<i32: 2>} : i32
+      %n_tile_num_232 = arith.divsi %n_tile_num_231, %c128_i32_227 {async_task_id = array<i32: 2>} : i32
+      %cluster_rank = tt.get_program_id x {async_task_id = array<i32: 2>} : i32
+      %prog_id = arith.divsi %cluster_rank, %kt_228 {async_task_id = array<i32: 2>} : i32
+      %num_progs = tt.get_num_programs x {async_task_id = array<i32: 2>} : i32
+      %num_progs_233 = arith.divsi %num_progs, %kt_228 {async_task_id = array<i32: 2>} : i32
+      %scheduled_n_tiles = arith.divsi %n_tile_num_232, %kt_228 {async_task_id = array<i32: 2>} : i32
+      %total_tiles = arith.muli %scheduled_n_tiles, %BATCH_145 {async_task_id = array<i32: 2>} : i32
+      %total_tiles_234 = arith.muli %total_tiles, %H_146 {async_task_id = array<i32: 2>} : i32
+      %tiles_per_sm = arith.divsi %total_tiles_234, %num_progs_233 {async_task_id = array<i32: 2>} : i32
+      %0 = arith.remsi %total_tiles_234, %num_progs_233 {async_task_id = array<i32: 2>} : i32
+      %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 2>} : i32
+      %2 = scf.if %1 -> (i32) {
+        %tiles_per_sm_235 = arith.addi %tiles_per_sm, %c1_i32_229 {async_task_id = array<i32: 2>} : i32
+        scf.yield {async_task_id = array<i32: 2>} %tiles_per_sm_235 : i32
+      } else {
+        scf.yield {async_task_id = array<i32: 2>} %tiles_per_sm : i32
+      } {async_task_id = array<i32: 2>}
+      %num_steps = arith.divsi %N_CTX_144, %c128_i32_227 {async_task_id = array<i32: 2>} : i32
+      %tile_idx = scf.for %tile_idx_235 = %c0_i32_230 to %2 step %c1_i32_229 iter_args(%tile_idx_236 = %c0_i64_226) -> (i64)  : i32 {
+        %curr_m = scf.for %curr_m_237 = %c0_i32_230 to %num_steps step %c1_i32_229 iter_args(%tile_idx_238 = %tile_idx_236) -> (i64)  : i32 {
+          %dsT_dq = arith.andi %tile_idx_238, %c1_i64_225 {async_task_id = array<i32: 2>} : i64
+          %dsT_dq_239 = arith.trunci %dsT_dq {async_task_id = array<i32: 2>} : i64 to i1
+          %dsT_dq_1_240 = ttg.memdesc_index %dsT_dq_1_181[%c0_i32_230] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_1_241 = ttg.memdesc_index %dsT_dq_1_219[%c0_i32_230] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_242 = arith.extui %dsT_dq_239 : i1 to i32
+          ttng.wait_barrier %dsT_dq_1_241, %dsT_dq_242 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.two_cta_peer_relay %dsT_dq_1_240 {async_task_id = array<i32: 2>} : <128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_1_243 = ttg.memdesc_index %dsT_dq_1_220[%c0_i32_230] {async_task_id = array<i32: 2>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_dq_1_243, 1 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %accum_cnt = arith.addi %tile_idx_238, %c1_i64_225 {async_task_id = array<i32: 2>} : i64
+          scf.yield {async_task_id = array<i32: 2>} %accum_cnt : i64
+        } {async_task_id = array<i32: 2>, tt.warp_specialize}
+        scf.yield {async_task_id = array<i32: 2>} %curr_m : i64
+      } {async_task_id = array<i32: 2>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    }
+    partition2(%N_CTX_144: i32, %BATCH_145: i32, %H_146: i32, %k_147: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_148: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_149: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qT_150: !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>, %qT_151: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %k_152: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_153: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_154: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %qkT_155: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_156: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_157: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_158: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_159: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_160: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_161: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_162: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_163: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_164: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_165: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %do_166: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_167: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_168: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_169: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %q_170: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_171: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_172: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_173: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_174: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_175: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_176: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_177: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_178: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_179: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %k_180: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_181: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %stride_tok_182: i32, %stride_h_183: i32, %stride_z_184: i32, %desc_k_185: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_186: !tt.tensordesc<256x64xf16, #shared>, %desc_v_187: !tt.tensordesc<128x128xf16, #shared>, %desc_q_188: !tt.tensordesc<128x64xf16, #shared>, %desc_qt_189: !tt.tensordesc<64x128xf16, #shared>, %m_190: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_191: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_m_192: !tt.tensordesc<128xf32, #shared3>, %desc_do_193: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_194: !tt.tensordesc<64x128xf16, #shared>, %Di_195: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_196: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_delta_197: !tt.tensordesc<128xf32, #shared3>, %sm_scale_198: f32, %desc_dv_staging_199: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dv_200: !tt.tensordesc<128x16xf16, #shared2>, %desc_dk_staging_201: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dk_202: !tt.tensordesc<128x16xf16, #shared2>, %dv_203: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_204: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_205: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_206: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_207: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_208: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_209: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_210: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_211: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_212: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_213: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_214: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_215: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_216: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_217: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_218: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_219: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_220: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_221: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_222: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_223: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_224: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(1) {
+      %c2_i64 = arith.constant {async_task_id = array<i32: 3>} 2 : i64
+      %true = arith.constant {async_task_id = array<i32: 3>} true
+      %c1_i64_225 = arith.constant {async_task_id = array<i32: 3>} 1 : i64
+      %c0_i64_226 = arith.constant {async_task_id = array<i32: 3>} 0 : i64
+      %kt_227 = arith.constant {async_task_id = array<i32: 3>} 64 : i32
+      %n_tile_num = arith.constant {async_task_id = array<i32: 3>} 127 : i32
+      %c128_i32_228 = arith.constant {async_task_id = array<i32: 3>} 128 : i32
+      %kt_229 = arith.constant {async_task_id = array<i32: 3>} 2 : i32
+      %c1_i32_230 = arith.constant {async_task_id = array<i32: 3>} 1 : i32
+      %c0_i32_231 = arith.constant {async_task_id = array<i32: 3>} 0 : i32
+      %n_tile_num_232 = arith.addi %N_CTX_144, %n_tile_num {async_task_id = array<i32: 3>} : i32
+      %n_tile_num_233 = arith.divsi %n_tile_num_232, %c128_i32_228 {async_task_id = array<i32: 3>} : i32
+      %cluster_rank = tt.get_program_id x {async_task_id = array<i32: 3>} : i32
+      %cluster_rank_234 = arith.remsi %cluster_rank, %kt_229 {async_task_id = array<i32: 3>} : i32
+      %prog_id = arith.divsi %cluster_rank, %kt_229 {async_task_id = array<i32: 3>} : i32
+      %num_progs = tt.get_num_programs x {async_task_id = array<i32: 3>} : i32
+      %num_progs_235 = arith.divsi %num_progs, %kt_229 {async_task_id = array<i32: 3>} : i32
+      %scheduled_n_tiles = arith.divsi %n_tile_num_233, %kt_229 {async_task_id = array<i32: 3>} : i32
+      %total_tiles = arith.muli %scheduled_n_tiles, %BATCH_145 {async_task_id = array<i32: 3>} : i32
+      %total_tiles_236 = arith.muli %total_tiles, %H_146 {async_task_id = array<i32: 3>} : i32
+      %tiles_per_sm = arith.divsi %total_tiles_236, %num_progs_235 {async_task_id = array<i32: 3>} : i32
+      %0 = arith.remsi %total_tiles_236, %num_progs_235 {async_task_id = array<i32: 3>} : i32
+      %1 = arith.cmpi slt, %prog_id, %0 {async_task_id = array<i32: 3>} : i32
+      %2 = scf.if %1 -> (i32) {
+        %tiles_per_sm_240 = arith.addi %tiles_per_sm, %c1_i32_230 {async_task_id = array<i32: 3>} : i32
+        scf.yield {async_task_id = array<i32: 3>} %tiles_per_sm_240 : i32
+      } else {
+        scf.yield {async_task_id = array<i32: 3>} %tiles_per_sm : i32
+      } {async_task_id = array<i32: 3>}
+      %off_bh = arith.extsi %stride_tok_182 {async_task_id = array<i32: 3>} : i32 to i64
+      %kt_start_n = arith.muli %cluster_rank_234, %c128_i32_228 {async_task_id = array<i32: 3>} : i32
+      %num_steps = arith.divsi %N_CTX_144, %c128_i32_228 {async_task_id = array<i32: 3>} : i32
+      %kt_237 = nvg.cluster_id {async_task_id = array<i32: 3>}
+      %kt_238 = arith.remsi %kt_237, %kt_229 {async_task_id = array<i32: 3>} : i32
+      %kt_239 = arith.muli %kt_238, %kt_227 {async_task_id = array<i32: 3>} : i32
+      %tile_idx:3 = scf.for %tile_idx_240 = %c0_i32_231 to %2 step %c1_i32_230 iter_args(%prog_id_241 = %prog_id, %tile_idx_242 = %c0_i64_226, %tile_idx_243 = %c0_i64_226) -> (i32, i64, i64)  : i32 {
+        %scheduled_pid = arith.remsi %prog_id_241, %scheduled_n_tiles {async_task_id = array<i32: 3>} : i32
+        %bhid = arith.divsi %prog_id_241, %scheduled_n_tiles {async_task_id = array<i32: 3>} : i32
+        %pid = arith.muli %scheduled_pid, %kt_229 {async_task_id = array<i32: 3>} : i32
+        %pid_244 = arith.addi %pid, %cluster_rank_234 {async_task_id = array<i32: 3>} : i32
+        %off_chz = arith.muli %bhid, %N_CTX_144 {async_task_id = array<i32: 3>} : i32
+        %off_chz_245 = arith.extsi %off_chz {async_task_id = array<i32: 3>} : i32 to i64
+        %off_bh_246 = arith.remsi %bhid, %H_146 {async_task_id = array<i32: 3>} : i32
+        %off_bh_247 = arith.muli %stride_h_183, %off_bh_246 {async_task_id = array<i32: 3>} : i32
+        %off_bh_248 = arith.divsi %bhid, %H_146 {async_task_id = array<i32: 3>} : i32
+        %off_bh_249 = arith.muli %stride_z_184, %off_bh_248 {async_task_id = array<i32: 3>} : i32
+        %off_bh_250 = arith.addi %off_bh_247, %off_bh_249 {async_task_id = array<i32: 3>} : i32
+        %off_bh_251 = arith.extsi %off_bh_250 {async_task_id = array<i32: 3>} : i32 to i64
+        %off_bh_252 = arith.divsi %off_bh_251, %off_bh {async_task_id = array<i32: 3>} : i64
+        %start_n = arith.muli %pid_244, %c128_i32_228 {async_task_id = array<i32: 3>} : i32
+        %k_253 = arith.extsi %start_n {async_task_id = array<i32: 3>} : i32 to i64
+        %k_254 = arith.addi %off_bh_252, %k_253 {async_task_id = array<i32: 3>} : i64
+        %k_255 = arith.trunci %k_254 {async_task_id = array<i32: 3>} : i64 to i32
+        %curr_m = arith.andi %tile_idx_242, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+        %curr_m_256 = arith.trunci %curr_m {async_task_id = array<i32: 3>} : i64 to i1
+        %k_257 = ttg.memdesc_index %k_180[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %k_258 = arith.xori %curr_m_256, %true {async_task_id = array<i32: 3>} : i1
+        %k_259 = arith.extui %k_258 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %k_257, %k_259 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %k_260 = ttg.memdesc_index %k_147[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.barrier_expect %k_260, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %k_261 = ttg.memdesc_index %k_152[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_k_185[%k_255, %c0_i32_231] %k_261, %k_260, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %kt_start_n_262 = arith.subi %start_n, %kt_start_n {async_task_id = array<i32: 3>} : i32
+        %kt_263 = arith.extsi %kt_start_n_262 {async_task_id = array<i32: 3>} : i32 to i64
+        %kt_264 = arith.addi %off_bh_252, %kt_263 {async_task_id = array<i32: 3>} : i64
+        %kt_265 = arith.trunci %kt_264 {async_task_id = array<i32: 3>} : i64 to i32
+        %curr_m_266 = arith.andi %tile_idx_242, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+        %curr_m_267 = arith.trunci %curr_m_266 {async_task_id = array<i32: 3>} : i64 to i1
+        %kt_268 = ttg.memdesc_index %kt_179[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_269 = arith.xori %curr_m_267, %true {async_task_id = array<i32: 3>} : i1
+        %kt_270 = arith.extui %kt_269 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %kt_268, %kt_270 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_271 = ttg.memdesc_index %kt_148[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.barrier_expect %kt_271, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %kt_272 = ttg.memdesc_index %kt_173[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_kt_186[%kt_265, %kt_239] %kt_272, %kt_271, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<256x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+        %curr_m_273 = arith.andi %tile_idx_242, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+        %curr_m_274 = arith.trunci %curr_m_273 {async_task_id = array<i32: 3>} : i64 to i1
+        %v_275 = ttg.memdesc_index %v_178[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_276 = arith.xori %curr_m_274, %true {async_task_id = array<i32: 3>} : i1
+        %v_277 = arith.extui %v_276 {async_task_id = array<i32: 3>} : i1 to i32
+        ttng.wait_barrier %v_275, %v_277 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_278 = ttg.memdesc_index %v_149[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.barrier_expect %v_278, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %v_279 = ttg.memdesc_index %v_159[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        ttng.async_tma_copy_global_to_local %desc_v_187[%k_255, %c0_i32_231] %v_279, %v_278, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+        %curr_m_280:2 = scf.for %curr_m_282 = %c0_i32_231 to %num_steps step %c1_i32_230 iter_args(%arg149 = %c0_i32_231, %tile_idx_283 = %tile_idx_243) -> (i32, i64)  : i32 {
+          %q_284 = arith.extsi %arg149 {async_task_id = array<i32: 3>} : i32 to i64
+          %q_285 = arith.addi %off_bh_252, %q_284 {async_task_id = array<i32: 3>} : i64
+          %q_286 = arith.trunci %q_285 {async_task_id = array<i32: 3>} : i64 to i32
+          %q_287 = arith.andi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %q_288 = arith.trunci %q_287 {async_task_id = array<i32: 3>} : i64 to i1
+          %q_289 = ttg.memdesc_index %q_169[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %q_290 = arith.xori %q_288, %true {async_task_id = array<i32: 3>} : i1
+          %q_291 = arith.extui %q_290 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %q_289, %q_291 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %q_292 = ttg.memdesc_index %q_170[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %q_292, 16384 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %q_293 = ttg.memdesc_index %q_168[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_q_188[%q_286, %kt_239] %q_293, %q_292, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %qt = arith.addi %q_286, %kt_239 {async_task_id = array<i32: 3>} : i32
+          %qT_294 = arith.divui %tile_idx_283, %c2_i64 {async_task_id = array<i32: 3>} : i64
+          %qT_295 = arith.muli %qT_294, %c2_i64 {async_task_id = array<i32: 3>} : i64
+          %qT_296 = arith.subi %tile_idx_283, %qT_295 {async_task_id = array<i32: 3>} : i64
+          %qT_297 = arith.trunci %qT_296 {async_task_id = array<i32: 3>} : i64 to i32
+          %qT_298 = arith.andi %qT_294, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %qT_299 = arith.trunci %qT_298 {async_task_id = array<i32: 3>} : i64 to i1
+          %qT_300 = ttg.memdesc_index %qT_154[%qT_297] {async_task_id = array<i32: 3>} : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qt_301 = arith.xori %qT_299, %true {async_task_id = array<i32: 3>} : i1
+          %qt_302 = arith.extui %qt_301 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %qT_300, %qt_302 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qT_303 = ttg.memdesc_index %qT_151[%qT_297] {async_task_id = array<i32: 3>} : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %qT_303, 16384 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qT_304 = ttg.memdesc_index %qT_150[%qT_297] {async_task_id = array<i32: 3>} : !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_qt_189[%qt, %c0_i32_231] %qT_304, %qT_303, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %offs_m_start = arith.addi %off_chz_245, %q_284 {async_task_id = array<i32: 3>} : i64
+          %m_305 = arith.trunci %offs_m_start {async_task_id = array<i32: 3>} : i64 to i32
+          %m_306 = arith.andi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %m_307 = arith.trunci %m_306 {async_task_id = array<i32: 3>} : i64 to i1
+          %m_308 = ttg.memdesc_index %m_208[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %m_309 = arith.xori %m_307, %true : i1
+          %m_310 = arith.extui %m_309 : i1 to i32
+          ttng.wait_barrier %m_308, %m_310 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %m_311 = ttg.memdesc_index %m_190[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %m_311, 512 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %m_312 = ttg.memdesc_index %m_191[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_m_192[%m_305] %m_312, %m_311, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %do_313 = arith.andi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %do_314 = arith.trunci %do_313 {async_task_id = array<i32: 3>} : i64 to i1
+          %do_315 = ttg.memdesc_index %do_165[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_316 = arith.xori %do_314, %true {async_task_id = array<i32: 3>} : i1
+          %do_317 = arith.extui %do_316 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %do_315, %do_317 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_318 = ttg.memdesc_index %do_166[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %do_318, 16384 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %do_319 = ttg.memdesc_index %do_164[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_do_193[%q_286, %kt_239] %do_319, %do_318, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dpT_320 = arith.andi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %dpT_321 = arith.trunci %dpT_320 {async_task_id = array<i32: 3>} : i64 to i1
+          %dpT_322 = ttg.memdesc_index %dpT_161[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dot = arith.xori %dpT_321, %true {async_task_id = array<i32: 3>} : i1
+          %dot_323 = arith.extui %dot {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %dpT_322, %dot_323 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_324 = ttg.memdesc_index %dpT_158[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %dpT_324, 16384 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_325 = ttg.memdesc_index %dpT_157[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_dot_194[%qt, %c0_i32_231] %dpT_325, %dpT_324, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %Di_326 = arith.andi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          %Di_327 = arith.trunci %Di_326 {async_task_id = array<i32: 3>} : i64 to i1
+          %Di_328 = ttg.memdesc_index %Di_216[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %Di_329 = arith.xori %Di_327, %true : i1
+          %Di_330 = arith.extui %Di_329 : i1 to i32
+          ttng.wait_barrier %Di_328, %Di_330 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %Di_331 = ttg.memdesc_index %Di_195[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %Di_331, 512 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %Di_332 = ttg.memdesc_index %Di_196[%c0_i32_231] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %desc_delta_197[%m_305] %Di_332, %Di_331, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %curr_m_333 = arith.addi %arg149, %c128_i32_228 {async_task_id = array<i32: 3>} : i32
+          %accum_cnt_334 = arith.addi %tile_idx_283, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+          scf.yield {async_task_id = array<i32: 3>} %curr_m_333, %accum_cnt_334 : i32, i64
+        } {async_task_id = array<i32: 3>, tt.warp_specialize}
+        %tile_idx_281 = arith.addi %prog_id_241, %num_progs_235 {async_task_id = array<i32: 3>} : i32
+        %accum_cnt = arith.addi %tile_idx_242, %c1_i64_225 {async_task_id = array<i32: 3>} : i64
+        scf.yield {async_task_id = array<i32: 3>} %tile_idx_281, %accum_cnt, %curr_m_280#1 : i32, i64, i64
+      } {async_task_id = array<i32: 3>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    }
+    partition3(%N_CTX_144: i32, %BATCH_145: i32, %H_146: i32, %k_147: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_148: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_149: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qT_150: !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>, %qT_151: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %k_152: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %qkT_153: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %qT_154: !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, %qkT_155: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_156: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_157: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %dpT_158: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_159: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %dpT_160: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %dpT_161: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_162: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_163: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %do_164: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %do_165: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %do_166: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_167: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %q_168: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %q_169: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %q_170: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_171: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_172: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %kt_173: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %dsT_dq_0_174: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_175: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_176: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_177: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %v_178: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %kt_179: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %k_180: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_181: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %stride_tok_182: i32, %stride_h_183: i32, %stride_z_184: i32, %desc_k_185: !tt.tensordesc<128x128xf16, #shared>, %desc_kt_186: !tt.tensordesc<256x64xf16, #shared>, %desc_v_187: !tt.tensordesc<128x128xf16, #shared>, %desc_q_188: !tt.tensordesc<128x64xf16, #shared>, %desc_qt_189: !tt.tensordesc<64x128xf16, #shared>, %m_190: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_191: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_m_192: !tt.tensordesc<128xf32, #shared3>, %desc_do_193: !tt.tensordesc<128x64xf16, #shared>, %desc_dot_194: !tt.tensordesc<64x128xf16, #shared>, %Di_195: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_196: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %desc_delta_197: !tt.tensordesc<128xf32, #shared3>, %sm_scale_198: f32, %desc_dv_staging_199: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dv_200: !tt.tensordesc<128x16xf16, #shared2>, %desc_dk_staging_201: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %desc_dk_202: !tt.tensordesc<128x16xf16, #shared2>, %dv_203: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dv_204: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_205: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dk_206: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_207: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %m_208: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_209: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %qkT_210: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_211: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %ppT_212: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_213: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dpT_214: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_215: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %Di_216: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_217: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_218: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_219: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_1_220: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_221: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dsT_dq_0_222: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_223: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %dq_224: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+      %0 = ub.poison : tensor<128x128xf16, #linear8>
+      %c1_i64_225 = arith.constant {async_task_id = array<i32: 4>} 1 : i64
+      %c0_i64_226 = arith.constant {async_task_id = array<i32: 4>} 0 : i64
+      %true = arith.constant {async_task_id = array<i32: 4>} true
+      %c112_i32_227 = arith.constant {async_task_id = array<i32: 4>} 112 : i32
+      %c96_i32_228 = arith.constant {async_task_id = array<i32: 4>} 96 : i32
+      %c80_i32_229 = arith.constant {async_task_id = array<i32: 4>} 80 : i32
+      %kt_230 = arith.constant {async_task_id = array<i32: 4>} 64 : i32
+      %c48_i32_231 = arith.constant {async_task_id = array<i32: 4>} 48 : i32
+      %c32_i32_232 = arith.constant {async_task_id = array<i32: 4>} 32 : i32
+      %c16_i32_233 = arith.constant {async_task_id = array<i32: 4>} 16 : i32
+      %n_tile_num = arith.constant {async_task_id = array<i32: 4>} 127 : i32
+      %c128_i32_234 = arith.constant {async_task_id = array<i32: 4>} 128 : i32
+      %kt_235 = arith.constant {async_task_id = array<i32: 4>} 2 : i32
+      %c1_i32_236 = arith.constant {async_task_id = array<i32: 4>} 1 : i32
+      %c0_i32_237 = arith.constant {async_task_id = array<i32: 4>} 0 : i32
+      %n_tile_num_238 = arith.addi %N_CTX_144, %n_tile_num {async_task_id = array<i32: 4>} : i32
+      %n_tile_num_239 = arith.divsi %n_tile_num_238, %c128_i32_234 {async_task_id = array<i32: 4>} : i32
+      %cluster_rank = tt.get_program_id x {async_task_id = array<i32: 4>} : i32
+      %cluster_rank_240 = arith.remsi %cluster_rank, %kt_235 {async_task_id = array<i32: 4>} : i32
+      %prog_id = arith.divsi %cluster_rank, %kt_235 {async_task_id = array<i32: 4>} : i32
+      %num_progs = tt.get_num_programs x {async_task_id = array<i32: 4>} : i32
+      %num_progs_241 = arith.divsi %num_progs, %kt_235 {async_task_id = array<i32: 4>} : i32
+      %scheduled_n_tiles = arith.divsi %n_tile_num_239, %kt_235 {async_task_id = array<i32: 4>} : i32
+      %total_tiles = arith.muli %scheduled_n_tiles, %BATCH_145 {async_task_id = array<i32: 4>} : i32
+      %total_tiles_242 = arith.muli %total_tiles, %H_146 {async_task_id = array<i32: 4>} : i32
+      %tiles_per_sm = arith.divsi %total_tiles_242, %num_progs_241 {async_task_id = array<i32: 4>} : i32
+      %1 = arith.remsi %total_tiles_242, %num_progs_241 {async_task_id = array<i32: 4>} : i32
+      %2 = arith.cmpi slt, %prog_id, %1 {async_task_id = array<i32: 4>} : i32
+      %3 = scf.if %2 -> (i32) {
+        %tiles_per_sm_243 = arith.addi %tiles_per_sm, %c1_i32_236 {async_task_id = array<i32: 4>} : i32
+        scf.yield {async_task_id = array<i32: 4>} %tiles_per_sm_243 : i32
+      } else {
+        scf.yield {async_task_id = array<i32: 4>} %tiles_per_sm : i32
+      } {async_task_id = array<i32: 4>}
+      %off_bh = arith.extsi %stride_tok_182 {async_task_id = array<i32: 4>} : i32 to i64
+      %num_steps = arith.divsi %N_CTX_144, %c128_i32_234 {async_task_id = array<i32: 4>} : i32
+      %dkN = tt.splat %sm_scale_198 {async_task_id = array<i32: 4>} : f32 -> tensor<128x16xf32, #linear9>
+      %tile_idx:3 = scf.for %tile_idx_243 = %c0_i32_237 to %3 step %c1_i32_236 iter_args(%prog_id_244 = %prog_id, %tile_idx_245 = %c0_i64_226, %tile_idx_246 = %c0_i64_226) -> (i32, i64, i64)  : i32 {
+        %scheduled_pid = arith.remsi %prog_id_244, %scheduled_n_tiles {async_task_id = array<i32: 4>} : i32
+        %bhid = arith.divsi %prog_id_244, %scheduled_n_tiles {async_task_id = array<i32: 4>} : i32
+        %pid = arith.muli %scheduled_pid, %kt_235 {async_task_id = array<i32: 4>} : i32
+        %pid_247 = arith.addi %pid, %cluster_rank_240 {async_task_id = array<i32: 4>} : i32
+        %off_bh_248 = arith.remsi %bhid, %H_146 {async_task_id = array<i32: 4>} : i32
+        %off_bh_249 = arith.muli %stride_h_183, %off_bh_248 {async_task_id = array<i32: 4>} : i32
+        %off_bh_250 = arith.divsi %bhid, %H_146 {async_task_id = array<i32: 4>} : i32
+        %off_bh_251 = arith.muli %stride_z_184, %off_bh_250 {async_task_id = array<i32: 4>} : i32
+        %off_bh_252 = arith.addi %off_bh_249, %off_bh_251 {async_task_id = array<i32: 4>} : i32
+        %off_bh_253 = arith.extsi %off_bh_252 {async_task_id = array<i32: 4>} : i32 to i64
+        %off_bh_254 = arith.divsi %off_bh_253, %off_bh {async_task_id = array<i32: 4>} : i64
+        %start_n = arith.muli %pid_247, %c128_i32_234 {async_task_id = array<i32: 4>} : i32
+        %k_255 = arith.extsi %start_n {async_task_id = array<i32: 4>} : i32 to i64
+        %k_256 = arith.addi %off_bh_254, %k_255 {async_task_id = array<i32: 4>} : i64
+        %k_257 = arith.trunci %k_256 {async_task_id = array<i32: 4>} : i64 to i32
+        %curr_m = arith.andi %tile_idx_245, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %curr_m_258 = arith.trunci %curr_m {async_task_id = array<i32: 4>} : i64 to i1
+        %curr_m_259 = arith.andi %tile_idx_245, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %curr_m_260 = arith.trunci %curr_m_259 {async_task_id = array<i32: 4>} : i64 to i1
+        %curr_m_261 = arith.cmpi sgt, %num_steps, %c0_i32_237 : i32
+        %m_262 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %m_263 = arith.trunci %m_262 {async_task_id = array<i32: 4>} : i64 to i1
+        %qkT_264 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %qkT_265 = arith.trunci %qkT_264 {async_task_id = array<i32: 4>} : i64 to i1
+        %dv_266 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %dv_267 = arith.trunci %dv_266 {async_task_id = array<i32: 4>} : i64 to i1
+        %m_268 = ttg.memdesc_index %m_191[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+        %m_269 = ttg.memdesc_index %m_190[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %m_270 = arith.extui %m_263 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %m_269, %m_270, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %m_271 = ttg.local_load %m_268 {async_task_id = array<i32: 4>} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked3>
+        %m_272 = ttg.memdesc_index %m_208[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %m_272, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %pT = ttg.convert_layout %m_271 {async_task_id = array<i32: 4>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+        %pT_273 = tt.expand_dims %pT {async_task_id = array<i32: 4>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+        %pT_274 = tt.broadcast %pT_273 {async_task_id = array<i32: 4>} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+        %qkT_275 = ttg.memdesc_index %qkT_153[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_276 = ttg.memdesc_index %qkT_155[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %qkT_277 = arith.extui %qkT_265 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %qkT_276, %qkT_277, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %qkT_278, %qkT_279 = ttng.tmem_load %qkT_275[] {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+        %qkT_280 = ttg.memdesc_index %qkT_210[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %qkT_280, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %pT_281 = arith.subf %qkT_278, %pT_274 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+        %pT_282 = math.exp2 %pT_281 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+        %ppT_283 = arith.truncf %pT_282 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+        %qkT_284 = ttng.tmem_subslice %qkT_153 {N = 0 : i32, async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+        %qkT_285 = ttg.memdesc_reinterpret %qkT_284 {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+        %ppT_286 = ttg.memdesc_index %qkT_285[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_287 = ttg.memdesc_index %qkT_210[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dv_288 = arith.extui %dv_267 : i1 to i32
+        ttng.wait_barrier %qkT_287, %dv_288, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {dstTask = 4 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tmem_store %ppT_283, %ppT_286, %curr_m_261 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %ppT_289 = ttg.memdesc_index %ppT_211[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %ppT_289, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dpT_290 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %dpT_291 = arith.trunci %dpT_290 {async_task_id = array<i32: 4>} : i64 to i1
+        %Di_292 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %Di_293 = arith.trunci %Di_292 {async_task_id = array<i32: 4>} : i64 to i1
+        %Di_294 = ttg.memdesc_index %Di_196[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+        %Di_295 = ttg.memdesc_index %Di_195[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %Di_296 = arith.extui %Di_293 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %Di_295, %Di_296, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %Di_297 = ttg.local_load %Di_294 {async_task_id = array<i32: 4>} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked3>
+        %Di_298 = ttg.memdesc_index %Di_216[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %Di_298, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dsT_299 = ttg.convert_layout %Di_297 {async_task_id = array<i32: 4>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+        %dsT_300 = tt.expand_dims %dsT_299 {async_task_id = array<i32: 4>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+        %dsT_301 = tt.broadcast %dsT_300 {async_task_id = array<i32: 4>} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+        %dpT_302 = ttg.memdesc_index %dpT_160[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_303 = ttg.memdesc_index %dpT_162[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dpT_304 = arith.extui %dpT_291 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %dpT_303, %dpT_304, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dpT_305, %dpT_306 = ttng.tmem_load %dpT_302[] {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+        %dpT_307 = ttg.memdesc_index %dpT_214[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %dpT_307, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dsT_308 = arith.subf %dpT_305, %dsT_301 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+        %dsT_309 = arith.mulf %pT_282, %dsT_308 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+        %dsT_310 = arith.truncf %dsT_309 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+        %dpT_311 = ttng.tmem_subslice %dpT_160 {N = 0 : i32, async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+        %dpT_312 = ttg.memdesc_reinterpret %dpT_311 {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+        %dsT_313 = ttg.memdesc_index %dpT_312[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dk_314 = arith.andi %tile_idx_246, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        %dk_315 = arith.trunci %dk_314 {async_task_id = array<i32: 4>} : i64 to i1
+        %dsT_316 = ttg.memdesc_index %dsT_171[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dk_317 = arith.xori %dk_315, %true {async_task_id = array<i32: 4>} : i1
+        %dk_318 = arith.extui %dk_317 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %dsT_316, %dk_318, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.tmem_store %dsT_310, %dsT_313, %curr_m_261 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+        %dsT_319 = ttg.memdesc_index %dsT_217[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %dsT_319, 1, %curr_m_261 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %curr_m_320 = arith.subi %num_steps, %c1_i32_236 : i32
+        %curr_m_321:2 = scf.for %curr_m_431 = %c0_i32_237 to %curr_m_320 step %c1_i32_236 iter_args(%tile_idx_432 = %tile_idx_246, %dsT_433 = %dsT_310) -> (i64, tensor<128x128xf16, #linear8>)  : i32 {
+          %dsT_dq = tt.reshape %dsT_433 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> tensor<128x2x64xf16, #linear10>
+          %dsT_dq_434 = tt.trans %dsT_dq {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear10> -> tensor<128x64x2xf16, #linear11>
+          %dsT_dq_435, %dsT_dq_436 = tt.split %dsT_dq_434 {async_task_id = array<i32: 4>} : tensor<128x64x2xf16, #linear11> -> tensor<128x64xf16, #linear12>
+          %dsT_dq_1_437 = ttg.memdesc_index %dsT_dq_1_181[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_438 = arith.andi %tile_idx_432, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dsT_dq_439 = arith.trunci %dsT_dq_438 {async_task_id = array<i32: 4>} : i64 to i1
+          %dsT_dq_1_440 = ttg.memdesc_index %dsT_dq_1_220[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_441 = arith.xori %dsT_dq_439, %true : i1
+          %dsT_dq_442 = arith.extui %dsT_dq_441 : i1 to i32
+          ttng.wait_barrier %dsT_dq_1_440, %dsT_dq_442 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttg.local_store %dsT_dq_435, %dsT_dq_1_437 {async_task_id = array<i32: 4>} : tensor<128x64xf16, #linear12> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_1_443 = ttg.memdesc_index %dsT_dq_1_219[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_dq_1_443, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_444 = ttng.two_cta_peer_gather %dsT_433 split_dim = 1 num_ctas = 2 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> tensor<64x256xf16, #linear13>
+          %dsT_dq_445 = tt.trans %dsT_dq_444 {async_task_id = array<i32: 4>, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear13> -> tensor<256x64xf16, #linear14>
+          %dsT_dq_0_446 = ttg.memdesc_index %dsT_dq_0_172[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dsT_dq_447 = arith.andi %tile_idx_432, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dsT_dq_448 = arith.trunci %dsT_dq_447 {async_task_id = array<i32: 4>} : i64 to i1
+          %dsT_dq_0_449 = ttg.memdesc_index %dsT_dq_0_174[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_450 = arith.xori %dsT_dq_448, %true {async_task_id = array<i32: 4>} : i1
+          %dsT_dq_451 = arith.extui %dsT_dq_450 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %dsT_dq_0_449, %dsT_dq_451 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttg.local_store %dsT_dq_445, %dsT_dq_0_446 {async_task_id = array<i32: 4>} : tensor<256x64xf16, #linear14> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dsT_dq_0_452 = ttg.memdesc_index %dsT_dq_0_221[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_dq_0_452, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %accum_cnt_453 = arith.addi %tile_idx_432, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %m_454 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %m_455 = arith.trunci %m_454 {async_task_id = array<i32: 4>} : i64 to i1
+          %qkT_456 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %qkT_457 = arith.trunci %qkT_456 {async_task_id = array<i32: 4>} : i64 to i1
+          %dv_458 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dv_459 = arith.trunci %dv_458 {async_task_id = array<i32: 4>} : i64 to i1
+          %m_460 = ttg.memdesc_index %m_191[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %m_461 = ttg.memdesc_index %m_190[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %m_462 = arith.extui %m_455 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %m_461, %m_462, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %m_463 = ttg.local_load %m_460 {async_task_id = array<i32: 4>} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked3>
+          %m_464 = ttg.memdesc_index %m_208[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %m_464, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %pT_465 = ttg.convert_layout %m_463 {async_task_id = array<i32: 4>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+          %pT_466 = tt.expand_dims %pT_465 {async_task_id = array<i32: 4>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+          %pT_467 = tt.broadcast %pT_466 {async_task_id = array<i32: 4>} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+          %qkT_468 = ttg.memdesc_index %qkT_153[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %qkT_469 = ttg.memdesc_index %qkT_155[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_470 = arith.extui %qkT_457 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %qkT_469, %qkT_470, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %qkT_471, %qkT_472 = ttng.tmem_load %qkT_468[] {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %qkT_473 = ttg.memdesc_index %qkT_210[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %qkT_473, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %pT_474 = arith.subf %qkT_471, %pT_467 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+          %pT_475 = math.exp2 %pT_474 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+          %ppT_476 = arith.truncf %pT_475 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+          %qkT_477 = ttng.tmem_subslice %qkT_153 {N = 0 : i32, async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %qkT_478 = ttg.memdesc_reinterpret %qkT_477 {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %ppT_479 = ttg.memdesc_index %qkT_478[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %qkT_480 = ttg.memdesc_index %qkT_210[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dv_481 = arith.extui %dv_459 : i1 to i32
+          ttng.wait_barrier %qkT_480, %dv_481, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {dstTask = 4 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tmem_store %ppT_476, %ppT_479, %true {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %ppT_482 = ttg.memdesc_index %ppT_211[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %ppT_482, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_483 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dpT_484 = arith.trunci %dpT_483 {async_task_id = array<i32: 4>} : i64 to i1
+          %Di_485 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %Di_486 = arith.trunci %Di_485 {async_task_id = array<i32: 4>} : i64 to i1
+          %Di_487 = ttg.memdesc_index %Di_196[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %Di_488 = ttg.memdesc_index %Di_195[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %Di_489 = arith.extui %Di_486 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %Di_488, %Di_489, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %Di_490 = ttg.local_load %Di_487 {async_task_id = array<i32: 4>} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked3>
+          %Di_491 = ttg.memdesc_index %Di_216[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %Di_491, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_492 = ttg.convert_layout %Di_490 {async_task_id = array<i32: 4>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+          %dsT_493 = tt.expand_dims %dsT_492 {async_task_id = array<i32: 4>, axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+          %dsT_494 = tt.broadcast %dsT_493 {async_task_id = array<i32: 4>} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+          %dpT_495 = ttg.memdesc_index %dpT_160[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %dpT_496 = ttg.memdesc_index %dpT_162[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_497 = arith.extui %dpT_484 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %dpT_496, %dpT_497, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dpT_498, %dpT_499 = ttng.tmem_load %dpT_495[] {async_task_id = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %dpT_500 = ttg.memdesc_index %dpT_214[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dpT_500, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_501 = arith.subf %dpT_498, %dsT_494 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+          %dsT_502 = arith.mulf %pT_475, %dsT_501 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8>
+          %dsT_503 = arith.truncf %dsT_502 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+          %dpT_504 = ttng.tmem_subslice %dpT_160 {N = 0 : i32, async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %dpT_505 = ttg.memdesc_reinterpret %dpT_504 {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %dsT_506 = ttg.memdesc_index %dpT_505[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %dk_507 = arith.andi %accum_cnt_453, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dk_508 = arith.trunci %dk_507 {async_task_id = array<i32: 4>} : i64 to i1
+          %dsT_509 = ttg.memdesc_index %dsT_171[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dk_510 = arith.xori %dk_508, %true {async_task_id = array<i32: 4>} : i1
+          %dk_511 = arith.extui %dk_510 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %dsT_509, %dk_511, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tmem_store %dsT_503, %dsT_506, %true {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %dsT_512 = ttg.memdesc_index %dsT_217[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_512, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          scf.yield %accum_cnt_453, %dsT_503 : i64, tensor<128x128xf16, #linear8>
+        } {async_task_id = array<i32: 4>, tt.warp_specialize}
+        %curr_m_322 = arith.cmpi sgt, %num_steps, %c0_i32_237 : i32
+        %curr_m_323:2 = scf.if %curr_m_322 -> (i64, tensor<128x128xf16, #linear8>) {
+          %dsT_dq = tt.reshape %curr_m_321#1 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> tensor<128x2x64xf16, #linear10>
+          %dsT_dq_431 = tt.trans %dsT_dq {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear10> -> tensor<128x64x2xf16, #linear11>
+          %dsT_dq_432, %dsT_dq_433 = tt.split %dsT_dq_431 {async_task_id = array<i32: 4>} : tensor<128x64x2xf16, #linear11> -> tensor<128x64xf16, #linear12>
+          %dsT_dq_1_434 = ttg.memdesc_index %dsT_dq_1_181[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_435 = arith.andi %curr_m_321#0, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dsT_dq_436 = arith.trunci %dsT_dq_435 {async_task_id = array<i32: 4>} : i64 to i1
+          %dsT_dq_1_437 = ttg.memdesc_index %dsT_dq_1_220[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_438 = arith.xori %dsT_dq_436, %true : i1
+          %dsT_dq_439 = arith.extui %dsT_dq_438 : i1 to i32
+          ttng.wait_barrier %dsT_dq_1_437, %dsT_dq_439 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttg.local_store %dsT_dq_432, %dsT_dq_1_434 {async_task_id = array<i32: 4>} : tensor<128x64xf16, #linear12> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %dsT_dq_1_440 = ttg.memdesc_index %dsT_dq_1_219[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_dq_1_440, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_441 = ttng.two_cta_peer_gather %curr_m_321#1 split_dim = 1 num_ctas = 2 {async_task_id = array<i32: 4>} : tensor<128x128xf16, #linear8> -> tensor<64x256xf16, #linear13>
+          %dsT_dq_442 = tt.trans %dsT_dq_441 {async_task_id = array<i32: 4>, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear13> -> tensor<256x64xf16, #linear14>
+          %dsT_dq_0_443 = ttg.memdesc_index %dsT_dq_0_172[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dsT_dq_444 = arith.andi %curr_m_321#0, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          %dsT_dq_445 = arith.trunci %dsT_dq_444 {async_task_id = array<i32: 4>} : i64 to i1
+          %dsT_dq_0_446 = ttg.memdesc_index %dsT_dq_0_174[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %dsT_dq_447 = arith.xori %dsT_dq_445, %true {async_task_id = array<i32: 4>} : i1
+          %dsT_dq_448 = arith.extui %dsT_dq_447 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %dsT_dq_0_446, %dsT_dq_448 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttg.local_store %dsT_dq_442, %dsT_dq_0_443 {async_task_id = array<i32: 4>} : tensor<256x64xf16, #linear14> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %dsT_dq_0_449 = ttg.memdesc_index %dsT_dq_0_221[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %dsT_dq_0_449, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %accum_cnt_450 = arith.addi %curr_m_321#0, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+          scf.yield %accum_cnt_450, %0 : i64, tensor<128x128xf16, #linear8>
+        } else {
+          scf.yield %curr_m_321#0, %curr_m_321#1 : i64, tensor<128x128xf16, #linear8>
+        }
+        %dv_324 = ttg.memdesc_index %dv_163[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dv_325 = ttg.memdesc_index %dv_177[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dv_326 = arith.extui %curr_m_258 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %dv_325, %dv_326 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dv_327, %dv_328 = ttng.tmem_load %dv_324[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+        %dv_329 = ttg.memdesc_index %dv_204[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %dv_329, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dvs = tt.reshape %dv_327 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear10>
+        %dvs_330 = tt.trans %dvs {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear10> -> tensor<128x64x2xf32, #linear11>
+        %dvs_331, %dvs_332 = tt.split %dvs_330 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear11> -> tensor<128x64xf32, #linear12>
+        %dvs_333 = tt.reshape %dvs_331 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear12> -> tensor<128x2x32xf32, #linear15>
+        %dvs_334 = tt.trans %dvs_333 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+        %dvs_335, %dvs_336 = tt.split %dvs_334 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+        %dvs_337 = tt.reshape %dvs_335 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dvs_338 = tt.trans %dvs_337 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dvs_339, %dvs_340 = tt.split %dvs_338 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dvs_341 = tt.reshape %dvs_336 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dvs_342 = tt.trans %dvs_341 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dvs_343, %dvs_344 = tt.split %dvs_342 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dvs_345 = tt.reshape %dvs_332 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear12> -> tensor<128x2x32xf32, #linear15>
+        %dvs_346 = tt.trans %dvs_345 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+        %dvs_347, %dvs_348 = tt.split %dvs_346 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+        %dvs_349 = tt.reshape %dvs_347 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dvs_350 = tt.trans %dvs_349 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dvs_351, %dvs_352 = tt.split %dvs_350 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dvs_353 = tt.reshape %dvs_348 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dvs_354 = tt.trans %dvs_353 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dvs_355, %dvs_356 = tt.split %dvs_354 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %4 = arith.truncf %dvs_339 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %5 = ttg.convert_layout %4 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_357 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %5, %desc_dv_staging_357 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_358 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %6 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c0_i32_237] %desc_dv_staging_358 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %6   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %7 = arith.truncf %dvs_340 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %8 = ttg.convert_layout %7 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_359 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %8, %desc_dv_staging_359 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_360 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %9 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c16_i32_233] %desc_dv_staging_360 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %9   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %10 = arith.truncf %dvs_343 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %11 = ttg.convert_layout %10 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_361 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %11, %desc_dv_staging_361 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_362 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %12 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c32_i32_232] %desc_dv_staging_362 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %12   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %13 = arith.truncf %dvs_344 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %14 = ttg.convert_layout %13 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_363 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %14, %desc_dv_staging_363 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_364 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %15 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c48_i32_231] %desc_dv_staging_364 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %15   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %16 = arith.truncf %dvs_351 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %17 = ttg.convert_layout %16 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_365 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %17, %desc_dv_staging_365 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_366 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %18 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %kt_230] %desc_dv_staging_366 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %18   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %19 = arith.truncf %dvs_352 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %20 = ttg.convert_layout %19 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_367 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %20, %desc_dv_staging_367 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_368 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %21 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c80_i32_229] %desc_dv_staging_368 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %21   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %22 = arith.truncf %dvs_355 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %23 = ttg.convert_layout %22 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_369 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %23, %desc_dv_staging_369 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_370 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %24 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c96_i32_228] %desc_dv_staging_370 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %24   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %25 = arith.truncf %dvs_356 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %26 = ttg.convert_layout %25 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dv_staging_371 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %26, %desc_dv_staging_371 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dv_staging_372 = ttg.memdesc_index %desc_dv_staging_199[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %27 = ttng.async_tma_copy_local_to_global %desc_dv_200[%k_257, %c112_i32_227] %desc_dv_staging_372 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %27   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dk_373 = ttg.memdesc_index %dk_167[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dk_374 = ttg.memdesc_index %dk_176[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dk_375 = arith.extui %curr_m_260 {async_task_id = array<i32: 4>} : i1 to i32
+        ttng.wait_barrier %dk_374, %dk_375 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dk_376, %dk_377 = ttng.tmem_load %dk_373[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+        %dk_378 = ttg.memdesc_index %dk_206[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        ttng.arrive_barrier %dk_378, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+        %dks = tt.reshape %dk_376 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear10>
+        %dks_379 = tt.trans %dks {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear10> -> tensor<128x64x2xf32, #linear11>
+        %dks_380, %dks_381 = tt.split %dks_379 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear11> -> tensor<128x64xf32, #linear12>
+        %dks_382 = tt.reshape %dks_380 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear12> -> tensor<128x2x32xf32, #linear15>
+        %dks_383 = tt.trans %dks_382 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+        %dks_384, %dks_385 = tt.split %dks_383 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+        %dks_386 = tt.reshape %dks_384 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dks_387 = tt.trans %dks_386 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dks_388, %dks_389 = tt.split %dks_387 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dks_390 = tt.reshape %dks_385 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dks_391 = tt.trans %dks_390 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dks_392, %dks_393 = tt.split %dks_391 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dks_394 = tt.reshape %dks_381 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear12> -> tensor<128x2x32xf32, #linear15>
+        %dks_395 = tt.trans %dks_394 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+        %dks_396, %dks_397 = tt.split %dks_395 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+        %dks_398 = tt.reshape %dks_396 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dks_399 = tt.trans %dks_398 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dks_400, %dks_401 = tt.split %dks_399 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dks_402 = tt.reshape %dks_397 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+        %dks_403 = tt.trans %dks_402 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+        %dks_404, %dks_405 = tt.split %dks_403 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear9>
+        %dkN_406 = arith.mulf %dks_388, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %28 = arith.truncf %dkN_406 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %29 = ttg.convert_layout %28 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_407 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %29, %desc_dk_staging_407 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_408 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %30 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c0_i32_237] %desc_dk_staging_408 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %30   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_409 = arith.mulf %dks_389, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %31 = arith.truncf %dkN_409 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %32 = ttg.convert_layout %31 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_410 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %32, %desc_dk_staging_410 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_411 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %33 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c16_i32_233] %desc_dk_staging_411 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %33   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_412 = arith.mulf %dks_392, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %34 = arith.truncf %dkN_412 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %35 = ttg.convert_layout %34 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_413 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %35, %desc_dk_staging_413 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_414 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %36 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c32_i32_232] %desc_dk_staging_414 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %36   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_415 = arith.mulf %dks_393, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %37 = arith.truncf %dkN_415 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %38 = ttg.convert_layout %37 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_416 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %38, %desc_dk_staging_416 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_417 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %39 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c48_i32_231] %desc_dk_staging_417 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %39   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_418 = arith.mulf %dks_400, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %40 = arith.truncf %dkN_418 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %41 = ttg.convert_layout %40 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_419 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %41, %desc_dk_staging_419 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_420 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %42 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %kt_230] %desc_dk_staging_420 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %42   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_421 = arith.mulf %dks_401, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %43 = arith.truncf %dkN_421 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %44 = ttg.convert_layout %43 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_422 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %44, %desc_dk_staging_422 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_423 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %45 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c80_i32_229] %desc_dk_staging_423 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %45   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_424 = arith.mulf %dks_404, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %46 = arith.truncf %dkN_424 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %47 = ttg.convert_layout %46 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_425 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %47, %desc_dk_staging_425 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_426 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %48 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c96_i32_228] %desc_dk_staging_426 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %48   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %dkN_427 = arith.mulf %dks_405, %dkN {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9>
+        %49 = arith.truncf %dkN_427 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear9> to tensor<128x16xf16, #linear9>
+        %50 = ttg.convert_layout %49 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear9> -> tensor<128x16xf16, #blocked4>
+        %desc_dk_staging_428 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        ttg.local_store %50, %desc_dk_staging_428 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked4> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %desc_dk_staging_429 = ttg.memdesc_index %desc_dk_staging_201[%c0_i32_237] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+        %51 = ttng.async_tma_copy_local_to_global %desc_dk_202[%k_257, %c112_i32_227] %desc_dk_staging_429 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %51   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+        %tile_idx_430 = arith.addi %prog_id_244, %num_progs_241 {async_task_id = array<i32: 4>} : i32
+        %accum_cnt = arith.addi %tile_idx_245, %c1_i64_225 {async_task_id = array<i32: 4>} : i64
+        scf.yield {async_task_id = array<i32: 4>} %tile_idx_430, %accum_cnt, %curr_m_323#0 : i32, i64, i64
+      } {async_task_id = array<i32: 4>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+      ttg.warp_return
+    } : (i32, i32, i32, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<2x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<2x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, i32, i32, i32, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<256x64xf16, #shared>, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<128x64xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, !tt.tensordesc<128x64xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, f32, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) -> ()
+    %k_96 = ttg.memdesc_index %k_32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %k_96 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %kt_97 = ttg.memdesc_index %kt_29[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %kt_97 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %v_98 = ttg.memdesc_index %v_26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %v_98 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_99 = ttg.memdesc_index %qT_17[%c0_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qT_99 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_100 = ttg.memdesc_index %qT_17[%c1_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qT_100 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_101 = ttg.memdesc_index %qT[%c0_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qT_101 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qT_102 = ttg.memdesc_index %qT[%c1_i32] : !ttg.memdesc<2x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qT_102 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qkT_103 = ttg.memdesc_index %qkT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qkT_103 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %ppT_104 = ttg.memdesc_index %ppT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %ppT_104 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_105 = ttg.memdesc_index %dpT_7[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dpT_105 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_106 = ttg.memdesc_index %dpT_5[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dpT_106 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_107 = ttg.memdesc_index %dpT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dpT_107 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %do_108 = ttg.memdesc_index %do[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %do_108 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %do_109 = ttg.memdesc_index %do_11[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %do_109 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %q_110 = ttg.memdesc_index %q[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %q_110 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %q_111 = ttg.memdesc_index %q_21[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %q_111 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_112 = ttg.memdesc_index %dsT[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_112 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_113 = ttg.memdesc_index %dsT_dq_0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_113 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dq_114 = ttg.memdesc_index %dq[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dq_114 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dk_115 = ttg.memdesc_index %dk[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dk_115 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv_116 = ttg.memdesc_index %dv[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dv_116 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %v_117 = ttg.memdesc_index %v[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %v_117 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %kt_118 = ttg.memdesc_index %kt[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %kt_118 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %k_119 = ttg.memdesc_index %k[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %k_119 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %m_120 = ttg.memdesc_index %m[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %m_120 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %Di_121 = ttg.memdesc_index %Di[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %Di_121 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv_122 = ttg.memdesc_index %dv_34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dv_122 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dv_123 = ttg.memdesc_index %dv_35[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dv_123 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dk_124 = ttg.memdesc_index %dk_38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dk_124 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dk_125 = ttg.memdesc_index %dk_39[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dk_125 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %m_126 = ttg.memdesc_index %m_42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %m_126 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %m_127 = ttg.memdesc_index %m_43[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %m_127 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qkT_128 = ttg.memdesc_index %qkT_46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qkT_128 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %qkT_129 = ttg.memdesc_index %qkT_47[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %qkT_129 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %ppT_130 = ttg.memdesc_index %ppT_50[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %ppT_130 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %ppT_131 = ttg.memdesc_index %ppT_51[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %ppT_131 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_132 = ttg.memdesc_index %dpT_54[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dpT_132 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dpT_133 = ttg.memdesc_index %dpT_55[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dpT_133 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %Di_134 = ttg.memdesc_index %Di_58[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %Di_134 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %Di_135 = ttg.memdesc_index %Di_59[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %Di_135 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_136 = ttg.memdesc_index %dsT_62[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_136 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_137 = ttg.memdesc_index %dsT_63[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_137 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_1_138 = ttg.memdesc_index %dsT_dq_1[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_1_138 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_1_139 = ttg.memdesc_index %dsT_dq_1_66[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_1_139 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_140 = ttg.memdesc_index %dsT_dq_0_69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_140 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dsT_dq_0_141 = ttg.memdesc_index %dsT_dq_0_70[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dsT_dq_0_141 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dq_142 = ttg.memdesc_index %dq_73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dq_142 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    %dq_143 = ttg.memdesc_index %dq_74[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    ttng.inval_barrier %dq_143 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm128_persistent.mlir
+++ b/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm128_persistent.mlir
@@ -1,5 +1,6 @@
 // RUN: triton-opt %s --nvgpu-materialize-2cta-exchange | FileCheck %s --check-prefix=SHAPE
 // RUN: triton-opt %s --nvgpu-materialize-2cta-exchange | FileCheck %s --check-prefix=CLEAN
+// RUN: triton-opt %s --tritongpu-optimize-partition-warps | FileCheck %s --check-prefix=WARPS
 
 // Full TTGIR captured immediately before NVGPUMaterialize2CTAExchange from
 // the non-causal persistent BM128 2-CTA configuration after AutoWS and
@@ -17,6 +18,12 @@
 // SHAPE-COUNT-2: ttng.tmem_load
 // CLEAN-NOT: ttng.two_cta_peer_gather
 // CLEAN-NOT: ttng.two_cta_peer_relay
+// WARPS: partition0({{.*}}) num_warps(1)
+// WARPS: partition1({{.*}}) num_warps(1)
+// WARPS: partition2({{.*}}) num_warps(1)
+// The single-CTA eight-warp computation override changes this kernel's
+// layouts and exceeds the Blackwell SMEM limit. Keep its computed four warps.
+// WARPS: partition3({{.*}}) num_warps(4)
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>

--- a/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm64_persistent.mlir
+++ b/test/Hopper/TwoCTA/materialize_2cta_exchange_bwd_bm64_persistent.mlir
@@ -959,7 +959,7 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
           ttng.tmem_store %296, %300, %true {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear8> -> !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable>
           %303 = ttg.memdesc_index %arg131[%c0_i32_8] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
           ttng.arrive_barrier %303, 1 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
-          %304 = ttng.two_cta_peer_gather %297 split_dim = 0 num_ctas = 2 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked3>
+          %304 = ttng.two_cta_peer_gather %297 split_dim = 0 num_ctas = 2 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked3> -> tensor<128x64xf16, #blocked3>
           %305 = ttg.memdesc_index %arg87[%c0_i32_8] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
           %306 = arith.andi %arg142, %c1_i64_15 {async_task_id = array<i32: 3>} : i64
           %307 = arith.trunci %306 {async_task_id = array<i32: 3>} : i64 to i1
@@ -1060,7 +1060,7 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
           ttng.tmem_store %296, %300, %true {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear8> -> !ttg.memdesc<128x64xf16, #tmem1, #ttng.tensor_memory, mutable>
           %303 = ttg.memdesc_index %arg131[%c0_i32_8] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared3, #smem, mutable> -> !ttg.memdesc<1xi64, #shared3, #smem, mutable>
           ttng.arrive_barrier %303, 1 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}} : !ttg.memdesc<1xi64, #shared3, #smem, mutable>
-          %304 = ttng.two_cta_peer_gather %297 split_dim = 0 num_ctas = 2 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked3>
+          %304 = ttng.two_cta_peer_gather %297 split_dim = 0 num_ctas = 2 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked3> -> tensor<128x64xf16, #blocked3>
           %305 = ttg.memdesc_index %arg87[%c0_i32_8] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
           %306 = arith.andi %232#0, %c1_i64_15 {async_task_id = array<i32: 3>} : i64
           %307 = arith.trunci %306 {async_task_id = array<i32: 3>} : i64 to i1

--- a/test/Hopper/TwoCTA/partition_scheduling_bwd_bm128_computation_default.mlir
+++ b/test/Hopper/TwoCTA/partition_scheduling_bwd_bm128_computation_default.mlir
@@ -1,0 +1,331 @@
+// RUN: triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+// CHECK: ttng.tc_gen5_mma {{.*}}ttg.partition = array<i32: 2>
+// CHECK: ttng.tmem_load {{.*}}ttg.partition = array<i32: 0>
+// CHECK: tt.descriptor_load {{.*}}ttg.partition = array<i32: 3>
+// CHECK: ttng.two_cta_peer_relay {{.*}}ttg.partition = array<i32: 4>
+// CHECK: ttng.async_tma_reduce {{.*}}ttg.partition = array<i32: 1>
+// CHECK: ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"]
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 2, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked9 = #ttg.blocked<{sizePerThread = [1, 2, 8], threadsPerWarp = [16, 1, 2], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked10 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [16, 2, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [32, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[128, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64], [0, 32]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 1, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 0, 1]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [64, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0], [32, 0, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [64, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [32, 0]], block = []}>
+#linear10 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 16, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0]], lane = [[0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear11 = #ttg.linear<{register = [[0, 32], [0, 16], [0, 1], [0, 2], [0, 4]], lane = [[0, 8], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[16, 0], [32, 0], [64, 0]], block = []}>
+#linear12 = #ttg.linear<{register = [[0, 1, 0], [0, 0, 16], [0, 0, 1], [0, 0, 2], [0, 0, 4]], lane = [[0, 0, 8], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear13 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0]], lane = [[0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear14 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [0, 4]], lane = [[0, 8], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[16, 0], [32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared4 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd_persist(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x128xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<256x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.tensordesc<128x128xf16, #shared>, %arg21: i32, %arg22: i32, %arg23: i64, %arg24: i64, %arg25: f32, %arg26: !tt.tensordesc<128x64xf16, #shared>, %arg27: i32, %arg28: i32, %arg29: i64, %arg30: i64, %arg31: !tt.tensordesc<64x128xf16, #shared>, %arg32: i32, %arg33: i32, %arg34: i64, %arg35: i64, %arg36: !tt.tensordesc<128x16xf32, #shared1>, %arg37: i32, %arg38: i32, %arg39: i64, %arg40: i64, %arg41: !tt.tensordesc<128x16xf16, #shared2>, %arg42: i32, %arg43: i32, %arg44: i64, %arg45: i64, %arg46: !tt.tensordesc<128x16xf16, #shared2>, %arg47: i32, %arg48: i32, %arg49: i64, %arg50: i64, %arg51: !tt.tensordesc<128xf32, #shared3>, %arg52: i32, %arg53: i64, %arg54: !tt.tensordesc<128xf32, #shared3>, %arg55: i32, %arg56: i64, %arg57: i32 {tt.divisibility = 16 : i32}, %arg58: i32 {tt.divisibility = 16 : i32}, %arg59: i32 {tt.divisibility = 16 : i32}, %arg60: i32, %arg61: i32, %arg62: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %cst = arith.constant dense<0.693147182> : tensor<128x16xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c80_i32 = arith.constant 80 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %c112_i32 = arith.constant 112 : i32
+    %true = arith.constant true
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = arith.addi %arg62, %c127_i32 : i32
+    %1 = arith.divsi %0, %c128_i32 : i32
+    %2 = tt.get_program_id x : i32
+    %3 = arith.remsi %2, %c2_i32 : i32
+    %4 = arith.divsi %2, %c2_i32 : i32
+    %5 = tt.get_num_programs x : i32
+    %6 = arith.divsi %5, %c2_i32 : i32
+    %7 = arith.divsi %1, %c2_i32 : i32
+    %8 = arith.muli %7, %arg60 : i32
+    %9 = arith.muli %8, %arg61 : i32
+    %10 = arith.divsi %9, %6 : i32
+    %11 = arith.remsi %9, %6 : i32
+    %12 = arith.cmpi slt, %4, %11 : i32
+    %13 = scf.if %12 -> (i32) {
+      %24 = arith.addi %10, %c1_i32 : i32
+      scf.yield %24 : i32
+    } else {
+      scf.yield %10 : i32
+    }
+    %14 = arith.extsi %arg59 : i32 to i64
+    %15 = arith.muli %3, %c128_i32 : i32
+    %16 = arith.divsi %arg62, %c128_i32 : i32
+    %17 = arith.muli %3, %c64_i32 : i32
+    %18 = arith.extsi %17 : i32 to i64
+    %19 = tt.splat %arg25 : f32 -> tensor<128x16xf32, #blocked1>
+    %20 = nvg.cluster_id
+    %21 = arith.remsi %20, %c2_i32 : i32
+    %22 = arith.muli %21, %c64_i32 : i32
+    %23 = scf.for %arg63 = %c0_i32 to %13 step %c1_i32 iter_args(%arg64 = %4) -> (i32)  : i32 {
+      %24 = arith.remsi %arg64, %7 : i32
+      %25 = arith.divsi %arg64, %7 : i32
+      %26 = arith.muli %24, %c2_i32 : i32
+      %27 = arith.addi %26, %3 : i32
+      %28 = arith.muli %25, %arg62 : i32
+      %29 = arith.extsi %28 : i32 to i64
+      %30 = arith.remsi %25, %arg61 : i32
+      %31 = arith.muli %arg58, %30 : i32
+      %32 = arith.divsi %25, %arg61 : i32
+      %33 = arith.muli %arg57, %32 : i32
+      %34 = arith.addi %31, %33 : i32
+      %35 = arith.extsi %34 : i32 to i64
+      %36 = arith.divsi %35, %14 : i64
+      %37 = arith.muli %27, %c128_i32 : i32
+      %38 = arith.extsi %37 : i32 to i64
+      %39 = arith.addi %36, %38 : i64
+      %40 = arith.trunci %39 : i64 to i32
+      %41 = tt.descriptor_load %arg10[%40, %c0_i32] : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked2>
+      %42 = ttg.local_alloc %41 : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %43 = arith.subi %37, %15 : i32
+      %44 = arith.extsi %43 : i32 to i64
+      %45 = arith.addi %36, %44 : i64
+      %46 = arith.trunci %45 : i64 to i32
+      %47 = tt.descriptor_load %arg15[%46, %22] {two_cta_b} : !tt.tensordesc<256x64xf16, #shared> -> tensor<256x64xf16, #blocked3>
+      %48 = ttg.local_alloc %47 : (tensor<256x64xf16, #blocked3>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+      %49 = tt.descriptor_load %arg20[%40, %c0_i32] : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked2>
+      %50 = ttg.local_alloc %49 : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_1, %token_2 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_3, %token_4 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_5, %token_6 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_7, %token_8 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %51 = ttng.tmem_store %cst_0, %result_5[%token_6], %true : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %52 = ttng.tmem_store %cst_0, %result_3[%token_4], %true : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %53:7 = scf.for %arg65 = %c0_i32 to %16 step %c1_i32 iter_args(%arg66 = %c0_i32, %arg67 = %false, %arg68 = %token, %arg69 = %token_2, %arg70 = %52, %arg71 = %51, %arg72 = %token_8) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+        %141 = arith.extsi %arg66 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 to i64
+        %142 = arith.addi %36, %141 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+        %143 = arith.trunci %142 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+        %144 = arith.addi %143, %22 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+        %145 = tt.descriptor_load %arg5[%144, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked2>
+        %146 = ttg.local_alloc %145 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : (tensor<64x128xf16, #blocked2>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %147 = ttg.memdesc_trans %146 {loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared4, #smem>
+        %148 = tt.descriptor_load %arg0[%143, %22] {loop.cluster = 1 : i32, loop.stage = 0 : i32, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked3>
+        %149 = ttg.local_alloc %148 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : (tensor<128x64xf16, #blocked3>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %150 = arith.addi %29, %141 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+        %151 = arith.trunci %150 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+        %152 = tt.descriptor_load %arg51[%151] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3> -> tensor<128xf32, #blocked4>
+        %153 = ttng.tc_gen5_mma %42, %147, %result[%arg68], %false, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %154 = ttg.convert_layout %152 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked4> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %155 = tt.expand_dims %154 {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %156 = tt.broadcast %155 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %result_39, %token_40 = ttng.tmem_load %result[%153] {loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %157 = arith.subf %result_39, %156 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear>
+        %158 = math.exp2 %157 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear>
+        %159 = tt.descriptor_load %arg26[%143, %22] {loop.cluster = 1 : i32, loop.stage = 0 : i32, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked3>
+        %160 = ttg.local_alloc %159 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x64xf16, #blocked3>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %161 = tt.descriptor_load %arg31[%144, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked2>
+        %162 = arith.truncf %158 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %result_41 = ttng.tmem_alloc %162 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+        %163 = ttg.local_alloc %161 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : (tensor<64x128xf16, #blocked2>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %164 = ttg.memdesc_trans %163 {loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared4, #smem>
+        %165 = ttng.tc_gen5_mma %50, %164, %result_1[%arg69], %false, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared4, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %166 = tt.descriptor_load %arg54[%151] {loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3> -> tensor<128xf32, #blocked4>
+        %167 = ttng.tc_gen5_mma %result_41, %160, %result_3[%arg70], %arg67, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %168 = ttg.convert_layout %166 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked4> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+        %169 = tt.expand_dims %168 {axis = 0 : i32, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+        %170 = tt.broadcast %169 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+        %result_42, %token_43 = ttng.tmem_load %result_1[%165] {loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+        %171 = arith.subf %result_42, %170 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear>
+        %172 = arith.mulf %158, %171 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear>
+        %173 = arith.truncf %172 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+        %result_44 = ttng.tmem_alloc %173 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+        %174 = ttng.tc_gen5_mma %result_44, %149, %result_5[%arg71], %arg67, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %175 = ttng.two_cta_peer_gather %173 split_dim = 1 num_ctas = 2 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear> -> tensor<64x256xf16, #linear1>
+        %176 = tt.trans %175 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear1> -> tensor<256x64xf16, #linear2>
+        %177 = tt.reshape %173 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear> -> tensor<128x2x64xf16, #linear3>
+        %178 = tt.trans %177 {loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear3> -> tensor<128x64x2xf16, #linear4>
+        %179 = ttg.convert_layout %178 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf16, #linear4> -> tensor<128x64x2xf16, #blocked5>
+        %outLHS_45, %outRHS_46 = tt.split %179 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf16, #blocked5> -> tensor<128x64xf16, #blocked6>
+        %180 = ttg.local_alloc %outLHS_45 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : (tensor<128x64xf16, #blocked6>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %181 = ttg.local_alloc %176 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<256x64xf16, #linear2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+        ttng.two_cta_peer_relay %180 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : <128x64xf16, #shared, #smem>
+        %182 = ttg.memdesc_trans %181 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem> -> !ttg.memdesc<64x256xf16, #shared4, #smem>
+        %183 = ttng.tc_gen5_mma %182, %48, %result_7[%arg72], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared4, #smem>, !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %result_47, %token_48 = ttng.tmem_load %result_7[%183] {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear5>
+        %184 = tt.reshape %result_47 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #linear5> -> tensor<128x2x32xf32, #linear6>
+        %185 = tt.trans %184 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear6> -> tensor<128x32x2xf32, #linear7>
+        %186 = ttg.convert_layout %185 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #linear7> -> tensor<128x32x2xf32, #linear8>
+        %outLHS_49, %outRHS_50 = tt.split %186 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32x2xf32, #linear8> -> tensor<128x32xf32, #linear9>
+        %187 = tt.reshape %outLHS_49 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked7>
+        %188 = tt.trans %187 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+        %outLHS_51, %outRHS_52 = tt.split %188 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked>
+        %189 = tt.reshape %outRHS_50 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked7>
+        %190 = tt.trans %189 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+        %outLHS_53, %outRHS_54 = tt.split %190 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked>
+        %191 = arith.addi %142, %18 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64
+        %192 = arith.muli %191, %c2_i64 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64
+        %193 = arith.mulf %outLHS_51, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16xf32, #blocked>
+        %194 = arith.trunci %192 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64 to i32
+        %195 = ttg.local_alloc %193 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %196 = ttng.async_tma_reduce add, %arg36[%194, %c0_i32] %195 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %196   {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %197 = arith.mulf %outRHS_52, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16xf32, #blocked>
+        %198 = ttg.local_alloc %197 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %199 = ttng.async_tma_reduce add, %arg36[%194, %c16_i32] %198 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %199   {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %200 = arith.mulf %outLHS_53, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16xf32, #blocked>
+        %201 = ttg.local_alloc %200 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %202 = ttng.async_tma_reduce add, %arg36[%194, %c32_i32] %201 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %202   {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %203 = arith.mulf %outRHS_54, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x16xf32, #blocked>
+        %204 = ttg.local_alloc %203 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+        %205 = ttng.async_tma_reduce add, %arg36[%194, %c48_i32] %204 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %205   {loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token
+        %206 = arith.addi %arg66, %c128_i32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+        scf.yield %206, %true, %token_40, %token_43, %167, %174, %token_48 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+      } {tt.scheduled_max_stage = 1 : i32}
+      %result_9, %token_10 = ttng.tmem_load %result_3[%53#4] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %54 = tt.reshape %result_9 : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+      %55 = tt.trans %54 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+      %56 = ttg.convert_layout %55 : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #linear10>
+      %outLHS, %outRHS = tt.split %56 : tensor<128x64x2xf32, #linear10> -> tensor<128x64xf32, #linear11>
+      %57 = tt.reshape %outLHS : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %58 = tt.trans %57 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %outLHS_11, %outRHS_12 = tt.split %58 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %59 = tt.reshape %outLHS_11 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %60 = tt.trans %59 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_13, %outRHS_14 = tt.split %60 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %61 = tt.reshape %outRHS_12 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %62 = tt.trans %61 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_15, %outRHS_16 = tt.split %62 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %63 = tt.reshape %outRHS : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %64 = tt.trans %63 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %outLHS_17, %outRHS_18 = tt.split %64 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %65 = tt.reshape %outLHS_17 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %66 = tt.trans %65 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_19, %outRHS_20 = tt.split %66 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %67 = tt.reshape %outRHS_18 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %68 = tt.trans %67 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_21, %outRHS_22 = tt.split %68 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %69 = arith.truncf %outLHS_13 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %70 = ttg.local_alloc %69 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %71 = ttng.async_tma_copy_local_to_global %arg46[%40, %c0_i32] %70 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %71   : !ttg.async.token
+      %72 = arith.truncf %outRHS_14 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %73 = ttg.local_alloc %72 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %74 = ttng.async_tma_copy_local_to_global %arg46[%40, %c16_i32] %73 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %74   : !ttg.async.token
+      %75 = arith.truncf %outLHS_15 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %76 = ttg.local_alloc %75 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %77 = ttng.async_tma_copy_local_to_global %arg46[%40, %c32_i32] %76 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %77   : !ttg.async.token
+      %78 = arith.truncf %outRHS_16 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %79 = ttg.local_alloc %78 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %80 = ttng.async_tma_copy_local_to_global %arg46[%40, %c48_i32] %79 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %80   : !ttg.async.token
+      %81 = arith.truncf %outLHS_19 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %82 = ttg.local_alloc %81 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %83 = ttng.async_tma_copy_local_to_global %arg46[%40, %c64_i32] %82 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %83   : !ttg.async.token
+      %84 = arith.truncf %outRHS_20 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %85 = ttg.local_alloc %84 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %86 = ttng.async_tma_copy_local_to_global %arg46[%40, %c80_i32] %85 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %86   : !ttg.async.token
+      %87 = arith.truncf %outLHS_21 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %88 = ttg.local_alloc %87 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %89 = ttng.async_tma_copy_local_to_global %arg46[%40, %c96_i32] %88 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %89   : !ttg.async.token
+      %90 = arith.truncf %outRHS_22 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %91 = ttg.local_alloc %90 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %92 = ttng.async_tma_copy_local_to_global %arg46[%40, %c112_i32] %91 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %92   : !ttg.async.token
+      %result_23, %token_24 = ttng.tmem_load %result_5[%53#5] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %93 = tt.reshape %result_23 : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+      %94 = tt.trans %93 {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+      %95 = ttg.convert_layout %94 : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #linear10>
+      %outLHS_25, %outRHS_26 = tt.split %95 : tensor<128x64x2xf32, #linear10> -> tensor<128x64xf32, #linear11>
+      %96 = tt.reshape %outLHS_25 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %97 = tt.trans %96 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %outLHS_27, %outRHS_28 = tt.split %97 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %98 = tt.reshape %outLHS_27 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %99 = tt.trans %98 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_29, %outRHS_30 = tt.split %99 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %100 = tt.reshape %outRHS_28 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %101 = tt.trans %100 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_31, %outRHS_32 = tt.split %101 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %102 = tt.reshape %outRHS_26 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %103 = tt.trans %102 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %outLHS_33, %outRHS_34 = tt.split %103 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %104 = tt.reshape %outLHS_33 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %105 = tt.trans %104 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_35, %outRHS_36 = tt.split %105 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %106 = tt.reshape %outRHS_34 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked9>
+      %107 = tt.trans %106 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked9> -> tensor<128x16x2xf32, #blocked10>
+      %outLHS_37, %outRHS_38 = tt.split %107 : tensor<128x16x2xf32, #blocked10> -> tensor<128x16xf32, #blocked1>
+      %108 = arith.mulf %outLHS_29, %19 : tensor<128x16xf32, #blocked1>
+      %109 = arith.truncf %108 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %110 = ttg.local_alloc %109 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %111 = ttng.async_tma_copy_local_to_global %arg41[%40, %c0_i32] %110 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %111   : !ttg.async.token
+      %112 = arith.mulf %outRHS_30, %19 : tensor<128x16xf32, #blocked1>
+      %113 = arith.truncf %112 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %114 = ttg.local_alloc %113 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %115 = ttng.async_tma_copy_local_to_global %arg41[%40, %c16_i32] %114 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %115   : !ttg.async.token
+      %116 = arith.mulf %outLHS_31, %19 : tensor<128x16xf32, #blocked1>
+      %117 = arith.truncf %116 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %118 = ttg.local_alloc %117 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %119 = ttng.async_tma_copy_local_to_global %arg41[%40, %c32_i32] %118 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %119   : !ttg.async.token
+      %120 = arith.mulf %outRHS_32, %19 : tensor<128x16xf32, #blocked1>
+      %121 = arith.truncf %120 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %122 = ttg.local_alloc %121 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %123 = ttng.async_tma_copy_local_to_global %arg41[%40, %c48_i32] %122 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %123   : !ttg.async.token
+      %124 = arith.mulf %outLHS_35, %19 : tensor<128x16xf32, #blocked1>
+      %125 = arith.truncf %124 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %126 = ttg.local_alloc %125 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %127 = ttng.async_tma_copy_local_to_global %arg41[%40, %c64_i32] %126 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %127   : !ttg.async.token
+      %128 = arith.mulf %outRHS_36, %19 : tensor<128x16xf32, #blocked1>
+      %129 = arith.truncf %128 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %130 = ttg.local_alloc %129 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %131 = ttng.async_tma_copy_local_to_global %arg41[%40, %c80_i32] %130 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %131   : !ttg.async.token
+      %132 = arith.mulf %outLHS_37, %19 : tensor<128x16xf32, #blocked1>
+      %133 = arith.truncf %132 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %134 = ttg.local_alloc %133 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %135 = ttng.async_tma_copy_local_to_global %arg41[%40, %c96_i32] %134 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %135   : !ttg.async.token
+      %136 = arith.mulf %outRHS_38, %19 : tensor<128x16xf32, #blocked1>
+      %137 = arith.truncf %136 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      %138 = ttg.local_alloc %137 : (tensor<128x16xf16, #blocked1>) -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+      %139 = ttng.async_tma_copy_local_to_global %arg41[%40, %c112_i32] %138 : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %139   : !ttg.async.token
+      %140 = arith.addi %arg64, %6 : i32
+      scf.yield %140 : i32
+    } {tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm128_nw8.mlir
+++ b/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm128_nw8.mlir
@@ -1,0 +1,302 @@
+// RUN: triton-opt %s --nvgpu-plan-2cta-exchange | FileCheck %s
+
+// Full BM128 2-CTA AutoWS TTGIR captured immediately before
+// NVGPUPlan2CTAExchange with the TLX-aligned eight-warp base layout.
+// CHECK: ttng.two_cta_peer_gather
+// CHECK: ttg.convert_layout
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 2, 8], threadsPerWarp = [16, 1, 2], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [16, 2, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64], [0, 32]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear2 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [64, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [32, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 1, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 0, 1]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [64, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0], [32, 0, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [64, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [32, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#linear10 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 16, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0]], lane = [[0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear11 = #ttg.linear<{register = [[0, 32], [0, 16], [0, 1], [0, 2], [0, 4]], lane = [[0, 8], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[16, 0], [32, 0], [64, 0]], block = []}>
+#linear12 = #ttg.linear<{register = [[0, 1, 0], [0, 0, 16], [0, 0, 1], [0, 0, 2], [0, 0, 4]], lane = [[0, 0, 8], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear13 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [0, 4, 0]], lane = [[0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0]], warp = [[16, 0, 0], [32, 0, 0], [64, 0, 0]], block = []}>
+#linear14 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [0, 4]], lane = [[0, 8], [1, 0], [2, 0], [4, 0], [8, 0]], warp = [[16, 0], [32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.tensordesc<128x64xf16>, %desc_q.shape.0: i32, %desc_q.shape.1: i32, %desc_q.stride.0: i64, %desc_q.stride.1: i64, %desc_qt: !tt.tensordesc<64x128xf16>, %desc_qt.shape.0: i32, %desc_qt.shape.1: i32, %desc_qt.stride.0: i64, %desc_qt.stride.1: i64, %desc_k: !tt.tensordesc<128x128xf16>, %desc_k.shape.0: i32, %desc_k.shape.1: i32, %desc_k.stride.0: i64, %desc_k.stride.1: i64, %desc_kt: !tt.tensordesc<256x64xf16>, %desc_kt.shape.0: i32, %desc_kt.shape.1: i32, %desc_kt.stride.0: i64, %desc_kt.stride.1: i64, %desc_v: !tt.tensordesc<128x128xf16>, %desc_v.shape.0: i32, %desc_v.shape.1: i32, %desc_v.stride.0: i64, %desc_v.stride.1: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<128x64xf16>, %desc_do.shape.0: i32, %desc_do.shape.1: i32, %desc_do.stride.0: i64, %desc_do.stride.1: i64, %desc_dot: !tt.tensordesc<64x128xf16>, %desc_dot.shape.0: i32, %desc_dot.shape.1: i32, %desc_dot.stride.0: i64, %desc_dot.stride.1: i64, %desc_dq: !tt.tensordesc<128x16xf32>, %desc_dq.shape.0: i32, %desc_dq.shape.1: i32, %desc_dq.stride.0: i64, %desc_dq.stride.1: i64, %desc_dk: !tt.tensordesc<128x16xf16>, %desc_dk.shape.0: i32, %desc_dk.shape.1: i32, %desc_dk.stride.0: i64, %desc_dk.stride.1: i64, %desc_dv: !tt.tensordesc<128x16xf16>, %desc_dv.shape.0: i32, %desc_dv.shape.1: i32, %desc_dv.stride.0: i64, %desc_dv.stride.1: i64, %desc_m: !tt.tensordesc<128xf32>, %desc_m.shape.0: i32, %desc_m.stride.0: i64, %desc_delta: !tt.tensordesc<128xf32>, %desc_delta.shape.0: i32, %desc_delta.stride.0: i64, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #linear>
+    %cst_0 = arith.constant dense<0.693147182> : tensor<128x16xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %n_tile_num = arith.constant 127 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c80_i32 = arith.constant 80 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %c112_i32 = arith.constant 112 : i32
+    %true = arith.constant true
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear1>
+    %n_tile_num_2 = arith.addi %N_CTX, %n_tile_num : i32
+    %n_tile_num_3 = arith.divsi %n_tile_num_2, %c128_i32 : i32
+    %cluster_rank = tt.get_program_id x : i32
+    %cluster_rank_4 = arith.remsi %cluster_rank, %c2_i32 : i32
+    %prog_id = arith.divsi %cluster_rank, %c2_i32 : i32
+    %num_progs = tt.get_num_programs x : i32
+    %num_progs_5 = arith.divsi %num_progs, %c2_i32 : i32
+    %scheduled_n_tiles = arith.divsi %n_tile_num_3, %c2_i32 : i32
+    %total_tiles = arith.muli %scheduled_n_tiles, %BATCH : i32
+    %total_tiles_6 = arith.muli %total_tiles, %H : i32
+    %tiles_per_sm = arith.divsi %total_tiles_6, %num_progs_5 : i32
+    %0 = arith.remsi %total_tiles_6, %num_progs_5 : i32
+    %1 = arith.cmpi slt, %prog_id, %0 : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_8 = arith.addi %tiles_per_sm, %c1_i32 : i32
+      scf.yield %tiles_per_sm_8 : i32
+    } else {
+      scf.yield %tiles_per_sm : i32
+    }
+    %off_bh = arith.extsi %stride_tok : i32 to i64
+    %kt_start_n = arith.muli %cluster_rank_4, %c128_i32 : i32
+    %num_steps = arith.divsi %N_CTX, %c128_i32 : i32
+    %dq_row = arith.muli %cluster_rank_4, %c64_i32 : i32
+    %dq_row_7 = arith.extsi %dq_row : i32 to i64
+    %dkN = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #blocked1>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_8 = %prog_id) -> (i32)  : i32 {
+      %scheduled_pid = arith.remsi %tile_idx_8, %scheduled_n_tiles : i32
+      %bhid = arith.divsi %tile_idx_8, %scheduled_n_tiles : i32
+      %pid = arith.muli %scheduled_pid, %c2_i32 : i32
+      %pid_9 = arith.addi %pid, %cluster_rank_4 : i32
+      %off_chz = arith.muli %bhid, %N_CTX : i32
+      %off_chz_10 = arith.extsi %off_chz : i32 to i64
+      %off_bh_11 = arith.remsi %bhid, %H : i32
+      %off_bh_12 = arith.muli %stride_h, %off_bh_11 : i32
+      %off_bh_13 = arith.divsi %bhid, %H : i32
+      %off_bh_14 = arith.muli %stride_z, %off_bh_13 : i32
+      %off_bh_15 = arith.addi %off_bh_12, %off_bh_14 : i32
+      %off_bh_16 = arith.extsi %off_bh_15 : i32 to i64
+      %off_bh_17 = arith.divsi %off_bh_16, %off_bh : i64
+      %start_n = arith.muli %pid_9, %c128_i32 : i32
+      %k = arith.extsi %start_n : i32 to i64
+      %k_18 = arith.addi %off_bh_17, %k : i64
+      %k_19 = arith.trunci %k_18 : i64 to i32
+      %k_20 = tt.descriptor_load %desc_k[%k_19, %c0_i32] : !tt.tensordesc<128x128xf16> -> tensor<128x128xf16, #blocked2>
+      %k_21 = ttg.local_alloc %k_20 : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %kt_start_n_22 = arith.subi %start_n, %kt_start_n : i32
+      %kt = arith.extsi %kt_start_n_22 : i32 to i64
+      %kt_23 = arith.addi %off_bh_17, %kt : i64
+      %kt_24 = arith.trunci %kt_23 : i64 to i32
+      %kt_25 = nvg.cluster_id
+      %kt_26 = arith.constant 2 : i32
+      %kt_27 = arith.remsi %kt_25, %kt_26 : i32
+      %kt_28 = arith.constant 64 : i32
+      %kt_29 = arith.muli %kt_27, %kt_28 : i32
+      %kt_30 = arith.addi %c0_i32, %kt_29 : i32
+      %kt_31 = tt.descriptor_load %desc_kt[%kt_24, %kt_30] {two_cta_b} : !tt.tensordesc<256x64xf16> -> tensor<256x64xf16, #blocked3>
+      %kt_32 = ttg.local_alloc %kt_31 : (tensor<256x64xf16, #blocked3>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+      %v = tt.descriptor_load %desc_v[%k_19, %c0_i32] : !tt.tensordesc<128x128xf16> -> tensor<128x128xf16, #blocked2>
+      %v_33 = ttg.local_alloc %v : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %curr_m:3 = scf.for %blk_idx = %c0_i32 to %num_steps step %c1_i32 iter_args(%dk = %cst_1, %dv = %cst_1, %curr_m_99 = %c0_i32) -> (tensor<128x128xf32, #linear1>, tensor<128x128xf32, #linear1>, i32)  : i32 {
+        %qt = arith.extsi %curr_m_99 : i32 to i64
+        %qt_100 = arith.addi %off_bh_17, %qt : i64
+        %qt_101 = arith.trunci %qt_100 : i64 to i32
+        %qt_102 = nvg.cluster_id
+        %qt_103 = arith.constant 2 : i32
+        %qt_104 = arith.remsi %qt_102, %qt_103 : i32
+        %qt_105 = arith.constant 64 : i32
+        %qt_106 = arith.muli %qt_104, %qt_105 : i32
+        %qt_107 = arith.addi %qt_101, %qt_106 : i32
+        %qt_108 = tt.descriptor_load %desc_qt[%qt_107, %c0_i32] {two_cta_b} : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #blocked2>
+        %qT = ttg.local_alloc %qt_108 : (tensor<64x128xf16, #blocked2>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %qT_109 = ttg.memdesc_trans %qT {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared1, #smem>
+        %q = nvg.cluster_id
+        %q_110 = arith.constant 2 : i32
+        %q_111 = arith.remsi %q, %q_110 : i32
+        %q_112 = arith.constant 64 : i32
+        %q_113 = arith.muli %q_111, %q_112 : i32
+        %q_114 = arith.addi %c0_i32, %q_113 : i32
+        %q_115 = tt.descriptor_load %desc_q[%qt_101, %q_114] {two_cta_b} : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16, #blocked3>
+        %q_116 = ttg.local_alloc %q_115 : (tensor<128x64xf16, #blocked3>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %offs_m_start = arith.addi %off_chz_10, %qt : i64
+        %m = arith.trunci %offs_m_start : i64 to i32
+        %m_117 = tt.descriptor_load %desc_m[%m] : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked4>
+        %qkT, %qkT_118 = ttng.tmem_alloc %cst_1 : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %qkT_119 = ttng.tc_gen5_mma %k_21, %qT_109, %qkT[%qkT_118], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_120, %qkT_121 = ttng.tmem_load %qkT[%qkT_119] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %pT = ttg.convert_layout %m_117 : tensor<128xf32, #blocked4> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %pT_122 = tt.expand_dims %pT {axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x128xf32, #linear1>
+        %pT_123 = tt.broadcast %pT_122 : tensor<1x128xf32, #linear1> -> tensor<128x128xf32, #linear1>
+        %pT_124 = arith.subf %qkT_120, %pT_123 : tensor<128x128xf32, #linear1>
+        %pT_125 = math.exp2 %pT_124 : tensor<128x128xf32, #linear1>
+        %do = nvg.cluster_id
+        %do_126 = arith.constant 2 : i32
+        %do_127 = arith.remsi %do, %do_126 : i32
+        %do_128 = arith.constant 64 : i32
+        %do_129 = arith.muli %do_127, %do_128 : i32
+        %do_130 = arith.addi %c0_i32, %do_129 : i32
+        %do_131 = tt.descriptor_load %desc_do[%qt_101, %do_130] {two_cta_b} : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16, #blocked3>
+        %do_132 = ttg.local_alloc %do_131 : (tensor<128x64xf16, #blocked3>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %dot = nvg.cluster_id
+        %dot_133 = arith.constant 2 : i32
+        %dot_134 = arith.remsi %dot, %dot_133 : i32
+        %dot_135 = arith.constant 64 : i32
+        %dot_136 = arith.muli %dot_134, %dot_135 : i32
+        %dot_137 = arith.addi %qt_101, %dot_136 : i32
+        %dot_138 = tt.descriptor_load %desc_dot[%dot_137, %c0_i32] {two_cta_b} : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #blocked2>
+        %ppT = arith.truncf %pT_125 : tensor<128x128xf32, #linear1> to tensor<128x128xf16, #linear1>
+        %ppT_139 = ttg.local_alloc %ppT : (tensor<128x128xf16, #linear1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dpT = ttg.local_alloc %dot_138 : (tensor<64x128xf16, #blocked2>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %dpT_140 = ttg.memdesc_trans %dpT {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared1, #smem>
+        %dpT_141, %dpT_142 = ttng.tmem_alloc %cst_1 : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dpT_143 = ttng.tc_gen5_mma %v_33, %dpT_140, %dpT_141[%dpT_142], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_144, %dpT_145 = ttng.tmem_load %dpT_141[%dpT_143] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %Di = tt.descriptor_load %desc_delta[%m] : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked4>
+        %dv_146, %dv_147 = ttng.tmem_alloc %dv : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dv_148 = ttng.tc_gen5_mma %ppT_139, %do_132, %dv_146[%dv_147], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dv_149, %dv_150 = ttng.tmem_load %dv_146[%dv_148] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %dsT = ttg.convert_layout %Di : tensor<128xf32, #blocked4> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %dsT_151 = tt.expand_dims %dsT {axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x128xf32, #linear1>
+        %dsT_152 = tt.broadcast %dsT_151 : tensor<1x128xf32, #linear1> -> tensor<128x128xf32, #linear1>
+        %dsT_153 = arith.subf %dpT_144, %dsT_152 : tensor<128x128xf32, #linear1>
+        %dsT_154 = arith.mulf %pT_125, %dsT_153 : tensor<128x128xf32, #linear1>
+        %dsT_155 = arith.truncf %dsT_154 : tensor<128x128xf32, #linear1> to tensor<128x128xf16, #linear1>
+        %dsT_156 = ttg.local_alloc %dsT_155 : (tensor<128x128xf16, #linear1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dk_157, %dk_158 = ttng.tmem_alloc %dk : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dk_159 = ttng.tc_gen5_mma %dsT_156, %q_116, %dk_157[%dk_158], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dk_160, %dk_161 = ttng.tmem_load %dk_157[%dk_159] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %dsT_dq = tt.trans %dsT_155 {order = array<i32: 1, 0>} : tensor<128x128xf16, #linear1> -> tensor<128x128xf16, #linear2>
+        %dsT_dq_162 = tt.reshape %dsT_dq : tensor<128x128xf16, #linear2> -> tensor<64x256xf16, #linear3>
+        %dsT_dq_163 = ttg.local_alloc %dsT_dq_162 : (tensor<64x256xf16, #linear3>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dq, %dq_164 = ttng.tmem_alloc %cst : (tensor<64x128xf32, #linear>) -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dq_165 = ttng.tc_gen5_mma %dsT_dq_163, %kt_32, %dq[%dq_164], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared, #smem>, !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %dq_166, %dq_167 = ttng.tmem_load %dq[%dq_165] : !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear>
+        %dqs = tt.reshape %dq_166 : tensor<64x128xf32, #linear> -> tensor<128x2x32xf32, #linear4>
+        %dqs_168 = tt.trans %dqs {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear4> -> tensor<128x32x2xf32, #linear5>
+        %dqs_169 = ttg.convert_layout %dqs_168 : tensor<128x32x2xf32, #linear5> -> tensor<128x32x2xf32, #linear6>
+        %dqs_170, %dqs_171 = tt.split %dqs_169 : tensor<128x32x2xf32, #linear6> -> tensor<128x32xf32, #linear7>
+        %dqs_172 = tt.reshape %dqs_170 : tensor<128x32xf32, #linear7> -> tensor<128x2x16xf32, #blocked5>
+        %dqs_173 = tt.trans %dqs_172 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked5> -> tensor<128x16x2xf32, #blocked6>
+        %dqs_174, %dqs_175 = tt.split %dqs_173 : tensor<128x16x2xf32, #blocked6> -> tensor<128x16xf32, #blocked>
+        %dqs_176 = tt.reshape %dqs_171 : tensor<128x32xf32, #linear7> -> tensor<128x2x16xf32, #blocked5>
+        %dqs_177 = tt.trans %dqs_176 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked5> -> tensor<128x16x2xf32, #blocked6>
+        %dqs_178, %dqs_179 = tt.split %dqs_177 : tensor<128x16x2xf32, #blocked6> -> tensor<128x16xf32, #blocked>
+        %dq_row_180 = arith.addi %qt_100, %dq_row_7 : i64
+        %dq_row_181 = arith.muli %dq_row_180, %c2_i64 : i64
+        %dqN = arith.mulf %dqs_174, %cst_0 : tensor<128x16xf32, #blocked>
+        %19 = arith.trunci %dq_row_181 : i64 to i32
+        tt.descriptor_reduce add, %desc_dq[%19, %c0_i32], %dqN : !tt.tensordesc<128x16xf32>, tensor<128x16xf32, #blocked>
+        %dqN_182 = arith.mulf %dqs_175, %cst_0 : tensor<128x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%19, %c16_i32], %dqN_182 : !tt.tensordesc<128x16xf32>, tensor<128x16xf32, #blocked>
+        %dqN_183 = arith.mulf %dqs_178, %cst_0 : tensor<128x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%19, %c32_i32], %dqN_183 : !tt.tensordesc<128x16xf32>, tensor<128x16xf32, #blocked>
+        %dqN_184 = arith.mulf %dqs_179, %cst_0 : tensor<128x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%19, %c48_i32], %dqN_184 : !tt.tensordesc<128x16xf32>, tensor<128x16xf32, #blocked>
+        %curr_m_185 = arith.addi %curr_m_99, %c128_i32 : i32
+        scf.yield %dk_160, %dv_149, %curr_m_185 : tensor<128x128xf32, #linear1>, tensor<128x128xf32, #linear1>, i32
+      }
+      %dvs = tt.reshape %curr_m#1 : tensor<128x128xf32, #linear1> -> tensor<128x2x64xf32, #linear8>
+      %dvs_34 = tt.trans %dvs {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear8> -> tensor<128x64x2xf32, #linear9>
+      %dvs_35 = ttg.convert_layout %dvs_34 : tensor<128x64x2xf32, #linear9> -> tensor<128x64x2xf32, #linear10>
+      %dvs_36, %dvs_37 = tt.split %dvs_35 : tensor<128x64x2xf32, #linear10> -> tensor<128x64xf32, #linear11>
+      %dvs_38 = tt.reshape %dvs_36 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %dvs_39 = tt.trans %dvs_38 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %dvs_40, %dvs_41 = tt.split %dvs_39 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %dvs_42 = tt.reshape %dvs_40 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dvs_43 = tt.trans %dvs_42 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dvs_44, %dvs_45 = tt.split %dvs_43 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dvs_46 = tt.reshape %dvs_41 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dvs_47 = tt.trans %dvs_46 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dvs_48, %dvs_49 = tt.split %dvs_47 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dvs_50 = tt.reshape %dvs_37 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %dvs_51 = tt.trans %dvs_50 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %dvs_52, %dvs_53 = tt.split %dvs_51 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %dvs_54 = tt.reshape %dvs_52 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dvs_55 = tt.trans %dvs_54 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dvs_56, %dvs_57 = tt.split %dvs_55 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dvs_58 = tt.reshape %dvs_53 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dvs_59 = tt.trans %dvs_58 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dvs_60, %dvs_61 = tt.split %dvs_59 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %3 = arith.truncf %dvs_44 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c0_i32], %3 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %4 = arith.truncf %dvs_45 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c16_i32], %4 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %5 = arith.truncf %dvs_48 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c32_i32], %5 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %6 = arith.truncf %dvs_49 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c48_i32], %6 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %7 = arith.truncf %dvs_56 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c64_i32], %7 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %8 = arith.truncf %dvs_57 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c80_i32], %8 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %9 = arith.truncf %dvs_60 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c96_i32], %9 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %10 = arith.truncf %dvs_61 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dv[%k_19, %c112_i32], %10 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dks = tt.reshape %curr_m#0 : tensor<128x128xf32, #linear1> -> tensor<128x2x64xf32, #linear8>
+      %dks_62 = tt.trans %dks {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear8> -> tensor<128x64x2xf32, #linear9>
+      %dks_63 = ttg.convert_layout %dks_62 : tensor<128x64x2xf32, #linear9> -> tensor<128x64x2xf32, #linear10>
+      %dks_64, %dks_65 = tt.split %dks_63 : tensor<128x64x2xf32, #linear10> -> tensor<128x64xf32, #linear11>
+      %dks_66 = tt.reshape %dks_64 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %dks_67 = tt.trans %dks_66 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %dks_68, %dks_69 = tt.split %dks_67 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %dks_70 = tt.reshape %dks_68 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dks_71 = tt.trans %dks_70 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dks_72, %dks_73 = tt.split %dks_71 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dks_74 = tt.reshape %dks_69 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dks_75 = tt.trans %dks_74 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dks_76, %dks_77 = tt.split %dks_75 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dks_78 = tt.reshape %dks_65 : tensor<128x64xf32, #linear11> -> tensor<128x2x32xf32, #linear12>
+      %dks_79 = tt.trans %dks_78 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear12> -> tensor<128x32x2xf32, #linear13>
+      %dks_80, %dks_81 = tt.split %dks_79 : tensor<128x32x2xf32, #linear13> -> tensor<128x32xf32, #linear14>
+      %dks_82 = tt.reshape %dks_80 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dks_83 = tt.trans %dks_82 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dks_84, %dks_85 = tt.split %dks_83 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dks_86 = tt.reshape %dks_81 : tensor<128x32xf32, #linear14> -> tensor<128x2x16xf32, #blocked7>
+      %dks_87 = tt.trans %dks_86 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #blocked7> -> tensor<128x16x2xf32, #blocked8>
+      %dks_88, %dks_89 = tt.split %dks_87 : tensor<128x16x2xf32, #blocked8> -> tensor<128x16xf32, #blocked1>
+      %dkN_90 = arith.mulf %dks_72, %dkN : tensor<128x16xf32, #blocked1>
+      %11 = arith.truncf %dkN_90 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c0_i32], %11 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_91 = arith.mulf %dks_73, %dkN : tensor<128x16xf32, #blocked1>
+      %12 = arith.truncf %dkN_91 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c16_i32], %12 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_92 = arith.mulf %dks_76, %dkN : tensor<128x16xf32, #blocked1>
+      %13 = arith.truncf %dkN_92 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c32_i32], %13 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_93 = arith.mulf %dks_77, %dkN : tensor<128x16xf32, #blocked1>
+      %14 = arith.truncf %dkN_93 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c48_i32], %14 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_94 = arith.mulf %dks_84, %dkN : tensor<128x16xf32, #blocked1>
+      %15 = arith.truncf %dkN_94 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c64_i32], %15 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_95 = arith.mulf %dks_85, %dkN : tensor<128x16xf32, #blocked1>
+      %16 = arith.truncf %dkN_95 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c80_i32], %16 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_96 = arith.mulf %dks_88, %dkN : tensor<128x16xf32, #blocked1>
+      %17 = arith.truncf %dkN_96 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c96_i32], %17 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %dkN_97 = arith.mulf %dks_89, %dkN : tensor<128x16xf32, #blocked1>
+      %18 = arith.truncf %dkN_97 : tensor<128x16xf32, #blocked1> to tensor<128x16xf16, #blocked1>
+      tt.descriptor_store %desc_dk[%k_19, %c112_i32], %18 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked1>
+      %tile_idx_98 = arith.addi %tile_idx_8, %num_progs_5 : i32
+      scf.yield %tile_idx_98 : i32
+    } {tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm128_persistent.mlir
+++ b/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm128_persistent.mlir
@@ -1,0 +1,354 @@
+// RUN: triton-opt %s --nvgpu-plan-2cta-exchange | FileCheck %s
+
+// Full TTGIR captured immediately before NVGPUPlan2CTAExchange from the
+// non-causal persistent BM128 2-CTA configuration with adjacent N ownership.
+// CHECK: %[[GATHER:.*]] = ttng.two_cta_peer_gather %{{.*}} split_dim = 1 num_ctas = 2
+// CHECK-SAME: tensor<128x128xf16{{.*}}> -> tensor<64x256xf16{{.*}}>
+// CHECK: %[[PHYSICAL:.*]] = tt.trans %[[GATHER]]
+// CHECK-SAME: tensor<64x256xf16{{.*}}> -> tensor<256x64xf16{{.*}}>
+// CHECK: %[[EXCHANGE:.*]] = ttg.local_alloc
+// CHECK-SAME: !ttg.memdesc<128x64xf16, #shared, #smem>
+// CHECK: %[[ALLOC:.*]] = ttg.local_alloc %[[PHYSICAL]]
+// CHECK-SAME: !ttg.memdesc<256x64xf16, #shared, #smem>
+// CHECK: ttng.two_cta_peer_relay %[[EXCHANGE]]
+// CHECK: %[[VIEW:.*]] = ttg.memdesc_trans %[[ALLOC]]
+// CHECK-SAME: !ttg.memdesc<256x64xf16, #shared, #smem> -> !ttg.memdesc<64x256xf16, #shared1, #smem>
+// CHECK: ttng.tc_gen5_mma %[[VIEW]],
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [0, 1, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [0, 0, 1]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 16, 0], [0, 1, 0], [0, 2, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 32], [0, 16], [0, 1], [0, 2], [32, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 1, 0], [0, 0, 16], [0, 0, 1], [0, 0, 2], [32, 0, 0]], lane = [[0, 0, 4], [0, 0, 8], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear10 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0]], block = []}>
+#linear11 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [32, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0]], block = []}>
+#linear12 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear13 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear14 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear15 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear16 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear17 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear18 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear19 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd_persist(%desc_q: !tt.tensordesc<128x64xf16>, %desc_q.shape.0: i32, %desc_q.shape.1: i32, %desc_q.stride.0: i64, %desc_q.stride.1: i64, %desc_qt: !tt.tensordesc<64x128xf16>, %desc_qt.shape.0: i32, %desc_qt.shape.1: i32, %desc_qt.stride.0: i64, %desc_qt.stride.1: i64, %desc_k: !tt.tensordesc<128x128xf16>, %desc_k.shape.0: i32, %desc_k.shape.1: i32, %desc_k.stride.0: i64, %desc_k.stride.1: i64, %desc_kt: !tt.tensordesc<256x64xf16>, %desc_kt.shape.0: i32, %desc_kt.shape.1: i32, %desc_kt.stride.0: i64, %desc_kt.stride.1: i64, %desc_v: !tt.tensordesc<128x128xf16>, %desc_v.shape.0: i32, %desc_v.shape.1: i32, %desc_v.stride.0: i64, %desc_v.stride.1: i64, %sm_scale: f32, %desc_do: !tt.tensordesc<128x64xf16>, %desc_do.shape.0: i32, %desc_do.shape.1: i32, %desc_do.stride.0: i64, %desc_do.stride.1: i64, %desc_dot: !tt.tensordesc<64x128xf16>, %desc_dot.shape.0: i32, %desc_dot.shape.1: i32, %desc_dot.stride.0: i64, %desc_dot.stride.1: i64, %desc_dq: !tt.tensordesc<64x16xf32>, %desc_dq.shape.0: i32, %desc_dq.shape.1: i32, %desc_dq.stride.0: i64, %desc_dq.stride.1: i64, %desc_dk: !tt.tensordesc<128x16xf16>, %desc_dk.shape.0: i32, %desc_dk.shape.1: i32, %desc_dk.stride.0: i64, %desc_dk.stride.1: i64, %desc_dv: !tt.tensordesc<128x16xf16>, %desc_dv.shape.0: i32, %desc_dv.shape.1: i32, %desc_dv.stride.0: i64, %desc_dv.stride.1: i64, %desc_m: !tt.tensordesc<128xf32>, %desc_m.shape.0: i32, %desc_m.stride.0: i64, %desc_delta: !tt.tensordesc<128xf32>, %desc_delta.shape.0: i32, %desc_delta.stride.0: i64, %stride_z: i32 {tt.divisibility = 16 : i32}, %stride_h: i32 {tt.divisibility = 16 : i32}, %stride_tok: i32 {tt.divisibility = 16 : i32}, %BATCH: i32, %H: i32 {tt.divisibility = 16 : i32}, %N_CTX: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #linear>
+    %cst_0 = arith.constant dense<0.693147182> : tensor<64x16xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %n_tile_num = arith.constant 127 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c80_i32 = arith.constant 80 : i32
+    %c96_i32 = arith.constant 96 : i32
+    %c112_i32 = arith.constant 112 : i32
+    %true = arith.constant true
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear1>
+    %n_tile_num_2 = arith.addi %N_CTX, %n_tile_num : i32
+    %n_tile_num_3 = arith.divsi %n_tile_num_2, %c128_i32 : i32
+    %cluster_rank = tt.get_program_id x : i32
+    %cluster_rank_4 = arith.remsi %cluster_rank, %c2_i32 : i32
+    %prog_id = arith.divsi %cluster_rank, %c2_i32 : i32
+    %num_progs = tt.get_num_programs x : i32
+    %num_progs_5 = arith.divsi %num_progs, %c2_i32 : i32
+    %scheduled_n_tiles = arith.divsi %n_tile_num_3, %c2_i32 : i32
+    %total_tiles = arith.muli %scheduled_n_tiles, %BATCH : i32
+    %total_tiles_6 = arith.muli %total_tiles, %H : i32
+    %tiles_per_sm = arith.divsi %total_tiles_6, %num_progs_5 : i32
+    %0 = arith.remsi %total_tiles_6, %num_progs_5 : i32
+    %1 = arith.cmpi slt, %prog_id, %0 : i32
+    %2 = scf.if %1 -> (i32) {
+      %tiles_per_sm_15 = arith.addi %tiles_per_sm, %c1_i32 : i32
+      scf.yield %tiles_per_sm_15 : i32
+    } else {
+      scf.yield %tiles_per_sm : i32
+    }
+    %off_bh = arith.extsi %stride_tok : i32 to i64
+    %kt_start_n = arith.muli %cluster_rank_4, %c128_i32 : i32
+    %num_steps = arith.divsi %N_CTX, %c128_i32 : i32
+    %dq_row = arith.muli %cluster_rank_4, %c64_i32 : i32
+    %dq_row_7 = arith.extsi %dq_row : i32 to i64
+    %dkN = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_8 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_9 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_10 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_11 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_12 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_13 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %dkN_14 = tt.splat %sm_scale : f32 -> tensor<128x16xf32, #linear2>
+    %tile_idx = scf.for %_ = %c0_i32 to %2 step %c1_i32 iter_args(%tile_idx_15 = %prog_id) -> (i32)  : i32 {
+      %scheduled_pid = arith.remsi %tile_idx_15, %scheduled_n_tiles : i32
+      %bhid = arith.divsi %tile_idx_15, %scheduled_n_tiles : i32
+      %pid = arith.muli %scheduled_pid, %c2_i32 : i32
+      %pid_16 = arith.addi %pid, %cluster_rank_4 : i32
+      %off_chz = arith.muli %bhid, %N_CTX : i32
+      %off_chz_17 = arith.extsi %off_chz : i32 to i64
+      %off_bh_18 = arith.remsi %bhid, %H : i32
+      %off_bh_19 = arith.muli %stride_h, %off_bh_18 : i32
+      %off_bh_20 = arith.divsi %bhid, %H : i32
+      %off_bh_21 = arith.muli %stride_z, %off_bh_20 : i32
+      %off_bh_22 = arith.addi %off_bh_19, %off_bh_21 : i32
+      %off_bh_23 = arith.extsi %off_bh_22 : i32 to i64
+      %off_bh_24 = arith.divsi %off_bh_23, %off_bh : i64
+      %start_n = arith.muli %pid_16, %c128_i32 : i32
+      %k = arith.extsi %start_n : i32 to i64
+      %k_25 = arith.addi %off_bh_24, %k : i64
+      %k_26 = arith.trunci %k_25 : i64 to i32
+      %k_27 = tt.descriptor_load %desc_k[%k_26, %c0_i32] : !tt.tensordesc<128x128xf16> -> tensor<128x128xf16, #blocked1>
+      %k_28 = ttg.local_alloc %k_27 : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %kt_start_n_29 = arith.subi %start_n, %kt_start_n : i32
+      %kt = arith.extsi %kt_start_n_29 : i32 to i64
+      %kt_30 = arith.addi %off_bh_24, %kt : i64
+      %kt_31 = arith.trunci %kt_30 : i64 to i32
+      %kt_32 = nvg.cluster_id
+      %kt_33 = arith.constant 2 : i32
+      %kt_34 = arith.remsi %kt_32, %kt_33 : i32
+      %kt_35 = arith.constant 64 : i32
+      %kt_36 = arith.muli %kt_34, %kt_35 : i32
+      %kt_37 = arith.addi %c0_i32, %kt_36 : i32
+      %kt_38 = tt.descriptor_load %desc_kt[%kt_31, %kt_37] {two_cta_b} : !tt.tensordesc<256x64xf16> -> tensor<256x64xf16, #blocked2>
+      %kt_39 = ttg.local_alloc %kt_38 : (tensor<256x64xf16, #blocked2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+      %v = tt.descriptor_load %desc_v[%k_26, %c0_i32] : !tt.tensordesc<128x128xf16> -> tensor<128x128xf16, #blocked1>
+      %v_40 = ttg.local_alloc %v : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+      %curr_m:3 = scf.for %blk_idx = %c0_i32 to %num_steps step %c1_i32 iter_args(%dk = %cst_1, %dv = %cst_1, %curr_m_104 = %c0_i32) -> (tensor<128x128xf32, #linear1>, tensor<128x128xf32, #linear1>, i32)  : i32 {
+        %q = arith.extsi %curr_m_104 : i32 to i64
+        %q_105 = arith.addi %off_bh_24, %q : i64
+        %q_106 = arith.trunci %q_105 : i64 to i32
+        %q_107 = nvg.cluster_id
+        %q_108 = arith.constant 2 : i32
+        %q_109 = arith.remsi %q_107, %q_108 : i32
+        %q_110 = arith.constant 64 : i32
+        %q_111 = arith.muli %q_109, %q_110 : i32
+        %q_112 = arith.addi %c0_i32, %q_111 : i32
+        %q_113 = tt.descriptor_load %desc_q[%q_106, %q_112] {two_cta_b} : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16, #blocked2>
+        %q_114 = ttg.local_alloc %q_113 : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %qt = nvg.cluster_id
+        %qt_115 = arith.constant 2 : i32
+        %qt_116 = arith.remsi %qt, %qt_115 : i32
+        %qt_117 = arith.constant 64 : i32
+        %qt_118 = arith.muli %qt_116, %qt_117 : i32
+        %qt_119 = arith.addi %q_106, %qt_118 : i32
+        %qt_120 = tt.descriptor_load %desc_qt[%qt_119, %c0_i32] {two_cta_b} : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #blocked1>
+        %qT = ttg.local_alloc %qt_120 : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %qT_121 = ttg.memdesc_trans %qT {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared1, #smem>
+        %offs_m_start = arith.addi %off_chz_17, %q : i64
+        %m = arith.trunci %offs_m_start : i64 to i32
+        %m_122 = tt.descriptor_load %desc_m[%m] : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked3>
+        %qkT, %qkT_123 = ttng.tmem_alloc %cst_1 : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %qkT_124 = ttng.tc_gen5_mma %k_28, %qT_121, %qkT[%qkT_123], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %qkT_125, %qkT_126 = ttng.tmem_load %qkT[%qkT_124] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %pT = ttg.convert_layout %m_122 : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %pT_127 = tt.expand_dims %pT {axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x128xf32, #linear1>
+        %pT_128 = tt.broadcast %pT_127 : tensor<1x128xf32, #linear1> -> tensor<128x128xf32, #linear1>
+        %pT_129 = arith.subf %qkT_125, %pT_128 : tensor<128x128xf32, #linear1>
+        %pT_130 = math.exp2 %pT_129 : tensor<128x128xf32, #linear1>
+        %do = nvg.cluster_id
+        %do_131 = arith.constant 2 : i32
+        %do_132 = arith.remsi %do, %do_131 : i32
+        %do_133 = arith.constant 64 : i32
+        %do_134 = arith.muli %do_132, %do_133 : i32
+        %do_135 = arith.addi %c0_i32, %do_134 : i32
+        %do_136 = tt.descriptor_load %desc_do[%q_106, %do_135] {two_cta_b} : !tt.tensordesc<128x64xf16> -> tensor<128x64xf16, #blocked2>
+        %do_137 = ttg.local_alloc %do_136 : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+        %dot = nvg.cluster_id
+        %dot_138 = arith.constant 2 : i32
+        %dot_139 = arith.remsi %dot, %dot_138 : i32
+        %dot_140 = arith.constant 64 : i32
+        %dot_141 = arith.muli %dot_139, %dot_140 : i32
+        %dot_142 = arith.addi %q_106, %dot_141 : i32
+        %dot_143 = tt.descriptor_load %desc_dot[%dot_142, %c0_i32] {two_cta_b} : !tt.tensordesc<64x128xf16> -> tensor<64x128xf16, #blocked1>
+        %ppT = arith.truncf %pT_130 : tensor<128x128xf32, #linear1> to tensor<128x128xf16, #linear1>
+        %ppT_144 = ttg.local_alloc %ppT : (tensor<128x128xf16, #linear1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dpT = ttg.local_alloc %dot_143 : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+        %dpT_145 = ttg.memdesc_trans %dpT {order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared1, #smem>
+        %dpT_146, %dpT_147 = ttng.tmem_alloc %cst_1 : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dpT_148 = ttng.tc_gen5_mma %v_40, %dpT_145, %dpT_146[%dpT_147], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dpT_149, %dpT_150 = ttng.tmem_load %dpT_146[%dpT_148] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %Di = tt.descriptor_load %desc_delta[%m] : !tt.tensordesc<128xf32> -> tensor<128xf32, #blocked3>
+        %dv_151, %dv_152 = ttng.tmem_alloc %dv : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dv_153 = ttng.tc_gen5_mma %ppT_144, %do_137, %dv_151[%dv_152], %true, %true {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dv_154, %dv_155 = ttng.tmem_load %dv_151[%dv_153] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %dsT = ttg.convert_layout %Di : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>>
+        %dsT_156 = tt.expand_dims %dsT {axis = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x128xf32, #linear1>
+        %dsT_157 = tt.broadcast %dsT_156 : tensor<1x128xf32, #linear1> -> tensor<128x128xf32, #linear1>
+        %dsT_158 = arith.subf %dpT_149, %dsT_157 : tensor<128x128xf32, #linear1>
+        %dsT_159 = arith.mulf %pT_130, %dsT_158 : tensor<128x128xf32, #linear1>
+        %dsT_160 = arith.truncf %dsT_159 : tensor<128x128xf32, #linear1> to tensor<128x128xf16, #linear1>
+        %dsT_161 = ttg.local_alloc %dsT_160 : (tensor<128x128xf16, #linear1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+        %dk_162, %dk_163 = ttng.tmem_alloc %dk : (tensor<128x128xf32, #linear1>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dk_164 = ttng.tc_gen5_mma %dsT_161, %q_114, %dk_162[%dk_163], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %dk_165, %dk_166 = ttng.tmem_load %dk_162[%dk_164] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear1>
+        %dsT_dq = tt.trans %dsT_160 {order = array<i32: 1, 0>} : tensor<128x128xf16, #linear1> -> tensor<128x128xf16, #linear3>
+        %dsT_dq_167 = tt.reshape %dsT_dq : tensor<128x128xf16, #linear3> -> tensor<64x256xf16, #linear4>
+        %dsT_dq_168 = ttg.local_alloc %dsT_dq_167 : (tensor<64x256xf16, #linear4>) -> !ttg.memdesc<64x256xf16, #shared, #smem>
+        %dq, %dq_169 = ttng.tmem_alloc %cst : (tensor<64x128xf32, #linear>) -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+        %dq_170 = ttng.tc_gen5_mma %dsT_dq_168, %kt_39, %dq[%dq_169], %true, %true {tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared, #smem>, !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+        %dq_171, %dq_172 = ttng.tmem_load %dq[%dq_170] : !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear>
+        %dqs = tt.reshape %dq_171 : tensor<64x128xf32, #linear> -> tensor<64x2x64xf32, #linear5>
+        %dqs_173 = tt.trans %dqs {order = array<i32: 0, 2, 1>} : tensor<64x2x64xf32, #linear5> -> tensor<64x64x2xf32, #linear6>
+        %dqs_174 = ttg.convert_layout %dqs_173 : tensor<64x64x2xf32, #linear6> -> tensor<64x64x2xf32, #linear7>
+        %dqs_175, %dqs_176 = tt.split %dqs_174 : tensor<64x64x2xf32, #linear7> -> tensor<64x64xf32, #linear8>
+        %dqs_177 = tt.reshape %dqs_175 : tensor<64x64xf32, #linear8> -> tensor<64x2x32xf32, #linear9>
+        %dqs_178 = tt.trans %dqs_177 {order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #linear9> -> tensor<64x32x2xf32, #linear10>
+        %dqs_179, %dqs_180 = tt.split %dqs_178 : tensor<64x32x2xf32, #linear10> -> tensor<64x32xf32, #linear11>
+        %dqs_181 = tt.reshape %dqs_179 : tensor<64x32xf32, #linear11> -> tensor<64x2x16xf32, #blocked4>
+        %dqs_182 = tt.trans %dqs_181 {order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked4> -> tensor<64x16x2xf32, #blocked5>
+        %dqs_183, %dqs_184 = tt.split %dqs_182 : tensor<64x16x2xf32, #blocked5> -> tensor<64x16xf32, #blocked>
+        %dqs_185 = tt.reshape %dqs_180 : tensor<64x32xf32, #linear11> -> tensor<64x2x16xf32, #blocked4>
+        %dqs_186 = tt.trans %dqs_185 {order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked4> -> tensor<64x16x2xf32, #blocked5>
+        %dqs_187, %dqs_188 = tt.split %dqs_186 : tensor<64x16x2xf32, #blocked5> -> tensor<64x16xf32, #blocked>
+        %dqs_189 = tt.reshape %dqs_176 : tensor<64x64xf32, #linear8> -> tensor<64x2x32xf32, #linear9>
+        %dqs_190 = tt.trans %dqs_189 {order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #linear9> -> tensor<64x32x2xf32, #linear10>
+        %dqs_191, %dqs_192 = tt.split %dqs_190 : tensor<64x32x2xf32, #linear10> -> tensor<64x32xf32, #linear11>
+        %dqs_193 = tt.reshape %dqs_191 : tensor<64x32xf32, #linear11> -> tensor<64x2x16xf32, #blocked4>
+        %dqs_194 = tt.trans %dqs_193 {order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked4> -> tensor<64x16x2xf32, #blocked5>
+        %dqs_195, %dqs_196 = tt.split %dqs_194 : tensor<64x16x2xf32, #blocked5> -> tensor<64x16xf32, #blocked>
+        %dqs_197 = tt.reshape %dqs_192 : tensor<64x32xf32, #linear11> -> tensor<64x2x16xf32, #blocked4>
+        %dqs_198 = tt.trans %dqs_197 {order = array<i32: 0, 2, 1>} : tensor<64x2x16xf32, #blocked4> -> tensor<64x16x2xf32, #blocked5>
+        %dqs_199, %dqs_200 = tt.split %dqs_198 : tensor<64x16x2xf32, #blocked5> -> tensor<64x16xf32, #blocked>
+        %dq_row_201 = arith.addi %q_105, %dq_row_7 : i64
+        %dqN = arith.mulf %dqs_183, %cst_0 : tensor<64x16xf32, #blocked>
+        %35 = arith.trunci %dq_row_201 : i64 to i32
+        tt.descriptor_reduce add, %desc_dq[%35, %c0_i32], %dqN : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_202 = arith.mulf %dqs_184, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c16_i32], %dqN_202 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_203 = arith.mulf %dqs_187, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c32_i32], %dqN_203 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_204 = arith.mulf %dqs_188, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c48_i32], %dqN_204 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_205 = arith.mulf %dqs_195, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c64_i32], %dqN_205 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_206 = arith.mulf %dqs_196, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c80_i32], %dqN_206 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_207 = arith.mulf %dqs_199, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c96_i32], %dqN_207 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %dqN_208 = arith.mulf %dqs_200, %cst_0 : tensor<64x16xf32, #blocked>
+        tt.descriptor_reduce add, %desc_dq[%35, %c112_i32], %dqN_208 : !tt.tensordesc<64x16xf32>, tensor<64x16xf32, #blocked>
+        %curr_m_209 = arith.addi %curr_m_104, %c128_i32 : i32
+        scf.yield %dk_165, %dv_154, %curr_m_209 : tensor<128x128xf32, #linear1>, tensor<128x128xf32, #linear1>, i32
+      }
+      %dvs = tt.reshape %curr_m#1 : tensor<128x128xf32, #linear1> -> tensor<128x2x64xf32, #linear12>
+      %dvs_41 = tt.trans %dvs {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear12> -> tensor<128x64x2xf32, #linear13>
+      %dvs_42, %dvs_43 = tt.split %dvs_41 : tensor<128x64x2xf32, #linear13> -> tensor<128x64xf32, #linear14>
+      %dvs_44 = tt.reshape %dvs_42 : tensor<128x64xf32, #linear14> -> tensor<128x2x32xf32, #linear15>
+      %dvs_45 = tt.trans %dvs_44 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+      %dvs_46, %dvs_47 = tt.split %dvs_45 : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+      %dvs_48 = tt.reshape %dvs_46 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dvs_49 = tt.trans %dvs_48 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dvs_50, %dvs_51 = tt.split %dvs_49 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dvs_52 = tt.reshape %dvs_47 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dvs_53 = tt.trans %dvs_52 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dvs_54, %dvs_55 = tt.split %dvs_53 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dvs_56 = tt.reshape %dvs_43 : tensor<128x64xf32, #linear14> -> tensor<128x2x32xf32, #linear15>
+      %dvs_57 = tt.trans %dvs_56 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+      %dvs_58, %dvs_59 = tt.split %dvs_57 : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+      %dvs_60 = tt.reshape %dvs_58 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dvs_61 = tt.trans %dvs_60 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dvs_62, %dvs_63 = tt.split %dvs_61 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dvs_64 = tt.reshape %dvs_59 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dvs_65 = tt.trans %dvs_64 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dvs_66, %dvs_67 = tt.split %dvs_65 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %3 = arith.truncf %dvs_50 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %4 = ttg.convert_layout %3 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c0_i32], %4 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %5 = arith.truncf %dvs_51 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %6 = ttg.convert_layout %5 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c16_i32], %6 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %7 = arith.truncf %dvs_54 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %8 = ttg.convert_layout %7 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c32_i32], %8 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %9 = arith.truncf %dvs_55 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %10 = ttg.convert_layout %9 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c48_i32], %10 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %11 = arith.truncf %dvs_62 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %12 = ttg.convert_layout %11 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c64_i32], %12 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %13 = arith.truncf %dvs_63 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %14 = ttg.convert_layout %13 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c80_i32], %14 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %15 = arith.truncf %dvs_66 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %16 = ttg.convert_layout %15 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c96_i32], %16 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %17 = arith.truncf %dvs_67 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %18 = ttg.convert_layout %17 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dv[%k_26, %c112_i32], %18 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dks = tt.reshape %curr_m#0 : tensor<128x128xf32, #linear1> -> tensor<128x2x64xf32, #linear12>
+      %dks_68 = tt.trans %dks {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear12> -> tensor<128x64x2xf32, #linear13>
+      %dks_69, %dks_70 = tt.split %dks_68 : tensor<128x64x2xf32, #linear13> -> tensor<128x64xf32, #linear14>
+      %dks_71 = tt.reshape %dks_69 : tensor<128x64xf32, #linear14> -> tensor<128x2x32xf32, #linear15>
+      %dks_72 = tt.trans %dks_71 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+      %dks_73, %dks_74 = tt.split %dks_72 : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+      %dks_75 = tt.reshape %dks_73 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dks_76 = tt.trans %dks_75 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dks_77, %dks_78 = tt.split %dks_76 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dks_79 = tt.reshape %dks_74 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dks_80 = tt.trans %dks_79 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dks_81, %dks_82 = tt.split %dks_80 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dks_83 = tt.reshape %dks_70 : tensor<128x64xf32, #linear14> -> tensor<128x2x32xf32, #linear15>
+      %dks_84 = tt.trans %dks_83 {order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear15> -> tensor<128x32x2xf32, #linear16>
+      %dks_85, %dks_86 = tt.split %dks_84 : tensor<128x32x2xf32, #linear16> -> tensor<128x32xf32, #linear17>
+      %dks_87 = tt.reshape %dks_85 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dks_88 = tt.trans %dks_87 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dks_89, %dks_90 = tt.split %dks_88 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dks_91 = tt.reshape %dks_86 : tensor<128x32xf32, #linear17> -> tensor<128x2x16xf32, #linear18>
+      %dks_92 = tt.trans %dks_91 {order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear18> -> tensor<128x16x2xf32, #linear19>
+      %dks_93, %dks_94 = tt.split %dks_92 : tensor<128x16x2xf32, #linear19> -> tensor<128x16xf32, #linear2>
+      %dkN_95 = arith.mulf %dks_77, %dkN_14 : tensor<128x16xf32, #linear2>
+      %19 = arith.truncf %dkN_95 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %20 = ttg.convert_layout %19 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c0_i32], %20 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_96 = arith.mulf %dks_78, %dkN_13 : tensor<128x16xf32, #linear2>
+      %21 = arith.truncf %dkN_96 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %22 = ttg.convert_layout %21 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c16_i32], %22 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_97 = arith.mulf %dks_81, %dkN_12 : tensor<128x16xf32, #linear2>
+      %23 = arith.truncf %dkN_97 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %24 = ttg.convert_layout %23 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c32_i32], %24 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_98 = arith.mulf %dks_82, %dkN_11 : tensor<128x16xf32, #linear2>
+      %25 = arith.truncf %dkN_98 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %26 = ttg.convert_layout %25 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c48_i32], %26 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_99 = arith.mulf %dks_89, %dkN_10 : tensor<128x16xf32, #linear2>
+      %27 = arith.truncf %dkN_99 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %28 = ttg.convert_layout %27 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c64_i32], %28 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_100 = arith.mulf %dks_90, %dkN_9 : tensor<128x16xf32, #linear2>
+      %29 = arith.truncf %dkN_100 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %30 = ttg.convert_layout %29 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c80_i32], %30 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_101 = arith.mulf %dks_93, %dkN_8 : tensor<128x16xf32, #linear2>
+      %31 = arith.truncf %dkN_101 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %32 = ttg.convert_layout %31 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c96_i32], %32 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %dkN_102 = arith.mulf %dks_94, %dkN : tensor<128x16xf32, #linear2>
+      %33 = arith.truncf %dkN_102 : tensor<128x16xf32, #linear2> to tensor<128x16xf16, #linear2>
+      %34 = ttg.convert_layout %33 : tensor<128x16xf16, #linear2> -> tensor<128x16xf16, #blocked6>
+      tt.descriptor_store %desc_dk[%k_26, %c112_i32], %34 : !tt.tensordesc<128x16xf16>, tensor<128x16xf16, #blocked6>
+      %tile_idx_103 = arith.addi %tile_idx_15, %num_progs_5 : i32
+      scf.yield %tile_idx_103 : i32
+    } {tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm64_persistent.mlir
+++ b/test/Hopper/TwoCTA/plan_2cta_exchange_bwd_bm64_persistent.mlir
@@ -7,6 +7,7 @@
 // COUNT-COUNT-1: ttng.two_cta_peer_gather
 // PLAN: %[[GATHER:.*]] = ttng.two_cta_peer_gather %{{.*}} split_dim = 0 num_ctas = 2
 // PLAN: ttg.local_alloc %[[GATHER]]
+// PLAN-NOT: ttng.two_cta_peer_relay
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
+++ b/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
@@ -1,0 +1,503 @@
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [4, 1, 8], warpsPerCTA = [4, 1, 1], order = [1, 2, 0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 1, 0]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 1]], warp = [[16, 0, 0], [32, 0, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 0, 1], [0, 32, 0], [0, 1, 0], [0, 2, 0], [16, 0, 0], [32, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [0, 16, 0], [1, 0, 0], [2, 0, 0]], warp = [[4, 0, 0], [8, 0, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 32], [0, 1], [0, 2], [16, 0], [32, 0]], lane = [[0, 4], [0, 8], [0, 16], [1, 0], [2, 0]], warp = [[4, 0], [8, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#loc = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1113:1)
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+#loc60 = loc("desc_q"(#loc))
+#loc61 = loc("desc_q.shape.0"(#loc))
+#loc62 = loc("desc_q.shape.1"(#loc))
+#loc63 = loc("desc_q.stride.0"(#loc))
+#loc64 = loc("desc_q.stride.1"(#loc))
+#loc65 = loc("desc_k"(#loc))
+#loc66 = loc("desc_k.shape.0"(#loc))
+#loc67 = loc("desc_k.shape.1"(#loc))
+#loc68 = loc("desc_k.stride.0"(#loc))
+#loc69 = loc("desc_k.stride.1"(#loc))
+#loc70 = loc("desc_v"(#loc))
+#loc71 = loc("desc_v.shape.0"(#loc))
+#loc72 = loc("desc_v.shape.1"(#loc))
+#loc73 = loc("desc_v.stride.0"(#loc))
+#loc74 = loc("desc_v.stride.1"(#loc))
+#loc75 = loc("sm_scale"(#loc))
+#loc76 = loc("desc_do"(#loc))
+#loc77 = loc("desc_do.shape.0"(#loc))
+#loc78 = loc("desc_do.shape.1"(#loc))
+#loc79 = loc("desc_do.stride.0"(#loc))
+#loc80 = loc("desc_do.stride.1"(#loc))
+#loc81 = loc("desc_dq"(#loc))
+#loc82 = loc("desc_dq.shape.0"(#loc))
+#loc83 = loc("desc_dq.shape.1"(#loc))
+#loc84 = loc("desc_dq.stride.0"(#loc))
+#loc85 = loc("desc_dq.stride.1"(#loc))
+#loc86 = loc("desc_dk"(#loc))
+#loc87 = loc("desc_dk.shape.0"(#loc))
+#loc88 = loc("desc_dk.shape.1"(#loc))
+#loc89 = loc("desc_dk.stride.0"(#loc))
+#loc90 = loc("desc_dk.stride.1"(#loc))
+#loc91 = loc("desc_dv"(#loc))
+#loc92 = loc("desc_dv.shape.0"(#loc))
+#loc93 = loc("desc_dv.shape.1"(#loc))
+#loc94 = loc("desc_dv.stride.0"(#loc))
+#loc95 = loc("desc_dv.stride.1"(#loc))
+#loc96 = loc("desc_m"(#loc))
+#loc97 = loc("desc_m.shape.0"(#loc))
+#loc98 = loc("desc_m.stride.0"(#loc))
+#loc99 = loc("desc_delta"(#loc))
+#loc100 = loc("desc_delta.shape.0"(#loc))
+#loc101 = loc("desc_delta.stride.0"(#loc))
+#loc102 = loc("stride_z"(#loc))
+#loc103 = loc("stride_h"(#loc))
+#loc104 = loc("stride_tok"(#loc))
+#loc105 = loc("BATCH"(#loc))
+#loc106 = loc("H"(#loc))
+#loc107 = loc("N_CTX"(#loc))
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @_attn_bwd(%desc_q: !tt.tensordesc<64x128xf16, #shared> loc("desc_q"(#loc)), %desc_q.shape.0: i32 loc("desc_q.shape.0"(#loc)), %desc_q.shape.1: i32 loc("desc_q.shape.1"(#loc)), %desc_q.stride.0: i64 loc("desc_q.stride.0"(#loc)), %desc_q.stride.1: i64 loc("desc_q.stride.1"(#loc)), %desc_k: !tt.tensordesc<128x128xf16, #shared> loc("desc_k"(#loc)), %desc_k.shape.0: i32 loc("desc_k.shape.0"(#loc)), %desc_k.shape.1: i32 loc("desc_k.shape.1"(#loc)), %desc_k.stride.0: i64 loc("desc_k.stride.0"(#loc)), %desc_k.stride.1: i64 loc("desc_k.stride.1"(#loc)), %desc_v: !tt.tensordesc<128x128xf16, #shared> loc("desc_v"(#loc)), %desc_v.shape.0: i32 loc("desc_v.shape.0"(#loc)), %desc_v.shape.1: i32 loc("desc_v.shape.1"(#loc)), %desc_v.stride.0: i64 loc("desc_v.stride.0"(#loc)), %desc_v.stride.1: i64 loc("desc_v.stride.1"(#loc)), %sm_scale: f32 loc("sm_scale"(#loc)), %desc_do: !tt.tensordesc<64x128xf16, #shared> loc("desc_do"(#loc)), %desc_do.shape.0: i32 loc("desc_do.shape.0"(#loc)), %desc_do.shape.1: i32 loc("desc_do.shape.1"(#loc)), %desc_do.stride.0: i64 loc("desc_do.stride.0"(#loc)), %desc_do.stride.1: i64 loc("desc_do.stride.1"(#loc)), %desc_dq: !tt.tensordesc<64x32xf32, #shared1> loc("desc_dq"(#loc)), %desc_dq.shape.0: i32 loc("desc_dq.shape.0"(#loc)), %desc_dq.shape.1: i32 loc("desc_dq.shape.1"(#loc)), %desc_dq.stride.0: i64 loc("desc_dq.stride.0"(#loc)), %desc_dq.stride.1: i64 loc("desc_dq.stride.1"(#loc)), %desc_dk: !tt.tensordesc<128x64xf16, #shared> loc("desc_dk"(#loc)), %desc_dk.shape.0: i32 loc("desc_dk.shape.0"(#loc)), %desc_dk.shape.1: i32 loc("desc_dk.shape.1"(#loc)), %desc_dk.stride.0: i64 loc("desc_dk.stride.0"(#loc)), %desc_dk.stride.1: i64 loc("desc_dk.stride.1"(#loc)), %desc_dv: !tt.tensordesc<128x64xf16, #shared> loc("desc_dv"(#loc)), %desc_dv.shape.0: i32 loc("desc_dv.shape.0"(#loc)), %desc_dv.shape.1: i32 loc("desc_dv.shape.1"(#loc)), %desc_dv.stride.0: i64 loc("desc_dv.stride.0"(#loc)), %desc_dv.stride.1: i64 loc("desc_dv.stride.1"(#loc)), %desc_m: !tt.tensordesc<64xf32, #shared2> loc("desc_m"(#loc)), %desc_m.shape.0: i32 loc("desc_m.shape.0"(#loc)), %desc_m.stride.0: i64 loc("desc_m.stride.0"(#loc)), %desc_delta: !tt.tensordesc<64xf32, #shared2> loc("desc_delta"(#loc)), %desc_delta.shape.0: i32 loc("desc_delta.shape.0"(#loc)), %desc_delta.stride.0: i64 loc("desc_delta.stride.0"(#loc)), %stride_z: i32 {tt.divisibility = 16 : i32} loc("stride_z"(#loc)), %stride_h: i32 {tt.divisibility = 16 : i32} loc("stride_h"(#loc)), %stride_tok: i32 {tt.divisibility = 16 : i32} loc("stride_tok"(#loc)), %BATCH: i32 loc("BATCH"(#loc)), %H: i32 {tt.divisibility = 16 : i32} loc("H"(#loc)), %N_CTX: i32 {tt.divisibility = 16 : i32} loc("N_CTX"(#loc))) attributes {noinline = false} {
+    %false = arith.constant {async_task_id = array<i32: 1>} false loc(#loc1)
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<64x32xf32, #blocked> loc(#loc163)
+    %c32_i32 = arith.constant {async_task_id = array<i32: 0>} 32 : i32 loc(#loc163)
+    %c96_i32 = arith.constant {async_task_id = array<i32: 0>} 96 : i32 loc(#loc163)
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32 loc(#loc164)
+    %c128_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 128 : i32 loc(#loc109)
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32 loc(#loc109)
+    %c64_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 64 : i32 loc(#loc109)
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true loc(#loc1)
+    %cst_0 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #linear> loc(#loc1)
+    %bhid = tt.get_program_id z {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc110)
+    %pid = tt.get_program_id x {async_task_id = array<i32: 2, 3>} : i32 loc(#loc111)
+    %off_chz = arith.muli %bhid, %N_CTX {async_task_id = array<i32: 2>} : i32 loc(#loc165)
+    %off_chz_1 = arith.extsi %off_chz {async_task_id = array<i32: 2>} : i32 to i64 loc(#loc166)
+    %off_bh = arith.remsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc167)
+    %off_bh_2 = arith.muli %stride_h, %off_bh {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc168)
+    %off_bh_3 = arith.divsi %bhid, %H {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc169)
+    %off_bh_4 = arith.muli %stride_z, %off_bh_3 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc170)
+    %off_bh_5 = arith.addi %off_bh_2, %off_bh_4 {async_task_id = array<i32: 0, 2, 3>} : i32 loc(#loc168)
+    %off_bh_6 = arith.extsi %off_bh_5 {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc171)
+    %off_bh_7 = arith.extsi %stride_tok {async_task_id = array<i32: 0, 2, 3>} : i32 to i64 loc(#loc172)
+    %off_bh_8 = arith.divsi %off_bh_6, %off_bh_7 {async_task_id = array<i32: 0, 2, 3>} : i64 loc(#loc172)
+    %start_n = arith.muli %pid, %c128_i32 {async_task_id = array<i32: 2, 3>} : i32 loc(#loc173)
+    %k = arith.extsi %start_n {async_task_id = array<i32: 2, 3>} : i32 to i64 loc(#loc174)
+    %k_9 = arith.addi %off_bh_8, %k {async_task_id = array<i32: 2, 3>} : i64 loc(#loc174)
+    %k_10 = arith.trunci %k_9 {async_task_id = array<i32: 2, 3>} : i64 to i32 loc(#loc175)
+    %k_11 = tt.descriptor_load %desc_k[%k_10, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1> loc(#loc176)
+    %k_12 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc176)
+    ttg.local_store %k_11, %k_12 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc176)
+    %v = tt.descriptor_load %desc_v[%k_10, %c0_i32] {async_task_id = array<i32: 2>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1> loc(#loc177)
+    %v_13 = ttg.local_alloc : () -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc177)
+    ttg.local_store %v, %v_13 {async_task_id = array<i32: 2>} : tensor<128x128xf16, #blocked1> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable> loc(#loc177)
+    %num_steps = arith.divsi %N_CTX, %c64_i32 {async_task_id = array<i32: 0, 1, 2, 3>} : i32 loc(#loc178)
+    %qkT, %qkT_14 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>} : () -> (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc186)
+    %dpT, %dpT_15 = ttng.tmem_alloc {async_task_id = array<i32: 1, 3>} : () -> (!ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc187)
+    %dv, %dv_16 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc188)
+    %dk, %dk_17 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1, 3>} : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc189)
+    %q = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc190)
+    %m = ttg.local_alloc : () -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc191)
+    %do = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc192)
+    %ppT = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc193)
+    %Di = ttg.local_alloc : () -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc194)
+    %dsT_0 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc195)
+    %dsT_1 = ttng.tmem_alloc : () -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc196)
+    %dq, %dq_18 = ttng.tmem_alloc {async_task_id = array<i32: 0, 1>} : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token) loc(#loc197)
+    %dk_19 = ttng.tmem_store %cst_0, %dk[%dk_17], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc189)
+    %dv_20 = ttng.tmem_store %cst_0, %dv[%dv_16], %true {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc188)
+    %curr_m:7 = scf.for %blk_idx = %c0_i32 to %num_steps step %c1_i32 iter_args(%curr_m_35 = %c0_i32, %dv_36 = %false, %qkT_37 = %qkT_14, %dpT_38 = %dpT_15, %dv_39 = %dv_20, %dk_40 = %dk_19, %dq_41 = %dq_18) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %q_42 = arith.extsi %curr_m_35 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32 to i64 loc(#loc199)
+      %q_43 = arith.addi %off_bh_8, %q_42 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 loc(#loc199)
+      %q_44 = arith.trunci %q_43 {async_task_id = array<i32: 0, 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32 loc(#loc200)
+      %q_45 = tt.descriptor_load %desc_q[%q_44, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1> loc(#loc190)
+      ttg.local_store %q_45, %q {async_task_id = array<i32: 2>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<64x128xf16, #blocked1> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc190)
+      %qT = ttg.memdesc_trans %q {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared3, #smem, mutable> loc(#loc201)
+      %offs_m_start = arith.addi %off_chz_1, %q_42 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 loc(#loc202)
+      %m_46 = arith.trunci %offs_m_start {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i32 loc(#loc203)
+      %m_47 = tt.descriptor_load %desc_m[%m_46] {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64xf32, #shared2> -> tensor<64xf32, #blocked2> loc(#loc191)
+      ttg.local_store %m_47, %m {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc191)
+      %qkT_48 = ttng.tc_gen5_mma %k_12, %qT, %qkT[%qkT_37], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,2,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc186)
+      %m_49 = ttg.local_load %m {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<64xf32, #shared2, #smem, mutable> -> tensor<64xf32, #blocked2> loc(#loc191)
+      %pT = ttg.convert_layout %m_49 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc204)
+      %pT_50 = ttg.convert_layout %m_47 {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc204)
+      %pT_51 = tt.expand_dims %pT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc205)
+      %pT_52 = tt.expand_dims %pT_50 {async_task_id = array<i32: 2>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc205)
+      %pT_53 = tt.broadcast %pT_51 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x64xf32, #linear1> -> tensor<128x64xf32, #linear1> loc(#loc204)
+      %qkT_54, %qkT_55 = ttng.tmem_load %qkT[%qkT_48] {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear1> loc(#loc186)
+      %pT_56 = arith.subf %qkT_54, %pT_53 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> loc(#loc204)
+      %pT_57 = math.exp2 %pT_56 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> loc(#loc206)
+      %do_58 = tt.descriptor_load %desc_do[%q_44, %c0_i32] {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1> loc(#loc192)
+      ttg.local_store %do_58, %do {async_task_id = array<i32: 2>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<64x128xf16, #blocked1> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable> loc(#loc192)
+      %ppT_59 = arith.truncf %pT_57 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc193)
+      %dv_60 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} true loc(#loc188)
+      ttng.tmem_store %ppT_59, %ppT, %dv_60 {async_task_id = array<i32: 3>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc188)
+      %dpT_61 = ttg.memdesc_trans %do {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared3, #smem, mutable> loc(#loc207)
+      %dpT_62 = ttng.tc_gen5_mma %v_13, %dpT_61, %dpT[%dpT_38], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> loc(#loc187)
+      %Di_63 = tt.descriptor_load %desc_delta[%m_46] {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64xf32, #shared2> -> tensor<64xf32, #blocked2> loc(#loc194)
+      ttg.local_store %Di_63, %Di {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> !ttg.memdesc<64xf32, #shared2, #smem, mutable> loc(#loc194)
+      %dv_64 = ttng.tc_gen5_mma %ppT, %do, %dv[%dv_39], %dv_36, %true {async_task_id = array<i32: 1>, loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc188)
+      %Di_65 = ttg.local_load %Di {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64xf32, #shared2, #smem, mutable> -> tensor<64xf32, #blocked2> loc(#loc194)
+      %dsT = ttg.convert_layout %Di_65 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc208)
+      %dsT_66 = ttg.convert_layout %Di_63 {async_task_id = array<i32: 2>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #blocked2> -> tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> loc(#loc208)
+      %dsT_67 = tt.expand_dims %dsT {async_task_id = array<i32: 3>, axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc209)
+      %dsT_68 = tt.expand_dims %dsT_66 {async_task_id = array<i32: 2>, axis = 0 : i32, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64xf32, #ttg.slice<{dim = 0, parent = #linear1}>> -> tensor<1x64xf32, #linear1> loc(#loc209)
+      %dsT_69 = tt.broadcast %dsT_67 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<1x64xf32, #linear1> -> tensor<128x64xf32, #linear1> loc(#loc208)
+      %dpT_70, %dpT_71 = ttng.tmem_load %dpT[%dpT_62] {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #linear1> loc(#loc187)
+      %dsT_72 = arith.subf %dpT_70, %dsT_69 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> loc(#loc208)
+      %dsT_73 = arith.mulf %pT_57, %dsT_72 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> loc(#loc210)
+      %dsT_74 = arith.truncf %dsT_73 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc211)
+      ttg.local_store %dsT_74, %dsT_0 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc211)
+      %dk_75 = arith.constant {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} true loc(#loc189)
+      ttng.tmem_store %dsT_74, %dsT_1, %dk_75 {async_task_id = array<i32: 3>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear1> -> !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable> loc(#loc189)
+      %dk_76 = ttng.tc_gen5_mma %dsT_1, %q, %dk[%dk_40], %dv_36, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,tmem,1,5\22, \22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> loc(#loc189)
+      %dq_77 = ttg.memdesc_trans %dsT_0 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared3, #smem, mutable> loc(#loc212)
+      %dq_78 = ttng.tc_gen5_mma %dq_77, %k_12, %dq[%dq_41], %false, %true {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,11\22]}"} : !ttg.memdesc<64x128xf16, #shared3, #smem, mutable>, !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> loc(#loc197)
+      %dq_79, %dq_80 = ttng.tmem_load %dq[%dq_78] {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear2> loc(#loc197)
+      %dqs = tt.reshape %dq_79 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x128xf32, #linear2> -> tensor<64x2x64xf32, #linear3> loc(#loc220)
+      %dqs_81 = tt.trans %dqs {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x64xf32, #linear3> -> tensor<64x64x2xf32, #linear4> loc(#loc220)
+      %dqs_82 = ttg.convert_layout %dqs_81 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64x2xf32, #linear4> -> tensor<64x64x2xf32, #linear5> loc(#loc220)
+      %dqs_83, %dqs_84 = tt.split %dqs_82 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64x2xf32, #linear5> -> tensor<64x64xf32, #linear6> loc(#loc220)
+      %dqs_85 = tt.reshape %dqs_83 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64xf32, #linear6> -> tensor<64x2x32xf32, #blocked3> loc(#loc224)
+      %dqs_86 = tt.trans %dqs_85 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #blocked3> -> tensor<64x32x2xf32, #blocked4> loc(#loc224)
+      %dqs_87, %dqs_88 = tt.split %dqs_86 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32x2xf32, #blocked4> -> tensor<64x32xf32, #blocked> loc(#loc224)
+      %dqs_89 = tt.reshape %dqs_84 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x64xf32, #linear6> -> tensor<64x2x32xf32, #blocked3> loc(#loc225)
+      %dqs_90 = tt.trans %dqs_89 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<64x2x32xf32, #blocked3> -> tensor<64x32x2xf32, #blocked4> loc(#loc225)
+      %dqs_91, %dqs_92 = tt.split %dqs_90 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32x2xf32, #blocked4> -> tensor<64x32xf32, #blocked> loc(#loc225)
+      %dqN = arith.mulf %dqs_87, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN, %desc_dq_reduce_staging {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %12 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c0_i32] %desc_dq_reduce_staging {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %12   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_93 = arith.mulf %dqs_88, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_94 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_93, %desc_dq_reduce_staging_94 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %13 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c32_i32] %desc_dq_reduce_staging_94 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %13   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_95 = arith.mulf %dqs_91, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_96 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_95, %desc_dq_reduce_staging_96 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %14 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c64_i32] %desc_dq_reduce_staging_96 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %14   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %dqN_97 = arith.mulf %dqs_92, %cst {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> loc(#loc214)
+      %desc_dq_reduce_staging_98 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      ttg.local_store %dqN_97, %desc_dq_reduce_staging_98 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : tensor<64x32xf32, #blocked> -> !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> loc(#loc223)
+      %15 = ttng.async_tma_reduce add, %desc_dq[%q_44, %c96_i32] %desc_dq_reduce_staging_98 {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !tt.tensordesc<64x32xf32, #shared1>, !ttg.memdesc<64x32xf32, #shared1, #smem, mutable> -> !ttg.async.token loc(#loc215)
+      ttng.async_tma_store_token_wait %15   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.async.token loc(#loc215)
+      %curr_m_99 = arith.addi %curr_m_35, %c64_i32 {async_task_id = array<i32: 0, 2>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32 loc(#loc216)
+      scf.yield {async_task_id = array<i32: 0, 1, 2, 3>} %curr_m_99, %true, %qkT_55, %dpT_71, %dv_64, %dk_76, %dq_80 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token loc(#loc164)
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.merge_epilogue_to_computation = true, tt.scheduled_max_stage = 1 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 202000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "load", "computation"], ttg.warp_specialize.tag = 0 : i32} loc(#loc219)
+    %dv_21, %dv_22 = ttng.tmem_load %dv[%curr_m#4] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear> loc(#loc188)
+    %dk_23, %dk_24 = ttng.tmem_load %dk[%curr_m#5] {async_task_id = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear> loc(#loc189)
+    %dvs = tt.reshape %dv_21 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear7> loc(#loc217)
+    %dvs_25 = tt.trans %dvs {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear7> -> tensor<128x64x2xf32, #linear8> loc(#loc217)
+    %dvs_26, %dvs_27 = tt.split %dvs_25 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #linear8> -> tensor<128x64xf32, #linear1> loc(#loc217)
+    %0 = arith.truncf %dvs_26 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc157)
+    %1 = ttg.convert_layout %0 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc157)
+    %desc_dv_staging = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    ttg.local_store %1, %desc_dv_staging {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    %2 = ttng.async_tma_copy_local_to_global %desc_dv[%k_10, %c0_i32] %desc_dv_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc158)
+    ttng.async_tma_store_token_wait %2   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc158)
+    %3 = arith.truncf %dvs_27 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc157)
+    %4 = ttg.convert_layout %3 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc157)
+    %desc_dv_staging_28 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    ttg.local_store %4, %desc_dv_staging_28 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc182)
+    %5 = ttng.async_tma_copy_local_to_global %desc_dv[%k_10, %c64_i32] %desc_dv_staging_28 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc158)
+    ttng.async_tma_store_token_wait %5   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc158)
+    %dks = tt.reshape %dk_23 {async_task_id = array<i32: 3>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear7> loc(#loc218)
+    %dks_29 = tt.trans %dks {async_task_id = array<i32: 3>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear7> -> tensor<128x64x2xf32, #linear8> loc(#loc218)
+    %dks_30, %dks_31 = tt.split %dks_29 {async_task_id = array<i32: 3>} : tensor<128x64x2xf32, #linear8> -> tensor<128x64xf32, #linear1> loc(#loc218)
+    %dkN = tt.splat %sm_scale {async_task_id = array<i32: 3>} : f32 -> tensor<128x64xf32, #linear1> loc(#loc184)
+    %dkN_32 = arith.mulf %dks_30, %dkN {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> loc(#loc184)
+    %6 = arith.truncf %dkN_32 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc161)
+    %7 = ttg.convert_layout %6 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc161)
+    %desc_dk_staging = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    ttg.local_store %7, %desc_dk_staging {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    %8 = ttng.async_tma_copy_local_to_global %desc_dk[%k_10, %c0_i32] %desc_dk_staging {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc162)
+    ttng.async_tma_store_token_wait %8   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc162)
+    %dkN_33 = arith.mulf %dks_31, %dkN {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> loc(#loc184)
+    %9 = arith.truncf %dkN_33 {async_task_id = array<i32: 3>} : tensor<128x64xf32, #linear1> to tensor<128x64xf16, #linear1> loc(#loc161)
+    %10 = ttg.convert_layout %9 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #linear1> -> tensor<128x64xf16, #blocked5> loc(#loc161)
+    %desc_dk_staging_34 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    ttg.local_store %10, %desc_dk_staging_34 {async_task_id = array<i32: 3>} : tensor<128x64xf16, #blocked5> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable> loc(#loc185)
+    %11 = ttng.async_tma_copy_local_to_global %desc_dk[%k_10, %c64_i32] %desc_dk_staging_34 {async_task_id = array<i32: 3>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token loc(#loc162)
+    ttng.async_tma_store_token_wait %11   {async_task_id = array<i32: 3>} : !ttg.async.token loc(#loc162)
+    tt.return loc(#loc)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc(unknown)
+#loc2 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1061:14)
+#loc3 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1148:5)
+#loc4 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":790:9)
+#loc5 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1145:12)
+#loc6 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1146:11)
+#loc7 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1049:16)
+#loc8 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1049:15)
+#loc9 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:28)
+#loc10 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:16)
+#loc11 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:52)
+#loc12 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:40)
+#loc13 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:15)
+#loc14 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1050:14)
+#loc15 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1055:15)
+#loc16 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:23)
+#loc17 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:22)
+#loc18 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1058:9)
+#loc19 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1059:9)
+#loc20 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1060:17)
+#loc21 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":707:15)
+#loc22 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":799:30)
+#loc23 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":719:15)
+#loc24 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":721:15)
+#loc25 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":733:15)
+#loc26 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:9)
+#loc27 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":705:9)
+#loc28 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":715:10)
+#loc29 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":717:11)
+#loc30 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":720:14)
+#loc31 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":727:11)
+#loc32 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":734:14)
+#loc33 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:23)
+#loc34 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":702:22)
+#loc35 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":703:10)
+#loc36 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":704:20)
+#loc37 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":705:22)
+#loc38 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:23)
+#loc39 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:29)
+#loc40 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":710:10)
+#loc41 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":719:25)
+#loc42 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:17)
+#loc43 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:23)
+#loc44 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":726:11)
+#loc45 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":734:21)
+#loc46 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":10:18)
+#loc47 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":738:11)
+#loc48 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":11:16)
+#loc49 = loc("/data/users/mren/MetaMain2/triton/python/triton/language/extra/subtile_ops.py":11:53)
+#loc50 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":741:15)
+#loc51 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":742:9)
+#loc52 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":743:5)
+#loc53 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1093:11)
+#loc54 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1099:13)
+#loc55 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1097:9)
+#loc56 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1102:11)
+#loc57 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1104:15)
+#loc58 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1107:13)
+#loc59 = loc("/data/users/mren/MetaMain2/triton/third_party/tlx/tutorials/fused_attention_ws_device_tma.py":1105:9)
+#loc108 = loc(callsite(#loc2 at #loc3))
+#loc109 = loc(callsite(#loc1 at #loc3))
+#loc110 = loc("bhid"(#loc5))
+#loc111 = loc("pid"(#loc6))
+#loc112 = loc("off_chz"(#loc7))
+#loc113 = loc("off_chz"(#loc8))
+#loc114 = loc("off_bh"(#loc9))
+#loc115 = loc("off_bh"(#loc10))
+#loc116 = loc("off_bh"(#loc11))
+#loc117 = loc("off_bh"(#loc12))
+#loc118 = loc("off_bh"(#loc13))
+#loc119 = loc("off_bh"(#loc14))
+#loc120 = loc("start_n"(#loc15))
+#loc121 = loc("k"(#loc16))
+#loc122 = loc("k"(#loc17))
+#loc123 = loc("k"(#loc18))
+#loc124 = loc("v"(#loc19))
+#loc125 = loc("num_steps"(#loc20))
+#loc126 = loc("qkT"(#loc21))
+#loc127 = loc("dpT"(#loc23))
+#loc128 = loc("dv"(#loc24))
+#loc129 = loc("dk"(#loc25))
+#loc130 = loc("q"(#loc26))
+#loc131 = loc("m"(#loc27))
+#loc132 = loc("do"(#loc28))
+#loc133 = loc("ppT"(#loc29))
+#loc134 = loc("Di"(#loc30))
+#loc135 = loc("dsT_0"(#loc31))
+#loc136 = loc("dsT_1"(#loc31))
+#loc137 = loc("dq"(#loc32))
+#loc138 = loc("dk"(#loc4))
+#loc139 = loc("q"(#loc33))
+#loc140 = loc("q"(#loc34))
+#loc141 = loc("qT"(#loc35))
+#loc142 = loc("offs_m_start"(#loc36))
+#loc143 = loc("m"(#loc37))
+#loc144 = loc("pT"(#loc38))
+#loc145 = loc("pT"(#loc39))
+#loc146 = loc("pT"(#loc40))
+#loc147 = loc("dpT"(#loc41))
+#loc148 = loc("dsT"(#loc42))
+#loc149 = loc("dsT"(#loc43))
+#loc150 = loc("dsT"(#loc44))
+#loc151 = loc("dsT"(#loc31))
+#loc152 = loc("dq"(#loc45))
+#loc153 = loc("dqs"(#loc47))
+#loc154 = loc("dqN"(#loc50))
+#loc155 = loc("curr_m"(#loc52))
+#loc156 = loc("dvs"(#loc53))
+#loc157 = loc(callsite(#loc54 at #loc3))
+#loc158 = loc(callsite(#loc55 at #loc3))
+#loc159 = loc("dks"(#loc56))
+#loc160 = loc("dkN"(#loc57))
+#loc161 = loc(callsite(#loc58 at #loc3))
+#loc162 = loc(callsite(#loc59 at #loc3))
+#loc163 = loc(callsite(#loc1 at #loc108))
+#loc164 = loc(callsite(#loc4 at #loc108))
+#loc165 = loc(callsite(#loc112 at #loc3))
+#loc166 = loc(callsite(#loc113 at #loc3))
+#loc167 = loc(callsite(#loc114 at #loc3))
+#loc168 = loc(callsite(#loc115 at #loc3))
+#loc169 = loc(callsite(#loc116 at #loc3))
+#loc170 = loc(callsite(#loc117 at #loc3))
+#loc171 = loc(callsite(#loc118 at #loc3))
+#loc172 = loc(callsite(#loc119 at #loc3))
+#loc173 = loc(callsite(#loc120 at #loc3))
+#loc174 = loc(callsite(#loc121 at #loc3))
+#loc175 = loc(callsite(#loc122 at #loc3))
+#loc176 = loc(callsite(#loc123 at #loc3))
+#loc177 = loc(callsite(#loc124 at #loc3))
+#loc178 = loc(callsite(#loc125 at #loc3))
+#loc179 = loc(callsite(#loc22 at #loc108))
+#loc180 = loc("dv"(#loc138))
+#loc181 = loc(callsite(#loc156 at #loc3))
+#loc182 = loc("desc_dv_staging"(#loc158))
+#loc183 = loc(callsite(#loc159 at #loc3))
+#loc184 = loc(callsite(#loc160 at #loc3))
+#loc185 = loc("desc_dk_staging"(#loc162))
+#loc186 = loc(callsite(#loc126 at #loc179))
+#loc187 = loc(callsite(#loc127 at #loc179))
+#loc188 = loc(callsite(#loc128 at #loc179))
+#loc189 = loc(callsite(#loc129 at #loc179))
+#loc190 = loc(callsite(#loc130 at #loc179))
+#loc191 = loc(callsite(#loc131 at #loc179))
+#loc192 = loc(callsite(#loc132 at #loc179))
+#loc193 = loc(callsite(#loc133 at #loc179))
+#loc194 = loc(callsite(#loc134 at #loc179))
+#loc195 = loc(callsite(#loc135 at #loc179))
+#loc196 = loc(callsite(#loc136 at #loc179))
+#loc197 = loc(callsite(#loc137 at #loc179))
+#loc198 = loc("curr_m"(#loc180))
+#loc199 = loc(callsite(#loc139 at #loc179))
+#loc200 = loc(callsite(#loc140 at #loc179))
+#loc201 = loc(callsite(#loc141 at #loc179))
+#loc202 = loc(callsite(#loc142 at #loc179))
+#loc203 = loc(callsite(#loc143 at #loc179))
+#loc204 = loc(callsite(#loc144 at #loc179))
+#loc205 = loc(callsite(#loc145 at #loc179))
+#loc206 = loc(callsite(#loc146 at #loc179))
+#loc207 = loc(callsite(#loc147 at #loc179))
+#loc208 = loc(callsite(#loc148 at #loc179))
+#loc209 = loc(callsite(#loc149 at #loc179))
+#loc210 = loc(callsite(#loc150 at #loc179))
+#loc211 = loc(callsite(#loc151 at #loc179))
+#loc212 = loc(callsite(#loc152 at #loc179))
+#loc213 = loc(callsite(#loc153 at #loc179))
+#loc214 = loc(callsite(#loc154 at #loc179))
+#loc215 = loc(callsite(#loc51 at #loc179))
+#loc216 = loc(callsite(#loc155 at #loc179))
+#loc217 = loc(callsite(#loc46 at #loc181))
+#loc218 = loc(callsite(#loc46 at #loc183))
+#loc219 = loc(callsite(#loc198 at #loc108))
+#loc220 = loc(callsite(#loc46 at #loc213))
+#loc221 = loc(callsite(#loc48 at #loc213))
+#loc222 = loc(callsite(#loc49 at #loc213))
+#loc223 = loc("desc_dq_reduce_staging"(#loc215))
+#loc224 = loc(callsite(#loc46 at #loc221))
+#loc225 = loc(callsite(#loc46 at #loc222))
+
+
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=PLANNER
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=ANNOTATE
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --nvgpu-test-tma-store-token-wait-reorder --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=REORDER
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=2 smem-budget=202000" --nvgpu-test-annotate-tma-store-waits --nvgpu-test-tma-store-token-wait-reorder --nvgpu-tma-store-token-wait-lowering --mlir-print-debuginfo --mlir-use-nameloc-as-prefix 2>&1 | FileCheck %s --check-prefix=LOWER
+
+// Generated from FA backward config idx 3 immediately after
+// doBufferAllocation: BLOCK_M1=64, EPILOGUE_SUBTILE=2, DQ_SUBTILE=4,
+// BWD_DOT_ATTRS=_BWD_DOT_ATTRS_BM64_TMEM.
+//
+// The budget comes from tt.smem_budget on the loop, not from the RUN-line
+// option; the two are kept in sync only for readability. It is 202000 rather
+// than the shipped 200000 because the point of this fixture is the dV
+// two-copy store-wait ring: at 200000 the effective budget is 195676 (2 KiB of
+// auxiliary SMEM) and Phase 3.7's dV bump lands at 197632, so the planner
+// reverts dV to one copy and there is no rotation left to check. dK must still
+// miss the bump for the asymmetry below to hold, so do not raise this further.
+// Whether the shipped 200000 config should still fit a two-copy dV is tracked
+// separately (T284939236).
+
+// PLANNER-LABEL: tt.func public @_attn_bwd
+// PLANNER-COUNT-4: %desc_dq_reduce_staging{{.*}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = [[DQ:[0-9]+]] : i32, buffer.tmaStaging = 2 : i32}
+// PLANNER-COUNT-2: %desc_dv_staging{{.*}} = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = [[DV:[0-9]+]] : i32, buffer.tmaStaging = 1 : i32}
+// PLANNER-COUNT-2: %desc_dk_staging{{.*}} = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = [[DK:[0-9]+]] : i32, buffer.tmaStaging = 1 : i32}
+
+// Only dQ is inside the merged computation loop. Its four token waits inherit
+// the two-copy ring and the stable wait_group(1) lowering contract.
+// ANNOTATE-LABEL: tt.func public @_attn_bwd
+// ANNOTATE-COUNT-4: ttng.async_tma_store_token_wait {{.*}}can_rotate_by_buffer_count = 2 : i32
+// ANNOTATE-NOT: planned_pending_count
+
+// Reordering materializes the two wraparound waits, keeps the two
+// same-iteration token waits at their future slot writers, and adds one drain.
+// REORDER-LABEL: tt.func public @_attn_bwd
+// REORDER-COUNT-2: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// REORDER-COUNT-2: ttng.async_tma_store_token_wait {{.*}}planned_pending_count = 1 : i32
+// REORDER: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+
+// Final lowering matches the one-CTA TLX topology: dQ rotates two staging
+// slots with wait_group(1); dV/dK use wait_group(0) at their overwrite and
+// drain points because idx 3 has one effective straight-line staging view.
+// LOWER-LABEL: tt.func public @_attn_bwd
+// Input descriptor loads must still land in their shared-memory buffers before
+// the corresponding consumers run. nvws.descriptor_load names the destination
+// buffer directly, so the load and its store are one op here rather than the
+// tt.descriptor_load + ttg.local_store pair this fixture was captured with.
+// LOWER: nvws.descriptor_load %desc_q{{.*}} %q
+// LOWER: nvws.descriptor_load %desc_do{{.*}} %do
+
+// dQ loads its accumulator, then rotates four reductions over two staging
+// slots. Every wait_group(1) is immediately before the next staging writer;
+// the loop is followed by a wait_group(0) drain.
+// LOWER: ttng.tmem_load %dq
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ0:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ0]]
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ1:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ1]]
+// LOWER: ttng.async_tma_store_wait {pendings = 1 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ2:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ2]]
+// LOWER: ttng.async_tma_store_wait {pendings = 1 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DQ3:desc_dq_reduce_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_reduce {{.*}} %[[DQ3]]
+// LOWER: scf.yield
+// LOWER: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+
+// The straight-line epilogue loads dV and dK before staging either output.
+// dV's final drain is delayed across dK preparation to the first dK writer.
+// LOWER-NEXT: {{.*}} = ttng.tmem_load %dv
+// LOWER-NEXT: {{.*}} = ttng.tmem_load %dk
+// LOWER: ttg.local_store {{.*}}, %[[DV0:desc_dv_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dv{{.*}} %[[DV0]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DV1:desc_dv_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dv{{.*}} %[[DV1]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DK0:desc_dk_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dk{{.*}} %[[DK0]]
+// LOWER: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NEXT: ttg.local_store {{.*}}, %[[DK1:desc_dk_staging[^ ]*]]
+// LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dk{{.*}} %[[DK1]]
+// LOWER-NEXT: ttng.async_tma_store_wait {pendings = 0 : i32}
+// LOWER-NOT: ttng.async_tma_store_token_wait

--- a/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
+++ b/test/Hopper/WarpSpecialization/ws_fa_bwd_idx3_store_wait_pipeline.mlir
@@ -486,7 +486,7 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
 
 // The straight-line epilogue loads dV and dK before staging either output.
 // dV's final drain is delayed across dK preparation to the first dK writer.
-// LOWER-NEXT: {{.*}} = ttng.tmem_load %dv
+// LOWER: {{.*}} = ttng.tmem_load %dv
 // LOWER-NEXT: {{.*}} = ttng.tmem_load %dk
 // LOWER: ttg.local_store {{.*}}, %[[DV0:desc_dv_staging[^ ]*]]
 // LOWER-NEXT: {{.*}} = ttng.async_tma_copy_local_to_global %desc_dv{{.*}} %[[DV0]]

--- a/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
@@ -7,6 +7,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: triple_buffer
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-SAME: can_rotate_by_buffer_count = 3
+// CHECK-NOT: planned_pending_count
   tt.func public @triple_buffer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -31,6 +32,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK-LABEL: single_buffer
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-SAME: can_rotate_by_buffer_count = 1
+// CHECK-NOT: planned_pending_count
   tt.func public @single_buffer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,

--- a/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
@@ -28,6 +28,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// One-CTA reductions use the same two-slot rotation as TLX. The reorder pass
+// is responsible for materializing the final queue drain.
+// CHECK-LABEL: one_cta_reduce_rotates
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-SAME: can_rotate_by_buffer_count = 2
+// CHECK-NOT: planned_pending_count
+  tt.func public @one_cta_reduce_rotates(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %lb: index, %ub: index, %step: index) {
+    %buf = ttg.local_alloc {"buffer.copy" = 2 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %c0 = arith.constant 0 : i32
+    scf.for %iv = %lb to %ub step %step {
+      ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok = ttng.async_tma_reduce add, %desc[%c0, %c0] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Single-buffered (buffer.copy = 1). K = 1 → annotated.
 // CHECK-LABEL: single_buffer
 // CHECK: ttng.async_tma_store_token_wait

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_pendings.mlir
@@ -10,8 +10,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
       %i: i32) {
     %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %src : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
-    // CHECK: ttng.async_tma_store_wait {pendings = 0 : i32}
-    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    // Explicit planner metadata takes precedence over reconstructing program
+    // order after software-pipeline schedule serialization.
+    // CHECK: ttng.async_tma_store_wait {pendings = 2 : i32}
+    ttng.async_tma_store_token_wait %tok {planned_pending_count = 2 : i32} : !ttg.async.token
     tt.return
   }
 }

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -29,6 +29,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// Production persistent FA has the dQ reduction loop nested inside the loop
+// carrying tt.merge_epilogue_to_computation. The inner loop must still
+// materialize TLX's wait_group(1) rotation and a final wait_group(0) drain.
+// CHECK-LABEL: nested_dq_loop_inherits_merged_epilogue
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK-NEXT: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// CHECK-NEXT: ttg.local_store
+// CHECK-NEXT: {{.*}} = ttng.async_tma_reduce{{.*}}
+// CHECK-NEXT: }
+// CHECK-NEXT: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+  tt.func public @nested_dq_loop_inherits_merged_epilogue(
+      %desc: !tt.tensordesc<64x32xf32, #shared>,
+      %src: tensor<64x32xf32>,
+      %lb: index, %ub: index, %step: index, %i: i32,
+      %buf: !ttg.memdesc<64x32xf32, #shared, #smem, mutable>) {
+    scf.for %outer = %lb to %ub step %step {
+      scf.for %inner = %lb to %ub step %step {
+        ttg.local_store %src, %buf {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<64x32xf32> -> !ttg.memdesc<64x32xf32, #shared, #smem, mutable>
+        %tok = ttng.async_tma_reduce add, %desc[%i, %i] %buf {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<64x32xf32, #shared>, !ttg.memdesc<64x32xf32, #shared, #smem, mutable> -> !ttg.async.token
+        ttng.async_tma_store_token_wait %tok {"can_rotate_by_buffer_count" = 2 : i32, "planned_pending_count" = 1 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      } {"tt.scheduled_max_stage" = 1 : i32}
+    } {"tt.merge_epilogue_to_computation"}
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -11,7 +11,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @single_buffer_k1(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -32,6 +32,201 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// A dQ-style four-subtile loop rotates over two staging slots. The wait for
+// store 0 must use store 2 as its reuse point, not store 0 merely because both
+// write equivalent slot-0 memdescs. Same-iteration rotation is also reflected
+// in block order for merged epilogue loops that are not later pipelined.
+// CHECK-LABEL: k2_four_stores_use_nearest_future_writer
+// CHECK: scf.for
+// CHECK-NEXT: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK: ttng.async_tma_store_wait {{.*}}pendings = 1 : i32
+// CHECK: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[BUF0:[^ ]+]]
+// CHECK: %[[TOK2:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF0]]
+// CHECK: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK1]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[BUF1:[^ ]+]]
+// CHECK: %[[TOK3:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF1]]
+// CHECK: ttng.async_tma_store_wait {{.*}}pendings = 0 : i32
+  tt.func public @k2_four_stores_use_nearest_future_writer(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %lb: index, %ub: index, %step: index, %i: i32, %x: f32) {
+    scf.for %iv = %lb to %ub step %step {
+      ttg.local_store %src, %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x1 = arith.addf %x, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok1 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x2 = arith.addf %x1, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok2 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok2 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+      %x3 = arith.addf %x2, %x {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : f32
+      ttg.local_store %src, %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok3 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 {"loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok3 {"can_rotate_by_buffer_count" = 2 : i32, "loop.stage" = 0 : i32, "loop.cluster" = 0 : i32} : !ttg.async.token
+    } {"tt.merge_epilogue_to_computation", "tt.scheduled_max_stage" = 1 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// TMA wait_group is queue-wide. The final wait for dV can move across
+// independent dK preparation and stop at dK's staging-buffer write.
+// CHECK-LABEL: straight_line_wait_before_next_staging_buffer
+// CHECK: %[[DVTOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[DVTOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[DKBUF:[^ ]+]]
+// CHECK: %[[DKTOK:.*]] = ttng.async_tma_copy_local_to_global {{.*}} %[[DKBUF]]
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[DKTOK]]
+  tt.func public @straight_line_wait_before_next_staging_buffer(
+      %dv_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %dk_desc: !tt.tensordesc<128x64xf16, #shared>,
+      %dv_src: tensor<128x64xf16>, %dk_src: tensor<128x64xf16>,
+      %dv_buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %dk_buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %x: f32) {
+    ttg.local_store %dv_src, %dv_buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %dv_tok = ttng.async_tma_copy_local_to_global %dv_desc[%i, %i] %dv_buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %dv_tok : !ttg.async.token
+    %y = arith.addf %x, %x : f32
+    ttg.local_store %dk_src, %dk_buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %dk_tok = ttng.async_tma_copy_local_to_global %dk_desc[%i, %i] %dk_buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %dk_tok : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// A straight-line epilogue can overlap independent work with the first TMA
+// store.  Delay its wait until immediately before the staging view is reused,
+// while preserving the wait after the final store as a drain.
+// CHECK-LABEL: straight_line_wait_before_staging_reuse
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: arith.addf
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: ttg.local_store
+// CHECK: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK1]]
+  tt.func public @straight_line_wait_before_staging_reuse(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src0: tensor<128x64xf16>, %src1: tensor<128x64xf16>,
+      %buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %x: f32) {
+    ttg.local_store %src0, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+    %y = arith.addf %x, %x : f32
+    ttg.local_store %src1, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Do not extend a queue-wide wait across a later TMA launch while looking for
+// the first store's staging-buffer reuse point.
+// CHECK-LABEL: straight_line_wait_does_not_cross_next_tma_launch
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttg.local_store
+  tt.func public @straight_line_wait_does_not_cross_next_tma_launch(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %i: i32) {
+    %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+    %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttg.local_store %src, %buf0 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Dynamic views of the same allocation may alias. Stop at the first such
+// writer instead of relying on structural equality and moving past it.
+// CHECK-LABEL: straight_line_dynamic_views_may_alias
+// CHECK: %[[TOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[SLOT1:.*]]
+  tt.func public @straight_line_dynamic_views_may_alias(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %multi: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>,
+      %i: i32, %j: i32) {
+    %slot0 = ttg.memdesc_index %multi[%i] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %slot1 = ttg.memdesc_index %multi[%j] : !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %slot0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    ttg.local_store %src, %slot1 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %src, %slot0 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+// Two distinct memdesc block arguments are not provably disjoint; both may be
+// views of one allocation. Stop at the scratch write instead of treating the
+// arguments as separate allocations and moving the wait past it. Unlike
+// straight_line_dynamic_views_may_alias, the two buffers share no base value,
+// so only the allocation-based disjointness rule can block the move.
+// CHECK-LABEL: straight_line_distinct_memdesc_args_may_alias
+// CHECK: %[[TOK:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK]]
+// CHECK-NEXT: ttg.local_store {{.*}}, %[[SCRATCH:.*]]
+  tt.func public @straight_line_distinct_memdesc_args_may_alias(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %scratch: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %i: i32) {
+    ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %tok : !ttg.async.token
+    ttg.local_store %src, %scratch : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // Double-buffered (K=2). One TMA copy at stage 1. Counting 2 copies forward
 // wraps twice to the copy at stage 1 + 2*numStages = stage 3 (with numStages=1
 // per wrap). Wait lands at stage 3.
@@ -41,7 +236,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 3 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 3 : i32
   tt.func public @double_buffer_k2(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -94,7 +289,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @no_schedule_creates_basic(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,
@@ -125,7 +320,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 1 : i32
   tt.func public @cross_partition_memdesc_index(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %multibuf: !ttg.memdesc<2x128x64xf16, #shared, #smem, mutable>,
@@ -157,7 +352,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @wraparound_considers_barrier_before_producer(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -186,12 +381,12 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 2 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 2 : i32
 // CHECK: ttng.wait_barrier
 // CHECK: ttng.async_tma_copy_local_to_global
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 3 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 3 : i32
   tt.func public @k3_two_stores_wraparound_uses_first_wait(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -228,22 +423,22 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 12 : i32, loop.stage = 0 : i32}
+// CHECK-SAME: loop.cluster = 12 : i32, loop.stage = 0 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 5 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 6 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 9 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 10 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 4 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 4 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 13 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 14 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 8 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 8 : i32, loop.stage = 1 : i32
   tt.func public @k3_four_stores_all_waits_wraparound(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
@@ -289,7 +484,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: scf.for
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 1 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 1 : i32, loop.stage = 1 : i32
 // CHECK: ttng.wait_barrier {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_copy_local_to_global {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32}
   tt.func public @loop_carried_token_with_dead_iter_arg(

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder_reduce_xfail.mlir
@@ -12,7 +12,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // CHECK: ttng.async_tma_reduce {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
 // CHECK: ttng.async_tma_store_token_wait
 // CHECK-NOT: can_rotate_by_buffer_count
-// CHECK-SAME: {loop.cluster = 0 : i32, loop.stage = 1 : i32}
+// CHECK-SAME: loop.cluster = 0 : i32, loop.stage = 1 : i32
   tt.func public @single_buffer_reduce_token_k1(
       %desc: !tt.tensordesc<128x64xf16, #shared>,
       %src: tensor<128x64xf16>,

--- a/test/TritonGPU/optimize-partition-warps-type-aware.mlir
+++ b/test/TritonGPU/optimize-partition-warps-type-aware.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-optimize-partition-warps | FileCheck %s
 
 // Tests for type-aware warp assignment in OptimizePartitionWarps pass.
 // When partition types are specified via ttg.partition.types attribute:
@@ -97,4 +97,65 @@ tt.func @empty_partition_types(%arg0: i32) {
   tt.return
 }
 
+// Test 5: A truncated type array must not be treated as if it described the
+// specialized partitions. In particular, do not apply the computation warp
+// override when role alignment is unknown.
+// CHECK-LABEL: @truncated_partition_types_do_not_mislabel
+// CHECK: ttg.warp_specialize({{.*}}) attributes {requestedRegisters = array<i32: 24, 24, 24>, ttg.partition.types = ["reduction", "computation"]}
+// CHECK: partition0({{.*}}) num_warps(1)
+// CHECK: partition1({{.*}}) num_warps(1)
+// CHECK: partition2({{.*}}) num_warps(1)
+tt.func @truncated_partition_types_do_not_mislabel(%arg0: i32) {
+  ttg.warp_specialize(%arg0) attributes {"ttg.partition.types" = ["reduction", "computation"]}
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg1: i32) num_warps(4) {
+    %0 = arith.addi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  partition1(%arg1: i32) num_warps(4) {
+    %0 = arith.subi %arg1, %arg1 : i32
+    ttg.warp_return
+  }
+  partition2(%arg1: i32) num_warps(4) {
+    %0 = arith.muli %arg1, %arg1 : i32
+    ttg.warp_return
+  } : (i32) -> ()
+  tt.return
+}
+
+}
+
+// -----
+
+// The 2-CTA backward schedule keeps computation in the default region. The
+// four specialized scalar partitions map to reduction, GEMM, load, and relay;
+// all shrink through the normal heuristic and use min_reg_auto_ws.
+// CHECK-LABEL: @two_cta_bwd_specialized_partitions
+// CHECK: ttg.warp_specialize() attributes {requestedRegisters = array<i32: 88, 88, 88, 88>, ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"]}
+// CHECK: partition0() num_warps(1)
+// CHECK: partition1() num_warps(1)
+// CHECK: partition2() num_warps(1)
+// CHECK: partition3() num_warps(1)
+module attributes {ttg.max_reg_auto_ws = 88 : i32, ttg.min_reg_auto_ws = 88 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+tt.func @two_cta_bwd_specialized_partitions() {
+  ttg.warp_specialize() attributes {"ttg.partition.types" = ["computation", "reduction", "gemm", "load", "relay"]}
+  default {
+    ttg.warp_yield
+  }
+  partition0() num_warps(8) {
+    ttg.warp_return
+  }
+  partition1() num_warps(8) {
+    ttg.warp_return
+  }
+  partition2() num_warps(8) {
+    ttg.warp_return
+  }
+  partition3() num_warps(8) {
+    ttg.warp_return
+  } : () -> ()
+  tt.return
+}
 }

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -797,7 +797,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90"} {
   tt.func @cluster_barrier_invalid() {
-    // expected-error @below {{requires ttg.num-ctas > 1}}
+    // expected-error @below {{requires more than one CTA per cluster}}
+    ttng.cluster_barrier
+    tt.return
+  }
+}
+
+// -----
+
+// An explicit CUDA-style physical cluster is also a valid multi-CTA cluster,
+// even though the logical Triton layout remains single-CTA.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.target = "cuda:90"} {
+  tt.func @cluster_barrier_explicit_cluster_valid() {
     ttng.cluster_barrier
     tt.return
   }
@@ -1411,6 +1422,30 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %b: tensor<256xf8E8M0FNU, #blocked>) {
     // expected-error @below {{'ttng.packed_arith' op unsupported add signature e4m3x4 <- (e4m3x4, ue8m0x4)}}
     %0 = ttng.packed_arith add %a, %b : (tensor<256xf8E4M3FN, #blocked>, tensor<256xf8E8M0FNU, #blocked>) -> tensor<256xf8E4M3FN, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @peer_gather_requires_two_ctas(
+      %src: tensor<64x64xf16, #blocked>) {
+    // expected-error @below {{'ttng.two_cta_peer_gather' op currently supports exactly two CTAs}}
+    %0 = ttng.two_cta_peer_gather %src split_dim = 0 num_ctas = 4 : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @peer_gather_preserves_elements(
+      %src: tensor<64x64xf16, #blocked>) {
+    // expected-error @below {{'ttng.two_cta_peer_gather' op source and result must preserve element type and element count}}
+    %0 = ttng.two_cta_peer_gather %src split_dim = 0 num_ctas = 2 : tensor<64x64xf16, #blocked> -> tensor<32x64xf16, #blocked>
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/Analyze2CTADependencies.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Analyze2CTADependencies.cpp
@@ -1,6 +1,14 @@
+// Classify dependent 2-CTA MMA operand chains before warp specialization.
+//
+// A collective contraction keeps its CTA-local operand; an operand that is a
+// transposed view of another 2-CTA MMA result cannot be re-loaded and must be
+// gathered from the peer CTA. See
+// WarpSpecialization/docs/AutoWS2CTABackwardPlan.md, "Dependency
+// classification and peer exchange".
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -39,10 +47,40 @@ static bool dependsOnTwoCTAMMA(Value root, Operation *consumer) {
   return false;
 }
 
-static bool isTransposedMemDesc(Value value) {
+static bool requiresPeerGather(Value value) {
   while (auto subview = value.getDefiningOp<ttg::MemDescSubsliceOp>())
     value = subview.getSrc();
-  return value.getDefiningOp<ttg::MemDescTransOp>() != nullptr;
+  if (value.getDefiningOp<ttg::MemDescTransOp>())
+    return true;
+
+  auto alloc = value.getDefiningOp<ttg::LocalAllocOp>();
+  if (!alloc || !alloc.getSrc())
+    return false;
+
+  SmallVector<Value> worklist{alloc.getSrc()};
+  DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!visited.insert(current).second)
+      continue;
+    Operation *def = current.getDefiningOp();
+    if (!def)
+      continue;
+    if (auto trans = dyn_cast<triton::TransOp>(def)) {
+      // Rank-3 transposes are also used to expose a size-two axis to tt.split
+      // when a collective contraction is statically subtiled. They only
+      // repack the contraction dimension and do not transpose the logical MMA
+      // operand across CTAs. Peer gathering is required for the rank-2 matrix
+      // transpose used by dQ-style dependent MMAs.
+      auto resultType = dyn_cast<RankedTensorType>(trans.getType());
+      if (resultType && resultType.getRank() == 2)
+        return true;
+    }
+    if (isa<ttng::TCGen5MMAOp>(def))
+      continue;
+    llvm::append_range(worklist, def->getOperands());
+  }
+  return false;
 }
 
 class Analyze2CTADependencies
@@ -60,8 +98,8 @@ public:
       if (!mma.getTwoCtas() || !dependsOnTwoCTAMMA(mma.getA(), mma))
         return;
 
-      StringRef kind = isTransposedMemDesc(mma.getA()) ? RequiresPeerGather
-                                                       : CollectiveContraction;
+      StringRef kind = requiresPeerGather(mma.getA()) ? RequiresPeerGather
+                                                      : CollectiveContraction;
       mma->setAttr(DependencyAttr, StringAttr::get(mma.getContext(), kind));
     });
   }

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -296,8 +296,40 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
 
     // Process standalone MMAs (rare: single-iteration epilogue).
     for (auto mma : nonLoopMMAs) {
-      Value barrierAlloc =
-          triton::createBarrierAlloc(mma, /*numBarriers=*/1, /*arriveCount=*/2);
+      Value barrierAlloc;
+      auto wsOp = mma->getParentOfType<ttg::WarpSpecializeOp>();
+      if (wsOp) {
+        // A software-pipelined loop can leave prologue/epilogue MMA copies
+        // directly in a partition region.  They still need a barrier created
+        // at kernel-entry scope; a partition-local init can race a peer CTA's
+        // first remote arrival. Find the top-level operation containing the
+        // WarpSpecializeOp so a surrounding loop, when present, is included in
+        // the barrier lifetime.
+        Location loc = wsOp->getLoc();
+        Operation *lifetimeAnchor = wsOp;
+        auto funcOp = wsOp->getParentOfType<triton::FuncOp>();
+        while (lifetimeAnchor->getParentOp() != funcOp)
+          lifetimeAnchor = lifetimeAnchor->getParentOp();
+        barrierAlloc = triton::createBarrierAlloc(
+            lifetimeAnchor, /*numBarriers=*/1, /*arriveCount=*/2);
+
+        if (!isInDefaultRegion(mma, wsOp)) {
+          auto partOp = wsOp.getPartitionOp();
+          partOp->insertOperands(partOp->getNumOperands(), barrierAlloc);
+          Value capturedBarrier;
+          for (Region *region : wsOp.getPartitionRegions()) {
+            BlockArgument arg =
+                region->addArgument(barrierAlloc.getType(), loc);
+            if (region->isAncestor(mma->getParentRegion()))
+              capturedBarrier = arg;
+          }
+          assert(capturedBarrier && "MMA not found in any partition region");
+          barrierAlloc = capturedBarrier;
+        }
+      } else {
+        barrierAlloc = triton::createBarrierAlloc(mma, /*numBarriers=*/1,
+                                                  /*arriveCount=*/2);
+      }
       insertSyncBeforeMMA(mma, barrierAlloc);
     }
   }

--- a/third_party/nvidia/hopper/lib/Transforms/Materialize2CTAExchange.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Materialize2CTAExchange.cpp
@@ -1,3 +1,13 @@
+// Lower planned 2-CTA peer gathers to DSMEM stores and barrier publication.
+//
+// Runs after warp specialization and software pipelining. Writes the CTA-owned
+// half locally and sends the peer half with an async remote shared-memory
+// store. Two empty/full lifetimes are involved -- the final dQ destination and
+// the temporary exchange staging slot -- and both are required. BM128 routes
+// completion through a one-warp relay rather than a cluster barrier, which
+// would deadlock inside a warp-specialized partition. See
+// WarpSpecialization/docs/AutoWS2CTABackwardPlan.md, "Dependency
+// classification and peer exchange" and "Synchronization lifetime".
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -7,6 +17,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <numeric>
@@ -23,10 +34,51 @@ namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 namespace nvgpu = triton::nvgpu;
 
+static FailureOr<int32_t> getFirstFreeWarpSpecializeBarrierId(Operation *op) {
+  auto ws = op->getParentOfType<ttg::WarpSpecializeOp>();
+  if (!ws)
+    return failure();
+
+  constexpr int32_t numReservedWarpSpecializeBarriers = 2;
+  constexpr int32_t maxNamedBarriers = 16;
+  int32_t totalPartitionWarps = ws.getTotalPartitionWarps();
+  int32_t maxPartitionWarpGroups = 0;
+  ws->getParentOfType<ModuleOp>().walk([&](ttg::WarpSpecializeOp candidate) {
+    maxPartitionWarpGroups =
+        std::max(maxPartitionWarpGroups,
+                 static_cast<int32_t>(
+                     llvm::divideCeil(candidate.getTotalPartitionWarps(), 4)));
+  });
+  // AllocateWarpGroups pads this region up to the module-wide warp-group count
+  // and assigns one named barrier per partition, so the first free id depends
+  // on how many padding partitions it creates. That count is not exposed, so it
+  // is re-derived here: padToMaxWarpGroups (AllocateWarpGroups.cpp) fills the
+  // shortfall with successive powers of two, making the partition count equal
+  // to the shortfall's popcount. Keep the two in sync -- if that filling
+  // strategy changes, this silently returns an id that collides with a real
+  // partition barrier rather than failing. The assert below is the
+  // strategy-independent bound: no filling can use more partitions than warps.
+  int32_t paddedPartitionWarps = maxPartitionWarpGroups * 4;
+  int32_t warpShortfall = paddedPartitionWarps - totalPartitionWarps;
+  int32_t paddingPartitions =
+      llvm::popcount(static_cast<uint32_t>(warpShortfall));
+  assert(warpShortfall >= 0 && paddingPartitions <= warpShortfall &&
+         "padding partition count must not exceed the warp shortfall");
+  int32_t firstFree = numReservedWarpSpecializeBarriers +
+                      ws.getPartitionRegions().size() + paddingPartitions;
+  if (firstFree >= maxNamedBarriers)
+    return failure();
+  return firstFree;
+}
+
 static FailureOr<ttg::LocalStoreOp>
 findDestinationStore(ttng::TwoCTAPeerGatherOp gather) {
+  Value value = gather.getResult();
+  if (value.hasOneUse())
+    if (auto trans = dyn_cast<tt::TransOp>(*value.getUsers().begin()))
+      value = trans.getResult();
   ttg::LocalStoreOp destination;
-  for (Operation *user : gather.getResult().getUsers()) {
+  for (Operation *user : value.getUsers()) {
     auto store = dyn_cast<ttg::LocalStoreOp>(user);
     if (!store || destination)
       return failure();
@@ -37,15 +89,16 @@ findDestinationStore(ttng::TwoCTAPeerGatherOp gather) {
   return destination;
 }
 
-static FailureOr<ttng::ArriveBarrierOp>
-findDestinationFullArrival(ttg::LocalStoreOp store) {
+static SmallVector<ttng::ArriveBarrierOp>
+findDestinationFullArrivals(ttg::LocalStoreOp store) {
+  SmallVector<ttng::ArriveBarrierOp> arrivals;
   for (Operation *op = store->getNextNode(); op; op = op->getNextNode()) {
     if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
-      return arrive;
+      arrivals.push_back(arrive);
     if (op->hasTrait<OpTrait::IsTerminator>())
       break;
   }
-  return failure();
+  return arrivals;
 }
 
 static Value unwrapWarpSpecializeCapture(Value value) {
@@ -59,6 +112,106 @@ static Value unwrapWarpSpecializeCapture(Value value) {
     value = partitions.getExplicitCaptures()[blockArg.getArgNumber()];
   }
   return value;
+}
+
+static Value getMemDescBase(Value value) {
+  while (true) {
+    value = unwrapWarpSpecializeCapture(value);
+    if (auto index = value.getDefiningOp<ttg::MemDescIndexOp>()) {
+      value = index.getSrc();
+      continue;
+    }
+    if (auto subview = value.getDefiningOp<ttg::MemDescSubsliceOp>()) {
+      value = subview.getSrc();
+      continue;
+    }
+    return unwrapWarpSpecializeCapture(value);
+  }
+}
+
+static FailureOr<ttg::LocalStoreOp>
+findExchangeStore(ttng::TwoCTAPeerGatherOp gather,
+                  ttng::TwoCTAPeerRelayOp relay) {
+  Value exchangeBase = getMemDescBase(relay.getSrc());
+  ttg::LocalStoreOp exchangeStore;
+  // The exchange buffer must have exactly one writer for the redirect below to
+  // be unambiguous. Count rather than toggle: toggling re-selects on the third
+  // match and would silently return the last of an odd number of writers.
+  unsigned numStores = 0;
+  gather->getParentRegion()->walk([&](ttg::LocalStoreOp store) {
+    if (getMemDescBase(store.getDst()) != exchangeBase)
+      return;
+    ++numStores;
+    exchangeStore = store;
+  });
+  if (numStores != 1)
+    return failure();
+  return exchangeStore;
+}
+
+static Value getLocalMemDescBase(Value value) {
+  while (true) {
+    if (auto index = value.getDefiningOp<ttg::MemDescIndexOp>()) {
+      value = index.getSrc();
+      continue;
+    }
+    if (auto subview = value.getDefiningOp<ttg::MemDescSubsliceOp>()) {
+      value = subview.getSrc();
+      continue;
+    }
+    return value;
+  }
+}
+
+static ttng::WaitBarrierOp findRelayWait(ttng::TwoCTAPeerRelayOp relay) {
+  for (Operation *op = relay->getPrevNode(); op; op = op->getPrevNode())
+    if (auto wait = dyn_cast<ttng::WaitBarrierOp>(op))
+      return wait;
+  return {};
+}
+
+static Value findCaptureInRelay(ttng::TwoCTAPeerRelayOp relay,
+                                Value outerValue) {
+  auto wsOp = relay->getParentOfType<ttg::WarpSpecializeOp>();
+  if (!wsOp)
+    return {};
+  Block *partitionBlock = nullptr;
+  for (Region *region : wsOp.getPartitionRegions()) {
+    if (region->isAncestor(relay->getParentRegion())) {
+      partitionBlock = &region->front();
+      break;
+    }
+  }
+  if (!partitionBlock)
+    return {};
+  if (auto arg = dyn_cast<BlockArgument>(getLocalMemDescBase(outerValue))) {
+    if (arg.getArgNumber() < partitionBlock->getNumArguments())
+      return partitionBlock->getArgument(arg.getArgNumber());
+  }
+  auto partitions = wsOp.getPartitionOp();
+  Value outerBase = getMemDescBase(outerValue);
+  for (auto [index, capture] :
+       llvm::enumerate(partitions.getExplicitCaptures())) {
+    if (getMemDescBase(capture) != outerBase ||
+        index >= partitionBlock->getNumArguments())
+      continue;
+    return partitionBlock->getArgument(index);
+  }
+  return {};
+}
+
+static Value indexBarrierLike(OpBuilder &builder, Location loc, Value barrier,
+                              Value indexedLike) {
+  auto likeIndex = indexedLike.getDefiningOp<ttg::MemDescIndexOp>();
+  if (!likeIndex)
+    return barrier;
+  auto barrierType = cast<ttg::MemDescType>(barrier.getType());
+  SmallVector<int64_t> shape(barrierType.getShape().drop_front());
+  auto viewType = ttg::MemDescType::get(
+      shape, barrierType.getElementType(), barrierType.getEncoding(),
+      barrierType.getMemorySpace(), barrierType.getMutableMemory());
+  return ttg::MemDescIndexOp::create(builder, loc, viewType, barrier,
+                                     likeIndex.getIndex());
 }
 
 static LogicalResult addExpectedArrival(Value barrier) {
@@ -90,7 +243,8 @@ static LogicalResult addExpectedArrival(Value barrier) {
 }
 
 static std::pair<Value, Value> splitTensor(OpBuilder &builder, Location loc,
-                                           Value source, unsigned splitDim) {
+                                           Value source, unsigned splitDim,
+                                           bool vectorizeOtherDim = false) {
   auto sourceType = cast<RankedTensorType>(source.getType());
   SmallVector<int64_t> reshapedShape;
   for (auto [dim, size] : llvm::enumerate(sourceType.getShape())) {
@@ -117,6 +271,14 @@ static std::pair<Value, Value> splitTensor(OpBuilder &builder, Location loc,
   SmallVector<unsigned> sizePerThread(transposedType.getRank(), 1);
   sizePerThread.back() = 2;
   sizePerThread[sizePerThread.size() - 2] = 2;
+  if (vectorizeOtherDim) {
+    unsigned otherSourceDim = splitDim == 0 ? 1 : 0;
+    unsigned reshapedOtherDim =
+        otherSourceDim < splitDim ? otherSourceDim : otherSourceDim + 1;
+    auto position = std::find(order.begin(), order.end(), reshapedOtherDim);
+    assert(position != order.end());
+    sizePerThread[std::distance(order.begin(), position)] = 2;
+  }
   int numWarps =
       ttg::lookupNumWarps(builder.getInsertionBlock()->getParentOp());
   auto ctaLayout = ttg::CGAEncodingAttr::fromSplitParams(
@@ -136,15 +298,108 @@ static std::pair<Value, Value> splitTensor(OpBuilder &builder, Location loc,
   return {split.getOutLHS(), split.getOutRHS()};
 }
 
-static LogicalResult materializeGather(ttng::TwoCTAPeerGatherOp gather) {
+// Resolve a pipelined dS value to the concrete value that seeded its loop
+// carry. The producer stores every carried version into the same single-ring
+// TMEM allocation before the peer exchange consumes it.
+static Value resolveLoopCarryInit(Value value) {
+  while (true) {
+    if (auto result = dyn_cast<OpResult>(value)) {
+      if (auto forOp = dyn_cast<scf::ForOp>(result.getOwner())) {
+        value = forOp.getInitArgs()[result.getResultNumber()];
+        continue;
+      }
+    }
+    if (auto arg = dyn_cast<BlockArgument>(value)) {
+      auto forOp = dyn_cast_or_null<scf::ForOp>(arg.getOwner()->getParentOp());
+      if (forOp && arg.getArgNumber() > 0) {
+        value = forOp.getInitArgs()[arg.getArgNumber() - 1];
+        continue;
+      }
+    }
+    return value;
+  }
+}
+
+// TLX reloads the two rank-owned dS halves from the reused dp/dQ TMEM slot.
+// Do the same when AutoWS has already materialized that store. This avoids a
+// full 128x128 register relayout scratch solely to make SplitOp legal at eight
+// warps.
+static std::optional<std::pair<Value, Value>>
+splitStoredTmem(OpBuilder &builder, Location loc, Value source,
+                unsigned splitDim) {
+  auto sourceType = dyn_cast<RankedTensorType>(source.getType());
+  if (!sourceType || sourceType.getRank() != 2 || splitDim != 1 ||
+      sourceType.getShape()[1] % 2 != 0)
+    return std::nullopt;
+
+  Value concreteSource = resolveLoopCarryInit(source);
+  ttng::TMEMStoreOp store;
+  for (Operation *user : concreteSource.getUsers()) {
+    if (auto candidate = dyn_cast<ttng::TMEMStoreOp>(user)) {
+      store = candidate;
+      break;
+    }
+  }
+  if (!store)
+    return std::nullopt;
+
+  int64_t halfN = sourceType.getShape()[1] / 2;
+  int numWarps =
+      ttg::lookupNumWarps(builder.getInsertionBlock()->getParentOp());
+  auto loadHalf = [&](int64_t offset) -> Value {
+    Value slice = ttng::TMEMSubSliceOp::create(builder, loc, store.getDst(),
+                                               offset, halfN);
+    auto sliceType = cast<ttg::MemDescType>(slice.getType());
+    Attribute layout = ttng::getDefaultLayoutForTmemLdSt(sliceType, numWarps);
+    auto loadType = RankedTensorType::get({sourceType.getShape()[0], halfN},
+                                          sourceType.getElementType(), layout);
+    return ttng::TMEMLoadOp::create(builder, loc, loadType, slice);
+  };
+  return std::pair<Value, Value>{loadHalf(0), loadHalf(halfN)};
+}
+
+static LogicalResult materializeGather(ttng::TwoCTAPeerGatherOp gather,
+                                       ttng::TwoCTAPeerRelayOp relay,
+                                       Value &mmaFullBase) {
   auto destinationStore = findDestinationStore(gather);
   if (failed(destinationStore))
     return gather.emitError(
         "expected exactly one AutoWS local_store gather consumer");
-  auto destinationFullArrival = findDestinationFullArrival(*destinationStore);
-  if (failed(destinationFullArrival))
+  FailureOr<ttg::LocalStoreOp> exchangeStore;
+  if (relay) {
+    exchangeStore = findExchangeStore(gather, relay);
+    if (failed(exchangeStore))
+      return gather.emitError(
+          "expected exactly one AutoWS peer-exchange staging store");
+  }
+  auto destinationFullArrivals = findDestinationFullArrivals(*destinationStore);
+  if (destinationFullArrivals.empty())
     return gather.emitError(
         "expected an AutoWS full-barrier arrival after the gather store");
+
+  ttng::WaitBarrierOp relayWait = relay ? findRelayWait(relay) : nullptr;
+  Value relayFullBase =
+      relayWait ? getMemDescBase(relayWait.getAlloc()) : Value();
+  ttng::ArriveBarrierOp relayFullArrival;
+  ttng::ArriveBarrierOp destinationFullArrival;
+  for (ttng::ArriveBarrierOp arrival : destinationFullArrivals) {
+    if (!destinationFullArrival)
+      destinationFullArrival = arrival;
+  }
+  if (relay) {
+    for (ttng::ArriveBarrierOp arrival :
+         findDestinationFullArrivals(*exchangeStore)) {
+      if (relayFullBase &&
+          getMemDescBase(arrival.getAlloc()) == relayFullBase) {
+        relayFullArrival = arrival;
+        break;
+      }
+    }
+  }
+  if (!destinationFullArrival)
+    return gather.emitError("could not identify the dQ MMA full barrier");
+  if (relay && !relayFullArrival)
+    return gather.emitError("could not identify the relay full barrier");
 
   Value source = gather.getSrc();
   unsigned splitDim = gather.getSplitDim();
@@ -160,36 +415,95 @@ static LogicalResult materializeGather(ttng::TwoCTAPeerGatherOp gather) {
   // source and the planned destination dominate the DSMEM lowering.
   OpBuilder builder(*destinationStore);
   Location loc = gather.getLoc();
-  auto [lhs, rhs] = splitTensor(builder, loc, source, splitDim);
+  auto resultType = cast<RankedTensorType>(gather.getType());
+  bool shapeChanging = sourceType != resultType;
 
   Value destination = destinationStore->getDst();
   auto destinationType = cast<ttg::MemDescType>(destination.getType());
+  bool physicalTranspose =
+      shapeChanging &&
+      destinationType.getShape() ==
+          ArrayRef<int64_t>{resultType.getShape()[1], resultType.getShape()[0]};
+  std::pair<Value, Value> halves;
+  if (shapeChanging) {
+    auto tmemHalves = splitStoredTmem(builder, loc, source, splitDim);
+    halves = tmemHalves ? *tmemHalves
+                        : splitTensor(builder, loc, source, splitDim,
+                                      /*vectorizeOtherDim=*/true);
+  } else {
+    halves = splitTensor(builder, loc, source, splitDim);
+  }
+  auto [lhs, rhs] = halves;
+  unsigned concatDim = splitDim;
+  Value lhsPayload = lhs;
+  Value rhsPayload = rhs;
+  if (shapeChanging && !physicalTranspose) {
+    auto lhsType = cast<RankedTensorType>(lhs.getType());
+    if (sourceType.getNumElements() != resultType.getNumElements())
+      return gather.emitError(
+          "shape-changing peer gather must preserve the element count");
+
+    // BM128 gathers rank-owned source M halves from adjacent CTA N domains.
+    // splitTensor assigns adjacent source-N pairs to each thread. Transposing
+    // [N,M/2] to [M/2,N] preserves those pairs as whole b32 DSMEM payloads.
+    SmallVector<int32_t> transposeOrder{1, 0};
+    lhsPayload = tt::TransOp::create(builder, loc, lhs, transposeOrder);
+    rhsPayload = tt::TransOp::create(builder, loc, rhs, transposeOrder);
+    bool foundConcatDim = false;
+    SmallVector<int64_t> transposedPayloadShape{lhsType.getShape()[1],
+                                                lhsType.getShape()[0]};
+    for (unsigned dim = 0; dim < resultType.getRank(); ++dim) {
+      SmallVector<int64_t> candidateShape(resultType.getShape());
+      candidateShape[dim] /= 2;
+      if (candidateShape == transposedPayloadShape) {
+        concatDim = dim;
+        foundConcatDim = true;
+        break;
+      }
+    }
+    if (!foundConcatDim || lhsType.getRank() != 2)
+      return gather.emitError(
+          "unsupported shape-changing peer gather destination");
+  } else if (physicalTranspose) {
+    // The planner exposed TLX's physical [2*N,M/2] allocation.  Source M
+    // halves are already native [N,M/2] payloads; concatenate them along the
+    // physical N dimension and let memdesc_trans present [M/2,2*N] to MMA.
+    concatDim = 0;
+  }
+
   SmallVector<int64_t> halfShape(destinationType.getShape());
-  halfShape[splitDim] /= 2;
+  halfShape[concatDim] /= 2;
   auto halfType = ttg::MemDescType::get(
       halfShape, destinationType.getElementType(),
       destinationType.getEncoding(), destinationType.getMemorySpace(),
       destinationType.getMutableMemory(), destinationType.getAllocShape());
   SmallVector<int32_t> firstOffset(sourceType.getRank(), 0);
   SmallVector<int32_t> secondOffset(sourceType.getRank(), 0);
-  secondOffset[splitDim] = halfShape[splitDim];
+  secondOffset[concatDim] = halfShape[concatDim];
   Value firstDestination = ttg::MemDescSubsliceOp::create(
       builder, loc, halfType, destination, firstOffset);
   Value secondDestination = ttg::MemDescSubsliceOp::create(
       builder, loc, halfType, destination, secondOffset);
+  Value firstStoreDestination = firstDestination;
+  Value secondStoreDestination = secondDestination;
+  Value exchangeDestination = relay ? (*exchangeStore).getDst() : Value();
 
   // The existing AutoWS empty-barrier wait before destinationStore protects
   // buffer reuse. Extend its full barrier with remote completion bytes so the
   // existing consumer wait also observes the peer half. This preserves the
   // barrier's pipelined phase rotation and avoids adding planner-visible state.
   int64_t expectedBytes =
-      cast<RankedTensorType>(lhs.getType()).getNumElements() *
+      cast<RankedTensorType>(lhsPayload.getType()).getNumElements() *
       sourceType.getElementTypeBitWidth() / 8;
   Value predTrue = arith::ConstantIntOp::create(builder, loc, 1, 1);
-  Value fullBarrier = (*destinationFullArrival).getAlloc();
-  if (failed(addExpectedArrival(fullBarrier)))
+  Value fullBarrier =
+      relay ? relayFullArrival.getAlloc() : destinationFullArrival.getAlloc();
+  if (!relay && failed(addExpectedArrival(fullBarrier)))
     return gather.emitError(
         "could not update the AutoWS full-barrier arrival count");
+  if (relay && failed(addExpectedArrival(destinationFullArrival.getAlloc())))
+    return gather.emitError("could not update the dQ MMA full-barrier count");
+  mmaFullBase = getLocalMemDescBase(destinationFullArrival.getAlloc());
   Operation *fullBarrierDef = fullBarrier.getDefiningOp();
   Operation *destinationStoreOp = (*destinationStore).getOperation();
   if (fullBarrierDef &&
@@ -204,25 +518,88 @@ static LogicalResult materializeGather(ttng::TwoCTAPeerGatherOp gather) {
   Value ctaRank =
       nvgpu::ClusterCTAIdOp::create(builder, loc, builder.getI32Type());
   Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+  Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
   Value isCTAZero = arith::CmpIOp::create(
       builder, loc, arith::CmpIPredicate::eq, ctaRank, zero);
   auto ifOp = scf::IfOp::create(builder, loc, TypeRange{}, isCTAZero,
                                 /*withElseRegion=*/true);
 
-  builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
-  Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
-  ttg::LocalStoreOp::create(builder, loc, lhs, firstDestination);
-  ttg::AsyncRemoteShmemStoreOp::create(builder, loc, lhs, firstDestination, one,
-                                       fullBarrier);
+  if (shapeChanging) {
+    // Store the rank-owned half in the final dQ destination and stage the
+    // other half in a dedicated exchange buffer, matching TLX.
+    // A CTA barrier makes all distributed local_store writes visible before
+    // the elected thread issues cp.async.bulk through the async proxy.
+    builder.setInsertionPoint(ifOp);
+    FailureOr<int32_t> stagingBarrierId =
+        getFirstFreeWarpSpecializeBarrierId(gather);
+    if (failed(stagingBarrierId))
+      return gather.emitError(
+          "no named-barrier slot remains for the 2-CTA staging rendezvous");
+    Value stagingBarrier =
+        arith::ConstantIntOp::create(builder, loc, *stagingBarrierId, 32);
+    int numThreads =
+        32 * ttg::lookupNumWarps(builder.getInsertionBlock()->getParentOp());
+    Value stagingThreads =
+        arith::ConstantIntOp::create(builder, loc, numThreads, 32);
+    builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    ttg::LocalStoreOp::create(builder, loc, lhsPayload, firstStoreDestination);
+    ttg::LocalStoreOp::create(builder, loc, rhsPayload, exchangeDestination);
+    ttng::NamedBarrierWaitOp::create(builder, loc, stagingBarrier,
+                                     stagingThreads);
+    ttng::FenceAsyncSharedOp::create(builder, loc, /*bCluster=*/false);
+    ttg::AsyncRemoteShmemCopyOp::create(builder, loc, exchangeDestination,
+                                        firstStoreDestination, one,
+                                        fullBarrier);
 
-  builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
-  ttg::LocalStoreOp::create(builder, loc, rhs, secondDestination);
-  ttg::AsyncRemoteShmemStoreOp::create(builder, loc, rhs, secondDestination,
-                                       zero, fullBarrier);
+    builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
+    ttg::LocalStoreOp::create(builder, loc, rhsPayload, secondStoreDestination);
+    ttg::LocalStoreOp::create(builder, loc, lhsPayload, exchangeDestination);
+    ttng::NamedBarrierWaitOp::create(builder, loc, stagingBarrier,
+                                     stagingThreads);
+    ttng::FenceAsyncSharedOp::create(builder, loc, /*bCluster=*/false);
+    ttg::AsyncRemoteShmemCopyOp::create(builder, loc, exchangeDestination,
+                                        secondStoreDestination, zero,
+                                        fullBarrier);
+  } else {
+    builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    ttg::LocalStoreOp::create(builder, loc, lhsPayload, firstStoreDestination);
+    ttg::AsyncRemoteShmemStoreOp::create(
+        builder, loc, lhsPayload, firstStoreDestination, one, fullBarrier);
+
+    builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
+    ttg::LocalStoreOp::create(builder, loc, rhsPayload, secondStoreDestination);
+    ttg::AsyncRemoteShmemStoreOp::create(
+        builder, loc, rhsPayload, secondStoreDestination, zero, fullBarrier);
+  }
 
   builder.setInsertionPointAfter(ifOp);
+  if (relay)
+    relayFullArrival.erase();
+  if (relay)
+    exchangeStore->erase();
   destinationStore->erase();
+  if (gather->hasOneUse())
+    gather->getUsers().begin()->erase();
   gather->erase();
+  return success();
+}
+
+static LogicalResult materializeRelay(ttng::TwoCTAPeerRelayOp relay,
+                                      Value mmaFullBase) {
+  ttng::WaitBarrierOp relayWait = findRelayWait(relay);
+  if (!relayWait)
+    return relay.emitError("expected an AutoWS relay-channel wait");
+  Value capturedMmaFull = findCaptureInRelay(relay, mmaFullBase);
+  if (!capturedMmaFull)
+    return relay.emitError("expected the dQ MMA full barrier to be captured");
+
+  OpBuilder builder(relay);
+  Location loc = relay.getLoc();
+  ttng::FenceAsyncSharedOp::create(builder, loc, /*bCluster=*/false);
+  Value mmaFull =
+      indexBarrierLike(builder, loc, capturedMmaFull, relayWait.getAlloc());
+  ttng::ArriveBarrierOp::create(builder, loc, mmaFull, 1);
+  relay.erase();
   return success();
 }
 
@@ -234,14 +611,26 @@ public:
 
   void runOnOperation() override {
     SmallVector<ttng::TwoCTAPeerGatherOp> gathers;
+    SmallVector<ttng::TwoCTAPeerRelayOp> relays;
     getOperation().walk(
         [&](ttng::TwoCTAPeerGatherOp gather) { gathers.push_back(gather); });
+    getOperation().walk(
+        [&](ttng::TwoCTAPeerRelayOp relay) { relays.push_back(relay); });
+    if (relays.size() > 1) {
+      relays.front().emitError("expected at most one 2-CTA relay per kernel");
+      return signalPassFailure();
+    }
+    ttng::TwoCTAPeerRelayOp relay = relays.empty() ? nullptr : relays.front();
+    Value mmaFullBase;
     for (auto gather : gathers) {
-      if (failed(materializeGather(gather))) {
+      if (failed(materializeGather(gather, relay, mmaFullBase))) {
         signalPassFailure();
         return;
       }
     }
+    if (relay &&
+        (gathers.empty() || failed(materializeRelay(relay, mmaFullBase))))
+      signalPassFailure();
   }
 };
 

--- a/third_party/nvidia/hopper/lib/Transforms/Plan2CTAExchange.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Plan2CTAExchange.cpp
@@ -1,6 +1,16 @@
+// Insert the abstract peer gather for dependent 2-CTA MMA operands.
+//
+// Runs before partition scheduling and memory planning so the exchange is
+// visible to AutoWS as real scheduled work: the gather result has a lifetime
+// and storage requirement, and the BM128 relay is a synchronization-only
+// consumer needing its own channel and warp. Hardware DSMEM is materialized
+// later by Materialize2CTAExchange. See
+// WarpSpecialization/docs/AutoWS2CTABackwardPlan.md, "Dependency
+// classification and peer exchange" and "Pass pipeline and ownership".
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -11,30 +21,115 @@ namespace mlir {
 
 namespace {
 
+namespace tt = triton;
 namespace ttg = triton::gpu;
 namespace ttng = triton::nvidia_gpu;
 
 constexpr StringLiteral DependencyAttr = "ttng.two_cta_dependency";
 constexpr StringLiteral RequiresPeerGather = "requires_peer_gather";
 
-static FailureOr<std::pair<ttg::LocalAllocOp, unsigned>>
-findGatherSource(ttng::TCGen5MMAOp mma) {
+struct GatherSource {
+  ttg::LocalAllocOp alloc;
+  Value tensor;
+  RankedTensorType resultType;
+  unsigned splitDim;
+};
+
+static Value createExchangeTensor(OpBuilder &builder, Location loc,
+                                  Value source, unsigned splitDim) {
+  auto sourceType = cast<RankedTensorType>(source.getType());
+  SmallVector<int64_t> reshapedShape;
+  for (auto [dim, size] : llvm::enumerate(sourceType.getShape())) {
+    if (dim == splitDim) {
+      reshapedShape.push_back(2);
+      reshapedShape.push_back(size / 2);
+    } else {
+      reshapedShape.push_back(size);
+    }
+  }
+  Value reshaped = tt::ReshapeOp::create(builder, loc, reshapedShape, source,
+                                         /*allowReorder=*/false);
+  SmallVector<int32_t> order;
+  for (unsigned dim = 0; dim < reshapedShape.size(); ++dim)
+    if (dim != splitDim)
+      order.push_back(dim);
+  order.push_back(splitDim);
+  Value transposed = tt::TransOp::create(builder, loc, reshaped, order);
+
+  // With eight base warps layout propagation may distribute the factor-of-two
+  // axis across warps. Split requires that axis in registers. Materialize the
+  // same split-compatible layout used by the later exchange lowering so the
+  // logical packing remains valid independently of the base warp count.
+  auto transposedType = cast<RankedTensorType>(transposed.getType());
+  SmallVector<unsigned> layoutOrder(transposedType.getRank());
+  std::iota(layoutOrder.begin(), layoutOrder.end(), 0);
+  std::reverse(layoutOrder.begin(), layoutOrder.end());
+  SmallVector<unsigned> sizePerThread(transposedType.getRank(), 1);
+  sizePerThread.back() = 2;
+  sizePerThread[sizePerThread.size() - 2] = 2;
+  int numWarps =
+      ttg::lookupNumWarps(builder.getInsertionBlock()->getParentOp());
+  auto ctaLayout = ttg::CGAEncodingAttr::fromSplitParams(
+      builder.getContext(), /*CTAsPerCGA=*/{1, 1, 1},
+      /*CTASplitNum=*/{1, 1, 1}, /*CTAOrder=*/{2, 1, 0});
+  auto splitEncoding = ttg::BlockedEncodingAttr::get(
+      builder.getContext(), sizePerThread,
+      /*threadsPerWarp=*/{1, 32, 1},
+      /*warpsPerCTA=*/{static_cast<unsigned>(numWarps), 1, 1}, layoutOrder,
+      ctaLayout);
+  auto splitInputType =
+      RankedTensorType::get(transposedType.getShape(),
+                            transposedType.getElementType(), splitEncoding);
+  Value splitInput =
+      ttg::ConvertLayoutOp::create(builder, loc, splitInputType, transposed);
+  return tt::SplitOp::create(builder, loc, splitInput).getOutLHS();
+}
+
+static FailureOr<GatherSource> findGatherSource(ttng::TCGen5MMAOp mma) {
   Value value = mma.getA();
   while (auto subview = value.getDefiningOp<ttg::MemDescSubsliceOp>())
     value = subview.getSrc();
 
-  auto trans = value.getDefiningOp<ttg::MemDescTransOp>();
+  if (auto trans = value.getDefiningOp<ttg::MemDescTransOp>()) {
+    if (trans.getOrder().size() != 2)
+      return failure();
+    auto alloc = trans.getSrc().getDefiningOp<ttg::LocalAllocOp>();
+    if (!alloc || !alloc.getSrc())
+      return failure();
+
+    // The dependent MMA needs a complete A contraction dimension. Map A
+    // dimension 1 through the memdesc transpose to the source tensor dimension
+    // distributed by the producing collective MMA.
+    return GatherSource{alloc, alloc.getSrc(),
+                        cast<RankedTensorType>(alloc.getSrc().getType()),
+                        static_cast<unsigned>(trans.getOrder()[1])};
+  }
+
+  // BM128 expresses the TLX physical dQ layout before shared-memory
+  // allocation: reshape(transpose(dS), [M/2, 2*N]). The peer gather consumes
+  // the untransposed [N,M] dS tensor and materializes that physical result.
+  auto alloc = value.getDefiningOp<ttg::LocalAllocOp>();
+  if (!alloc || !alloc.getSrc())
+    return failure();
+  auto reshape = alloc.getSrc().getDefiningOp<tt::ReshapeOp>();
+  if (!reshape)
+    return failure();
+  auto trans = reshape.getSrc().getDefiningOp<tt::TransOp>();
   if (!trans || trans.getOrder().size() != 2)
     return failure();
 
-  auto alloc = trans.getSrc().getDefiningOp<ttg::LocalAllocOp>();
-  if (!alloc || !alloc.getSrc())
+  auto sourceType = dyn_cast<RankedTensorType>(trans.getSrc().getType());
+  auto resultType = dyn_cast<RankedTensorType>(alloc.getSrc().getType());
+  if (!sourceType || !resultType || sourceType.getRank() != 2 ||
+      resultType.getRank() != 2)
     return failure();
 
-  // The dependent MMA needs a complete A contraction dimension. Map A
-  // dimension 1 through the memdesc transpose to the source tensor dimension
-  // distributed by the producing collective MMA.
-  return std::make_pair(alloc, static_cast<unsigned>(trans.getOrder()[1]));
+  unsigned splitDim = static_cast<unsigned>(trans.getOrder()[0]);
+  unsigned otherDim = splitDim == 0 ? 1 : 0;
+  if (sourceType.getShape()[splitDim] != resultType.getShape()[0] * 2 ||
+      resultType.getShape()[1] != sourceType.getShape()[otherDim] * 2)
+    return failure();
+  return GatherSource{alloc, trans.getSrc(), resultType, splitDim};
 }
 
 class Plan2CTAExchange
@@ -60,9 +155,9 @@ public:
         return WalkResult::interrupt();
       }
 
-      ttg::LocalAllocOp alloc = source->first;
-      unsigned splitDim = source->second;
-      Value tensor = alloc.getSrc();
+      ttg::LocalAllocOp alloc = source->alloc;
+      unsigned splitDim = source->splitDim;
+      Value tensor = source->tensor;
       auto tensorType = cast<RankedTensorType>(tensor.getType());
       if (splitDim >= tensorType.getRank() ||
           tensorType.getShape()[splitDim] % 2 != 0) {
@@ -76,9 +171,52 @@ public:
 
       OpBuilder builder(alloc);
       auto gather = ttng::TwoCTAPeerGatherOp::create(
-          builder, alloc.getLoc(), tensorType, tensor,
+          builder, alloc.getLoc(), source->resultType, tensor,
           builder.getI32IntegerAttr(splitDim), builder.getI32IntegerAttr(2));
-      alloc->setOperand(0, gather.getResult());
+      // BM64's direct completion protocol is already validated. Match the TLX
+      // relay only for a combined BM128 query tile.
+      unsigned queryDim = splitDim == 0 ? 1 : 0;
+      if (tensorType.getShape()[queryDim] >= 128) {
+        // Keep the peer gather's logical [M/2,2*N] result, but allocate its
+        // transpose as physical [2*N,M/2] shared memory.  The dependent MMA
+        // consumes a transposed memdesc view, matching TLX's operand-A layout.
+        SmallVector<int32_t> transposeOrder{1, 0};
+        Value physicalTensor = tt::TransOp::create(
+            builder, alloc.getLoc(), gather.getResult(), transposeOrder);
+        alloc->setOperand(0, physicalTensor);
+
+        auto oldAllocType = cast<ttg::MemDescType>(alloc.getType());
+        auto physicalTensorType =
+            cast<RankedTensorType>(physicalTensor.getType());
+        auto physicalAllocType = ttg::MemDescType::get(
+            physicalTensorType.getShape(), oldAllocType.getElementType(),
+            oldAllocType.getEncoding(), oldAllocType.getMemorySpace(),
+            oldAllocType.getMutableMemory());
+        alloc.getResult().setType(physicalAllocType);
+
+        builder.setInsertionPointAfter(alloc);
+        Value mmaView = ttg::MemDescTransOp::create(
+            builder, alloc.getLoc(), alloc.getResult(), transposeOrder);
+        mma.getAMutable().assign(mmaView);
+
+        builder.setInsertionPoint(alloc);
+        Value exchangeTensor =
+            createExchangeTensor(builder, alloc.getLoc(), tensor, splitDim);
+        auto exchangeTensorType =
+            cast<RankedTensorType>(exchangeTensor.getType());
+        auto exchangeAllocType = ttg::MemDescType::get(
+            exchangeTensorType.getShape(), oldAllocType.getElementType(),
+            oldAllocType.getEncoding(), oldAllocType.getMemorySpace(),
+            oldAllocType.getMutableMemory());
+        auto exchangeAlloc = ttg::LocalAllocOp::create(
+            builder, alloc.getLoc(), exchangeAllocType, exchangeTensor);
+
+        builder.setInsertionPointAfter(alloc);
+        ttng::TwoCTAPeerRelayOp::create(builder, alloc.getLoc(),
+                                        exchangeAlloc.getResult());
+      } else {
+        alloc->setOperand(0, gather.getResult());
+      }
       return WalkResult::advance();
     });
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -147,6 +147,7 @@ enum class OpCategory {
   MemDescView,   // Memory descriptor views
   EpilogueStore, // Descriptor stores
   TMAReduction,  // TMA reduction operations
+  Relay,         // One-warp 2-CTA DSMEM completion relay
   DataPartition, // Ops exclusive to one MMA's slice
   Correction,    // Cross-iteration MMA users
   Default        // Everything else
@@ -168,6 +169,8 @@ static llvm::StringRef toString(OpCategory category) {
     return "EpilogueStore";
   case OpCategory::TMAReduction:
     return "TMAReduction";
+  case OpCategory::Relay:
+    return "Relay";
   case OpCategory::Correction:
     return "Correction";
   case OpCategory::DataPartition:
@@ -342,6 +345,7 @@ struct PartitionLayout {
   Partition *loadPartition = nullptr;
   Partition *epiloguePartition = nullptr;
   Partition *epilogueStorePartition = nullptr;
+  Partition *relayPartition = nullptr;
   Partition *defaultPartition = nullptr; // computed alias
   SmallVector<Partition *, 2> computationPartitions;
 
@@ -415,6 +419,7 @@ public:
     categorizeMMAs();
     categorizeEpilogueStores();
     categorizeTMAReductions();
+    categorizeRelays();
     categorizeCorrectionOps(); // Before DataPartition to prevent stealing
     categorizeDataPartitionOps();
   }
@@ -478,10 +483,11 @@ public:
 
     // Group ops by category in deterministic order
     constexpr OpCategory categoryOrder[] = {
-        OpCategory::MMA,           OpCategory::Load,
-        OpCategory::MemDescView,   OpCategory::EpilogueStore,
-        OpCategory::TMAReduction,  OpCategory::Correction,
-        OpCategory::DataPartition, OpCategory::Default};
+        OpCategory::MMA,          OpCategory::Load,
+        OpCategory::MemDescView,  OpCategory::EpilogueStore,
+        OpCategory::TMAReduction, OpCategory::Correction,
+        OpCategory::Relay,        OpCategory::DataPartition,
+        OpCategory::Default};
 
     for (OpCategory cat : categoryOrder) {
       SmallVector<const CategorizedOp *> ops;
@@ -945,6 +951,12 @@ private:
     }
   }
 
+  void categorizeRelays() {
+    getLoopBodyRegion(mainLoop).walk([&](ttng::TwoCTAPeerRelayOp relay) {
+      addCategorizedOp(relay, OpCategory::Relay);
+    });
+  }
+
   void addCategorizedOp(Operation *op, OpCategory cat,
                         unsigned dataPartitionId = 0,
                         Operation *parentMMA = nullptr) {
@@ -985,6 +997,7 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
       !categorizer.getOpsInCategory(OpCategory::TMAReduction).empty();
   bool hasEpilogue =
       !categorizer.getOpsInCategory(OpCategory::EpilogueStore).empty();
+  bool hasRelay = !categorizer.getOpsInCategory(OpCategory::Relay).empty();
   bool hasMMAv5 = categorizer.hasMMAv5();
   // No-MMA reduction kernels (RMS norm / LayerNorm / softmax-only): no MMA and
   // no TMA-atomic reduce, but an in-register tt.reduce. These need a reduction
@@ -1032,6 +1045,11 @@ static PartitionLayout createPartitionLayout(PartitionSet &schedule,
   if (options.separateEpilogueStore && hasEpilogue && !deferLoadPartition) {
     layout.epilogueStorePartition = schedule.addPartition(0);
     layout.epilogueStorePartition->setType("epilogue_store");
+  }
+
+  if (hasRelay) {
+    layout.relayPartition = schedule.addPartition(0);
+    layout.relayPartition->setType("relay");
   }
 
   // Load partition: created last so it gets the highest partition index,
@@ -1568,6 +1586,9 @@ getInitialSchedule(LoopLikeOpInterface mainLoop,
   Partition *epiloguePartition = layout.epiloguePartition;
   Partition *correctionPartition = layout.correctionPartition;
   Partition *reductionPartition = layout.reductionPartition;
+
+  for (const auto &catOp : categorizer.getOpsInCategory(OpCategory::Relay))
+    tryScheduleOp(layout.relayPartition, catOp.op);
 
   // For backward compatibility: use default as fallback
   if (!correctionPartition)
@@ -2109,8 +2130,30 @@ getInitialSchedule(LoopLikeOpInterface mainLoop,
   schedulePostLoopOps(mainLoop, schedule, layout, localSchedOpts,
                       categorizer.getOpToDpIdMap(), dpIdToPartition);
 
-  // Update defaultPartition after computation partitions are created.
-  layout.defaultPartition = layout.getDefaultPartition();
+  // Match the explicit TLX backward layout for dependent 2-CTA attention.
+  // The eight-warp base group owns computation/epilogue, while the TMEM/TMA
+  // reduction is a specialized four-warp group. Selecting computation as the
+  // default here lets memory planning see the final role placement; changing a
+  // four-warp computation partition to eight warps after planning introduces a
+  // full-tile relayout buffer and can exceed the Blackwell SMEM limit.
+  ModuleOp module = mainLoop->getParentOfType<ModuleOp>();
+  bool preferComputationDefault =
+      module && module->hasAttr("ttng.two-ctas") && layout.relayPartition &&
+      layout.reductionPartition && dataPartitionFactor == 1 &&
+      localSchedOpts.mergeEpilogueToComputation && sharedComputePartition;
+  if (preferComputationDefault) {
+    layout.makeDefaultPartition(schedule, sharedComputePartition, mainLoop);
+    // Match TLX's specialized task order as well: reduction, GEMM, load,
+    // relay. Besides making IR comparison direct, this keeps warp-group and
+    // requested-register arrays role-aligned in downstream passes.
+    schedule.swapPartitions(1, layout.reductionPartition->getIndex(), mainLoop);
+    schedule.swapPartitions(2, layout.gemmPartition->getIndex(), mainLoop);
+  }
+
+  // Update the fallback default after computation partitions are created.
+  // makeDefaultPartition already set the deliberate 2-CTA default above.
+  if (!preferComputationDefault)
+    layout.defaultPartition = layout.getDefaultPartition();
 
   // Scan partitions for one that requires 4 warps (TMEM or WarpGroupDot
   // ops) and promote it to index 0 so it becomes the default warp group.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2138,9 +2138,10 @@ getInitialSchedule(LoopLikeOpInterface mainLoop,
   // full-tile relayout buffer and can exceed the Blackwell SMEM limit.
   ModuleOp module = mainLoop->getParentOfType<ModuleOp>();
   bool preferComputationDefault =
-      module && module->hasAttr("ttng.two-ctas") && layout.relayPartition &&
-      layout.reductionPartition && dataPartitionFactor == 1 &&
-      localSchedOpts.mergeEpilogueToComputation && sharedComputePartition;
+      module && module->hasAttr(ttng::AttrTwoCTAsName) &&
+      layout.relayPartition && layout.reductionPartition &&
+      dataPartitionFactor == 1 && localSchedOpts.mergeEpilogueToComputation &&
+      sharedComputePartition;
   if (preferComputationDefault) {
     layout.makeDefaultPartition(schedule, sharedComputePartition, mainLoop);
     // Match TLX's specialized task order as well: reduction, GEMM, load,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -4817,6 +4817,7 @@ static void mergeDuplicateLocalAllocs(triton::FuncOp &funcOp) {
 // allocation) prevents the autoWS compiler from creating a
 // cross-partition channel for it.
 void removeRedundantTmemZeroStores(triton::FuncOp funcOp) {
+  DominanceInfo dominance(funcOp);
   auto isConstZeroTensor = [](Value v) -> bool {
     auto constOp = v.getDefiningOp<arith::ConstantOp>();
     if (!constOp)
@@ -4907,9 +4908,14 @@ void removeRedundantTmemZeroStores(triton::FuncOp funcOp) {
           zeroStoreOp->getParentOfType<scf::ForOp>();
       if (!zeroStoreParentLoop)
         zeroStoreParentLoop = zeroStoreOp->getParentOfType<scf::WhileOp>();
-      if (zeroStoreParentLoop &&
+      bool commonOuterLoop =
+          zeroStoreParentLoop &&
           (zeroStoreParentLoop == mmaParentLoop.getOperation() ||
-           zeroStoreParentLoop->isProperAncestor(mmaParentLoop))) {
+           zeroStoreParentLoop->isProperAncestor(mmaParentLoop));
+      bool dominatesKnownNonEmptyLoop =
+          mmaParentLoop->hasAttr("tt.assume_nonempty") &&
+          dominance.properlyDominates(zeroStoreOp, mmaParentLoop);
+      if (commonOuterLoop || dominatesKnownNonEmptyLoop) {
         LLVM_DEBUG({
           LDBG("Removing redundant TMEM zero-store for operand D: "
                << "MMA useAccumulator=false already handles zeroing");

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -412,6 +412,14 @@ struct NVGPUTestAnnotateTMAStoreWaitsPass
   }
 };
 
+static bool isInMergedEpilogueLoop(scf::ForOp forOp) {
+  for (Operation *op = forOp; op; op = op->getParentOp()) {
+    if (op->hasAttr("tt.merge_epilogue_to_computation"))
+      return true;
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Validate TMA store annotations (safety checks)
 // ---------------------------------------------------------------------------
@@ -715,7 +723,7 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
           schedule.insert(waitOp, targetStage, waitCluster);
           waitOp->moveBefore(targetWriter);
         } else if (targetWriter && !sameIteration &&
-                   forOp->hasAttr("tt.merge_epilogue_to_computation") &&
+                   isInMergedEpilogueLoop(forOp) &&
                    waitOp.getBarriers().empty() &&
                    waitOp.getBarrierPreds().empty() &&
                    waitOp.getNvwsTokens().empty() &&

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -1,6 +1,7 @@
 #include "CodePartitionUtility.h"
 #include "WarpSpecializationPipeline.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
@@ -193,6 +194,7 @@ struct NVGPUWSTMAStoreLoweringPass
 
 static constexpr const char *kCanRotateByBufferCount =
     "can_rotate_by_buffer_count";
+static constexpr const char *kPlannedPendingCount = "planned_pending_count";
 
 static bool isTMAStoreLikeOp(Operation *op) {
   return isa<ttng::AsyncTMACopyLocalToGlobalOp, ttng::AsyncTMAReduceOp>(op);
@@ -299,17 +301,75 @@ static bool sameMemDescValue(Value lhs, Value rhs) {
   return true;
 }
 
+static Value findMemDescBase(Value value) {
+  while (Operation *def = value.getDefiningOp()) {
+    if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+             ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+             ttg::MemDescReshapeOp>(def))
+      break;
+    value = def->getOperand(0);
+  }
+  return value;
+}
+
+// Only a distinct local allocation proves two memory descriptors cannot
+// overlap. A block argument does not: two memdesc arguments of the same
+// function, or two loop iter args, may both be views of one allocation.
+// Treating them as distinct would let memDescMayAlias answer "no alias" for
+// buffers that do alias, which is the unsafe direction for the wait-motion
+// checks below.
+static bool isKnownMemDescBase(Value value) {
+  return value.getDefiningOp<ttg::LocalAllocOp>() != nullptr;
+}
+
+static bool memDescMayAlias(Value lhs, Value rhs) {
+  Value lhsBase = findMemDescBase(lhs);
+  Value rhsBase = findMemDescBase(rhs);
+  if (lhsBase == rhsBase)
+    return true;
+  return !(isKnownMemDescBase(lhsBase) && isKnownMemDescBase(rhsBase));
+}
+
+static bool mayWriteOrFreeMemDesc(Operation *op, Value buffer) {
+  auto effectsOp = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!effectsOp)
+    return !isMemoryEffectFree(op);
+
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  effectsOp.getEffects(effects);
+  for (const auto &effect : effects) {
+    if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
+      continue;
+    if (isa<SideEffects::DefaultResource>(effect.getResource()))
+      return true;
+    if (effect.getResource() == ttg::SharedMemory::get() &&
+        (!effect.getValue() || memDescMayAlias(effect.getValue(), buffer)))
+      return true;
+  }
+  return false;
+}
+
 static Operation *
-findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer,
+findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer, Operation *before,
                             const tt::CoarseSchedule &schedule) {
+  Operation *beforeInBody = forOp.getBody()->findAncestorOpInBlock(*before);
+  if (!beforeInBody)
+    return nullptr;
+
+  Operation *writer = nullptr;
   for (auto &op : forOp.getBody()->without_terminator()) {
+    if (&op == beforeInBody)
+      break;
     auto localStore = dyn_cast<ttg::LocalStoreOp>(&op);
     if (!localStore || !schedule.count(&op))
       continue;
-    if (sameMemDescValue(localStore.getDst(), buffer))
-      return &op;
+    if (!memDescMayAlias(localStore.getDst(), buffer))
+      continue;
+    // The last potentially-aliasing writer must be the exact staging view.
+    // Otherwise we cannot identify the overwrite point safely.
+    writer = sameMemDescValue(localStore.getDst(), buffer) ? &op : nullptr;
   }
-  return nullptr;
+  return writer;
 }
 
 void doAnnotateTMAStoreWaits(triton::FuncOp funcOp) {
@@ -366,12 +426,14 @@ void doValidateTMAStoreAnnotations(triton::FuncOp funcOp) {
       auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
       if (!tmaOp) {
         waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->removeAttr(kPlannedPendingCount);
         return;
       }
 
       auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
       if (!allocOp) {
         waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->removeAttr(kPlannedPendingCount);
         return;
       }
     });
@@ -425,6 +487,77 @@ findScheduledWaitBarrierBetween(Operation *producer, Operation *insertionTarget,
 // logs (see the LDBG sites below); there is no failure mode, so this returns
 // void rather than a LogicalResult.
 void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
+  DominanceInfo dominance(funcOp);
+  auto operandsDominate = [&](Operation *op, Operation *target) {
+    return llvm::all_of(op->getOperands(), [&](Value operand) {
+      return dominance.dominates(operand, target);
+    });
+  };
+
+  // Straight-line epilogues are not software-pipelined, but can still overlap
+  // a TMA store with independent work.  Delay a token wait until immediately
+  // before the next write to a TMA staging view. A wait_group applies to the
+  // warp's TMA store queue, not to one descriptor or SMEM allocation, so the
+  // final wait for one output can overlap independent setup for the next
+  // output and land immediately before that output starts reusing the queue.
+  // This is deliberately limited to direct tokens and staging writers in the
+  // same block. The final use remains a drain.
+  SmallVector<ttng::TMAStoreTokenWaitOp> straightLineWaits;
+  funcOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
+    if (!waitOp->getParentOfType<scf::ForOp>())
+      straightLineWaits.push_back(waitOp);
+  });
+  for (ttng::TMAStoreTokenWaitOp waitOp : straightLineWaits) {
+    Operation *tmaStore = waitOp.getToken().getDefiningOp();
+    if (!tmaStore || !isTMAStoreLikeOp(tmaStore) ||
+        tmaStore->getBlock() != waitOp->getBlock())
+      continue;
+
+    Value buffer = getTMAStoreSource(tmaStore);
+    for (auto it = std::next(waitOp->getIterator()),
+              end = waitOp->getBlock()->end();
+         it != end; ++it) {
+      auto localStore = dyn_cast<ttg::LocalStoreOp>(&*it);
+      if (!localStore) {
+        if (isa<ttg::LocalAllocOp>(&*it))
+          continue;
+        if (isTMAStoreLikeOp(&*it) || mayWriteOrFreeMemDesc(&*it, buffer))
+          break;
+        continue;
+      }
+
+      bool writesTMAStaging = sameMemDescValue(localStore.getDst(), buffer);
+      if (!writesTMAStaging) {
+        for (auto next = std::next(localStore->getIterator()); next != end;
+             ++next) {
+          if (isTMAStoreLikeOp(&*next)) {
+            writesTMAStaging = sameMemDescValue(localStore.getDst(),
+                                                getTMAStoreSource(&*next));
+            break;
+          }
+          if (auto nextStore = dyn_cast<ttg::LocalStoreOp>(&*next)) {
+            if (memDescMayAlias(nextStore.getDst(), localStore.getDst()))
+              break;
+            continue;
+          }
+          if (isa<ttg::LocalAllocOp>(&*next))
+            continue;
+          if (mayWriteOrFreeMemDesc(&*next, localStore.getDst()))
+            break;
+        }
+      }
+      if (!writesTMAStaging) {
+        if (memDescMayAlias(localStore.getDst(), buffer))
+          break;
+        continue;
+      }
+      if (!operandsDominate(waitOp, localStore))
+        break;
+      waitOp->moveBefore(localStore);
+      break;
+    }
+  }
+
   funcOp.walk([&](scf::ForOp forOp) {
     bool hasNestedFor = false;
     forOp.getBody()->walk([&](scf::ForOp) { hasNestedFor = true; });
@@ -473,11 +606,15 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
     }
 
     bool changed = false;
+    bool needsFinalQueueDrain = false;
+    SmallVector<Attribute> finalDrainTaskIds;
     for (auto waitOp : waits) {
+      bool erasedWait = false;
       auto attr = waitOp->getAttrOfType<IntegerAttr>(kCanRotateByBufferCount);
       if (!attr)
         continue;
       int k = attr.getInt();
+      waitOp->removeAttr(kPlannedPendingCount);
 
       // Find the defining TMA store op.
       Value buffer;
@@ -528,9 +665,9 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
 
         Value targetBuffer = getTMAStoreSource(targetTMAStore);
         Operation *targetWriter =
-            targetBuffer
-                ? findLocalStoreWritingBuffer(forOp, targetBuffer, schedule)
-                : nullptr;
+            targetBuffer ? findLocalStoreWritingBuffer(forOp, targetBuffer,
+                                                       targetTMAStore, schedule)
+                         : nullptr;
         if (targetWriter) {
           insertionTarget = targetWriter;
         } else {
@@ -550,14 +687,65 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
           insertionTarget = waitBarrier;
         }
 
-        // Split the cluster at the insertion target: ops before it remain
-        // in the original cluster, the target and subsequent ops stay in
-        // the returned cluster.
+        // A same-iteration reuse does not need software-pipeline expansion to
+        // realize the rotation. Keep the block order consistent with the
+        // coarse schedule so loops that are deliberately not pipelined (for
+        // example a merged FA backward epilogue) still place the wait after
+        // the target writer's dependency slice and immediately before the
+        // staging write. Cross-iteration targets remain schedule-only because
+        // their token must be carried through the pipeline boundary.
+        auto targetIt = schedule.find(targetTMAStore);
+        bool sameIteration =
+            targetIt != schedule.end() && targetStage == targetIt->second.first;
+        if (targetWriter && sameIteration &&
+            !operandsDominate(waitOp, targetWriter)) {
+          LDBG("TMA store wait operands do not dominate the target writer for "
+               "loop at "
+               << forOp.getLoc() << "; leaving TMA store wait unchanged");
+          continue;
+        }
+
+        // Split the cluster at the insertion target only after all safety
+        // checks pass, so a rejected move leaves the schedule untouched.
         auto targetCluster =
             schedule.splitClusterBefore(insertionTarget, forOp);
-        // Insert a new cluster for our wait between the split halves.
         auto waitCluster = schedule.clusters.newBefore(targetCluster);
-        schedule.insert(waitOp, targetStage, waitCluster);
+
+        if (targetWriter && sameIteration) {
+          schedule.insert(waitOp, targetStage, waitCluster);
+          waitOp->moveBefore(targetWriter);
+        } else if (targetWriter && !sameIteration &&
+                   forOp->hasAttr("tt.merge_epilogue_to_computation") &&
+                   waitOp.getBarriers().empty() &&
+                   waitOp.getBarrierPreds().empty() &&
+                   waitOp.getNvwsTokens().empty() &&
+                   waitOp.getNvwsTokenIndices().empty()) {
+          // Merged epilogue loops are intentionally not expanded by the GPU
+          // pipeliner. Materialize a wraparound token wait as the equivalent
+          // queue-wide wait_group before the next iteration's staging writer,
+          // then add one queue drain after the loop. This is the concrete
+          // prologue/steady-state/epilogue protocol used by TLX.
+          int pendings = k - 1;
+          OpBuilder builder(targetWriter);
+          auto queueWait =
+              ttng::TMAStoreWaitOp::create(builder, waitOp.getLoc(), pendings);
+          Attribute taskIds = waitOp->getAttr("async_task_id");
+          if (taskIds)
+            queueWait->setAttr("async_task_id", taskIds);
+          if (!llvm::is_contained(finalDrainTaskIds, taskIds))
+            finalDrainTaskIds.push_back(taskIds);
+          // Read the target's stage before erasing the wait: schedule.erase
+          // removes an entry from a MapVector, which shifts the remaining
+          // elements and invalidates targetIt.
+          int targetOwnStage = targetIt->second.first;
+          schedule.erase(waitOp);
+          schedule.insert(queueWait, targetOwnStage, waitCluster);
+          waitOp.erase();
+          erasedWait = true;
+          needsFinalQueueDrain = true;
+        } else {
+          schedule.insert(waitOp, targetStage, waitCluster);
+        }
       } else {
         // Target not found; leave the schedule unchanged for this wait.
         LDBG("no reorder target found for TMA store wait in loop at "
@@ -565,12 +753,27 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
         continue;
       }
 
-      waitOp->removeAttr(kCanRotateByBufferCount);
+      if (!erasedWait) {
+        waitOp->removeAttr(kCanRotateByBufferCount);
+        waitOp->setAttr(
+            kPlannedPendingCount,
+            IntegerAttr::get(IntegerType::get(funcOp.getContext(), 32), k - 1));
+      }
       changed = true;
     }
 
     if (changed)
       schedule.serialize(forOp);
+
+    if (needsFinalQueueDrain) {
+      OpBuilder builder(forOp);
+      builder.setInsertionPointAfter(forOp);
+      for (Attribute taskIds : finalDrainTaskIds) {
+        auto drain = ttng::TMAStoreWaitOp::create(builder, forOp.getLoc(), 0);
+        if (taskIds)
+          drain->setAttr("async_task_id", taskIds);
+      }
+    }
   });
 }
 
@@ -795,6 +998,9 @@ computePendingsFromToken(Value token, ttng::TMAStoreTokenWaitOp waitOp,
 // pendings = number of TMA store-like ops issued after the token's defining
 // store and before this wait, in program execution order.
 static int computePendings(ttng::TMAStoreTokenWaitOp waitOp) {
+  if (auto planned = waitOp->getAttrOfType<IntegerAttr>(kPlannedPendingCount))
+    return planned.getInt();
+
   ConditionContext context = getConditionContext(waitOp);
   if (std::optional<int> count =
           computePendingsFromToken(waitOp.getToken(), waitOp, context))

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWS2CTABackwardPlan.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWS2CTABackwardPlan.md
@@ -147,12 +147,33 @@ partition scheduling and memory planning. BM128 also receives a
 `ttng.two_cta_peer_relay` marker. Inserting these operations early makes the
 dependency and destination lifetime visible to AutoWS.
 
+They are operations rather than pass-private annotations because AutoWS must
+treat the exchange as real scheduled work: the gather result has a lifetime
+and storage requirement, and the relay is a synchronization-only consumer that
+needs its own channel and warp allocation. Hiding either until final lowering
+would let partitioning or memory planning erase ordering and liveness
+constraints required by the DSMEM protocol.
+
 After software pipelining, `Materialize2CTAExchange` lowers the plan to packed
 local stores, asynchronous remote DSMEM copies, fences, and barrier
 publication. The BM128 one-warp relay waits for peer-copy completion and then
 publishes the existing dQ consumer channel. It is not a CTA-wide cluster
 rendezvous; placing a cluster barrier inside a warp-specialized partition can
 deadlock because not every CTA warp participates.
+
+The exchange uses two distinct empty/full lifetimes:
+
+- the final dQ destination keeps its existing AutoWS empty wait before either
+  CTA overwrites the slot, and its full barrier remains the MMA consumer's
+  readiness condition;
+- the temporary peer-exchange allocation has its own empty/full channel. The
+  producer waits for that staging slot to become empty, remote DSMEM completion
+  satisfies its full side, and the relay converts that completion into an
+  arrival on the final dQ full barrier.
+
+Both sides are required. Reusing only the destination barrier would not protect
+the temporary exchange slot, while publishing only the exchange full barrier
+would leave the dQ consumer disconnected from peer completion.
 
 ## Cooperative TMA loads
 
@@ -195,6 +216,14 @@ The relay is a typed one-warp partition. The computation partition retains the
 softmax work; the GEMM partition owns the software-pipelined collective MMAs;
 the load partition owns descriptor loads; and the reduction partition owns
 dQ's TMA reduction path.
+
+The separate relay partition lets exactly one warp wait on the exchange
+channel and publish dQ readiness without requiring every compute warp to enter
+a cluster-wide rendezvous. The planner recognizes the rank-two dependent-MMA
+gather shapes described above; this is a reusable two-CTA exchange mechanism,
+but it is not a claim to support arbitrary kernels or arbitrary dependent-MMA
+graphs. Unsupported shapes fail planning rather than receiving an FA-specific
+fallback.
 
 Important storage relationships are:
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -269,7 +269,8 @@ for one output (for example dV) may cross independent preparation for the next
 output (dK) and stop at dK's staging write. The last wait in the block remains
 the final drain.
 
-Merged epilogue loops (`tt.merge_epilogue_to_computation`) serialize the
+For annotated operations, merged epilogue loops
+(`tt.merge_epilogue_to_computation`) serialize the
 same-iteration part of the coarse schedule directly into block order: the pass
 selects the nearest matching writer before the chosen future TMA operation, so
 a two-slot dQ ring maps store 0's wait to store 2 rather than the earlier
@@ -278,6 +279,12 @@ pipeliner. Barrier-free wraparound token waits are therefore materialized as
 queue-wide `wait_group(K-1)` operations before the next iteration's staging
 writers, followed by one `wait_group(0)` drain after the loop. Ordinary
 software-pipelined loops retain their loop-carried token schedule.
+
+The merge attribute can be on an enclosing persistent loop rather than the
+loop containing the dQ stores. The pass therefore searches the loop ancestry:
+an inner reduction loop inherits the merged-epilogue realization and receives
+its final drain immediately after that inner loop. Checking only the immediate
+loop leaves loop-carried token waits in final TTGIR and loses the drain.
 
 ### Algorithm
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -102,12 +102,35 @@ into a reinterpret view of the host alloc (see
 [CodePartition: Realizing `allocation.reuseTarget`](#code-partition-realizing-allocationreuetarget)
 below).
 
-### Phase 4.5: Epilogue Group Copy Increase
+### Phase 3.7: Epilogue Group Copy Increase
 
 Each fused P2_Other group (including TMA staging groups) is treated as
 an epilogue group. `increaseFusedEpilogueCopies` iteratively bumps
 `numCopies` from the current value up to `numBuffers`, accepting each
 bump as long as `computeTotalSmem ≤ smemBudget`.
+
+This reservation runs before the general Phase 4 P0/P1 copy increase. TMA
+store/reduce staging is on the output critical path and must get first claim on
+the discretionary budget; otherwise small operand buffers can consume the last
+few KiB before a high-value staging ring (for example FA-bwd dQ) is considered.
+
+TMA-fed operands of a compiler data-partitioned MMA loop with
+`tt.disallow_acc_multi_buffer` are not discretionary: before Phase 3.7, the
+planner pins them to the configured pipeline depth. Their acquire/release
+schedule assumes that depth, and shortening the ring can overwrite an operand
+while a partitioned, pipelined MMA still consumes it.
+Phase 3.7 therefore reserves output staging only from the budget remaining
+after these operand correctness floors. Ordinary single-group MMA operands and
+TMA-fed metadata used only by elementwise computation remain discretionary, so
+FA-backward dQ/dK/dV staging stays prioritized over their extra copies.
+
+Groups whose members all reuse another allocation (`isAllocated=false`) are
+bumped only when every Phase 3.6 host has enough physical capacity for the
+enlarged ring (`stagingSize × copies ≤ hostSize × hostCopies`). Their apparent
+cost in `computeTotalSmem` is zero, so omitting this capacity check makes an
+increase look free even when reuse realization must reject the alias and
+materialize a separate allocation, which can make the final physical layout
+exceed the planner budget.
 
 #### `K | S` cap for same-partition (wait_group-drained) staging
 
@@ -127,7 +150,7 @@ are *correct* — depends on the channel's producer/consumer topology:
   `desc_o`): the slot/phase come from a continuous `accumCnt` producer/consumer
   mbarrier rotation and tolerate **any** K.
 
-Phase 4.5 therefore detects same-partition staging via
+Phase 3.7 therefore detects same-partition staging via
 `getAsyncTaskIds(ch->getSrcOp()) == getAsyncTaskIds(ch->getDstOp())` and, for
 those groups, only accepts a `tryCopies` that divides S (others are skipped).
 This is a **defensive backstop**: in all shipped configs `num_stages = 2` and
@@ -197,13 +220,21 @@ then looks at the SMEM buffer used by that store:
 1. Get the `LocalAllocOp` that produces the buffer.
 2. Read the `buffer.copy` attribute (set earlier by the memory planner),
    which records how many physical copies of this buffer exist.
-3. If `buffer.copy = K`, set `can_rotate_by_buffer_count = K`
-   on the wait op.
+3. If `buffer.copy = K`, set `can_rotate_by_buffer_count = K` on the wait op.
 
 The attribute means: "K buffer copies exist, so this wait can be delayed
 until the K-th subsequent TMA store to the same buffer — at that point
 the buffer slot is about to be overwritten and the earlier store must
 have finished reading."
+
+After the reorder is successfully realized, the pass records
+`planned_pending_count = K - 1` as stable lowering metadata for the equivalent
+`cp.async.bulk.wait_group(K-1)` protocol. Delaying this metadata prevents a
+failed or skipped rotation from changing the original wait semantics.
+Software-pipeline schedule serialization can move token waits through clusters
+without retaining enough linear IR context to reconstruct K reliably; final
+wait lowering therefore uses this explicit count when present and falls back
+to program-order counting for unplanned waits.
 
 ### Token Tracing
 
@@ -229,6 +260,24 @@ and reordering that might invalidate assumptions.
 This pass runs **after** `scheduleLoops` has assigned pipeline stages and
 clusters to every op. It uses the SWP `CoarseSchedule` to move waits
 forward in the linearized pipeline order.
+
+Straight-line epilogues use the same reuse-point rule without a coarse
+schedule. A direct-token wait moves to immediately before the next
+`local_store` that feeds any TMA store in the block. TMA `wait_group` is
+queue-wide rather than descriptor- or allocation-specific, so the final wait
+for one output (for example dV) may cross independent preparation for the next
+output (dK) and stop at dK's staging write. The last wait in the block remains
+the final drain.
+
+Merged epilogue loops (`tt.merge_epilogue_to_computation`) serialize the
+same-iteration part of the coarse schedule directly into block order: the pass
+selects the nearest matching writer before the chosen future TMA operation, so
+a two-slot dQ ring maps store 0's wait to store 2 rather than the earlier
+equivalent slot-0 writer. These loops are intentionally not expanded by the GPU
+pipeliner. Barrier-free wraparound token waits are therefore materialized as
+queue-wide `wait_group(K-1)` operations before the next iteration's staging
+writers, followed by one `wait_group(0)` drain after the loop. Ordinary
+software-pipelined loops retain their loop-carried token schedule.
 
 ### Algorithm
 

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -1871,6 +1871,74 @@ def test_op(
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_bm64_1cta_persistent_store_wait_drain():
+    # Regression for rotating a one-CTA dQ TMA-reduction wait across the
+    # persistent loop. At the production shape, the missing final queue drain
+    # raced the next tile and produced nondeterministic dQ. Smaller N_CTX=1024
+    # tests did not reliably expose the race.
+    import blackwell_fa_ws_pipelined_persistent as tlx
+
+    config = next(config for config in configs_bwd_persist
+                  if config.kwargs.get("BWD_DOT_ATTRS") == _BWD_DOT_ATTRS_BM64_MEMTYPE)
+    config = copy.copy(config)
+    config.kwargs = dict(config.kwargs)
+    # Make the legacy one-CTA default explicit: the persistent grid consumes
+    # NUM_CTAS before Triton's config defaults are applied.
+    config.kwargs["NUM_CTAS"] = 1
+
+    tlx_configs = [
+        config for config in tlx.configs_bwd_tlx
+        if config.kwargs.get("NUM_CTAS", 1) == 1
+        and config.kwargs.get("BLOCK_M1") == 64
+        and config.kwargs.get("USE_WARP_BARRIER") is False
+    ]
+    assert len(tlx_configs) == 1
+
+    old_autows_configs = _attn_bwd_persist.configs
+    old_autows_cache = _attn_bwd_persist.cache
+    old_tlx_configs = tlx._attn_bwd_ws.configs
+    old_tlx_cache = tlx._attn_bwd_ws.cache
+    _attn_bwd_persist.configs = [config]
+    _attn_bwd_persist.cache = {}
+    tlx._attn_bwd_ws.configs = tlx_configs
+    tlx._attn_bwd_ws.cache = {}
+
+    torch.manual_seed(20)
+    shape = (4, 48, 4096, 128)
+    q = torch.empty(shape, dtype=torch.float16, device=DEVICE).normal_(0.0, 0.5)
+    k = torch.empty_like(q).normal_(0.0, 0.5)
+    v = torch.empty_like(q).normal_(0.0, 0.5)
+    dout = torch.randn_like(q)
+
+    def run(attention_fn):
+        qq = q.clone().requires_grad_()
+        kk = k.clone().requires_grad_()
+        vv = v.clone().requires_grad_()
+        out = attention_fn(qq, kk, vv).half()
+        out.backward(dout)
+        return qq.grad, kk.grad, vv.grad
+
+    try:
+        reference = run(lambda qq, kk, vv: tlx.attention(qq, kk, vv, 0.5, False))
+        first = None
+        for _ in range(10):
+            actual = run(lambda qq, kk, vv: attention(
+                qq, kk, vv, False, 0.5, "ws_persistent", False, 0, False))
+            for actual_grad, reference_grad in zip(actual, reference):
+                torch.testing.assert_close(actual_grad, reference_grad, atol=1e-2, rtol=0)
+            if first is None:
+                first = actual
+            else:
+                for actual_grad, first_grad in zip(actual, first):
+                    torch.testing.assert_close(actual_grad, first_grad, atol=1e-2, rtol=0)
+    finally:
+        _attn_bwd_persist.configs = old_autows_configs
+        _attn_bwd_persist.cache = old_autows_cache
+        tlx._attn_bwd_ws.configs = old_tlx_configs
+        tlx._attn_bwd_ws.cache = old_tlx_cache
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
 def test_bwd_tmem_dsT_reuse_3group():
     # Regression for the 3-group TMEM-reuse accuracy bug.
     #


### PR DESCRIPTION
Summary:

Propagate the BM128 two-CTA task register budgets through partition-warp optimization and final warp-group allocation. Add minimized production-derived fixtures for requested and actual register assignments.

Reviewed By: njriasan

Differential Revision: D114617483
