### PR TITLE
Support AutoWS load wavefront scheduling

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -700,6 +700,49 @@ scheduleKeyOpsUpstream(scf::ForOp forOp,
   return schedule;
 }
 
+// Parse a tt.autows JSON annotation of the form {"stage": "0", "order": "2"}.
+// Both fields must be present as decimal integer *strings*. Any deviation is
+// reported through LDBG and returns nullopt so the caller falls back to
+// inferred scheduling; the annotation is user input and must never abort the
+// compiler.
+static std::optional<std::pair<int, int>>
+parseAutoWSStageOrder(Operation *op, StringRef context) {
+  auto attr = op->getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName);
+  if (!attr)
+    return std::nullopt;
+  auto parsed = llvm::json::parse(attr.getValue());
+  if (!parsed) {
+    llvm::consumeError(parsed.takeError());
+    LDBG(context << ": ignoring " << tt::kAutoWSAnnotationAttrName
+                 << " annotation that is not valid JSON: " << attr.getValue());
+    return std::nullopt;
+  }
+  auto *obj = parsed->getAsObject();
+  if (!obj) {
+    LDBG(context << ": ignoring " << tt::kAutoWSAnnotationAttrName
+                 << " annotation that is not a JSON object: "
+                 << attr.getValue());
+    return std::nullopt;
+  }
+  auto stageStr = obj->getString(tt::kAutoWSStageKey);
+  auto orderStr = obj->getString(tt::kAutoWSOrderKey);
+  if (!stageStr || !orderStr) {
+    LDBG(context << ": ignoring " << tt::kAutoWSAnnotationAttrName
+                 << " annotation missing string \"" << tt::kAutoWSStageKey
+                 << "\"/\"" << tt::kAutoWSOrderKey
+                 << "\" fields: " << attr.getValue());
+    return std::nullopt;
+  }
+  int stage, order;
+  if (stageStr->getAsInteger(10, stage) || orderStr->getAsInteger(10, order)) {
+    LDBG(context << ": ignoring " << tt::kAutoWSAnnotationAttrName
+                 << " annotation with non-integer stage/order: "
+                 << attr.getValue());
+    return std::nullopt;
+  }
+  return std::make_pair(stage, order);
+}
+
 // Schedule key ops based on user-provided tt.autows annotations on MMA ops.
 // The tt.autows attribute is a JSON string like {"stage": "0", "order": "2"}
 // that specifies the desired stage and cluster for each MMA.
@@ -713,24 +756,8 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
 
   for (auto &op : forOp.getBody()->without_terminator()) {
     if (auto mmaOp = dyn_cast<ttng::MMAv5OpInterface>(&op)) {
-      if (auto attr =
-              op.getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName)) {
-        auto parsed = llvm::json::parse(attr.getValue());
-        if (!parsed) {
-          llvm::consumeError(parsed.takeError());
-          continue;
-        }
-        auto *obj = parsed->getAsObject();
-        if (!obj)
-          continue;
-        auto stageStr = obj->getString(tt::kAutoWSStageKey);
-        auto clusterStr = obj->getString(tt::kAutoWSOrderKey);
-        if (!stageStr || !clusterStr)
-          continue;
-        int stage = std::stoi(stageStr->str());
-        int cluster = std::stoi(clusterStr->str());
-        annotatedMMAs.push_back({mmaOp, stage, cluster});
-      }
+      if (auto stageOrder = parseAutoWSStageOrder(&op, "annotated MMA"))
+        annotatedMMAs.push_back({mmaOp, stageOrder->first, stageOrder->second});
     }
   }
 
@@ -746,19 +773,71 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
   }
 
   CoarseSchedule schedule(numStages);
