### PR TITLE
[AutoWS] Erase dead rematerialization chains before descriptor-load conversion

### DIFF
--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -172,6 +172,12 @@
 - **Companion**: `ws_code_partition_empty_producer_guard.mlir` now runs `--nvgpu-partition-scheduling-meta` before `--nvgpu-warp-specialization`. Its raw kernel carries no `ttg.partition`, so under the new gate the pass rejected it early and the test silently stopped covering bug #7 — while its pre-fix output had been pinning 4 unlowered `nvws.descriptor_load` ops and no `ttg.warp_specialize`. With PSM in the pipeline it gets real partitions, emits physical WS regions, and reaches `createChannelPost` as intended.
 - **Key insight**: `tt.warp_specialize` on a loop is a *request*, not a decision. Any pass that rewrites ops on the strength of that marker must first confirm partitions exist, because the pass that undoes the rewrite only runs when they do.
 
+### 23. Dead scalar rematerialization clones create descriptor-load self-consumers (2026-08-18, fixed)
+- **Symptom**: BM128 2-CTA FA backward is nondeterministically numerically wrong after rebasing; dV reports first, but dK/dQ are also corrupted.
+- **Root cause**: partition scheduling clones the `m`/`delta` convert-layout chain into the load task, but those clones are dead. Descriptor-load conversion counted the dead task-3 users when assigning the replacement `local_load`, creating a producer-task self-consumer channel and unsafe TMA-buffer rotation.
+- **Fix**: before converting each descriptor load, recursively erase only dead `convert_layout`/`broadcast`/`expand_dims` rematerialization chains, then derive consumer task IDs from the remaining users. Whole-function DCE is intentionally avoided because test/debug IR may contain unrelated dead consumers.
+- **Regression**: `ws_code_partition.mlir` pins the alloc set after the dead chain is erased. The `ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir` assertion that both rank-1 statistic `local_load`s belong only to computation task 0 is added with that fixture, which a later commit introduces.
+
 ## Debugging Workflow
 - `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)

--- a/test/Hopper/WarpSpecialization/ws_code_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition.mlir
@@ -142,12 +142,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// CHECK-DAG: #[[$SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
-// CHECK-DAG: #[[$SHARED1:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
+// CHECK-DAG: #[[$SHARED:.*]] = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 8}>
 // CHECK-LABEL: @_fbgemm_grouped_gemm_fp8_rowwise_ws
-// CHECK-DAG: ttg.local_alloc {{.*}} : () -> !ttg.memdesc<1x64x64xf8E4M3FN, #[[$SHARED1]], #smem, mutable>
-// CHECK-DAG: ttg.local_alloc {{.*}} : () -> !ttg.memdesc<1x128x64xf8E4M3FN, #[[$SHARED1]], #smem, mutable>
-// CHECK-DAG: ttg.local_alloc {{.*}} : () -> !ttg.memdesc<1x128xf32, #[[$SHARED]], #smem, mutable>
+// CHECK-DAG: ttg.local_alloc {{.*}} : () -> !ttg.memdesc<1x64x64xf8E4M3FN, #[[$SHARED]], #smem, mutable>
+// CHECK-DAG: ttg.local_alloc {{.*}} : () -> !ttg.memdesc<1x128x64xf8E4M3FN, #[[$SHARED]], #smem, mutable>
 // CHECK: ttg.warp_specialize
 // CHECK: partition0
 // CHECK: ttg.memdesc_trans

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Transforms/RegionUtils.h"
 #include "nvidia/include/Dialect/NVGPU/IR/Dialect.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Analysis/Utility.h"
@@ -25,6 +24,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/TMAUtilities.h"
 #include "triton/Tools/Sys/GetEnv.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include <list>
 #include <unordered_set>
 
@@ -61,15 +61,56 @@ static bool isValidTMADestEncoding(Attribute bufferEnc, Attribute descEnc) {
          descNvmma.getFp4Padded() == nvmma.getFp4Padded();
 }
 
+static bool isScheduleRematerialization(Operation *op) {
+  return isa<ttg::ConvertLayoutOp, tt::BroadcastOp, tt::ExpandDimsOp>(op);
+}
+
+static void eraseDeadScheduleRematerializations(Value value) {
+  SmallVector<Operation *> worklist(value.getUsers());
+  SmallVector<Operation *> candidates;
+  llvm::SmallPtrSet<Operation *, 8> visited;
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (!isScheduleRematerialization(op))
+      continue;
+    if (!visited.insert(op).second)
+      continue;
+    candidates.push_back(op);
+    for (Value result : op->getResults())
+      llvm::append_range(worklist, result.getUsers());
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *&op : llvm::reverse(candidates)) {
+      if (op && op->use_empty()) {
+        op->erase();
+        op = nullptr;
+        changed = true;
+      }
+    }
+  }
+}
+
 LogicalResult doConvertDescriptorLoadsToNVWS(triton::FuncOp funcOp) {
+  // Schedule rematerialization can leave dead per-task clones attached to a
+  // descriptor load. Remove only dead layout-rematerialization chains before
+  // deriving the replacement local_load's consumer task IDs; whole-function
+  // DCE would also erase intentionally dead consumers in test/debug IR.
   SmallVector<tt::DescriptorLoadOp> loads;
   funcOp.walk([&](tt::DescriptorLoadOp load) { loads.push_back(load); });
 
   for (tt::DescriptorLoadOp load : loads) {
+    eraseDeadScheduleRematerializations(load.getResult());
+    if (load.getResult().use_empty()) {
+      load.erase();
+      continue;
+    }
+
     auto tensorType = dyn_cast<RankedTensorType>(load.getType());
     if (!tensorType)
       return load.emitError("expected a ranked tensor descriptor load result");
-
     Attribute descEnc =
         cast<tt::TensorDescType>(load.getDesc().getType()).getSharedLayout();
 


### PR DESCRIPTION
Summary:
Partition scheduling clones the m/delta convert-layout chain into the load
task, but those clones are dead. doConvertDescriptorLoadsToNVWS counted the
dead task-3 users when deriving the replacement local_load's consumer task
IDs, so the load came out tagged {0, 3} -- a producer-task self-consumer
channel, which gives unsafe TMA-buffer rotation and silently corrupts the
BM128 2-CTA FA backward.

Before converting each descriptor load, recursively erase only the dead
convert_layout/broadcast/expand_dims rematerialization chains hanging off it,
then derive the consumer task IDs from the remaining users. Whole-function DCE
is deliberately avoided: test and debug IR legitimately contain unrelated dead
consumers.

The ws_code_partition.mlir update is required by the fix rather than optional:
erasing the dead chain removes a rank-1 f32 shared alloc from
_fbgemm_grouped_gemm_fp8_rowwise_ws, so the old CHECKs no longer match.

Upstream this change also asserted the fix in
ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir, but that fixture is
created by the BM128 GEMM pipelining change, which now lands after this one.
The assertion moves to the commit that introduces the fixture.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D117027918


