### PR TITLE
[TritonGPU] Pipeline BM128 backward GEMM partitions in lockstep

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -10,6 +10,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/Triton/Transforms/LoopPeeling.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/Transforms/Partition.h"
 #include "triton/Dialect/TritonGPU/Transforms/PartitionLoopPeeling.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipelineExpander.h"
@@ -64,6 +65,78 @@ static bool hasMMAv5WaitsInLastStage(scf::ForOp forOp,
   return hasMMAv5 && hasWaitInLastStage;
 }
 
+static std::optional<StringRef>
+getWarpSpecializedPartitionType(scf::ForOp forOp) {
+  auto wsOp = forOp->getParentOfType<triton::gpu::WarpSpecializeOp>();
+  if (!wsOp)
+    return std::nullopt;
+  auto typesAttr = wsOp->getAttrOfType<ArrayAttr>(kPartitionTypesAttrName);
+  if (!typesAttr)
+    return std::nullopt;
+
+  SmallVector<StringRef> partitionTypes;
+  for (Attribute attr : typesAttr) {
+    auto type = dyn_cast<StringAttr>(attr);
+    if (!type)
+      return std::nullopt;
+    partitionTypes.push_back(type.getValue());
+  }
+
+  Region *loopRegion = forOp->getParentRegion();
+  if (wsOp.getDefaultRegion().isAncestor(loopRegion))
+    return partitionTypes.empty() ? std::nullopt
+                                  : std::optional(partitionTypes.front());
+
+  auto partitionRegions = wsOp.getPartitionRegions();
+  if (partitionTypes.size() < partitionRegions.size())
+    return std::nullopt;
+  size_t typeOffset = partitionTypes.size() - partitionRegions.size();
+  for (auto [idx, partitionRegion] : llvm::enumerate(partitionRegions)) {
+    if (partitionRegion->isAncestor(loopRegion))
+      return partitionTypes[idx + typeOffset];
+  }
+  return std::nullopt;
+}
+
+static bool containsMMA(scf::ForOp forOp) {
+  return forOp
+      ->walk([](Operation *op) {
+        return isa<triton::nvidia_gpu::MMAv5OpInterface,
+                   triton::DotOpInterface>(op)
+                   ? WalkResult::interrupt()
+                   : WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
+static bool containsMMAv5(scf::ForOp forOp) {
+  return forOp
+      ->walk([](triton::nvidia_gpu::MMAv5OpInterface) {
+        return WalkResult::interrupt();
+      })
+      .wasInterrupted();
+}
+
+static bool needsCustomMetaWSEpiloguePeeling(scf::ForOp forOp) {
+  Operation *scope = forOp.getOperation();
+  if (auto wsOp = forOp->getParentOfType<triton::gpu::WarpSpecializeOp>())
+    scope = wsOp.getOperation();
+
+  // The generic pipeline expander predicates peeled epilogue operations.
+  // Peer gathers cannot be predicated, and predicating a TMA reduction in one
+  // partition independently of its sibling GEMM partitions breaks their
+  // iteration lockstep. Keep the legacy PredicateStage-based peeling for the
+  // entire warp-specialize operation when either operation is present.
+  return scope
+      ->walk([&](Operation *op) {
+        if (isa<triton::nvidia_gpu::TwoCTAPeerGatherOp,
+                triton::nvidia_gpu::AsyncTMAReduceOp>(op))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      })
+      .wasInterrupted();
+}
+
 static void expandLoops(ModuleOp moduleOp) {
   DenseSet<MaskOp> peeledMaskOps;
   auto processPeeledEpilogueOp = [&](RewriterBase &rewriter, Operation *op,
@@ -103,6 +176,22 @@ static void expandLoops(ModuleOp moduleOp) {
   auto metaWS = triton::tools::getBoolEnv("TRITON_USE_META_WS");
 
   for (scf::ForOp forOp : loops) {
+    std::optional<StringRef> partitionType;
+    if (metaWS) {
+      if (forOp->getParentOfType<triton::gpu::WarpSpecializeOp>()) {
+        partitionType = getWarpSpecializedPartitionType(forOp);
+        if (!partitionType)
+          continue;
+        if (*partitionType == "gemm") {
+          if (!containsMMA(forOp))
+            continue;
+        } else if (*partitionType != "load") {
+          // Load-worker loops carry their own software-pipeline schedule and
+          // must be expanded to materialize the TMA prologue.
+          continue;
+        }
+      }
+    }
     CoarseSchedule schedule;
     if (failed(schedule.deSerialize(forOp))) {
       continue;
@@ -114,9 +203,22 @@ static void expandLoops(ModuleOp moduleOp) {
 
     std::vector<std::pair<Operation *, unsigned>> finalSchedule =
         schedule.createFinalSchedule(forOp);
+    if (metaWS && containsMMAv5(forOp)) {
+      unsigned maxMMAStage = 0;
+      for (auto &[op, stage] : finalSchedule)
+        if (isa<triton::nvidia_gpu::MMAv5OpInterface>(op))
+          maxMMAStage = std::max(maxMMAStage, stage);
+      for (auto &[op, stage] : finalSchedule) {
+        auto wait = dyn_cast<triton::nvidia_gpu::WaitBarrierOp>(op);
+        if (wait && !wait.getDeps().empty() && stage > maxMMAStage)
+          stage = maxMMAStage;
+      }
+    }
     triton::PipeliningOption options;
+    bool useCustomMetaWSEpilogue =
+        metaWS && needsCustomMetaWSEpiloguePeeling(forOp);
     options.supportDynamicLoops = true;
-    options.peelEpilogue = false;
+    options.peelEpilogue = metaWS && !useCustomMetaWSEpilogue;
     options.predicateFn = wrapInMaskOp;
     options.getScheduleFn =
         [&](scf::ForOp forOp,
@@ -135,8 +237,8 @@ static void expandLoops(ModuleOp moduleOp) {
         !forOp->getParentOfType<triton::gpu::WarpSpecializeOp>() &&
         !keepPredicateStage; // do not peel if we are testing the stage
                              // predication
-    if (metaWS && hasWarpSpec)
-      customEpiloguePeeling = true;
+    if (metaWS)
+      customEpiloguePeeling = useCustomMetaWSEpilogue;
 
     if (keepPredicateStage || customEpiloguePeeling) {
       options.emitPredicateStageFn =

--- a/test/Hopper/TwoCTA/pipeline_bwd_bm128_gemm_only.mlir
+++ b/test/Hopper/TwoCTA/pipeline_bwd_bm128_gemm_only.mlir
@@ -1,0 +1,2501 @@
+// RUN: TRITON_USE_META_WS=1 triton-opt %s '-tritongpu-schedule-loops=use-meta-ws=true num-stages=2' '--tritongpu-pipeline=num-stages=2' | FileCheck %s
+// Regression: warp-specialized loops containing a peer gather or TMA reduction
+// must use lockstep epilogue peeling. Generic epilogue predication cannot mask
+// the gather and independently predicating the reduction desynchronizes sibling
+// partitions.
+// CHECK-LABEL: partition0({{.*}}) num_warps(4)
+// CHECK-COUNT-10: ttng.tc_gen5_mma
+// CHECK-LABEL: partition1({{.*}}) num_warps(4)
+// CHECK-NOT: ttng.tc_gen5_mma
+// CHECK-LABEL: partition2({{.*}}) num_warps(4)
+// CHECK-NOT: ttng.tc_gen5_mma
+// The load worker must still pass through the pipeline expander. Leaving its
+// scheduled loop unexpanded keeps loop.stage metadata on the steady-state TMA
+// loads and loses the prologue/steady-state overlap.
+// CHECK: ttng.async_tma_copy_global_to_local %arg107{{.*}} {async_task_id = array<i32: 3>}
+// CHECK-LABEL: partition3({{.*}}) num_warps(4)
+//
+// Two input modules: the first is the 5-MMA / 1-peer-gather shape the CHECKs
+// above pin, the second the 10-MMA / 2-peer-gather shape. A third module that
+// differed from the first only by tt.self_latency on four tc_gen5_mma ops was
+// dropped -- 1098 lines of whole-kernel IR to vary one attribute, with no
+// assertions of its own.
+//
+// Scope of what these CHECKs actually catch, measured by disabling each
+// mechanism and re-running: they fail when the gemm-partition gate is removed,
+// but still pass with lockstep epilogue peeling disabled and with the MMA
+// stage clamp disabled.  So this fixture pins partition assignment and GEMM
+// expansion, not the peeling strategy the header describes.  Covering those
+// two needs assertions on the epilogue shape, which this file does not have.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8]], lane = [[2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], warp = [[64, 0], [1, 0]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 1, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 0, 1]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], warp = [[64, 0], [1, 0]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 1, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 0, 1]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64]], block = []}>
+#linear10 = #ttg.linear<{register = [[128, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear11 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear12 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear13 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear14 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear15 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear16 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#linear17 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 1, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#linear18 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 0, 1]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared4 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared5 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem2 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+#tmem3 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, twoCTAs = true>
+#tmem4 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 2, twoCTAs = true>
+module {
+  module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+    tt.func public @_attn_bwd_persist(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x128xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<256x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.tensordesc<128x128xf16, #shared>, %arg21: i32, %arg22: i32, %arg23: i64, %arg24: i64, %arg25: f32, %arg26: !tt.tensordesc<128x64xf16, #shared>, %arg27: i32, %arg28: i32, %arg29: i64, %arg30: i64, %arg31: !tt.tensordesc<64x128xf16, #shared>, %arg32: i32, %arg33: i32, %arg34: i64, %arg35: i64, %arg36: !tt.tensordesc<128x16xf32, #shared1>, %arg37: i32, %arg38: i32, %arg39: i64, %arg40: i64, %arg41: !tt.tensordesc<128x16xf16, #shared2>, %arg42: i32, %arg43: i32, %arg44: i64, %arg45: i64, %arg46: !tt.tensordesc<128x16xf16, #shared2>, %arg47: i32, %arg48: i32, %arg49: i64, %arg50: i64, %arg51: !tt.tensordesc<128xf32, #shared3>, %arg52: i32, %arg53: i64, %arg54: !tt.tensordesc<128xf32, #shared3>, %arg55: i32, %arg56: i64, %arg57: i32 {tt.divisibility = 16 : i32}, %arg58: i32 {tt.divisibility = 16 : i32}, %arg59: i32 {tt.divisibility = 16 : i32}, %arg60: i32, %arg61: i32, %arg62: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+      %c1_i64 = arith.constant {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} 1 : i64
+      %c0_i64 = arith.constant {async_task_id = array<i32: 0>} 0 : i64
+      %c1_i32 = arith.constant {async_task_id = array<i32: 0>} 1 : i32
+      %c2_i32 = arith.constant {async_task_id = array<i32: 0>} 2 : i32
+      %c128_i32 = arith.constant {async_task_id = array<i32: 0>} 128 : i32
+      %c127_i32 = arith.constant {async_task_id = array<i32: 0>} 127 : i32
+      %c2_i64 = arith.constant {async_task_id = array<i32: 0>} 2 : i64
+      %c16_i32 = arith.constant {async_task_id = array<i32: 0>} 16 : i32
+      %c32_i32 = arith.constant {async_task_id = array<i32: 0>} 32 : i32
+      %c48_i32 = arith.constant {async_task_id = array<i32: 0>} 48 : i32
+      %c64_i32 = arith.constant {async_task_id = array<i32: 0>} 64 : i32
+      %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<128x16xf32, #linear>
+      %c0_i32 = arith.constant 0 : i32
+      %0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %2 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %3 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %4 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %5 = ttg.memdesc_index %4[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %5, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %6 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %7 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %7, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %8 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %9 = ttg.memdesc_index %8[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %9, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %10 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %11 = ttg.memdesc_index %10[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %11, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %12 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %13 = ttg.memdesc_index %12[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %13, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %14 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %15 = ttg.memdesc_index %14[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %15, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %16 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %17 = ttg.memdesc_index %16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %17, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %18 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %19 = ttg.memdesc_index %18[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %19, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %20 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %21 = ttg.memdesc_index %20[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %21, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %22 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %23 = ttg.memdesc_index %22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %23, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %24 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %25 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %25, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %26 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %27 = ttg.memdesc_index %26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %27, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %28 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %29 = ttg.memdesc_index %28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %29, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %30 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %31 = ttg.memdesc_index %30[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %31, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %32 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %33 = ttg.memdesc_index %32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %33, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %34 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %35 = ttg.memdesc_index %34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %35, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %36 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %37 = ttg.memdesc_index %36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %37, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %38 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %39 = ttg.memdesc_index %38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %39, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %40 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %41 = ttg.memdesc_index %40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %41, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %42 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %43 = ttg.memdesc_index %42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %43, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %44 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %45 = ttg.memdesc_index %44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %45, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %46 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %47 = ttg.memdesc_index %46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %47, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %48 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %49 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %50 = ttg.memdesc_index %48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %50, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %51 = ttg.memdesc_index %49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %51, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %52 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %53 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %54 = ttg.memdesc_index %52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %54, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %55 = ttg.memdesc_index %53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %55, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %56 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %57 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %58 = ttg.memdesc_index %56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %58, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %59 = ttg.memdesc_index %57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %59, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %60 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %61 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %62 = ttg.memdesc_index %60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %62, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %63 = ttg.memdesc_index %61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %63, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %64 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %65 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %66 = ttg.memdesc_index %64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %66, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %67 = ttg.memdesc_index %65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %67, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %68 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %69 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %70 = ttg.memdesc_index %68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %70, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %71 = ttg.memdesc_index %69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %71, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %72 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %73 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %74 = ttg.memdesc_index %72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %74, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %75 = ttg.memdesc_index %73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %75, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %76 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %77 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %78 = ttg.memdesc_index %76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %78, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %79 = ttg.memdesc_index %77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %79, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %80 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %81 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %82 = ttg.memdesc_index %80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %82, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %83 = ttg.memdesc_index %81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %83, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %84 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %85 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %86 = ttg.memdesc_index %84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %86, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %87 = ttg.memdesc_index %85[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %87, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %88 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %89 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %90 = ttg.memdesc_index %88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %90, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %91 = ttg.memdesc_index %89[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %91, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %92 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+      %93 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 12 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+      %94 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+      %result, %token = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_0, %token_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %95 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+      %96 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 15 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %97 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 16 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+      %result_2, %token_3 = ttng.tmem_alloc {allocation.shareGroup = 1 : i32, buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %98 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 17 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %99 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+      %result_4, %token_5 = ttng.tmem_alloc {allocation.shareGroup = 4 : i32, buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %100 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 19 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+      %101 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 20 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %102 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+      %103 = ttg.local_alloc {allocation.shareGroup = 3 : i32, buffer.copy = 1 : i32, buffer.id = 22 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>
+      %104 = ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 1 : i32, buffer.id = 26 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+      %105 = ttg.local_alloc {allocation.shareGroup = 2 : i32, buffer.copy = 1 : i32, buffer.id = 34 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+      ttg.warp_specialize(%arg62, %arg60, %arg61, %46, %42, %38, %95, %30, %92, %result_2, %28, %20, %14, %99, %12, %94, %result_4, %10, %8, %result, %98, %16, %18, %result_0, %96, %24, %26, %4, %102, %93, %2, %0, %32, %34, %36, %40, %44, %101, %arg59, %arg58, %arg57, %arg10, %arg15, %arg20, %arg5, %arg0, %22, %97, %arg51, %arg26, %arg31, %6, %100, %arg54, %arg25, %104, %arg46, %105, %arg41, %48, %49, %52, %53, %56, %57, %60, %61, %64, %65, %68, %69, %72, %73, %76, %77, %80, %81, %84, %85, %88, %89) attributes {ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"]}
+      default {
+        %152 = arith.addi %arg62, %c127_i32 {async_task_id = array<i32: 0>} : i32
+        %153 = arith.divsi %152, %c128_i32 {async_task_id = array<i32: 0>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 0>} : i32
+        %155 = arith.remsi %154, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %156 = arith.divsi %154, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 0>} : i32
+        %158 = arith.divsi %157, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %159 = arith.divsi %153, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %160 = arith.muli %159, %arg60 {async_task_id = array<i32: 0>} : i32
+        %161 = arith.muli %160, %arg61 {async_task_id = array<i32: 0>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 0>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 0>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 0>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %171 = arith.addi %162, %c1_i32 {async_task_id = array<i32: 0>} : i32
+          scf.yield {async_task_id = array<i32: 0>} %171 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 0>} %162 : i32
+        } {async_task_id = array<i32: 0>}
+        %166 = arith.extsi %arg59 {async_task_id = array<i32: 0>} : i32 to i64
+        %167 = arith.divsi %arg62, %c128_i32 {async_task_id = array<i32: 0>} : i32
+        %168 = arith.muli %155, %c64_i32 {async_task_id = array<i32: 0>} : i32
+        %169 = arith.extsi %168 {async_task_id = array<i32: 0>} : i32 to i64
+        %170:2 = scf.for %arg63 = %c0_i32 to %165 step %c1_i32 iter_args(%arg64 = %156, %arg65 = %c0_i64) -> (i32, i64)  : i32 {
+          %171 = arith.divsi %arg64, %159 {async_task_id = array<i32: 0>} : i32
+          %172 = arith.remsi %171, %arg61 {async_task_id = array<i32: 0>} : i32
+          %173 = arith.muli %arg58, %172 {async_task_id = array<i32: 0>} : i32
+          %174 = arith.divsi %171, %arg61 {async_task_id = array<i32: 0>} : i32
+          %175 = arith.muli %arg57, %174 {async_task_id = array<i32: 0>} : i32
+          %176 = arith.addi %173, %175 {async_task_id = array<i32: 0>} : i32
+          %177 = arith.extsi %176 {async_task_id = array<i32: 0>} : i32 to i64
+          %178 = arith.divsi %177, %166 {async_task_id = array<i32: 0>} : i64
+          %179:2 = scf.for %arg66 = %c0_i32 to %167 step %c1_i32 iter_args(%arg67 = %c0_i32, %arg68 = %arg65) -> (i32, i64)  : i32 {
+            %181 = arith.extsi %arg67 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+            %182 = arith.addi %178, %181 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %183 = arith.andi %arg68, %c1_i64 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %184 = arith.trunci %183 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %185 = ttng.tmem_subslice %result_4 {N = 0 : i32, async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %186 = ttg.memdesc_reinterpret %185 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+            %187 = ttg.memdesc_index %186[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+            %188 = ttg.memdesc_index %0[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %189 = arith.extui %184 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %188, %189 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_6, %token_7 = ttng.tmem_load %187[] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear1>
+            %190 = ttg.memdesc_index %89[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %190, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %191 = tt.reshape %result_6 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<64x128xf32, #linear1> -> tensor<128x2x32xf32, #linear2>
+            %192 = tt.trans %191 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear2> -> tensor<128x32x2xf32, #linear3>
+            %outLHS, %outRHS = tt.split %192 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32x2xf32, #linear3> -> tensor<128x32xf32, #linear4>
+            %193 = tt.reshape %outLHS {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32xf32, #linear4> -> tensor<128x2x16xf32, #linear5>
+            %194 = tt.trans %193 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear5> -> tensor<128x16x2xf32, #linear6>
+            %outLHS_8, %outRHS_9 = tt.split %194 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16x2xf32, #linear6> -> tensor<128x16xf32, #linear>
+            %195 = tt.reshape %outRHS {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32xf32, #linear4> -> tensor<128x2x16xf32, #linear5>
+            %196 = tt.trans %195 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear5> -> tensor<128x16x2xf32, #linear6>
+            %outLHS_10, %outRHS_11 = tt.split %196 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16x2xf32, #linear6> -> tensor<128x16xf32, #linear>
+            %197 = arith.addi %182, %169 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %198 = arith.muli %197, %c2_i64 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %199 = arith.mulf %outLHS_8, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %200 = ttg.convert_layout %199 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %201 = arith.trunci %198 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %202 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %200, %202 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %203 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %204 = ttng.async_tma_reduce add, %arg36[%201, %c0_i32] %203 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %204   {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %205 = arith.mulf %outRHS_9, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %206 = ttg.convert_layout %205 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %207 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %206, %207 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %208 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %209 = ttng.async_tma_reduce add, %arg36[%201, %c16_i32] %208 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %209   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %210 = arith.mulf %outLHS_10, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %211 = ttg.convert_layout %210 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %212 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %211, %212 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %213 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %214 = ttng.async_tma_reduce add, %arg36[%201, %c32_i32] %213 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %214   {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %215 = arith.mulf %outRHS_11, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %216 = ttg.convert_layout %215 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %217 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %216, %217 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %218 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %219 = ttng.async_tma_reduce add, %arg36[%201, %c48_i32] %218 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %219   {async_task_id = array<i32: 0>, loop.cluster = 4 : i32, loop.stage = 1 : i32} : !ttg.async.token
+            %220 = arith.addi %arg67, %c128_i32 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i32
+            %221 = arith.addi %arg68, %c1_i64 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 0>} %220, %221 : i32, i64
+          } {async_task_id = array<i32: 0>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %180 = arith.addi %arg64, %158 {async_task_id = array<i32: 0>} : i32
+          scf.yield {async_task_id = array<i32: 0>} %180, %179#1 : i32, i64
+        } {async_task_id = array<i32: 0>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_yield
+      }
+      partition0(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 1>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 1>} 0 : i64
+        %true = arith.constant {async_task_id = array<i32: 1>} true
+        %c127_i32_8 = arith.constant {async_task_id = array<i32: 1>} 127 : i32
+        %c128_i32_9 = arith.constant {async_task_id = array<i32: 1>} 128 : i32
+        %c2_i32_10 = arith.constant {async_task_id = array<i32: 1>} 2 : i32
+        %c1_i32_11 = arith.constant {async_task_id = array<i32: 1>} 1 : i32
+        %c0_i32_12 = arith.constant {async_task_id = array<i32: 1>} 0 : i32
+        %false = arith.constant {async_task_id = array<i32: 1>} false
+        %152 = arith.addi %arg63, %c127_i32_8 {async_task_id = array<i32: 1>} : i32
+        %153 = arith.divsi %152, %c128_i32_9 {async_task_id = array<i32: 1>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 1>} : i32
+        %155 = arith.divsi %154, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %156 = tt.get_num_programs x {async_task_id = array<i32: 1>} : i32
+        %157 = arith.divsi %156, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %158 = arith.divsi %153, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %159 = arith.muli %158, %arg64 {async_task_id = array<i32: 1>} : i32
+        %160 = arith.muli %159, %arg65 {async_task_id = array<i32: 1>} : i32
+        %161 = arith.divsi %160, %157 {async_task_id = array<i32: 1>} : i32
+        %162 = arith.remsi %160, %157 {async_task_id = array<i32: 1>} : i32
+        %163 = arith.cmpi slt, %155, %162 {async_task_id = array<i32: 1>} : i32
+        %164 = scf.if %163 -> (i32) {
+          %167 = arith.addi %161, %c1_i32_11 {async_task_id = array<i32: 1>} : i32
+          scf.yield {async_task_id = array<i32: 1>} %167 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 1>} %161 : i32
+        } {async_task_id = array<i32: 1>}
+        %165 = arith.divsi %arg63, %c128_i32_9 {async_task_id = array<i32: 1>} : i32
+        %166:2 = scf.for %arg144 = %c0_i32_12 to %164 step %c1_i32_11 iter_args(%arg145 = %c0_i64_7, %arg146 = %c0_i64_7) -> (i64, i64)  : i32 {
+          %167 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %168 = arith.trunci %167 {async_task_id = array<i32: 1>} : i64 to i1
+          %169 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %170 = arith.trunci %169 {async_task_id = array<i32: 1>} : i64 to i1
+          %171 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %172 = arith.trunci %171 {async_task_id = array<i32: 1>} : i64 to i1
+          %173 = ttg.memdesc_index %arg66[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %174 = arith.extui %168 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %173, %174, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %175 = ttg.memdesc_index %arg67[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %176 = arith.extui %170 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %175, %176, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %177 = ttg.memdesc_index %arg68[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %178 = arith.extui %172 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %177, %178, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %179 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %180 = arith.trunci %179 {async_task_id = array<i32: 1>} : i64 to i1
+          %181 = ttg.memdesc_index %arg123[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %182 = arith.xori %180, %true : i1
+          %183 = arith.extui %182 : i1 to i32
+          ttng.wait_barrier %181, %183 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %184 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %185 = arith.trunci %184 {async_task_id = array<i32: 1>} : i64 to i1
+          %186 = ttg.memdesc_index %arg125[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %187 = arith.xori %185, %true : i1
+          %188 = arith.extui %187 : i1 to i32
+          ttng.wait_barrier %186, %188 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %189:2 = scf.for %arg147 = %c0_i32_12 to %165 step %c1_i32_11 iter_args(%arg148 = %false, %arg149 = %arg146) -> (i1, i64)  : i32 {
+            %196 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %197 = arith.trunci %196 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %198 = ttg.memdesc_index %arg69[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %199 = ttg.memdesc_index %arg70[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %200 = arith.extui %197 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %199, %200, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %201 = ttg.memdesc_trans %198 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+            %202 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+            %203 = arith.trunci %202 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+            %204 = ttg.memdesc_index %arg71[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+            %205 = ttg.memdesc_index %arg72[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %206 = ttg.memdesc_index %arg73[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %207 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %208 = arith.trunci %207 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %209 = ttg.memdesc_index %arg74[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %210 = ttg.memdesc_index %arg129[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %211 = arith.xori %208, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+            %212 = arith.extui %211 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %210, %212 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %213 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %214 = arith.trunci %213 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %215 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %216 = arith.xori %214, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+            %217 = arith.extui %216 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %215, %217 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {direction = "backward", dstTask = 1 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %218 = ttng.tc_gen5_mma %204, %201, %205[], %false, %true, %206[%true], %209[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %219 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %220 = arith.trunci %219 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %221 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %222 = arith.trunci %221 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %223 = ttg.memdesc_index %arg76[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %224 = ttg.memdesc_index %arg77[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %225 = arith.extui %222 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %224, %225, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %226 = ttg.memdesc_trans %223 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+            %227 = ttg.memdesc_index %arg78[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+            %228 = ttg.memdesc_index %arg79[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %229 = ttg.memdesc_index %arg80[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %230 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %231 = arith.trunci %230 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %232 = ttg.memdesc_index %arg81[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %233 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %234 = arith.xori %231, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %235 = arith.extui %234 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %233, %235 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %236 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %237 = arith.trunci %236 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %238 = ttg.memdesc_index %arg143[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %239 = arith.xori %237, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %240 = arith.extui %239 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %238, %240 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %241 = ttng.tc_gen5_mma %227, %226, %228[], %false, %true, %229[%true], %232[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %242 = ttg.memdesc_index %arg82[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %243 = ttg.memdesc_index %arg83[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %244 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %245 = ttg.memdesc_reinterpret %244 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %246 = ttg.memdesc_index %245[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %247 = ttg.memdesc_index %arg84[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %248 = ttg.memdesc_index %arg85[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %249 = arith.extui %220 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %248, %249, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %250 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %251 = ttg.memdesc_index %arg130[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %252 = arith.extui %214 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %251, %252 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %253 = ttng.tc_gen5_mma %246, %243, %242[], %arg148, %true, %247[%true], %250[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 3>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %254 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+            %255 = arith.trunci %254 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+            %256 = ttg.memdesc_index %arg86[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %257 = ttg.memdesc_index %arg87[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %258 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %259 = ttg.memdesc_reinterpret %258 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %260 = ttg.memdesc_index %259[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %261 = ttg.memdesc_index %arg88[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %262 = ttg.memdesc_index %arg89[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %263 = arith.extui %203 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %262, %263, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %264 = ttg.memdesc_index %arg90[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %265 = ttg.memdesc_index %arg136[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %266 = arith.extui %255 {loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %265, %266 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %267 = ttng.tc_gen5_mma %260, %257, %256[], %arg148, %true, %261[%true], %264[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 6 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 4>, tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %268 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64
+            %269 = arith.trunci %268 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64 to i1
+            %270 = ttg.memdesc_index %arg91[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %271 = ttg.memdesc_index %arg140[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %272 = arith.extui %269 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %271, %272 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %273 = ttg.memdesc_trans %270 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>
+            %274 = ttg.memdesc_index %arg92[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %275 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %276 = ttg.memdesc_reinterpret %275 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+            %277 = ttg.memdesc_index %276[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+            %278 = ttg.memdesc_index %arg93[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %279 = ttg.memdesc_index %arg94[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %280 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %281 = arith.extui %237 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %280, %281 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %282 = ttng.tc_gen5_mma %273, %274, %277[], %false, %true, %278[%true], %279[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %283 = arith.addi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            scf.yield {async_task_id = array<i32: 1>} %true, %283 : i1, i64
+          } {async_task_id = array<i32: 1>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %190 = ttg.memdesc_index %arg95[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %190 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %191 = ttg.memdesc_index %arg96[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %191 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %192 = ttg.memdesc_index %arg97[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %192 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %193 = ttg.memdesc_index %arg98[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %193 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %194 = ttg.memdesc_index %arg99[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %194 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %195 = arith.addi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          scf.yield {async_task_id = array<i32: 1>} %195, %189#1 : i64, i64
+        } {async_task_id = array<i32: 1>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition1(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 2>} 0 : i64
+        %c127_i32_8 = arith.constant {async_task_id = array<i32: 2>} 127 : i32
+        %c128_i32_9 = arith.constant {async_task_id = array<i32: 2>} 128 : i32
+        %c2_i32_10 = arith.constant {async_task_id = array<i32: 2>} 2 : i32
+        %c1_i32_11 = arith.constant {async_task_id = array<i32: 2>} 1 : i32
+        %c0_i32_12 = arith.constant {async_task_id = array<i32: 2>} 0 : i32
+        %152 = arith.addi %arg63, %c127_i32_8 {async_task_id = array<i32: 2>} : i32
+        %153 = arith.divsi %152, %c128_i32_9 {async_task_id = array<i32: 2>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 2>} : i32
+        %155 = arith.divsi %154, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %156 = tt.get_num_programs x {async_task_id = array<i32: 2>} : i32
+        %157 = arith.divsi %156, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %158 = arith.divsi %153, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %159 = arith.muli %158, %arg64 {async_task_id = array<i32: 2>} : i32
+        %160 = arith.muli %159, %arg65 {async_task_id = array<i32: 2>} : i32
+        %161 = arith.divsi %160, %157 {async_task_id = array<i32: 2>} : i32
+        %162 = arith.remsi %160, %157 {async_task_id = array<i32: 2>} : i32
+        %163 = arith.cmpi slt, %155, %162 {async_task_id = array<i32: 2>} : i32
+        %164 = scf.if %163 -> (i32) {
+          %167 = arith.addi %161, %c1_i32_11 {async_task_id = array<i32: 2>} : i32
+          scf.yield {async_task_id = array<i32: 2>} %167 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 2>} %161 : i32
+        } {async_task_id = array<i32: 2>}
+        %165 = arith.divsi %arg63, %c128_i32_9 {async_task_id = array<i32: 2>} : i32
+        %166 = scf.for %arg144 = %c0_i32_12 to %164 step %c1_i32_11 iter_args(%arg145 = %c0_i64_7) -> (i64)  : i32 {
+          %167 = scf.for %arg146 = %c0_i32_12 to %165 step %c1_i32_11 iter_args(%arg147 = %arg145) -> (i64)  : i32 {
+            %168 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %169 = arith.trunci %168 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %170 = ttg.memdesc_index %arg100[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %171 = ttg.memdesc_index %arg138[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %172 = arith.extui %169 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %171, %172 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.two_cta_peer_relay %170 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : <128x64xf16, #shared, #smem, mutable>
+            %173 = ttg.memdesc_index %arg139[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %173, 1 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %174 = arith.addi %arg147, %c1_i64_6 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 2>} %174 : i64
+          } {async_task_id = array<i32: 2>, tt.scheduled_max_stage = 0 : i32, tt.warp_specialize}
+          scf.yield {async_task_id = array<i32: 2>} %167 : i64
+        } {async_task_id = array<i32: 2>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition2(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %true = arith.constant {async_task_id = array<i32: 3>} true
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 3>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 3>} 0 : i64
+        %c64_i32_8 = arith.constant {async_task_id = array<i32: 3>} 64 : i32
+        %c127_i32_9 = arith.constant {async_task_id = array<i32: 3>} 127 : i32
+        %c128_i32_10 = arith.constant {async_task_id = array<i32: 3>} 128 : i32
+        %c2_i32_11 = arith.constant {async_task_id = array<i32: 3>} 2 : i32
+        %c1_i32_12 = arith.constant {async_task_id = array<i32: 3>} 1 : i32
+        %c0_i32_13 = arith.constant {async_task_id = array<i32: 3>} 0 : i32
+        %152 = arith.addi %arg63, %c127_i32_9 {async_task_id = array<i32: 3>} : i32
+        %153 = arith.divsi %152, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 3>} : i32
+        %155 = arith.remsi %154, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %156 = arith.divsi %154, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 3>} : i32
+        %158 = arith.divsi %157, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %159 = arith.divsi %153, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %160 = arith.muli %159, %arg64 {async_task_id = array<i32: 3>} : i32
+        %161 = arith.muli %160, %arg65 {async_task_id = array<i32: 3>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 3>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 3>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 3>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %173 = arith.addi %162, %c1_i32_12 {async_task_id = array<i32: 3>} : i32
+          scf.yield {async_task_id = array<i32: 3>} %173 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 3>} %162 : i32
+        } {async_task_id = array<i32: 3>}
+        %166 = arith.extsi %arg101 {async_task_id = array<i32: 3>} : i32 to i64
+        %167 = arith.muli %155, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %168 = arith.divsi %arg63, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %169 = nvg.cluster_id {async_task_id = array<i32: 3>}
+        %170 = arith.remsi %169, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %171 = arith.muli %170, %c64_i32_8 {async_task_id = array<i32: 3>} : i32
+        %172:3 = scf.for %arg144 = %c0_i32_13 to %165 step %c1_i32_12 iter_args(%arg145 = %156, %arg146 = %c0_i64_7, %arg147 = %c0_i64_7) -> (i32, i64, i64)  : i32 {
+          %173 = arith.remsi %arg145, %159 {async_task_id = array<i32: 3>} : i32
+          %174 = arith.divsi %arg145, %159 {async_task_id = array<i32: 3>} : i32
+          %175 = arith.muli %173, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+          %176 = arith.addi %175, %155 {async_task_id = array<i32: 3>} : i32
+          %177 = arith.muli %174, %arg63 {async_task_id = array<i32: 3>} : i32
+          %178 = arith.extsi %177 {async_task_id = array<i32: 3>} : i32 to i64
+          %179 = arith.remsi %174, %arg65 {async_task_id = array<i32: 3>} : i32
+          %180 = arith.muli %arg102, %179 {async_task_id = array<i32: 3>} : i32
+          %181 = arith.divsi %174, %arg65 {async_task_id = array<i32: 3>} : i32
+          %182 = arith.muli %arg103, %181 {async_task_id = array<i32: 3>} : i32
+          %183 = arith.addi %180, %182 {async_task_id = array<i32: 3>} : i32
+          %184 = arith.extsi %183 {async_task_id = array<i32: 3>} : i32 to i64
+          %185 = arith.divsi %184, %166 {async_task_id = array<i32: 3>} : i64
+          %186 = arith.muli %176, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+          %187 = arith.extsi %186 {async_task_id = array<i32: 3>} : i32 to i64
+          %188 = arith.addi %185, %187 {async_task_id = array<i32: 3>} : i64
+          %189 = arith.trunci %188 {async_task_id = array<i32: 3>} : i64 to i32
+          %190 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %191 = arith.trunci %190 {async_task_id = array<i32: 3>} : i64 to i1
+          %192 = ttg.memdesc_index %arg99[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %193 = arith.xori %191, %true {async_task_id = array<i32: 3>} : i1
+          %194 = arith.extui %193 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %192, %194 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %195 = ttg.memdesc_index %arg66[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %195, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %196 = ttg.memdesc_index %arg71[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg104[%189, %c0_i32_13] %196, %195, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %197 = arith.subi %186, %167 {async_task_id = array<i32: 3>} : i32
+          %198 = arith.extsi %197 {async_task_id = array<i32: 3>} : i32 to i64
+          %199 = arith.addi %185, %198 {async_task_id = array<i32: 3>} : i64
+          %200 = arith.trunci %199 {async_task_id = array<i32: 3>} : i64 to i32
+          %201 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %202 = arith.trunci %201 {async_task_id = array<i32: 3>} : i64 to i1
+          %203 = ttg.memdesc_index %arg98[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %204 = arith.xori %202, %true {async_task_id = array<i32: 3>} : i1
+          %205 = arith.extui %204 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %203, %205 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %206 = ttg.memdesc_index %arg67[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %206, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %207 = ttg.memdesc_index %arg92[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg105[%200, %171] %207, %206, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<256x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %208 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %209 = arith.trunci %208 {async_task_id = array<i32: 3>} : i64 to i1
+          %210 = ttg.memdesc_index %arg97[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %211 = arith.xori %209, %true {async_task_id = array<i32: 3>} : i1
+          %212 = arith.extui %211 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %210, %212 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %213 = ttg.memdesc_index %arg68[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %213, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %214 = ttg.memdesc_index %arg78[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg106[%189, %c0_i32_13] %214, %213, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %215:2 = scf.for %arg148 = %c0_i32_13 to %168 step %c1_i32_12 iter_args(%arg149 = %c0_i32_13, %arg150 = %arg147) -> (i32, i64)  : i32 {
+            %218 = arith.extsi %arg149 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+            %219 = arith.addi %185, %218 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %220 = arith.trunci %219 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %221 = arith.addi %220, %171 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32
+            %222 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %223 = arith.trunci %222 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %224 = ttg.memdesc_index %arg73[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %225 = arith.xori %223, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %226 = arith.extui %225 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %224, %226 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %227 = ttg.memdesc_index %arg70[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %227, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %228 = ttg.memdesc_index %arg69[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg107[%221, %c0_i32_13] %228, %227, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %229 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %230 = arith.trunci %229 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %231 = ttg.memdesc_index %arg88[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %232 = arith.xori %230, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %233 = arith.extui %232 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %231, %233 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %234 = ttg.memdesc_index %arg89[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %234, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %235 = ttg.memdesc_index %arg87[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg108[%220, %171] %235, %234, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %236 = arith.addi %178, %218 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %237 = arith.trunci %236 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %238 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %239 = arith.trunci %238 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %240 = ttg.memdesc_index %arg127[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %241 = arith.xori %239, %true {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %242 = arith.extui %241 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %240, %242 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %243 = ttg.memdesc_index %arg109[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %243, 512 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %244 = ttg.memdesc_index %arg110[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg111[%237] %244, %243, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %245 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %246 = arith.trunci %245 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %247 = ttg.memdesc_index %arg84[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %248 = arith.xori %246, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %249 = arith.extui %248 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %247, %249 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %250 = ttg.memdesc_index %arg85[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %250, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %251 = ttg.memdesc_index %arg83[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg112[%220, %171] %251, %250, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %252 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %253 = arith.trunci %252 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %254 = ttg.memdesc_index %arg80[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %255 = arith.xori %253, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %256 = arith.extui %255 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %254, %256 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %257 = ttg.memdesc_index %arg77[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %257, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %258 = ttg.memdesc_index %arg76[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg113[%221, %c0_i32_13] %258, %257, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %259 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %260 = arith.trunci %259 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %261 = ttg.memdesc_index %arg135[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %262 = arith.xori %260, %true {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %263 = arith.extui %262 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %261, %263 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %264 = ttg.memdesc_index %arg114[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %264, 512 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %265 = ttg.memdesc_index %arg115[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg116[%237] %265, %264, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %266 = arith.addi %arg149, %c128_i32_10 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32
+            %267 = arith.addi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 3>} %266, %267 : i32, i64
+          } {async_task_id = array<i32: 3>, tt.scheduled_max_stage = 0 : i32, tt.warp_specialize}
+          %216 = arith.addi %arg145, %158 {async_task_id = array<i32: 3>} : i32
+          %217 = arith.addi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          scf.yield {async_task_id = array<i32: 3>} %216, %217, %215#1 : i32, i64, i64
+        } {async_task_id = array<i32: 3>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition3(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 4>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 4>} 0 : i64
+        %true = arith.constant {async_task_id = array<i32: 4>} true
+        %c112_i32 = arith.constant {async_task_id = array<i32: 4>} 112 : i32
+        %c96_i32 = arith.constant {async_task_id = array<i32: 4>} 96 : i32
+        %c80_i32 = arith.constant {async_task_id = array<i32: 4>} 80 : i32
+        %c64_i32_8 = arith.constant {async_task_id = array<i32: 4>} 64 : i32
+        %c48_i32_9 = arith.constant {async_task_id = array<i32: 4>} 48 : i32
+        %c32_i32_10 = arith.constant {async_task_id = array<i32: 4>} 32 : i32
+        %c16_i32_11 = arith.constant {async_task_id = array<i32: 4>} 16 : i32
+        %c127_i32_12 = arith.constant {async_task_id = array<i32: 4>} 127 : i32
+        %c128_i32_13 = arith.constant {async_task_id = array<i32: 4>} 128 : i32
+        %c2_i32_14 = arith.constant {async_task_id = array<i32: 4>} 2 : i32
+        %c1_i32_15 = arith.constant {async_task_id = array<i32: 4>} 1 : i32
+        %c0_i32_16 = arith.constant {async_task_id = array<i32: 4>} 0 : i32
+        %152 = arith.addi %arg63, %c127_i32_12 {async_task_id = array<i32: 4>} : i32
+        %153 = arith.divsi %152, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 4>} : i32
+        %155 = arith.remsi %154, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %156 = arith.divsi %154, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 4>} : i32
+        %158 = arith.divsi %157, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %159 = arith.divsi %153, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %160 = arith.muli %159, %arg64 {async_task_id = array<i32: 4>} : i32
+        %161 = arith.muli %160, %arg65 {async_task_id = array<i32: 4>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 4>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 4>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 4>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %170 = arith.addi %162, %c1_i32_15 {async_task_id = array<i32: 4>} : i32
+          scf.yield {async_task_id = array<i32: 4>} %170 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 4>} %162 : i32
+        } {async_task_id = array<i32: 4>}
+        %166 = arith.extsi %arg101 {async_task_id = array<i32: 4>} : i32 to i64
+        %167 = arith.divsi %arg63, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+        %168 = tt.splat %arg117 {async_task_id = array<i32: 4>} : f32 -> tensor<128x16xf32, #linear7>
+        %169:3 = scf.for %arg144 = %c0_i32_16 to %165 step %c1_i32_15 iter_args(%arg145 = %156, %arg146 = %c0_i64_7, %arg147 = %c0_i64_7) -> (i32, i64, i64)  : i32 {
+          %170 = arith.remsi %arg145, %159 {async_task_id = array<i32: 4>} : i32
+          %171 = arith.divsi %arg145, %159 {async_task_id = array<i32: 4>} : i32
+          %172 = arith.muli %170, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+          %173 = arith.addi %172, %155 {async_task_id = array<i32: 4>} : i32
+          %174 = arith.remsi %171, %arg65 {async_task_id = array<i32: 4>} : i32
+          %175 = arith.muli %arg102, %174 {async_task_id = array<i32: 4>} : i32
+          %176 = arith.divsi %171, %arg65 {async_task_id = array<i32: 4>} : i32
+          %177 = arith.muli %arg103, %176 {async_task_id = array<i32: 4>} : i32
+          %178 = arith.addi %175, %177 {async_task_id = array<i32: 4>} : i32
+          %179 = arith.extsi %178 {async_task_id = array<i32: 4>} : i32 to i64
+          %180 = arith.divsi %179, %166 {async_task_id = array<i32: 4>} : i64
+          %181 = arith.muli %173, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+          %182 = arith.extsi %181 {async_task_id = array<i32: 4>} : i32 to i64
+          %183 = arith.addi %180, %182 {async_task_id = array<i32: 4>} : i64
+          %184 = arith.trunci %183 {async_task_id = array<i32: 4>} : i64 to i32
+          %185 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          %186 = arith.trunci %185 {async_task_id = array<i32: 4>} : i64 to i1
+          %187 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          %188 = arith.trunci %187 {async_task_id = array<i32: 4>} : i64 to i1
+          %189 = scf.for %arg148 = %c0_i32_16 to %167 step %c1_i32_15 iter_args(%arg149 = %arg147) -> (i64)  : i32 {
+            %316 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %317 = arith.trunci %316 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %318 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %319 = arith.trunci %318 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %320 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %321 = arith.trunci %320 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %322 = ttg.memdesc_index %arg110[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %323 = ttg.memdesc_index %arg109[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %324 = arith.extui %317 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %323, %324, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %325 = ttg.local_load %322 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+            %326 = ttg.memdesc_index %arg127[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %326, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %327 = ttg.convert_layout %325 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+            %328 = tt.expand_dims %327 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+            %329 = tt.broadcast %328 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+            %330 = ttg.memdesc_index %arg72[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %331 = ttg.memdesc_index %arg74[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %332 = arith.extui %319 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %331, %332 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_47, %token_48 = ttng.tmem_load %330[] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+            %333 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %333, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %334 = arith.subf %result_47, %329 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %335 = math.exp2 %334 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %336 = arith.truncf %335 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+            %337 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %338 = ttg.memdesc_reinterpret %337 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %339 = ttg.memdesc_index %338[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %340 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %341 = arith.extui %321 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %340, %341 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {dstTask = 4 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.tmem_store %336, %339, %true {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %342 = ttg.memdesc_index %arg130[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %342, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %343 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %344 = arith.trunci %343 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %345 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %346 = arith.trunci %345 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %347 = ttg.memdesc_index %arg115[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %348 = ttg.memdesc_index %arg114[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %349 = arith.extui %346 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %348, %349, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %350 = ttg.local_load %347 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+            %351 = ttg.memdesc_index %arg135[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %351, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %352 = ttg.convert_layout %350 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+            %353 = tt.expand_dims %352 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+            %354 = tt.broadcast %353 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+            %355 = ttg.memdesc_index %arg79[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %356 = ttg.memdesc_index %arg81[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %357 = arith.extui %344 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %356, %357 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_49, %token_50 = ttng.tmem_load %355[] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+            %358 = ttg.memdesc_index %arg133[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %358, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %359 = arith.subf %result_49, %354 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %360 = arith.mulf %335, %359 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %361 = arith.truncf %360 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+            %362 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %363 = ttg.memdesc_reinterpret %362 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %364 = ttg.memdesc_index %363[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %365 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %366 = arith.trunci %365 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %367 = ttg.memdesc_index %arg90[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %368 = arith.xori %366, %true {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %369 = arith.extui %368 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %367, %369 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.tmem_store %361, %364, %true {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %370 = ttg.memdesc_index %arg136[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %370, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %371 = ttng.two_cta_peer_gather %361 split_dim = 1 num_ctas = 2 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<64x256xf16, #linear9>
+            %372 = tt.trans %371 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear9> -> tensor<256x64xf16, #linear10>
+            %373 = tt.reshape %361 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<128x2x64xf16, #linear11>
+            %374 = tt.trans %373 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear11> -> tensor<128x64x2xf16, #linear12>
+            %outLHS_51, %outRHS_52 = tt.split %374 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf16, #linear12> -> tensor<128x64xf16, #linear13>
+            %375 = ttg.memdesc_index %arg100[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %376 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            %377 = arith.trunci %376 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64 to i1
+            %378 = ttg.memdesc_index %arg139[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %379 = arith.xori %377, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1
+            %380 = arith.extui %379 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %378, %380 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %outLHS_51, %375 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear13> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %381 = ttg.memdesc_index %arg138[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %381, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %382 = ttg.memdesc_index %arg91[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %383 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64
+            %384 = arith.trunci %383 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64 to i1
+            %385 = ttg.memdesc_index %arg93[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %386 = arith.xori %384, %true {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1
+            %387 = arith.extui %386 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %385, %387 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %372, %382 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<256x64xf16, #linear10> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %388 = ttg.memdesc_index %arg140[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %388, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %389 = arith.addi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : i64
+            scf.yield {async_task_id = array<i32: 4>} %389 : i64
+          } {async_task_id = array<i32: 4>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %190 = ttg.memdesc_index %arg82[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %191 = ttg.memdesc_index %arg96[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %192 = arith.extui %186 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %191, %192 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_17, %token_18 = ttng.tmem_load %190[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %193 = ttg.memdesc_index %arg123[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %193, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %194 = tt.reshape %result_17 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear11>
+          %195 = tt.trans %194 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear11> -> tensor<128x64x2xf32, #linear12>
+          %outLHS, %outRHS = tt.split %195 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear12> -> tensor<128x64xf32, #linear13>
+          %196 = tt.reshape %outLHS {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %197 = tt.trans %196 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_19, %outRHS_20 = tt.split %197 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %198 = tt.reshape %outLHS_19 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %199 = tt.trans %198 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_21, %outRHS_22 = tt.split %199 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %200 = tt.reshape %outRHS_20 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %201 = tt.trans %200 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_23, %outRHS_24 = tt.split %201 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %202 = tt.reshape %outRHS {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %203 = tt.trans %202 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_25, %outRHS_26 = tt.split %203 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %204 = tt.reshape %outLHS_25 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %205 = tt.trans %204 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_27, %outRHS_28 = tt.split %205 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %206 = tt.reshape %outRHS_26 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %207 = tt.trans %206 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_29, %outRHS_30 = tt.split %207 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %208 = arith.truncf %outLHS_21 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %209 = ttg.convert_layout %208 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %210 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %209, %210 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %211 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %212 = ttng.async_tma_copy_local_to_global %arg119[%184, %c0_i32_16] %211 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %212   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %213 = arith.truncf %outRHS_22 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %214 = ttg.convert_layout %213 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %215 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %214, %215 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %216 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %217 = ttng.async_tma_copy_local_to_global %arg119[%184, %c16_i32_11] %216 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %217   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %218 = arith.truncf %outLHS_23 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %219 = ttg.convert_layout %218 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %220 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %219, %220 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %221 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %222 = ttng.async_tma_copy_local_to_global %arg119[%184, %c32_i32_10] %221 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %222   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %223 = arith.truncf %outRHS_24 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %224 = ttg.convert_layout %223 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %225 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %224, %225 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %226 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %227 = ttng.async_tma_copy_local_to_global %arg119[%184, %c48_i32_9] %226 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %227   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %228 = arith.truncf %outLHS_27 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %229 = ttg.convert_layout %228 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %230 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %229, %230 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %231 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %232 = ttng.async_tma_copy_local_to_global %arg119[%184, %c64_i32_8] %231 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %232   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %233 = arith.truncf %outRHS_28 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %234 = ttg.convert_layout %233 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %235 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %234, %235 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %236 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %237 = ttng.async_tma_copy_local_to_global %arg119[%184, %c80_i32] %236 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %237   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %238 = arith.truncf %outLHS_29 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %239 = ttg.convert_layout %238 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %240 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %239, %240 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %241 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %242 = ttng.async_tma_copy_local_to_global %arg119[%184, %c96_i32] %241 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %242   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %243 = arith.truncf %outRHS_30 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %244 = ttg.convert_layout %243 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %245 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %244, %245 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %246 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %247 = ttng.async_tma_copy_local_to_global %arg119[%184, %c112_i32] %246 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %247   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %248 = ttg.memdesc_index %arg86[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %249 = ttg.memdesc_index %arg95[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %250 = arith.extui %188 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %249, %250 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_31, %token_32 = ttng.tmem_load %248[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %251 = ttg.memdesc_index %arg125[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %251, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %252 = tt.reshape %result_31 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear11>
+          %253 = tt.trans %252 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear11> -> tensor<128x64x2xf32, #linear12>
+          %outLHS_33, %outRHS_34 = tt.split %253 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear12> -> tensor<128x64xf32, #linear13>
+          %254 = tt.reshape %outLHS_33 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %255 = tt.trans %254 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_35, %outRHS_36 = tt.split %255 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %256 = tt.reshape %outLHS_35 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %257 = tt.trans %256 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_37, %outRHS_38 = tt.split %257 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %258 = tt.reshape %outRHS_36 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %259 = tt.trans %258 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_39, %outRHS_40 = tt.split %259 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %260 = tt.reshape %outRHS_34 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %261 = tt.trans %260 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_41, %outRHS_42 = tt.split %261 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %262 = tt.reshape %outLHS_41 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %263 = tt.trans %262 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_43, %outRHS_44 = tt.split %263 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %264 = tt.reshape %outRHS_42 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %265 = tt.trans %264 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_45, %outRHS_46 = tt.split %265 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %266 = arith.mulf %outLHS_37, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %267 = arith.truncf %266 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %268 = ttg.convert_layout %267 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %269 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %268, %269 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %270 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %271 = ttng.async_tma_copy_local_to_global %arg121[%184, %c0_i32_16] %270 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %271   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %272 = arith.mulf %outRHS_38, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %273 = arith.truncf %272 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %274 = ttg.convert_layout %273 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %275 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %274, %275 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %276 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %277 = ttng.async_tma_copy_local_to_global %arg121[%184, %c16_i32_11] %276 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %277   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %278 = arith.mulf %outLHS_39, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %279 = arith.truncf %278 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %280 = ttg.convert_layout %279 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %281 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %280, %281 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %282 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %283 = ttng.async_tma_copy_local_to_global %arg121[%184, %c32_i32_10] %282 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %283   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %284 = arith.mulf %outRHS_40, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %285 = arith.truncf %284 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %286 = ttg.convert_layout %285 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %287 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %286, %287 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %288 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %289 = ttng.async_tma_copy_local_to_global %arg121[%184, %c48_i32_9] %288 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %289   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %290 = arith.mulf %outLHS_43, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %291 = arith.truncf %290 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %292 = ttg.convert_layout %291 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %293 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %292, %293 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %294 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %295 = ttng.async_tma_copy_local_to_global %arg121[%184, %c64_i32_8] %294 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %295   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %296 = arith.mulf %outRHS_44, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %297 = arith.truncf %296 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %298 = ttg.convert_layout %297 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %299 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %298, %299 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %300 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %301 = ttng.async_tma_copy_local_to_global %arg121[%184, %c80_i32] %300 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %301   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %302 = arith.mulf %outLHS_45, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %303 = arith.truncf %302 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %304 = ttg.convert_layout %303 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %305 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %304, %305 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %306 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %307 = ttng.async_tma_copy_local_to_global %arg121[%184, %c96_i32] %306 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %307   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %308 = arith.mulf %outRHS_46, %168 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %309 = arith.truncf %308 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %310 = ttg.convert_layout %309 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %311 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %310, %311 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %312 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %313 = ttng.async_tma_copy_local_to_global %arg121[%184, %c112_i32] %312 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %313   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %314 = arith.addi %arg145, %158 {async_task_id = array<i32: 4>} : i32
+          %315 = arith.addi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          scf.yield {async_task_id = array<i32: 4>} %314, %315, %189 : i32, i64, i64
+        } {async_task_id = array<i32: 4>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      } : (i32, i32, i32, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, i32, i32, i32, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<256x64xf16, #shared>, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, !tt.tensordesc<128x64xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, f32, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) -> ()
+      %106 = ttg.memdesc_index %46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %106 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %107 = ttg.memdesc_index %42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %107 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %108 = ttg.memdesc_index %38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %108 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %109 = ttg.memdesc_index %30[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %109 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %110 = ttg.memdesc_index %28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %110 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %111 = ttg.memdesc_index %20[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %111 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %112 = ttg.memdesc_index %14[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %112 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %113 = ttg.memdesc_index %12[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %113 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %114 = ttg.memdesc_index %10[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %114 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %115 = ttg.memdesc_index %8[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %115 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %116 = ttg.memdesc_index %16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %116 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %117 = ttg.memdesc_index %18[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %117 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %118 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %118 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %119 = ttg.memdesc_index %26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %119 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %120 = ttg.memdesc_index %4[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %120 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %121 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %121 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %122 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %122 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %123 = ttg.memdesc_index %32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %123 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %124 = ttg.memdesc_index %34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %124 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %125 = ttg.memdesc_index %36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %125 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %126 = ttg.memdesc_index %40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %126 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %127 = ttg.memdesc_index %44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %127 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %128 = ttg.memdesc_index %22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %128 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %129 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %129 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %130 = ttg.memdesc_index %48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %130 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %131 = ttg.memdesc_index %49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %131 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %132 = ttg.memdesc_index %52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %132 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %133 = ttg.memdesc_index %53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %133 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %134 = ttg.memdesc_index %56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %134 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %135 = ttg.memdesc_index %57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %135 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %136 = ttg.memdesc_index %60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %136 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %137 = ttg.memdesc_index %61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %137 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %138 = ttg.memdesc_index %64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %138 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %139 = ttg.memdesc_index %65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %139 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %140 = ttg.memdesc_index %68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %140 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %141 = ttg.memdesc_index %69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %141 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %142 = ttg.memdesc_index %72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %142 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %143 = ttg.memdesc_index %73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %143 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %144 = ttg.memdesc_index %76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %144 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %145 = ttg.memdesc_index %77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %145 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %146 = ttg.memdesc_index %80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %146 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %147 = ttg.memdesc_index %81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %147 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %148 = ttg.memdesc_index %84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %148 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %149 = ttg.memdesc_index %85[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %149 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %150 = ttg.memdesc_index %88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %150 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %151 = ttg.memdesc_index %89[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %151 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      tt.return
+    }
+  }
+  module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 192 : i32, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+    tt.func public @_attn_bwd_persist(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x128xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<256x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.tensordesc<128x128xf16, #shared>, %arg21: i32, %arg22: i32, %arg23: i64, %arg24: i64, %arg25: f32, %arg26: !tt.tensordesc<128x64xf16, #shared>, %arg27: i32, %arg28: i32, %arg29: i64, %arg30: i64, %arg31: !tt.tensordesc<64x128xf16, #shared>, %arg32: i32, %arg33: i32, %arg34: i64, %arg35: i64, %arg36: !tt.tensordesc<128x16xf32, #shared1>, %arg37: i32, %arg38: i32, %arg39: i64, %arg40: i64, %arg41: !tt.tensordesc<128x16xf16, #shared2>, %arg42: i32, %arg43: i32, %arg44: i64, %arg45: i64, %arg46: !tt.tensordesc<128x16xf16, #shared2>, %arg47: i32, %arg48: i32, %arg49: i64, %arg50: i64, %arg51: !tt.tensordesc<128xf32, #shared3>, %arg52: i32, %arg53: i64, %arg54: !tt.tensordesc<128xf32, #shared3>, %arg55: i32, %arg56: i64, %arg57: i32 {tt.divisibility = 16 : i32}, %arg58: i32 {tt.divisibility = 16 : i32}, %arg59: i32 {tt.divisibility = 16 : i32}, %arg60: i32, %arg61: i32, %arg62: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+      %c1_i64 = arith.constant {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} 1 : i64
+      %c0_i64 = arith.constant {async_task_id = array<i32: 0>} 0 : i64
+      %c1_i32 = arith.constant {async_task_id = array<i32: 0>} 1 : i32
+      %c2_i32 = arith.constant {async_task_id = array<i32: 0>} 2 : i32
+      %c128_i32 = arith.constant {async_task_id = array<i32: 0>} 128 : i32
+      %c127_i32 = arith.constant {async_task_id = array<i32: 0>} 127 : i32
+      %c2_i64 = arith.constant {async_task_id = array<i32: 0>} 2 : i64
+      %c16_i32 = arith.constant {async_task_id = array<i32: 0>} 16 : i32
+      %c32_i32 = arith.constant {async_task_id = array<i32: 0>} 32 : i32
+      %c48_i32 = arith.constant {async_task_id = array<i32: 0>} 48 : i32
+      %c64_i32 = arith.constant {async_task_id = array<i32: 0>} 64 : i32
+      %cst = arith.constant {async_task_id = array<i32: 0>} dense<0.693147182> : tensor<128x16xf32, #linear>
+      %c0_i32 = arith.constant 0 : i32
+      %0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %1 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %1, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %2 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %3 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %3, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %4 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %5 = ttg.memdesc_index %4[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %5, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %6 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %7 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %7, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %8 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %9 = ttg.memdesc_index %8[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %9, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %10 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %11 = ttg.memdesc_index %10[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %11, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %12 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %13 = ttg.memdesc_index %12[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %13, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %14 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %15 = ttg.memdesc_index %14[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %15, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %16 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %17 = ttg.memdesc_index %16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %17, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %18 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %19 = ttg.memdesc_index %18[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %19, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %20 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %21 = ttg.memdesc_index %20[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %21, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %22 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %23 = ttg.memdesc_index %22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %23, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %24 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %25 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %25, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %26 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %27 = ttg.memdesc_index %26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %27, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %28 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %29 = ttg.memdesc_index %28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %29, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %30 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %31 = ttg.memdesc_index %30[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %31, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %32 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %33 = ttg.memdesc_index %32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %33, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %34 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %35 = ttg.memdesc_index %34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %35, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %36 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %37 = ttg.memdesc_index %36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %37, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %38 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %39 = ttg.memdesc_index %38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %39, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %40 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %41 = ttg.memdesc_index %40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %41, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %42 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %43 = ttg.memdesc_index %42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %43, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %44 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %45 = ttg.memdesc_index %44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %45, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %46 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %47 = ttg.memdesc_index %46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %47, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %48 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %49 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %50 = ttg.memdesc_index %48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %50, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %51 = ttg.memdesc_index %49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %51, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %52 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %53 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %54 = ttg.memdesc_index %52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %54, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %55 = ttg.memdesc_index %53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %55, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %56 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %57 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %58 = ttg.memdesc_index %56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %58, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %59 = ttg.memdesc_index %57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %59, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %60 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %61 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %62 = ttg.memdesc_index %60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %62, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %63 = ttg.memdesc_index %61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %63, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %64 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %65 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %66 = ttg.memdesc_index %64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %66, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %67 = ttg.memdesc_index %65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %67, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %68 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %69 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %70 = ttg.memdesc_index %68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %70, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %71 = ttg.memdesc_index %69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %71, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %72 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %73 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %74 = ttg.memdesc_index %72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %74, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %75 = ttg.memdesc_index %73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %75, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %76 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %77 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %78 = ttg.memdesc_index %76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %78, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %79 = ttg.memdesc_index %77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %79, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %80 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %81 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %82 = ttg.memdesc_index %80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %82, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %83 = ttg.memdesc_index %81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %83, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %84 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %85 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %86 = ttg.memdesc_index %84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %86, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %87 = ttg.memdesc_index %85[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %87, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %88 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %89 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>
+      %90 = ttg.memdesc_index %88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %90, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %91 = ttg.memdesc_index %89[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.init_barrier %91, 1 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttg.barrier local
+      %92 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+      %93 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 12 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+      %94 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 3 : i32} : () -> !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>
+      %result, %token = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 7 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %result_0, %token_1 = ttng.tmem_alloc {buffer.copy = 1 : i32, buffer.id = 10 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %95 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 1 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+      %96 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 15 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %97 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 16 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+      %result_2, %token_3 = ttng.tmem_alloc {allocation.shareGroup = 1 : i32, buffer.copy = 1 : i32, buffer.id = 2 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %98 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 17 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %99 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 4 : i32} : () -> !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>
+      %result_4, %token_5 = ttng.tmem_alloc {allocation.shareGroup = 4 : i32, buffer.copy = 1 : i32, buffer.id = 5 : i32} : () -> (!ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %100 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 19 : i32} : () -> !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>
+      %101 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 20 : i32} : () -> !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>
+      %102 = ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = 8 : i32} : () -> !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>
+      %103 = ttg.local_alloc {allocation.shareGroup = 3 : i32, buffer.copy = 1 : i32, buffer.id = 22 : i32, buffer.tmaStaging = 2 : i32} : () -> !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable>
+      %104 = ttg.local_alloc {allocation.shareGroup = 0 : i32, buffer.copy = 1 : i32, buffer.id = 26 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+      %105 = ttg.local_alloc {allocation.shareGroup = 2 : i32, buffer.copy = 1 : i32, buffer.id = 34 : i32, buffer.tmaStaging = 1 : i32} : () -> !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>
+      ttg.warp_specialize(%arg62, %arg60, %arg61, %46, %42, %38, %95, %30, %92, %result_2, %28, %20, %14, %99, %12, %94, %result_4, %10, %8, %result, %98, %16, %18, %result_0, %96, %24, %26, %4, %102, %93, %2, %0, %32, %34, %36, %40, %44, %101, %arg59, %arg58, %arg57, %arg10, %arg15, %arg20, %arg5, %arg0, %22, %97, %arg51, %arg26, %arg31, %6, %100, %arg54, %arg25, %104, %arg46, %105, %arg41, %48, %49, %52, %53, %56, %57, %60, %61, %64, %65, %68, %69, %72, %73, %76, %77, %80, %81, %84, %85, %88, %89) attributes {ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"]}
+      default {
+        %152 = arith.addi %arg62, %c127_i32 {async_task_id = array<i32: 0>} : i32
+        %153 = arith.divsi %152, %c128_i32 {async_task_id = array<i32: 0>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 0>} : i32
+        %155 = arith.remsi %154, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %156 = arith.divsi %154, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 0>} : i32
+        %158 = arith.divsi %157, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %159 = arith.divsi %153, %c2_i32 {async_task_id = array<i32: 0>} : i32
+        %160 = arith.muli %159, %arg60 {async_task_id = array<i32: 0>} : i32
+        %161 = arith.muli %160, %arg61 {async_task_id = array<i32: 0>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 0>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 0>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 0>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %171 = arith.addi %162, %c1_i32 {async_task_id = array<i32: 0>} : i32
+          scf.yield {async_task_id = array<i32: 0>} %171 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 0>} %162 : i32
+        } {async_task_id = array<i32: 0>}
+        %166 = arith.extsi %arg59 {async_task_id = array<i32: 0>} : i32 to i64
+        %167 = arith.divsi %arg62, %c128_i32 {async_task_id = array<i32: 0>} : i32
+        %168 = arith.muli %155, %c64_i32 {async_task_id = array<i32: 0>} : i32
+        %169 = arith.extsi %168 {async_task_id = array<i32: 0>} : i32 to i64
+        %170:2 = scf.for %arg63 = %c0_i32 to %165 step %c1_i32 iter_args(%arg64 = %156, %arg65 = %c0_i64) -> (i32, i64)  : i32 {
+          %171 = arith.divsi %arg64, %159 {async_task_id = array<i32: 0>} : i32
+          %172 = arith.remsi %171, %arg61 {async_task_id = array<i32: 0>} : i32
+          %173 = arith.muli %arg58, %172 {async_task_id = array<i32: 0>} : i32
+          %174 = arith.divsi %171, %arg61 {async_task_id = array<i32: 0>} : i32
+          %175 = arith.muli %arg57, %174 {async_task_id = array<i32: 0>} : i32
+          %176 = arith.addi %173, %175 {async_task_id = array<i32: 0>} : i32
+          %177 = arith.extsi %176 {async_task_id = array<i32: 0>} : i32 to i64
+          %178 = arith.divsi %177, %166 {async_task_id = array<i32: 0>} : i64
+          %179:2 = scf.for %arg66 = %c0_i32 to %167 step %c1_i32 iter_args(%arg67 = %c0_i32, %arg68 = %arg65) -> (i32, i64)  : i32 {
+            %181 = arith.extsi %arg67 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+            %182 = arith.addi %178, %181 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %183 = arith.andi %arg68, %c1_i64 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %184 = arith.trunci %183 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %185 = ttng.tmem_subslice %result_4 {N = 0 : i32, async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %186 = ttg.memdesc_reinterpret %185 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+            %187 = ttg.memdesc_index %186[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+            %188 = ttg.memdesc_index %0[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %189 = arith.extui %184 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %188, %189 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_6, %token_7 = ttng.tmem_load %187[] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear1>
+            %190 = ttg.memdesc_index %89[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %190, 1 {async_task_id = array<i32: 0>, constraints = {WSBarrier = {channelGraph = array<i32: 1, 2, 3, 4>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %191 = tt.reshape %result_6 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<64x128xf32, #linear1> -> tensor<128x2x32xf32, #linear2>
+            %192 = tt.trans %191 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear2> -> tensor<128x32x2xf32, #linear3>
+            %outLHS, %outRHS = tt.split %192 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32x2xf32, #linear3> -> tensor<128x32xf32, #linear4>
+            %193 = tt.reshape %outLHS {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32xf32, #linear4> -> tensor<128x2x16xf32, #linear5>
+            %194 = tt.trans %193 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear5> -> tensor<128x16x2xf32, #linear6>
+            %outLHS_8, %outRHS_9 = tt.split %194 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16x2xf32, #linear6> -> tensor<128x16xf32, #linear>
+            %195 = tt.reshape %outRHS {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x32xf32, #linear4> -> tensor<128x2x16xf32, #linear5>
+            %196 = tt.trans %195 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear5> -> tensor<128x16x2xf32, #linear6>
+            %outLHS_10, %outRHS_11 = tt.split %196 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16x2xf32, #linear6> -> tensor<128x16xf32, #linear>
+            %197 = arith.addi %182, %169 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %198 = arith.muli %197, %c2_i64 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %199 = arith.mulf %outLHS_8, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %200 = ttg.convert_layout %199 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %201 = arith.trunci %198 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %202 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %200, %202 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %203 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %204 = ttng.async_tma_reduce add, %arg36[%201, %c0_i32] %203 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %204   {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %205 = arith.mulf %outRHS_9, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %206 = ttg.convert_layout %205 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %207 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %206, %207 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %208 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %209 = ttng.async_tma_reduce add, %arg36[%201, %c16_i32] %208 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %209   {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %210 = arith.mulf %outLHS_10, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %211 = ttg.convert_layout %210 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %212 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %211, %212 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %213 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %214 = ttng.async_tma_reduce add, %arg36[%201, %c32_i32] %213 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %214   {async_task_id = array<i32: 0>, loop.cluster = 3 : i32, loop.stage = 0 : i32} : !ttg.async.token
+            %215 = arith.mulf %outRHS_11, %cst {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear>
+            %216 = ttg.convert_layout %215 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #linear> -> tensor<128x16xf32, #blocked>
+            %217 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            ttg.local_store %216, %217 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x16xf32, #blocked> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %218 = ttg.memdesc_index %103[%c0_i32] {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x16xf32, #shared1, #smem, mutable> -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+            %219 = ttng.async_tma_reduce add, %arg36[%201, %c48_i32] %218 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+            ttng.async_tma_store_token_wait %219   {async_task_id = array<i32: 0>, loop.cluster = 4 : i32, loop.stage = 1 : i32} : !ttg.async.token
+            %220 = arith.addi %arg67, %c128_i32 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i32
+            %221 = arith.addi %arg68, %c1_i64 {async_task_id = array<i32: 0>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 0>} %220, %221 : i32, i64
+          } {async_task_id = array<i32: 0>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %180 = arith.addi %arg64, %158 {async_task_id = array<i32: 0>} : i32
+          scf.yield {async_task_id = array<i32: 0>} %180, %179#1 : i32, i64
+        } {async_task_id = array<i32: 0>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_yield
+      }
+      partition0(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %152 = ub.poison : i1
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 1>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 1>} 0 : i64
+        %true = arith.constant {async_task_id = array<i32: 1>} true
+        %c127_i32_8 = arith.constant {async_task_id = array<i32: 1>} 127 : i32
+        %c128_i32_9 = arith.constant {async_task_id = array<i32: 1>} 128 : i32
+        %c2_i32_10 = arith.constant {async_task_id = array<i32: 1>} 2 : i32
+        %c1_i32_11 = arith.constant {async_task_id = array<i32: 1>} 1 : i32
+        %c0_i32_12 = arith.constant {async_task_id = array<i32: 1>} 0 : i32
+        %false = arith.constant {async_task_id = array<i32: 1>} false
+        %153 = arith.addi %arg63, %c127_i32_8 {async_task_id = array<i32: 1>} : i32
+        %154 = arith.divsi %153, %c128_i32_9 {async_task_id = array<i32: 1>} : i32
+        %155 = tt.get_program_id x {async_task_id = array<i32: 1>} : i32
+        %156 = arith.divsi %155, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 1>} : i32
+        %158 = arith.divsi %157, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %159 = arith.divsi %154, %c2_i32_10 {async_task_id = array<i32: 1>} : i32
+        %160 = arith.muli %159, %arg64 {async_task_id = array<i32: 1>} : i32
+        %161 = arith.muli %160, %arg65 {async_task_id = array<i32: 1>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 1>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 1>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 1>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %168 = arith.addi %162, %c1_i32_11 {async_task_id = array<i32: 1>} : i32
+          scf.yield {async_task_id = array<i32: 1>} %168 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 1>} %162 : i32
+        } {async_task_id = array<i32: 1>}
+        %166 = arith.divsi %arg63, %c128_i32_9 {async_task_id = array<i32: 1>} : i32
+        %167:2 = scf.for %arg144 = %c0_i32_12 to %165 step %c1_i32_11 iter_args(%arg145 = %c0_i64_7, %arg146 = %c0_i64_7) -> (i64, i64)  : i32 {
+          %168 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %169 = arith.trunci %168 {async_task_id = array<i32: 1>} : i64 to i1
+          %170 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %171 = arith.trunci %170 {async_task_id = array<i32: 1>} : i64 to i1
+          %172 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %173 = arith.trunci %172 {async_task_id = array<i32: 1>} : i64 to i1
+          %174 = ttg.memdesc_index %arg66[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %175 = arith.extui %169 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %174, %175, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %176 = ttg.memdesc_index %arg67[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %177 = arith.extui %171 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %176, %177, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %178 = ttg.memdesc_index %arg68[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %179 = arith.extui %173 {async_task_id = array<i32: 1>} : i1 to i32
+          ttng.wait_barrier %178, %179, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %180 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %181 = arith.trunci %180 {async_task_id = array<i32: 1>} : i64 to i1
+          %182 = ttg.memdesc_index %arg123[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %183 = arith.xori %181, %true : i1
+          %184 = arith.extui %183 : i1 to i32
+          ttng.wait_barrier %182, %184 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %185 = arith.andi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          %186 = arith.trunci %185 {async_task_id = array<i32: 1>} : i64 to i1
+          %187 = ttg.memdesc_index %arg125[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %188 = arith.xori %186, %true : i1
+          %189 = arith.extui %188 : i1 to i32
+          ttng.wait_barrier %187, %189 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %190 = arith.cmpi sgt, %166, %c0_i32_12 : i32
+          %191 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+          %192 = arith.trunci %191 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+          %193 = ttg.memdesc_index %arg69[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %194 = ttg.memdesc_index %arg70[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %195 = arith.extui %192 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+          %196 = arith.andi %190, %true : i1
+          ttng.wait_barrier %194, %195, %196 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %197 = ttg.memdesc_trans %193 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+          %198 = ttg.memdesc_index %arg71[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %199 = ttg.memdesc_index %arg72[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %200 = ttg.memdesc_index %arg73[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %201 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+          %202 = arith.trunci %201 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+          %203 = ttg.memdesc_index %arg74[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %204 = ttg.memdesc_index %arg129[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %205 = arith.xori %202, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+          %206 = arith.extui %205 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %204, %206, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %207 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+          %208 = arith.trunci %207 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+          %209 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %210 = arith.xori %208, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+          %211 = arith.extui %210 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %209, %211, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {direction = "backward", dstTask = 1 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %212 = arith.andi %190, %true : i1
+          %213 = ttng.tc_gen5_mma %198, %197, %199[], %false, %212, %200[%true], %203[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %214 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %215 = arith.trunci %214 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %216 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %217 = arith.trunci %216 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %218 = ttg.memdesc_index %arg76[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+          %219 = ttg.memdesc_index %arg77[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %220 = arith.extui %217 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          %221 = arith.andi %190, %true : i1
+          ttng.wait_barrier %219, %220, %221 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %222 = ttg.memdesc_trans %218 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+          %223 = ttg.memdesc_index %arg78[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %224 = ttg.memdesc_index %arg79[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %225 = ttg.memdesc_index %arg80[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %226 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %227 = arith.trunci %226 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %228 = ttg.memdesc_index %arg81[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %229 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %230 = arith.xori %227, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+          %231 = arith.extui %230 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %229, %231, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %232 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %233 = arith.trunci %232 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %234 = ttg.memdesc_index %arg143[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %235 = arith.xori %233, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+          %236 = arith.extui %235 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %234, %236, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %237 = arith.andi %190, %true : i1
+          %238 = ttng.tc_gen5_mma %223, %222, %224[], %false, %237, %225[%true], %228[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %239 = ttg.memdesc_index %arg82[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %240 = ttg.memdesc_index %arg83[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %241 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %242 = ttg.memdesc_reinterpret %241 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %243 = ttg.memdesc_index %242[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %244 = ttg.memdesc_index %arg84[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %245 = ttg.memdesc_index %arg85[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %246 = arith.extui %215 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          %247 = arith.andi %190, %true : i1
+          ttng.wait_barrier %245, %246, %247 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %248 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %249 = ttg.memdesc_index %arg130[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %250 = arith.extui %208 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %249, %250, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %251 = arith.andi %190, %true : i1
+          %252 = ttng.tc_gen5_mma %243, %240, %239[], %false, %251, %244[%true], %248[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 3>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %253 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+          %254 = arith.trunci %253 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+          %255 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+          %256 = arith.trunci %255 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+          %257 = ttg.memdesc_index %arg86[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %258 = ttg.memdesc_index %arg87[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+          %259 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %260 = ttg.memdesc_reinterpret %259 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %261 = ttg.memdesc_index %260[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %262 = ttg.memdesc_index %arg88[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %263 = ttg.memdesc_index %arg89[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %264 = arith.extui %254 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+          %265 = arith.andi %190, %true : i1
+          ttng.wait_barrier %263, %264, %265 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %266 = ttg.memdesc_index %arg90[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %267 = ttg.memdesc_index %arg136[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %268 = arith.extui %256 {loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %267, %268, %190 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %269 = arith.andi %190, %true : i1
+          %270 = ttng.tc_gen5_mma %261, %258, %257[], %false, %269, %262[%true], %266[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 6 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 4>, tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %271 = arith.subi %166, %c1_i32_11 : i32
+          %272:3 = scf.for %arg147 = %c0_i32_12 to %271 step %c1_i32_11 iter_args(%arg148 = %false, %arg149 = %arg146, %arg150 = %233) -> (i1, i64, i1)  : i32 {
+            %281 = arith.addi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            %282 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %283 = arith.trunci %282 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %284 = ttg.memdesc_index %arg69[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %285 = ttg.memdesc_index %arg70[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %286 = arith.extui %283 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            %287 = arith.andi %true, %true : i1
+            ttng.wait_barrier %285, %286, %287 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %288 = ttg.memdesc_trans %284 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+            %289 = ttg.memdesc_index %arg71[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+            %290 = ttg.memdesc_index %arg72[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %291 = ttg.memdesc_index %arg73[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %292 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %293 = arith.trunci %292 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %294 = ttg.memdesc_index %arg74[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %295 = ttg.memdesc_index %arg129[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %296 = arith.xori %293, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+            %297 = arith.extui %296 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %295, %297, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %298 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+            %299 = arith.trunci %298 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i1
+            %300 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %301 = arith.xori %299, %true {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1
+            %302 = arith.extui %301 {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %300, %302, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {direction = "backward", dstTask = 1 : i32}}, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %303 = arith.andi %true, %true : i1
+            %304 = ttng.tc_gen5_mma %289, %288, %290[], %false, %303, %291[%true], %294[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %305 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64
+            %306 = arith.trunci %305 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64 to i1
+            %307 = ttg.memdesc_index %arg91[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %308 = ttg.memdesc_index %arg140[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %309 = arith.extui %306 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %308, %309 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %310 = ttg.memdesc_trans %307 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>
+            %311 = ttg.memdesc_index %arg92[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %312 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %313 = ttg.memdesc_reinterpret %312 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+            %314 = ttg.memdesc_index %313[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+            %315 = ttg.memdesc_index %arg93[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %316 = ttg.memdesc_index %arg94[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %317 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %318 = arith.extui %arg150 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %317, %318 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %319 = ttng.tc_gen5_mma %310, %311, %314[], %false, %true, %315[%true], %316[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %320 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %321 = arith.trunci %320 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %322 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %323 = arith.trunci %322 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %324 = ttg.memdesc_index %arg76[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %325 = ttg.memdesc_index %arg77[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %326 = arith.extui %323 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            %327 = arith.andi %true, %true : i1
+            ttng.wait_barrier %325, %326, %327 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %328 = ttg.memdesc_trans %324 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>
+            %329 = ttg.memdesc_index %arg78[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+            %330 = ttg.memdesc_index %arg79[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %331 = ttg.memdesc_index %arg80[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %332 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %333 = arith.trunci %332 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %334 = ttg.memdesc_index %arg81[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %335 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %336 = arith.xori %333, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %337 = arith.extui %336 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %335, %337, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %338 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %339 = arith.trunci %338 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %340 = ttg.memdesc_index %arg143[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %341 = arith.xori %339, %true {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %342 = arith.extui %341 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %340, %342, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 0>, dstTask = 0 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %343 = arith.andi %true, %true : i1
+            %344 = ttng.tc_gen5_mma %329, %328, %330[], %false, %343, %331[%true], %334[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<128x64xf16, #shared5, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %345 = ttg.memdesc_index %arg82[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %346 = ttg.memdesc_index %arg83[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %347 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %348 = ttg.memdesc_reinterpret %347 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %349 = ttg.memdesc_index %348[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %350 = ttg.memdesc_index %arg84[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %351 = ttg.memdesc_index %arg85[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %352 = arith.extui %321 {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            %353 = arith.andi %true, %true : i1
+            ttng.wait_barrier %351, %352, %353 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %354 = ttg.memdesc_index %arg75[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %355 = ttg.memdesc_index %arg130[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %356 = arith.extui %299 {loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %355, %356, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %357 = arith.andi %true, %true : i1
+            %358 = ttng.tc_gen5_mma %349, %346, %345[], %true, %357, %350[%true], %354[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 5 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 3>, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %359 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+            %360 = arith.trunci %359 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+            %361 = arith.andi %281, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64
+            %362 = arith.trunci %361 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i64 to i1
+            %363 = ttg.memdesc_index %arg86[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %364 = ttg.memdesc_index %arg87[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %365 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %366 = ttg.memdesc_reinterpret %365 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %367 = ttg.memdesc_index %366[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %368 = ttg.memdesc_index %arg88[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %369 = ttg.memdesc_index %arg89[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %370 = arith.extui %360 {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+            %371 = arith.andi %true, %true : i1
+            ttng.wait_barrier %369, %370, %371 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %372 = ttg.memdesc_index %arg90[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %373 = ttg.memdesc_index %arg136[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %374 = arith.extui %362 {loop.cluster = 6 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %373, %374, %true {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 6 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %375 = arith.andi %true, %true : i1
+            %376 = ttng.tc_gen5_mma %367, %364, %363[], %true, %375, %368[%true], %372[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 6 : i32, loop.stage = 0 : i32, tmem.start = array<i32: 4>, tt.autows = "{\22stage\22: \220\22, \22order\22: \223\22, \22channels\22: [\22opndD,tmem,1,10\22]}", ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            scf.yield %true, %281, %339 : i1, i64, i1
+          } {async_task_id = array<i32: 1>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %273 = arith.cmpi sgt, %166, %c0_i32_12 : i32
+          %274:3 = scf.if %273 -> (i1, i64, i1) {
+            %281 = arith.addi %272#1, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            %282 = arith.andi %272#1, %c1_i64_6 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64
+            %283 = arith.trunci %282 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : i64 to i1
+            %284 = ttg.memdesc_index %arg91[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %285 = ttg.memdesc_index %arg140[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %286 = arith.extui %283 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %285, %286 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %287 = ttg.memdesc_trans %284 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>
+            %288 = ttg.memdesc_index %arg92[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %289 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %290 = ttg.memdesc_reinterpret %289 {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+            %291 = ttg.memdesc_index %290[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>
+            %292 = ttg.memdesc_index %arg93[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %293 = ttg.memdesc_index %arg94[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %294 = ttg.memdesc_index %arg133[%c0_i32_12] {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %295 = arith.extui %272#2 {loop.cluster = 2 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %294, %295 {async_task_id = array<i32: 1>, constraints = {WSBarrier = {channelGraph = array<i32: 2, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 2 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %296 = ttng.tc_gen5_mma %287, %288, %291[], %false, %true, %292[%true], %293[%true] {async_task_id = array<i32: 1>, is_async, loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared5, #smem, mutable>, !ttg.memdesc<256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            scf.yield %true, %281, %152 : i1, i64, i1
+          } else {
+            scf.yield %272#0, %272#1, %272#2 : i1, i64, i1
+          }
+          %275 = ttg.memdesc_index %arg95[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %275 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %276 = ttg.memdesc_index %arg96[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %276 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %277 = ttg.memdesc_index %arg97[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %277 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %278 = ttg.memdesc_index %arg98[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %278 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %279 = ttg.memdesc_index %arg99[%c0_i32_12] {async_task_id = array<i32: 1>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.tc_gen5_commit %279 {async_task_id = array<i32: 1>} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %280 = arith.addi %arg145, %c1_i64_6 {async_task_id = array<i32: 1>} : i64
+          scf.yield {async_task_id = array<i32: 1>} %280, %274#1 : i64, i64
+        } {async_task_id = array<i32: 1>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition1(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 2>} 0 : i64
+        %c127_i32_8 = arith.constant {async_task_id = array<i32: 2>} 127 : i32
+        %c128_i32_9 = arith.constant {async_task_id = array<i32: 2>} 128 : i32
+        %c2_i32_10 = arith.constant {async_task_id = array<i32: 2>} 2 : i32
+        %c1_i32_11 = arith.constant {async_task_id = array<i32: 2>} 1 : i32
+        %c0_i32_12 = arith.constant {async_task_id = array<i32: 2>} 0 : i32
+        %152 = arith.addi %arg63, %c127_i32_8 {async_task_id = array<i32: 2>} : i32
+        %153 = arith.divsi %152, %c128_i32_9 {async_task_id = array<i32: 2>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 2>} : i32
+        %155 = arith.divsi %154, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %156 = tt.get_num_programs x {async_task_id = array<i32: 2>} : i32
+        %157 = arith.divsi %156, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %158 = arith.divsi %153, %c2_i32_10 {async_task_id = array<i32: 2>} : i32
+        %159 = arith.muli %158, %arg64 {async_task_id = array<i32: 2>} : i32
+        %160 = arith.muli %159, %arg65 {async_task_id = array<i32: 2>} : i32
+        %161 = arith.divsi %160, %157 {async_task_id = array<i32: 2>} : i32
+        %162 = arith.remsi %160, %157 {async_task_id = array<i32: 2>} : i32
+        %163 = arith.cmpi slt, %155, %162 {async_task_id = array<i32: 2>} : i32
+        %164 = scf.if %163 -> (i32) {
+          %167 = arith.addi %161, %c1_i32_11 {async_task_id = array<i32: 2>} : i32
+          scf.yield {async_task_id = array<i32: 2>} %167 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 2>} %161 : i32
+        } {async_task_id = array<i32: 2>}
+        %165 = arith.divsi %arg63, %c128_i32_9 {async_task_id = array<i32: 2>} : i32
+        %166 = scf.for %arg144 = %c0_i32_12 to %164 step %c1_i32_11 iter_args(%arg145 = %c0_i64_7) -> (i64)  : i32 {
+          %167 = scf.for %arg146 = %c0_i32_12 to %165 step %c1_i32_11 iter_args(%arg147 = %arg145) -> (i64)  : i32 {
+            %168 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %169 = arith.trunci %168 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %170 = ttg.memdesc_index %arg100[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %171 = ttg.memdesc_index %arg138[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %172 = arith.extui %169 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %171, %172 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.two_cta_peer_relay %170 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : <128x64xf16, #shared, #smem, mutable>
+            %173 = ttg.memdesc_index %arg139[%c0_i32_12] {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %173, 1 {async_task_id = array<i32: 2>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %174 = arith.addi %arg147, %c1_i64_6 {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 2>} %174 : i64
+          } {async_task_id = array<i32: 2>, tt.scheduled_max_stage = 0 : i32, tt.warp_specialize}
+          scf.yield {async_task_id = array<i32: 2>} %167 : i64
+        } {async_task_id = array<i32: 2>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition2(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %true = arith.constant {async_task_id = array<i32: 3>} true
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 3>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 3>} 0 : i64
+        %c64_i32_8 = arith.constant {async_task_id = array<i32: 3>} 64 : i32
+        %c127_i32_9 = arith.constant {async_task_id = array<i32: 3>} 127 : i32
+        %c128_i32_10 = arith.constant {async_task_id = array<i32: 3>} 128 : i32
+        %c2_i32_11 = arith.constant {async_task_id = array<i32: 3>} 2 : i32
+        %c1_i32_12 = arith.constant {async_task_id = array<i32: 3>} 1 : i32
+        %c0_i32_13 = arith.constant {async_task_id = array<i32: 3>} 0 : i32
+        %152 = arith.addi %arg63, %c127_i32_9 {async_task_id = array<i32: 3>} : i32
+        %153 = arith.divsi %152, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %154 = tt.get_program_id x {async_task_id = array<i32: 3>} : i32
+        %155 = arith.remsi %154, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %156 = arith.divsi %154, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %157 = tt.get_num_programs x {async_task_id = array<i32: 3>} : i32
+        %158 = arith.divsi %157, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %159 = arith.divsi %153, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %160 = arith.muli %159, %arg64 {async_task_id = array<i32: 3>} : i32
+        %161 = arith.muli %160, %arg65 {async_task_id = array<i32: 3>} : i32
+        %162 = arith.divsi %161, %158 {async_task_id = array<i32: 3>} : i32
+        %163 = arith.remsi %161, %158 {async_task_id = array<i32: 3>} : i32
+        %164 = arith.cmpi slt, %156, %163 {async_task_id = array<i32: 3>} : i32
+        %165 = scf.if %164 -> (i32) {
+          %173 = arith.addi %162, %c1_i32_12 {async_task_id = array<i32: 3>} : i32
+          scf.yield {async_task_id = array<i32: 3>} %173 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 3>} %162 : i32
+        } {async_task_id = array<i32: 3>}
+        %166 = arith.extsi %arg101 {async_task_id = array<i32: 3>} : i32 to i64
+        %167 = arith.muli %155, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %168 = arith.divsi %arg63, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+        %169 = nvg.cluster_id {async_task_id = array<i32: 3>}
+        %170 = arith.remsi %169, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+        %171 = arith.muli %170, %c64_i32_8 {async_task_id = array<i32: 3>} : i32
+        %172:3 = scf.for %arg144 = %c0_i32_13 to %165 step %c1_i32_12 iter_args(%arg145 = %156, %arg146 = %c0_i64_7, %arg147 = %c0_i64_7) -> (i32, i64, i64)  : i32 {
+          %173 = arith.remsi %arg145, %159 {async_task_id = array<i32: 3>} : i32
+          %174 = arith.divsi %arg145, %159 {async_task_id = array<i32: 3>} : i32
+          %175 = arith.muli %173, %c2_i32_11 {async_task_id = array<i32: 3>} : i32
+          %176 = arith.addi %175, %155 {async_task_id = array<i32: 3>} : i32
+          %177 = arith.muli %174, %arg63 {async_task_id = array<i32: 3>} : i32
+          %178 = arith.extsi %177 {async_task_id = array<i32: 3>} : i32 to i64
+          %179 = arith.remsi %174, %arg65 {async_task_id = array<i32: 3>} : i32
+          %180 = arith.muli %arg102, %179 {async_task_id = array<i32: 3>} : i32
+          %181 = arith.divsi %174, %arg65 {async_task_id = array<i32: 3>} : i32
+          %182 = arith.muli %arg103, %181 {async_task_id = array<i32: 3>} : i32
+          %183 = arith.addi %180, %182 {async_task_id = array<i32: 3>} : i32
+          %184 = arith.extsi %183 {async_task_id = array<i32: 3>} : i32 to i64
+          %185 = arith.divsi %184, %166 {async_task_id = array<i32: 3>} : i64
+          %186 = arith.muli %176, %c128_i32_10 {async_task_id = array<i32: 3>} : i32
+          %187 = arith.extsi %186 {async_task_id = array<i32: 3>} : i32 to i64
+          %188 = arith.addi %185, %187 {async_task_id = array<i32: 3>} : i64
+          %189 = arith.trunci %188 {async_task_id = array<i32: 3>} : i64 to i32
+          %190 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %191 = arith.trunci %190 {async_task_id = array<i32: 3>} : i64 to i1
+          %192 = ttg.memdesc_index %arg99[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %193 = arith.xori %191, %true {async_task_id = array<i32: 3>} : i1
+          %194 = arith.extui %193 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %192, %194 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %195 = ttg.memdesc_index %arg66[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %195, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %196 = ttg.memdesc_index %arg71[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg104[%189, %c0_i32_13] %196, %195, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %197 = arith.subi %186, %167 {async_task_id = array<i32: 3>} : i32
+          %198 = arith.extsi %197 {async_task_id = array<i32: 3>} : i32 to i64
+          %199 = arith.addi %185, %198 {async_task_id = array<i32: 3>} : i64
+          %200 = arith.trunci %199 {async_task_id = array<i32: 3>} : i64 to i32
+          %201 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %202 = arith.trunci %201 {async_task_id = array<i32: 3>} : i64 to i1
+          %203 = ttg.memdesc_index %arg98[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %204 = arith.xori %202, %true {async_task_id = array<i32: 3>} : i1
+          %205 = arith.extui %204 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %203, %205 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %206 = ttg.memdesc_index %arg67[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %206, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %207 = ttg.memdesc_index %arg92[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg105[%200, %171] %207, %206, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<256x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+          %208 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          %209 = arith.trunci %208 {async_task_id = array<i32: 3>} : i64 to i1
+          %210 = ttg.memdesc_index %arg97[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %211 = arith.xori %209, %true {async_task_id = array<i32: 3>} : i1
+          %212 = arith.extui %211 {async_task_id = array<i32: 3>} : i1 to i32
+          ttng.wait_barrier %210, %212 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 3 : i32, minRegionId = 3 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %213 = ttg.memdesc_index %arg68[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.barrier_expect %213, 32768 {async_task_id = array<i32: 3>}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %214 = ttg.memdesc_index %arg78[%c0_i32_13] {async_task_id = array<i32: 3>} : !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          ttng.async_tma_copy_global_to_local %arg106[%189, %c0_i32_13] %214, %213, %true {async_task_id = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x128xf16, #shared, #smem, mutable>
+          %215:2 = scf.for %arg148 = %c0_i32_13 to %168 step %c1_i32_12 iter_args(%arg149 = %c0_i32_13, %arg150 = %arg147) -> (i32, i64)  : i32 {
+            %218 = arith.extsi %arg149 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32 to i64
+            %219 = arith.addi %185, %218 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %220 = arith.trunci %219 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %221 = arith.addi %220, %171 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32
+            %222 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %223 = arith.trunci %222 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %224 = ttg.memdesc_index %arg73[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %225 = arith.xori %223, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %226 = arith.extui %225 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %224, %226 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %227 = ttg.memdesc_index %arg70[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %227, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %228 = ttg.memdesc_index %arg69[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg107[%221, %c0_i32_13] %228, %227, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %229 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %230 = arith.trunci %229 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %231 = ttg.memdesc_index %arg88[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %232 = arith.xori %230, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %233 = arith.extui %232 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %231, %233 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %234 = ttg.memdesc_index %arg89[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %234, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %235 = ttg.memdesc_index %arg87[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg108[%220, %171] %235, %234, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %236 = arith.addi %178, %218 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %237 = arith.trunci %236 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i32
+            %238 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %239 = arith.trunci %238 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %240 = ttg.memdesc_index %arg127[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %241 = arith.xori %239, %true {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %242 = arith.extui %241 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %240, %242 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %243 = ttg.memdesc_index %arg109[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %243, 512 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %244 = ttg.memdesc_index %arg110[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg111[%237] %244, %243, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %245 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %246 = arith.trunci %245 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %247 = ttg.memdesc_index %arg84[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %248 = arith.xori %246, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %249 = arith.extui %248 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %247, %249 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %250 = ttg.memdesc_index %arg85[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %250, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %251 = ttg.memdesc_index %arg83[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg112[%220, %171] %251, %250, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %252 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %253 = arith.trunci %252 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %254 = ttg.memdesc_index %arg80[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %255 = arith.xori %253, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %256 = arith.extui %255 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %254, %256 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %257 = ttg.memdesc_index %arg77[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %257, 16384 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %258 = ttg.memdesc_index %arg76[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg113[%221, %c0_i32_13] %258, %257, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<64x128xf16, #shared, #smem, mutable>
+            %259 = arith.andi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            %260 = arith.trunci %259 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64 to i1
+            %261 = ttg.memdesc_index %arg135[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %262 = arith.xori %260, %true {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1
+            %263 = arith.extui %262 {loop.cluster = 0 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %261, %263 {async_task_id = array<i32: 3>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 2, 4>, dstTask = 4 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %264 = ttg.memdesc_index %arg114[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.barrier_expect %264, 512 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32}, %true : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %265 = ttg.memdesc_index %arg115[%c0_i32_13] {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            ttng.async_tma_copy_global_to_local %arg116[%237] %265, %264, %true {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128xf32, #shared3>, !ttg.memdesc<1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %266 = arith.addi %arg149, %c128_i32_10 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i32
+            %267 = arith.addi %arg150, %c1_i64_6 {async_task_id = array<i32: 3>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : i64
+            scf.yield {async_task_id = array<i32: 3>} %266, %267 : i32, i64
+          } {async_task_id = array<i32: 3>, tt.scheduled_max_stage = 0 : i32, tt.warp_specialize}
+          %216 = arith.addi %arg145, %158 {async_task_id = array<i32: 3>} : i32
+          %217 = arith.addi %arg146, %c1_i64_6 {async_task_id = array<i32: 3>} : i64
+          scf.yield {async_task_id = array<i32: 3>} %216, %217, %215#1 : i32, i64, i64
+        } {async_task_id = array<i32: 3>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      }
+      partition3(%arg63: i32, %arg64: i32, %arg65: i32, %arg66: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg67: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg68: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg69: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg70: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg71: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg72: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg73: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg74: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg75: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg76: !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, %arg77: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg78: !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, %arg79: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg80: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg81: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg82: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg83: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg84: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg85: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg86: !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %arg87: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg88: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg89: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg90: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg91: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg92: !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, %arg93: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg94: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg95: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg96: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg97: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg98: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg99: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg100: !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, %arg101: i32, %arg102: i32, %arg103: i32, %arg104: !tt.tensordesc<128x128xf16, #shared>, %arg105: !tt.tensordesc<256x64xf16, #shared>, %arg106: !tt.tensordesc<128x128xf16, #shared>, %arg107: !tt.tensordesc<64x128xf16, #shared>, %arg108: !tt.tensordesc<128x64xf16, #shared>, %arg109: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg110: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg111: !tt.tensordesc<128xf32, #shared3>, %arg112: !tt.tensordesc<128x64xf16, #shared>, %arg113: !tt.tensordesc<64x128xf16, #shared>, %arg114: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg115: !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, %arg116: !tt.tensordesc<128xf32, #shared3>, %arg117: f32, %arg118: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg119: !tt.tensordesc<128x16xf16, #shared2>, %arg120: !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, %arg121: !tt.tensordesc<128x16xf16, #shared2>, %arg122: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg123: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg124: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg125: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg126: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg127: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg128: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg129: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg130: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg131: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg132: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg133: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg134: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg135: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg136: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg137: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg138: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg139: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg140: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg141: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg142: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, %arg143: !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) num_warps(4) {
+        %152 = ub.poison : tensor<128x128xf16, #linear8>
+        %c1_i64_6 = arith.constant {async_task_id = array<i32: 4>} 1 : i64
+        %c0_i64_7 = arith.constant {async_task_id = array<i32: 4>} 0 : i64
+        %true = arith.constant {async_task_id = array<i32: 4>} true
+        %c112_i32 = arith.constant {async_task_id = array<i32: 4>} 112 : i32
+        %c96_i32 = arith.constant {async_task_id = array<i32: 4>} 96 : i32
+        %c80_i32 = arith.constant {async_task_id = array<i32: 4>} 80 : i32
+        %c64_i32_8 = arith.constant {async_task_id = array<i32: 4>} 64 : i32
+        %c48_i32_9 = arith.constant {async_task_id = array<i32: 4>} 48 : i32
+        %c32_i32_10 = arith.constant {async_task_id = array<i32: 4>} 32 : i32
+        %c16_i32_11 = arith.constant {async_task_id = array<i32: 4>} 16 : i32
+        %c127_i32_12 = arith.constant {async_task_id = array<i32: 4>} 127 : i32
+        %c128_i32_13 = arith.constant {async_task_id = array<i32: 4>} 128 : i32
+        %c2_i32_14 = arith.constant {async_task_id = array<i32: 4>} 2 : i32
+        %c1_i32_15 = arith.constant {async_task_id = array<i32: 4>} 1 : i32
+        %c0_i32_16 = arith.constant {async_task_id = array<i32: 4>} 0 : i32
+        %153 = arith.addi %arg63, %c127_i32_12 {async_task_id = array<i32: 4>} : i32
+        %154 = arith.divsi %153, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+        %155 = tt.get_program_id x {async_task_id = array<i32: 4>} : i32
+        %156 = arith.remsi %155, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %157 = arith.divsi %155, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %158 = tt.get_num_programs x {async_task_id = array<i32: 4>} : i32
+        %159 = arith.divsi %158, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %160 = arith.divsi %154, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+        %161 = arith.muli %160, %arg64 {async_task_id = array<i32: 4>} : i32
+        %162 = arith.muli %161, %arg65 {async_task_id = array<i32: 4>} : i32
+        %163 = arith.divsi %162, %159 {async_task_id = array<i32: 4>} : i32
+        %164 = arith.remsi %162, %159 {async_task_id = array<i32: 4>} : i32
+        %165 = arith.cmpi slt, %157, %164 {async_task_id = array<i32: 4>} : i32
+        %166 = scf.if %165 -> (i32) {
+          %171 = arith.addi %163, %c1_i32_15 {async_task_id = array<i32: 4>} : i32
+          scf.yield {async_task_id = array<i32: 4>} %171 : i32
+        } else {
+          scf.yield {async_task_id = array<i32: 4>} %163 : i32
+        } {async_task_id = array<i32: 4>}
+        %167 = arith.extsi %arg101 {async_task_id = array<i32: 4>} : i32 to i64
+        %168 = arith.divsi %arg63, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+        %169 = tt.splat %arg117 {async_task_id = array<i32: 4>} : f32 -> tensor<128x16xf32, #linear7>
+        %170:3 = scf.for %arg144 = %c0_i32_16 to %166 step %c1_i32_15 iter_args(%arg145 = %157, %arg146 = %c0_i64_7, %arg147 = %c0_i64_7) -> (i32, i64, i64)  : i32 {
+          %171 = arith.remsi %arg145, %160 {async_task_id = array<i32: 4>} : i32
+          %172 = arith.divsi %arg145, %160 {async_task_id = array<i32: 4>} : i32
+          %173 = arith.muli %171, %c2_i32_14 {async_task_id = array<i32: 4>} : i32
+          %174 = arith.addi %173, %156 {async_task_id = array<i32: 4>} : i32
+          %175 = arith.remsi %172, %arg65 {async_task_id = array<i32: 4>} : i32
+          %176 = arith.muli %arg102, %175 {async_task_id = array<i32: 4>} : i32
+          %177 = arith.divsi %172, %arg65 {async_task_id = array<i32: 4>} : i32
+          %178 = arith.muli %arg103, %177 {async_task_id = array<i32: 4>} : i32
+          %179 = arith.addi %176, %178 {async_task_id = array<i32: 4>} : i32
+          %180 = arith.extsi %179 {async_task_id = array<i32: 4>} : i32 to i64
+          %181 = arith.divsi %180, %167 {async_task_id = array<i32: 4>} : i64
+          %182 = arith.muli %174, %c128_i32_13 {async_task_id = array<i32: 4>} : i32
+          %183 = arith.extsi %182 {async_task_id = array<i32: 4>} : i32 to i64
+          %184 = arith.addi %181, %183 {async_task_id = array<i32: 4>} : i64
+          %185 = arith.trunci %184 {async_task_id = array<i32: 4>} : i64 to i32
+          %186 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          %187 = arith.trunci %186 {async_task_id = array<i32: 4>} : i64 to i1
+          %188 = arith.andi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          %189 = arith.trunci %188 {async_task_id = array<i32: 4>} : i64 to i1
+          %190 = arith.cmpi sgt, %168, %c0_i32_16 : i32
+          %191 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+          %192 = arith.trunci %191 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+          %193 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+          %194 = arith.trunci %193 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+          %195 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+          %196 = arith.trunci %195 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+          %197 = ttg.memdesc_index %arg110[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %198 = ttg.memdesc_index %arg109[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %199 = arith.extui %192 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+          %200 = arith.andi %190, %true : i1
+          ttng.wait_barrier %198, %199, %200 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %201 = ttg.local_load %197 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+          %202 = ttg.memdesc_index %arg127[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %202, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %203 = ttg.convert_layout %201 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+          %204 = tt.expand_dims %203 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+          %205 = tt.broadcast %204 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+          %206 = ttg.memdesc_index %arg72[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %207 = ttg.memdesc_index %arg74[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %208 = arith.extui %194 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %207, %208, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_17, %token_18 = ttng.tmem_load %206[] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %209 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %209, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %210 = arith.subf %result_17, %205 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+          %211 = math.exp2 %210 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+          %212 = arith.truncf %211 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+          %213 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %214 = ttg.memdesc_reinterpret %213 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %215 = ttg.memdesc_index %214[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %216 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %217 = arith.extui %196 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %216, %217, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {dstTask = 4 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %218 = arith.andi %190, %true : i1
+          ttng.tmem_store %212, %215, %218 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %219 = ttg.memdesc_index %arg130[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %219, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %220 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %221 = arith.trunci %220 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %222 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %223 = arith.trunci %222 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %224 = ttg.memdesc_index %arg115[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+          %225 = ttg.memdesc_index %arg114[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %226 = arith.extui %223 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          %227 = arith.andi %190, %true : i1
+          ttng.wait_barrier %225, %226, %227 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %228 = ttg.local_load %224 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+          %229 = ttg.memdesc_index %arg135[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %229, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %230 = ttg.convert_layout %228 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+          %231 = tt.expand_dims %230 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+          %232 = tt.broadcast %231 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+          %233 = ttg.memdesc_index %arg79[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %234 = ttg.memdesc_index %arg81[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %235 = arith.extui %221 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %234, %235, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_19, %token_20 = ttng.tmem_load %233[] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %236 = ttg.memdesc_index %arg133[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %236, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %237 = arith.subf %result_19, %232 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+          %238 = arith.mulf %211, %237 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+          %239 = arith.truncf %238 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+          %240 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+          %241 = ttg.memdesc_reinterpret %240 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+          %242 = ttg.memdesc_index %241[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %243 = arith.andi %arg147, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+          %244 = arith.trunci %243 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+          %245 = ttg.memdesc_index %arg90[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %246 = arith.xori %244, %true {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+          %247 = arith.extui %246 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+          ttng.wait_barrier %245, %247, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %248 = arith.andi %190, %true : i1
+          ttng.tmem_store %239, %242, %248 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+          %249 = ttg.memdesc_index %arg136[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %249, 1, %190 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %250 = arith.subi %168, %c1_i32_15 : i32
+          %251:2 = scf.for %arg148 = %c0_i32_16 to %250 step %c1_i32_15 iter_args(%arg149 = %arg147, %arg150 = %239) -> (i64, tensor<128x128xf16, #linear8>)  : i32 {
+            %380 = tt.reshape %arg150 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<128x2x64xf16, #linear11>
+            %381 = tt.trans %380 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear11> -> tensor<128x64x2xf16, #linear12>
+            %outLHS_51, %outRHS_52 = tt.split %381 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf16, #linear12> -> tensor<128x64xf16, #linear13>
+            %382 = ttg.memdesc_index %arg100[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %383 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            %384 = arith.trunci %383 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64 to i1
+            %385 = ttg.memdesc_index %arg139[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %386 = arith.xori %384, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1
+            %387 = arith.extui %386 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %385, %387 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %outLHS_51, %382 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear13> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %388 = ttg.memdesc_index %arg138[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %388, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %389 = ttng.two_cta_peer_gather %arg150 split_dim = 1 num_ctas = 2 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<64x256xf16, #linear9>
+            %390 = tt.trans %389 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear9> -> tensor<256x64xf16, #linear10>
+            %391 = ttg.memdesc_index %arg91[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %392 = arith.andi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64
+            %393 = arith.trunci %392 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64 to i1
+            %394 = ttg.memdesc_index %arg93[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %395 = arith.xori %393, %true {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1
+            %396 = arith.extui %395 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %394, %396 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %390, %391 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<256x64xf16, #linear10> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %397 = ttg.memdesc_index %arg140[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %397, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %398 = arith.addi %arg149, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : i64
+            %399 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %400 = arith.trunci %399 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %401 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %402 = arith.trunci %401 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %403 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64
+            %404 = arith.trunci %403 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i64 to i1
+            %405 = ttg.memdesc_index %arg110[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %406 = ttg.memdesc_index %arg109[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %407 = arith.extui %400 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            %408 = arith.andi %true, %true : i1
+            ttng.wait_barrier %406, %407, %408 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %409 = ttg.local_load %405 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+            %410 = ttg.memdesc_index %arg127[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %410, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %411 = ttg.convert_layout %409 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+            %412 = tt.expand_dims %411 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+            %413 = tt.broadcast %412 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+            %414 = ttg.memdesc_index %arg72[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %415 = ttg.memdesc_index %arg74[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %416 = arith.extui %402 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %415, %416, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_53, %token_54 = ttng.tmem_load %414[] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+            %417 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %417, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %418 = arith.subf %result_53, %413 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %419 = math.exp2 %418 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %420 = arith.truncf %419 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+            %421 = ttng.tmem_subslice %arg72 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %422 = ttg.memdesc_reinterpret %421 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %423 = ttg.memdesc_index %422[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %424 = ttg.memdesc_index %arg129[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %425 = arith.extui %404 {loop.cluster = 4 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %424, %425, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {dstTask = 4 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %426 = arith.andi %true, %true : i1
+            ttng.tmem_store %420, %423, %426 {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %427 = ttg.memdesc_index %arg130[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %427, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 4 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %428 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %429 = arith.trunci %428 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %430 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %431 = arith.trunci %430 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %432 = ttg.memdesc_index %arg115[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128xf32, #shared3, #smem, mutable> -> !ttg.memdesc<128xf32, #shared3, #smem, mutable>
+            %433 = ttg.memdesc_index %arg114[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %434 = arith.extui %431 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            %435 = arith.andi %true, %true : i1
+            ttng.wait_barrier %433, %434, %435 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %436 = ttg.local_load %432 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128xf32, #shared3, #smem, mutable> -> tensor<128xf32, #blocked1>
+            %437 = ttg.memdesc_index %arg135[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %437, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %438 = ttg.convert_layout %436 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #blocked1> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>>
+            %439 = tt.expand_dims %438 {async_task_id = array<i32: 4>, axis = 0 : i32, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear8}>> -> tensor<1x128xf32, #linear8>
+            %440 = tt.broadcast %439 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<1x128xf32, #linear8> -> tensor<128x128xf32, #linear8>
+            %441 = ttg.memdesc_index %arg79[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+            %442 = ttg.memdesc_index %arg81[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %443 = arith.extui %429 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %442, %443, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %result_55, %token_56 = ttng.tmem_load %441[] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+            %444 = ttg.memdesc_index %arg133[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %444, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %445 = arith.subf %result_55, %440 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %446 = arith.mulf %419, %445 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8>
+            %447 = arith.truncf %446 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf32, #linear8> to tensor<128x128xf16, #linear8>
+            %448 = ttng.tmem_subslice %arg79 {N = 0 : i32, async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128>
+            %449 = ttg.memdesc_reinterpret %448 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x64xf32, #tmem3, #ttng.tensor_memory, mutable, 1x128x128> -> !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable>
+            %450 = ttg.memdesc_index %449[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x128x128xf16, #tmem4, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %451 = arith.andi %398, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64
+            %452 = arith.trunci %451 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i64 to i1
+            %453 = ttg.memdesc_index %arg90[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %454 = arith.xori %452, %true {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1
+            %455 = arith.extui %454 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : i1 to i32
+            ttng.wait_barrier %453, %455, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %456 = arith.andi %true, %true : i1
+            ttng.tmem_store %447, %450, %456 {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : tensor<128x128xf16, #linear8> -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory, mutable>
+            %457 = ttg.memdesc_index %arg136[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %457, 1, %true {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 5 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            scf.yield %398, %447 : i64, tensor<128x128xf16, #linear8>
+          } {async_task_id = array<i32: 4>, tt.scheduled_max_stage = 1 : i32, tt.warp_specialize}
+          %252 = arith.cmpi sgt, %168, %c0_i32_16 : i32
+          %253:2 = scf.if %252 -> (i64, tensor<128x128xf16, #linear8>) {
+            %380 = tt.reshape %251#1 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<128x2x64xf16, #linear11>
+            %381 = tt.trans %380 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf16, #linear11> -> tensor<128x64x2xf16, #linear12>
+            %outLHS_51, %outRHS_52 = tt.split %381 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64x2xf16, #linear12> -> tensor<128x64xf16, #linear13>
+            %382 = ttg.memdesc_index %arg100[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %383 = arith.andi %251#0, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64
+            %384 = arith.trunci %383 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : i64 to i1
+            %385 = ttg.memdesc_index %arg139[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %386 = arith.xori %384, %true {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1
+            %387 = arith.extui %386 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %385, %387 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %outLHS_51, %382 {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #linear13> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+            %388 = ttg.memdesc_index %arg138[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %388, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 2>, dstTask = 2 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 0 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %389 = ttng.two_cta_peer_gather %251#1 split_dim = 1 num_ctas = 2 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x128xf16, #linear8> -> tensor<64x256xf16, #linear9>
+            %390 = tt.trans %389 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>} : tensor<64x256xf16, #linear9> -> tensor<256x64xf16, #linear10>
+            %391 = ttg.memdesc_index %arg91[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %392 = arith.andi %251#0, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64
+            %393 = arith.trunci %392 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i64 to i1
+            %394 = ttg.memdesc_index %arg93[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %395 = arith.xori %393, %true {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1
+            %396 = arith.extui %395 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : i1 to i32
+            ttng.wait_barrier %394, %396 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "backward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttg.local_store %390, %391 {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<256x64xf16, #linear10> -> !ttg.memdesc<256x64xf16, #shared, #smem, mutable>
+            %397 = ttg.memdesc_index %arg140[%c0_i32_16] {async_task_id = array<i32: 4>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            ttng.arrive_barrier %397, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 1 : i32, minRegionId = 1 : i32, parentId = 2 : i32}}, loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+            %398 = arith.addi %251#0, %c1_i64_6 {async_task_id = array<i32: 4>, loop.cluster = 3 : i32, loop.stage = 1 : i32} : i64
+            scf.yield %398, %152 : i64, tensor<128x128xf16, #linear8>
+          } else {
+            scf.yield %251#0, %251#1 : i64, tensor<128x128xf16, #linear8>
+          }
+          %254 = ttg.memdesc_index %arg82[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %255 = ttg.memdesc_index %arg96[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %256 = arith.extui %187 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %255, %256 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_21, %token_22 = ttng.tmem_load %254[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 3>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %257 = ttg.memdesc_index %arg123[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %257, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %258 = tt.reshape %result_21 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear11>
+          %259 = tt.trans %258 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear11> -> tensor<128x64x2xf32, #linear12>
+          %outLHS, %outRHS = tt.split %259 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear12> -> tensor<128x64xf32, #linear13>
+          %260 = tt.reshape %outLHS {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %261 = tt.trans %260 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_23, %outRHS_24 = tt.split %261 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %262 = tt.reshape %outLHS_23 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %263 = tt.trans %262 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_25, %outRHS_26 = tt.split %263 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %264 = tt.reshape %outRHS_24 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %265 = tt.trans %264 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_27, %outRHS_28 = tt.split %265 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %266 = tt.reshape %outRHS {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %267 = tt.trans %266 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_29, %outRHS_30 = tt.split %267 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %268 = tt.reshape %outLHS_29 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %269 = tt.trans %268 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_31, %outRHS_32 = tt.split %269 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %270 = tt.reshape %outRHS_30 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %271 = tt.trans %270 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_33, %outRHS_34 = tt.split %271 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %272 = arith.truncf %outLHS_25 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %273 = ttg.convert_layout %272 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %274 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %273, %274 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %275 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %276 = ttng.async_tma_copy_local_to_global %arg119[%185, %c0_i32_16] %275 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %276   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %277 = arith.truncf %outRHS_26 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %278 = ttg.convert_layout %277 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %279 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %278, %279 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %280 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %281 = ttng.async_tma_copy_local_to_global %arg119[%185, %c16_i32_11] %280 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %281   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %282 = arith.truncf %outLHS_27 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %283 = ttg.convert_layout %282 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %284 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %283, %284 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %285 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %286 = ttng.async_tma_copy_local_to_global %arg119[%185, %c32_i32_10] %285 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %286   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %287 = arith.truncf %outRHS_28 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %288 = ttg.convert_layout %287 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %289 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %288, %289 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %290 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %291 = ttng.async_tma_copy_local_to_global %arg119[%185, %c48_i32_9] %290 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %291   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %292 = arith.truncf %outLHS_31 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %293 = ttg.convert_layout %292 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %294 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %293, %294 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %295 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %296 = ttng.async_tma_copy_local_to_global %arg119[%185, %c64_i32_8] %295 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %296   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %297 = arith.truncf %outRHS_32 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %298 = ttg.convert_layout %297 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %299 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %298, %299 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %300 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %301 = ttng.async_tma_copy_local_to_global %arg119[%185, %c80_i32] %300 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %301   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %302 = arith.truncf %outLHS_33 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %303 = ttg.convert_layout %302 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %304 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %303, %304 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %305 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %306 = ttng.async_tma_copy_local_to_global %arg119[%185, %c96_i32] %305 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %306   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %307 = arith.truncf %outRHS_34 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %308 = ttg.convert_layout %307 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %309 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %308, %309 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %310 = ttg.memdesc_index %arg118[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %311 = ttng.async_tma_copy_local_to_global %arg119[%185, %c112_i32] %310 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %311   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %312 = ttg.memdesc_index %arg86[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+          %313 = ttg.memdesc_index %arg95[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %314 = arith.extui %189 {async_task_id = array<i32: 4>} : i1 to i32
+          ttng.wait_barrier %313, %314 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %result_35, %token_36 = ttng.tmem_load %312[] {async_task_id = array<i32: 4>, tmem.end = array<i32: 4>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear8>
+          %315 = ttg.memdesc_index %arg125[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          ttng.arrive_barrier %315, 1 {async_task_id = array<i32: 4>, constraints = {WSBarrier = {channelGraph = array<i32: 0, 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+          %316 = tt.reshape %result_35 {async_task_id = array<i32: 4>} : tensor<128x128xf32, #linear8> -> tensor<128x2x64xf32, #linear11>
+          %317 = tt.trans %316 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear11> -> tensor<128x64x2xf32, #linear12>
+          %outLHS_37, %outRHS_38 = tt.split %317 {async_task_id = array<i32: 4>} : tensor<128x64x2xf32, #linear12> -> tensor<128x64xf32, #linear13>
+          %318 = tt.reshape %outLHS_37 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %319 = tt.trans %318 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_39, %outRHS_40 = tt.split %319 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %320 = tt.reshape %outLHS_39 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %321 = tt.trans %320 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_41, %outRHS_42 = tt.split %321 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %322 = tt.reshape %outRHS_40 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %323 = tt.trans %322 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_43, %outRHS_44 = tt.split %323 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %324 = tt.reshape %outRHS_38 {async_task_id = array<i32: 4>} : tensor<128x64xf32, #linear13> -> tensor<128x2x32xf32, #linear14>
+          %325 = tt.trans %324 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x32xf32, #linear14> -> tensor<128x32x2xf32, #linear15>
+          %outLHS_45, %outRHS_46 = tt.split %325 {async_task_id = array<i32: 4>} : tensor<128x32x2xf32, #linear15> -> tensor<128x32xf32, #linear16>
+          %326 = tt.reshape %outLHS_45 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %327 = tt.trans %326 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_47, %outRHS_48 = tt.split %327 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %328 = tt.reshape %outRHS_46 {async_task_id = array<i32: 4>} : tensor<128x32xf32, #linear16> -> tensor<128x2x16xf32, #linear17>
+          %329 = tt.trans %328 {async_task_id = array<i32: 4>, order = array<i32: 0, 2, 1>} : tensor<128x2x16xf32, #linear17> -> tensor<128x16x2xf32, #linear18>
+          %outLHS_49, %outRHS_50 = tt.split %329 {async_task_id = array<i32: 4>} : tensor<128x16x2xf32, #linear18> -> tensor<128x16xf32, #linear7>
+          %330 = arith.mulf %outLHS_41, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %331 = arith.truncf %330 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %332 = ttg.convert_layout %331 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %333 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %332, %333 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %334 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %335 = ttng.async_tma_copy_local_to_global %arg121[%185, %c0_i32_16] %334 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %335   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %336 = arith.mulf %outRHS_42, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %337 = arith.truncf %336 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %338 = ttg.convert_layout %337 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %339 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %338, %339 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %340 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %341 = ttng.async_tma_copy_local_to_global %arg121[%185, %c16_i32_11] %340 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %341   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %342 = arith.mulf %outLHS_43, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %343 = arith.truncf %342 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %344 = ttg.convert_layout %343 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %345 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %344, %345 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %346 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %347 = ttng.async_tma_copy_local_to_global %arg121[%185, %c32_i32_10] %346 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %347   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %348 = arith.mulf %outRHS_44, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %349 = arith.truncf %348 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %350 = ttg.convert_layout %349 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %351 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %350, %351 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %352 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %353 = ttng.async_tma_copy_local_to_global %arg121[%185, %c48_i32_9] %352 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %353   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %354 = arith.mulf %outLHS_47, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %355 = arith.truncf %354 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %356 = ttg.convert_layout %355 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %357 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %356, %357 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %358 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %359 = ttng.async_tma_copy_local_to_global %arg121[%185, %c64_i32_8] %358 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %359   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %360 = arith.mulf %outRHS_48, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %361 = arith.truncf %360 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %362 = ttg.convert_layout %361 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %363 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %362, %363 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %364 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %365 = ttng.async_tma_copy_local_to_global %arg121[%185, %c80_i32] %364 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %365   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %366 = arith.mulf %outLHS_49, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %367 = arith.truncf %366 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %368 = ttg.convert_layout %367 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %369 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %368, %369 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %370 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %371 = ttng.async_tma_copy_local_to_global %arg121[%185, %c96_i32] %370 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %371   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %372 = arith.mulf %outRHS_50, %169 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7>
+          %373 = arith.truncf %372 {async_task_id = array<i32: 4>} : tensor<128x16xf32, #linear7> to tensor<128x16xf16, #linear7>
+          %374 = ttg.convert_layout %373 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #linear7> -> tensor<128x16xf16, #blocked2>
+          %375 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          ttg.local_store %374, %375 {async_task_id = array<i32: 4>} : tensor<128x16xf16, #blocked2> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %376 = ttg.memdesc_index %arg120[%c0_i32_16] {async_task_id = array<i32: 4>} : !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable> -> !ttg.memdesc<128x16xf16, #shared2, #smem, mutable>
+          %377 = ttng.async_tma_copy_local_to_global %arg121[%185, %c112_i32] %376 {async_task_id = array<i32: 4>} : !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<128x16xf16, #shared2, #smem, mutable> -> !ttg.async.token
+          ttng.async_tma_store_token_wait %377   {async_task_id = array<i32: 4>, can_rotate_by_buffer_count = 1 : i32} : !ttg.async.token
+          %378 = arith.addi %arg145, %159 {async_task_id = array<i32: 4>} : i32
+          %379 = arith.addi %arg146, %c1_i64_6 {async_task_id = array<i32: 4>} : i64
+          scf.yield {async_task_id = array<i32: 4>} %378, %379, %253#0 : i32, i64, i64
+        } {async_task_id = array<i32: 4>, tt.merge_epilogue_to_computation = true, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["reduction", "gemm", "relay", "load", "computation"], ttg.warp_specialize.tag = 0 : i32}
+        ttg.warp_return
+      } : (i32, i32, i32, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x64x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf16, #shared, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x256x64xf16, #shared, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128x64xf16, #shared, #smem, mutable>, i32, i32, i32, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<256x64xf16, #shared>, !tt.tensordesc<128x128xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, !tt.tensordesc<128x64xf16, #shared>, !tt.tensordesc<64x128xf16, #shared>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x128xf32, #shared3, #smem, mutable>, !tt.tensordesc<128xf32, #shared3>, f32, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x128x16xf16, #shared2, #smem, mutable>, !tt.tensordesc<128x16xf16, #shared2>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>, !ttg.memdesc<1x1xi64, #shared4, #smem, mutable>) -> ()
+      %106 = ttg.memdesc_index %46[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %106 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %107 = ttg.memdesc_index %42[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %107 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %108 = ttg.memdesc_index %38[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %108 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %109 = ttg.memdesc_index %30[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %109 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %110 = ttg.memdesc_index %28[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %110 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %111 = ttg.memdesc_index %20[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %111 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %112 = ttg.memdesc_index %14[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %112 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %113 = ttg.memdesc_index %12[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %113 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %114 = ttg.memdesc_index %10[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %114 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %115 = ttg.memdesc_index %8[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %115 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %116 = ttg.memdesc_index %16[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %116 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %117 = ttg.memdesc_index %18[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %117 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %118 = ttg.memdesc_index %24[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %118 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %119 = ttg.memdesc_index %26[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %119 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %120 = ttg.memdesc_index %4[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %120 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %121 = ttg.memdesc_index %2[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %121 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %122 = ttg.memdesc_index %0[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %122 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %123 = ttg.memdesc_index %32[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %123 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %124 = ttg.memdesc_index %34[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %124 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %125 = ttg.memdesc_index %36[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %125 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %126 = ttg.memdesc_index %40[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %126 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %127 = ttg.memdesc_index %44[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %127 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %128 = ttg.memdesc_index %22[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %128 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %129 = ttg.memdesc_index %6[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %129 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %130 = ttg.memdesc_index %48[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %130 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %131 = ttg.memdesc_index %49[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %131 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %132 = ttg.memdesc_index %52[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %132 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %133 = ttg.memdesc_index %53[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %133 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %134 = ttg.memdesc_index %56[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %134 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %135 = ttg.memdesc_index %57[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %135 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %136 = ttg.memdesc_index %60[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %136 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %137 = ttg.memdesc_index %61[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %137 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %138 = ttg.memdesc_index %64[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %138 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %139 = ttg.memdesc_index %65[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %139 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %140 = ttg.memdesc_index %68[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %140 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %141 = ttg.memdesc_index %69[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %141 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %142 = ttg.memdesc_index %72[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %142 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %143 = ttg.memdesc_index %73[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %143 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %144 = ttg.memdesc_index %76[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %144 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %145 = ttg.memdesc_index %77[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %145 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %146 = ttg.memdesc_index %80[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %146 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %147 = ttg.memdesc_index %81[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %147 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %148 = ttg.memdesc_index %84[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %148 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %149 = ttg.memdesc_index %85[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %149 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %150 = ttg.memdesc_index %88[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %150 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      %151 = ttg.memdesc_index %89[%c0_i32] : !ttg.memdesc<1x1xi64, #shared4, #smem, mutable> -> !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      ttng.inval_barrier %151 : !ttg.memdesc<1xi64, #shared4, #smem, mutable>
+      tt.return
+    }
+  }
+}

--- a/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir
+++ b/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir
@@ -1,0 +1,209 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=2 smem-budget=232448" | FileCheck %s
+// CHECK-LABEL: tt.func public @_attn_bwd
+// Dead load-task rematerialization clones of m/Di must be removed before
+// descriptor conversion derives the local_load consumer set. Otherwise these
+// loads carry tasks {0, 3} and create an unsafe self-consumer TMA channel.
+// CHECK-COUNT-2: ttg.local_load {{.*}}async_task_id = array<i32: 0>{{.*}}!ttg.memdesc<128xf32
+// CHECK-NOT: ttng.tmem_store %cst
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [32, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[128, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64], [0, 32]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 1, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 0, 1]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [64, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0], [32, 0, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [64, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [32, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 88 : i32, ttg.min_reg_auto_ws = 88 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x128xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<256x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.tensordesc<128x128xf16, #shared>, %arg21: i32, %arg22: i32, %arg23: i64, %arg24: i64, %arg25: f32, %arg26: !tt.tensordesc<128x64xf16, #shared>, %arg27: i32, %arg28: i32, %arg29: i64, %arg30: i64, %arg31: !tt.tensordesc<64x128xf16, #shared>, %arg32: i32, %arg33: i32, %arg34: i64, %arg35: i64, %arg36: !tt.tensordesc<128x16xf32, #shared1>, %arg37: i32, %arg38: i32, %arg39: i64, %arg40: i64, %arg41: !tt.tensordesc<128x64xf16, #shared>, %arg42: i32, %arg43: i32, %arg44: i64, %arg45: i64, %arg46: !tt.tensordesc<128x64xf16, #shared>, %arg47: i32, %arg48: i32, %arg49: i64, %arg50: i64, %arg51: !tt.tensordesc<128xf32, #shared2>, %arg52: i32, %arg53: i64, %arg54: !tt.tensordesc<128xf32, #shared2>, %arg55: i32, %arg56: i64, %arg57: i32 {tt.divisibility = 16 : i32}, %arg58: i32 {tt.divisibility = 16 : i32}, %arg59: i32 {tt.divisibility = 16 : i32}, %arg60: i32, %arg61: i32, %arg62: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %cst = arith.constant dense<0.693147182> : tensor<128x16xf32, #blocked>
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %true = arith.constant true
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = tt.get_program_id z : i32
+    %1 = tt.get_program_id x : i32
+    %2 = arith.muli %0, %arg62 : i32
+    %3 = arith.extsi %2 : i32 to i64
+    %4 = arith.remsi %0, %arg61 : i32
+    %5 = arith.muli %arg58, %4 : i32
+    %6 = arith.divsi %0, %arg61 : i32
+    %7 = arith.muli %arg57, %6 : i32
+    %8 = arith.addi %5, %7 : i32
+    %9 = arith.extsi %8 : i32 to i64
+    %10 = arith.extsi %arg59 : i32 to i64
+    %11 = arith.divsi %9, %10 : i64
+    %12 = arith.muli %1, %c128_i32 : i32
+    %13 = arith.remsi %1, %c2_i32 : i32
+    %14 = arith.extsi %12 : i32 to i64
+    %15 = arith.addi %11, %14 : i64
+    %16 = arith.trunci %15 : i64 to i32
+    %17 = tt.descriptor_load %arg10[%16, %c0_i32] {ttg.partition = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1>
+    %18 = ttg.local_alloc %17 {ttg.partition = array<i32: 3>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %19 = arith.muli %13, %c128_i32 : i32
+    %20 = arith.subi %12, %19 : i32
+    %21 = arith.extsi %20 : i32 to i64
+    %22 = arith.addi %11, %21 : i64
+    %23 = arith.trunci %22 : i64 to i32
+    %24 = nvg.cluster_id
+    %25 = arith.remsi %24, %c2_i32 : i32
+    %26 = arith.muli %25, %c64_i32 : i32
+    %27 = tt.descriptor_load %arg15[%23, %26] {ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<256x64xf16, #shared> -> tensor<256x64xf16, #blocked2>
+    %28 = ttg.local_alloc %27 {ttg.partition = array<i32: 3>} : (tensor<256x64xf16, #blocked2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+    %29 = tt.descriptor_load %arg20[%16, %c0_i32] {ttg.partition = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1>
+    %30 = ttg.local_alloc %29 {ttg.partition = array<i32: 3>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %31 = arith.divsi %arg62, %c128_i32 : i32
+    %32 = arith.muli %13, %c64_i32 : i32
+    %33 = arith.extsi %32 : i32 to i64
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_1, %token_2 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_3, %token_4 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_5, %token_6 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_7, %token_8 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %34 = ttng.tmem_store %cst_0, %result_5[%token_6], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %35 = ttng.tmem_store %cst_0, %result_3[%token_4], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %36:7 = scf.for %arg63 = %c0_i32 to %31 step %c1_i32 iter_args(%arg64 = %c0_i32, %arg65 = %false, %arg66 = %token, %arg67 = %token_2, %arg68 = %35, %arg69 = %34, %arg70 = %token_8) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %58 = arith.extsi %arg64 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : i32 to i64
+      %59 = arith.addi %11, %58 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : i64
+      %60 = arith.trunci %59 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+      %61 = arith.addi %60, %26 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+      %62 = tt.descriptor_load %arg5[%61, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1>
+      %63 = ttg.local_alloc %62 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+      %64 = ttg.memdesc_trans %63 {loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared3, #smem>
+      %65 = tt.descriptor_load %arg0[%60, %26] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked2>
+      %66 = ttg.local_alloc %65 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %67 = arith.addi %3, %58 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+      %68 = arith.trunci %67 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+      %69 = tt.descriptor_load %arg51[%68] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2> -> tensor<128xf32, #blocked3>
+      %70 = ttng.tc_gen5_mma %18, %64, %result[%arg66], %false, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %71 = ttg.convert_layout %69 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %72 = ttg.convert_layout %69 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %73 = tt.expand_dims %71 {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %74 = tt.expand_dims %72 {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %75 = tt.broadcast %73 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %result_15, %token_16 = ttng.tmem_load %result[%70] {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %76 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 4 : i32, loop.stage = 0 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %result_15, %75 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %77 = math.exp2 %76 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear>
+      %78 = tt.descriptor_load %arg26[%60, %26] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked2>
+      %79 = ttg.local_alloc %78 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %80 = tt.descriptor_load %arg31[%61, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1>
+      %81 = arith.truncf %77 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %result_17 = ttng.tmem_alloc %81 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+      %82 = ttg.local_alloc %80 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+      %83 = ttg.memdesc_trans %82 {loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared3, #smem>
+      %84 = ttng.tc_gen5_mma %30, %83, %result_1[%arg67], %false, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %85 = tt.descriptor_load %arg54[%68] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2> -> tensor<128xf32, #blocked3>
+      %86 = ttng.tc_gen5_mma %result_17, %79, %result_3[%arg68], %arg65, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %87 = ttg.convert_layout %85 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %88 = ttg.convert_layout %85 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %89 = tt.expand_dims %87 {axis = 0 : i32, loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %90 = tt.expand_dims %88 {axis = 0 : i32, loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %91 = tt.broadcast %89 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %result_18, %token_19 = ttng.tmem_load %result_1[%84] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %92 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %result_18, %91 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %93 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %77, %92 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %94 = arith.truncf %93 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %result_20 = ttng.tmem_alloc %94 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+      %95 = ttng.tc_gen5_mma %result_20, %66, %result_5[%arg69], %arg65, %true {loop.cluster = 1 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %96 = ttng.two_cta_peer_gather %94 split_dim = 1 num_ctas = 2 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<64x256xf16, #linear1>
+      %97 = tt.trans %96 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 0>} : tensor<64x256xf16, #linear1> -> tensor<256x64xf16, #linear2>
+      %98 = tt.reshape %94 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x2x64xf16, #linear3>
+      %99 = tt.trans %98 {loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf16, #linear3> -> tensor<128x64x2xf16, #linear4>
+      %100 = ttg.convert_layout %99 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x64x2xf16, #linear4> -> tensor<128x64x2xf16, #blocked4>
+      %outLHS_21, %outRHS_22 = tt.split %100 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x64x2xf16, #blocked4> -> tensor<128x64xf16, #blocked5>
+      %101 = ttg.local_alloc %outLHS_21 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked5>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %102 = ttg.local_alloc %97 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<256x64xf16, #linear2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+      ttng.two_cta_peer_relay %101 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 4>} : <128x64xf16, #shared, #smem>
+      %103 = ttg.memdesc_trans %102 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<256x64xf16, #shared, #smem> -> !ttg.memdesc<64x256xf16, #shared3, #smem>
+      %104 = ttng.tc_gen5_mma %103, %28, %result_7[%arg70], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared3, #smem>, !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %result_23, %token_24 = ttng.tmem_load %result_7[%104] {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear5>
+      %105 = tt.reshape %result_23 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<64x128xf32, #linear5> -> tensor<128x2x32xf32, #linear6>
+      %106 = tt.trans %105 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x32xf32, #linear6> -> tensor<128x32x2xf32, #linear7>
+      %107 = ttg.convert_layout %106 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32x2xf32, #linear7> -> tensor<128x32x2xf32, #linear8>
+      %outLHS_25, %outRHS_26 = tt.split %107 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32x2xf32, #linear8> -> tensor<128x32xf32, #linear9>
+      %108 = tt.reshape %outLHS_25 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked6>
+      %109 = tt.trans %108 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x16xf32, #blocked6> -> tensor<128x16x2xf32, #blocked7>
+      %outLHS_27, %outRHS_28 = tt.split %109 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16x2xf32, #blocked7> -> tensor<128x16xf32, #blocked>
+      %110 = tt.reshape %outRHS_26 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked6>
+      %111 = tt.trans %110 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x16xf32, #blocked6> -> tensor<128x16x2xf32, #blocked7>
+      %outLHS_29, %outRHS_30 = tt.split %111 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16x2xf32, #blocked7> -> tensor<128x16xf32, #blocked>
+      %112 = arith.addi %59, %33 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64
+      %113 = arith.muli %112, %c2_i64 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64
+      %114 = arith.mulf %outLHS_27, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %115 = arith.trunci %113 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64 to i32
+      %116 = ttg.local_alloc %114 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %117 = ttng.async_tma_reduce add, %arg36[%115, %c0_i32] %116 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %117   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %118 = arith.mulf %outRHS_28, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %119 = ttg.local_alloc %118 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %120 = ttng.async_tma_reduce add, %arg36[%115, %c16_i32] %119 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %120   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %121 = arith.mulf %outLHS_29, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %122 = ttg.local_alloc %121 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %123 = ttng.async_tma_reduce add, %arg36[%115, %c32_i32] %122 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %123   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %124 = arith.mulf %outRHS_30, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %125 = ttg.local_alloc %124 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %126 = ttng.async_tma_reduce add, %arg36[%115, %c48_i32] %125 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %126   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %127 = arith.addi %arg64, %c128_i32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %127, %true, %token_16, %token_19, %86, %95, %token_24 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    } {tt.assume_nonempty, tt.merge_epilogue_to_computation = true, tt.scheduled_max_stage = 1 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+    %result_9, %token_10 = ttng.tmem_load %result_3[%36#4] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %result_11, %token_12 = ttng.tmem_load %result_5[%36#5] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %37 = tt.reshape %result_9 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+    %38 = tt.trans %37 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+    %39 = ttg.convert_layout %38 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #blocked8>
+    %outLHS, %outRHS = tt.split %39 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #blocked8> -> tensor<128x64xf32, #blocked2>
+    %40 = arith.truncf %outLHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %41 = ttg.local_alloc %40 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %42 = ttng.async_tma_copy_local_to_global %arg46[%16, %c0_i32] %41 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %42   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %43 = arith.truncf %outRHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %44 = ttg.local_alloc %43 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %45 = ttng.async_tma_copy_local_to_global %arg46[%16, %c64_i32] %44 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %45   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %46 = tt.reshape %result_11 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+    %47 = tt.trans %46 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+    %48 = ttg.convert_layout %47 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #blocked8>
+    %outLHS_13, %outRHS_14 = tt.split %48 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #blocked8> -> tensor<128x64xf32, #blocked2>
+    %49 = tt.splat %arg25 : f32 -> tensor<128x64xf32, #blocked2>
+    %50 = arith.mulf %outLHS_13, %49 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+    %51 = arith.truncf %50 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %52 = ttg.local_alloc %51 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %53 = ttng.async_tma_copy_local_to_global %arg41[%16, %c0_i32] %52 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %53   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %54 = arith.mulf %outRHS_14, %49 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+    %55 = arith.truncf %54 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %56 = ttg.local_alloc %55 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %57 = ttng.async_tma_copy_local_to_global %arg41[%16, %c64_i32] %56 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %57   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    tt.return
+  }
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1012,6 +1012,16 @@ class CUDABackend(BaseBackend):
                     knobs.nvidia.ws_tile_prefetch_depth,
                     tma_store_pipelining,
                 )
+                # AutoWS clones the original partial schedule into each
+                # partition. Re-schedule those cloned loops so newly inserted
+                # partition-local ops receive stages and unused stages are
+                # pruned before software-pipeline expansion.
+                # Restrict it to the 2-CTA path: on the 1-CTA path the post-WS
+                # schedule is already correct and re-running the scheduler
+                # overwrites it, which silently miscompiles kernels that have a
+                # separate epilogue-store partition.
+                if opt.cluster_dims is not None and max(opt.cluster_dims) >= 2:
+                    passes.ttgpuir.add_schedule_loops(pm, opt.num_stages, knobs.nvidia.use_meta_ws)
             passes.ttgpuir.add_pipeline(pm, opt.num_stages, dump_enabled)
             passes.ttgpuir.add_optimize_partition_warps(pm)
             if (opt.cluster_dims is not None and max(opt.cluster_dims) >= 2 and opt.allowDependentTwoCTA):


### PR DESCRIPTION
Summary:
Keep the backward MMAs in the GEMM partition during software pipelining and remove redundant TMEM initialization in the specialized path. Use predicate-stage epilogue peeling for the two-CTA peer gather and TMA reduction so sibling partitions remain in lockstep, then cover the production path with minimized fixtures.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D114617484