+
+  // Schedule latency operations in dedicated prefetch clusters ahead of the
+  // annotated MMA clusters. Rank a load by the wavefront of its earliest
+  // annotated consumer: stage + order, then stage. This keeps stage-0 inputs
+  // for the next contraction ahead of stage-1 inputs for the current
+  // contraction when they share a compute-order cluster (FA backward's dOt
+  // before delayed q), without changing the annotated MMA execution order.
+  DenseMap<Operation *, std::tuple<int, int, int>> latencySchedule;
+  DenseSet<Operation *> explicitlyScheduledLatency;
+  SmallVector<std::tuple<int, int, int>> prefetchKeys;
+  for (auto &[mma, stage, order] : annotatedMMAs) {
+    SetVector<Operation *> backwardSlice;
+    BackwardSliceOptions options;
+    options.omitBlockArguments = true;
+    options.omitUsesFromAbove = false;
+    (void)getBackwardSlice(mma, &backwardSlice, options);
+    std::tuple<int, int, int> key = {stage + order, stage, order};
+    for (Operation *dependency : backwardSlice) {
+      if (!opLatency.count(dependency))
+        continue;
+      if (auto stageOrder =
+              parseAutoWSStageOrder(dependency, "annotated load")) {
+        auto [loadStage, loadOrder] = *stageOrder;
+        latencySchedule[dependency] = {loadStage + loadOrder, loadStage,
+                                       loadOrder};
+        explicitlyScheduledLatency.insert(dependency);
+        continue;
+      }
+      if (explicitlyScheduledLatency.contains(dependency))
+        continue;
+      auto it = latencySchedule.find(dependency);
+      if (it == latencySchedule.end() || key < it->second)
+        latencySchedule[dependency] = key;
+    }
+  }
+  for (auto &[op, key] : latencySchedule)
+    prefetchKeys.push_back(key);
+  llvm::sort(prefetchKeys);
+  prefetchKeys.erase(std::unique(prefetchKeys.begin(), prefetchKeys.end()),
+                     prefetchKeys.end());
+
+  SmallVector<std::pair<std::tuple<int, int, int>, CoarseSchedule::Cluster>>
+      prefetchClusters;
+  for (auto key : prefetchKeys)
+    prefetchClusters.push_back({key, schedule.clusters.newAtBack()});
+
   SmallVector<CoarseSchedule::Cluster> clusters;
   for (int i = 0; i < numClusters; ++i)
     clusters.push_back(schedule.clusters.newAtBack());
+
+  for (auto &[op, key] : latencySchedule) {
+    auto cluster = llvm::find_if(prefetchClusters, [&](const auto &entry) {
+      return entry.first == key;
+    });
+    assert(cluster != prefetchClusters.end());
+    schedule.insert(op, std::get<1>(key), cluster->second);
+  }
 
   // Assign annotated MMAs to their specified stage/cluster.
   for (auto &[mma, stage, cluster] : annotatedMMAs) {
     schedule.insert(mma, stage, clusters[cluster]);
   }
 
-  // Leave latency ops unscheduled here. scheduleDependencies() places each
-  // load with its annotated consumer. This realizes the qT/dOt prologue and
-  // delayed-q epilogue of FA backward without speculatively prefetching a
-  // single-buffered metadata channel such as delta/Di.
+  // Latency ops outside annotated MMA backward slices remain unscheduled;
+  // scheduleDependencies() places them with their first scheduled consumer.
 
   LDBG("scheduleKeyOpsAnnotation: scheduled "
        << annotatedMMAs.size() << " annotated MMAs with " << numStages

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1553,7 +1553,8 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: Sequence[constexpr | tensor], latency=None, multicast=None, _semantic=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], latency=None, multicast=None, attrs=None,
+             _semantic=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
@@ -1564,11 +1565,16 @@ class tensor_descriptor_base(base_value):
             permission to use multicast when it can prove a legal recipient
             group; it does not guarantee multicast emission. See
             :doc:`the TMA multicast design </design/triton_tma_multicast>`.
+        :param attrs: optional compiler scheduling attributes, a ``dict`` whose
+            keys and values must both be strings. AutoWS accepts ``stage`` and
+            ``order`` to place the load in a prefetch wavefront, e.g.
+            ``attrs={"stage": "0", "order": "2"}``.
         :note: Offset must be a multiple of 16-bytes
         """
         latency = _unwrap_if_constexpr(latency)
         multicast = _unwrap_if_constexpr(multicast)
-        return _semantic.descriptor_load(self, offsets, "", "", latency, multicast)
+        attrs = _unwrap_if_constexpr(attrs)
+        return _semantic.descriptor_load(self, offsets, "", "", latency, multicast, attrs)
 
     @builtin
     def store(

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1104,7 +1104,7 @@ class TritonSemantic(Generic[TensorTy]):
         return tl.tensor_descriptor_base(handle, block_ty)
 
     def descriptor_load(self, desc: tl.tensor_descriptor_base, offsets, cache_modifier: str, eviction_policy: str,
-                        latency: Optional[int], multicast: Optional[bool] = None) -> TensorTy:
+                        latency: Optional[int], multicast: Optional[bool] = None, attrs=None) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base), \
             f"expected a tensor descriptor, got {type(desc).__name__}"
         ndim = len(desc.block_shape)
@@ -1126,7 +1126,17 @@ class TritonSemantic(Generic[TensorTy]):
             if not isinstance(latency, int) or latency < 0:
                 raise TypeError(
                     f"If provided, latency argument to load must be a non-negative integer. Found: {latency}")
-            x.handle.set_attr("tt.latency", self.builder.get_int32_attr(latency))
+            x.set_attr("tt.latency", self.builder.get_int32_attr(latency))
+        if attrs is not None:
+            if not isinstance(attrs, dict):
+                raise TypeError(f"attrs must be a dict, got {type(attrs).__name__}")
+            # The compiler reads tt.autows as a JSON object of string->string;
+            # a JSON number would be silently ignored, so reject it here.
+            for key, value in attrs.items():
+                if not isinstance(key, str) or not isinstance(value, str):
+                    raise TypeError("attrs keys and values must be strings, got "
+                                    f"{key!r}: {value!r}. Use e.g. attrs={{'stage': '0', 'order': '2'}}")
+            x.set_attr("tt.autows", self.builder.get_string_attr(json.dumps(attrs)))
         return self.tensor(x, desc.block_type)
 
     def validate_store_like(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> None:

--- a/test/TritonGPU/schedule-loops-annotation.mlir
+++ b/test/TritonGPU/schedule-loops-annotation.mlir
@@ -8,56 +8,64 @@
 // CHECK-LABEL: @_attn_bwd_annotated
 // CHECK: scf.for
 
-// --- Cluster 1: qk operand loads and address computation (stage 0) ---
+// Latency ops land in the dedicated prefetch clusters 1-3, which the pass
+// creates ahead of the annotated MMA clusters 4-7. Loads are ranked by the
+// wavefront (stage + order) of their earliest annotated consumer, except for
+// the two metadata tt.loads, which carry their own tt.autows stage/order.
+
+// --- qkT operands: prefetched in cluster 1, m metadata load in cluster 2 ---
 // CHECK: tt.descriptor_load {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32}
-// CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32
-// CHECK: tt.load {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-
-// --- qkT MMA: stage 0, cluster 1 ---
-// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 1 : i32, loop.stage = 0 : i32
-
-// --- Cluster 4: qkT result consumption + softmax (stage 0) ---
-// CHECK: ttg.convert_layout {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-// CHECK: arith.subf {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-// CHECK: math.exp2 {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-
-// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
 // CHECK: ttg.local_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-// CHECK: arith.truncf {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-// CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32}
-
-// --- dv MMA: stage 0, cluster 4 ---
-// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32
-
-// CHECK: tt.load {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
 // CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32
+// CHECK: tt.load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32
 
-// --- dpT MMA: stage 0, cluster 4 ---
+// --- qkT MMA (tt.autows stage 0, order 0): stage 0, cluster 4 ---
 // CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 4 : i32, loop.stage = 0 : i32
 
-// --- Cluster 2: dpT result consumption + dk/dq operand prep (stage 1) ---
-// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: arith.subf {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: arith.mulf {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: arith.truncf {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
+// --- Cluster 7: qkT result consumption + softmax (stage 0) ---
+// CHECK: ttg.convert_layout {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
+// CHECK: arith.subf {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
+// CHECK: math.exp2 {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
 
-// --- dk MMA: stage 1, cluster 2 ---
-// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32
+// CHECK: tt.descriptor_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 0 : i32}
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
+// CHECK: arith.truncf {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
+// CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32}
 
-// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32
+// --- dv MMA (tt.autows stage 0, order 2): stage 0, cluster 7 ---
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32
 
-// --- dq MMA: stage 1, cluster 2 ---
-// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32
+// --- Di metadata load: its own tt.autows stage 0/order 4 puts it in the last
+// --- prefetch cluster at stage 0, rather than the stage 1 its dk/dq consumers
+// --- would have inferred.
+// CHECK: tt.load {{.*}} {loop.cluster = 3 : i32, loop.stage = 0 : i32
+// CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32
 
-// --- dq epilogue: tmem_load + reduce (stage 1, cluster 2) ---
-// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: arith.mulf {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: ttg.convert_layout {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
-// CHECK: tt.descriptor_reduce {{.*}} {loop.cluster = 2 : i32, loop.stage = 1 : i32}
+// --- dpT MMA (tt.autows stage 0, order 2): stage 0, cluster 7 ---
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 7 : i32, loop.stage = 0 : i32
+
+// --- Cluster 5: dpT result consumption + dk/dq operand prep (stage 1) ---
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: arith.subf {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: arith.mulf {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: arith.truncf {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: ttng.tmem_alloc {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+
+// --- dk MMA (tt.autows stage 1, order 1): stage 1, cluster 5 ---
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32
+
+// CHECK: ttg.local_alloc {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: ttg.memdesc_trans {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32
+
+// --- dq MMA (tt.autows stage 1, order 1): stage 1, cluster 5 ---
+// CHECK: ttng.tc_gen5_mma {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32
+
+// --- dq epilogue: tmem_load + reduce (stage 1, cluster 5) ---
+// CHECK: ttng.tmem_load {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: arith.mulf {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: ttg.convert_layout {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
+// CHECK: tt.descriptor_reduce {{.*}} {loop.cluster = 5 : i32, loop.stage = 1 : i32}
 
 // CHECK: } {tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
 
@@ -122,7 +130,7 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       %41 = tt.splat %arg44 : i32 -> tensor<128xi32, #blocked2>
       %42 = arith.addi %41, %23 : tensor<128xi32, #blocked2>
       %43 = tt.addptr %24, %42 : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
-      %44 = tt.load %43 {tt.latency = 1 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+      %44 = tt.load %43 {tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22}", tt.latency = 1 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
       // qkT MMA
       %45 = ttng.tc_gen5_mma %19, %40, %result[%arg46], %false, %true {tt.autows = "{\"stage\": \"0\", \"order\": \"0\"}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       %46 = ttg.convert_layout %44 : tensor<128xf32, #blocked2> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #blocked}>>
@@ -138,7 +146,7 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       // dv MMA
       %54 = ttng.tc_gen5_mma %result_15, %52, %result_1[%arg47], %arg45, %true {tt.autows = "{\"stage\": \"0\", \"order\": \"2\"}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
       %55 = tt.addptr %25, %42 : tensor<128x!tt.ptr<f32>, #blocked2>, tensor<128xi32, #blocked2>
-      %56 = tt.load %55 {tt.latency = 1 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
+      %56 = tt.load %55 {tt.autows = "{\22stage\22: \220\22, \22order\22: \224\22}", tt.latency = 1 : i32} : tensor<128x!tt.ptr<f32>, #blocked2>
       %57 = ttg.memdesc_trans %52 {order = array<i32: 1, 0>} : !ttg.memdesc<128x128xbf16, #shared, #smem> -> !ttg.memdesc<128x128xbf16, #shared2, #smem>
       // dpT MMA
       %58 = ttng.tc_gen5_mma %21, %57, %result_3[%arg48], %false, %true {tt.autows = "{\"stage\": \"0\", \"order\": \"2\"}", tt.self_latency = 1 : i32} : !ttg.memdesc<128x128xbf16, #shared, #smem>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWS2CTABackwardPlan.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWS2CTABackwardPlan.md
@@ -24,6 +24,18 @@ BM128 has no known deadlock. Its final TTGIR matches TLX in the primary
 structural counts: loops, MMAs, TMEM allocations, TMEM loads, output TMA
 stores, and dQ TMA reductions.
 
+The software-pipelined steady-state load sequence also matches TLX:
+
+```text
+qT -> dOt -> q -> M -> dO -> D
+```
+
+The kernel's dot `stage`/`order` annotations define the contraction schedule,
+and explicit metadata-load annotations place M and D in the corresponding
+prefetch wavefront. The remaining ordering differences are confined to the
+one-time prologue: AutoWS currently issues Kt before the generated pipeline
+prologue and places dOt before M/dO there.
+
 The implementation supports:
 
 - all five backward MMAs (`qK`, `dK`, `dP`, `dQ`, and `dV`) as two-CTA

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
@@ -60,6 +60,35 @@ AutoWS inventory.
 See `PartitionSchedulingMeta.md` for how the `merge_*` / `separate_epilogue_store`
 knobs shape the partition layout.
 
+## Operation scheduling annotations
+
+AutoWS kernels may also attach `tt.autows` to individual dot operations and
+latency-bearing loads. A dot annotation has `stage` and `order` fields and
+defines the computation order within an annotated loop. `ScheduleLoops` keeps
+that dot order unchanged while placing loads from each dot's backward slice in
+dedicated prefetch clusters. The default load rank is:
+
+```text
+(dot stage + dot order, dot stage, dot order)
+```
+
+This rank expresses the prefetch wavefront independently of the computation
+wavefront. For example, a stage-zero input for the next contraction can be
+issued before a stage-one input for the current contraction.
+
+`tensor_descriptor.load(..., attrs={"stage": "0", "order": "2"})` supplies an
+explicit load rank when dependency inference is insufficient, such as scalar
+metadata shared by multiple contractions. Explicit load annotations override
+the inferred consumer rank. Loads outside every annotated dot's backward slice
+retain dependency-based scheduling.
+
+Both fields are JSON **strings** holding a decimal integer, matching the dot
+annotation encoding; the frontend rejects non-string `attrs` values so an
+integer cannot be silently dropped by the compiler-side parse. An annotation
+that is not a JSON object, is missing a field, or holds a non-integer string
+is ignored with a `-debug-only=triton-loop-pipeline` message and the op falls
+back to the inferred rank.
+
 ## Status on `scf.while` (current gaps)
 
 The unified tile scheduler (`triton.language.schedule`) drives a persistent


### PR DESCRIPTION
Summary: Use annotated dot dependencies to form independent load-prefetch clusters, with explicit descriptor-load stage and order anchors for shared metadata. Document the annotations and cover the scheduler behavior in lit.

Reviewed By: njriasan

Differential Revision: D114617479


