### PR TITLE
[AutoWS] Honor CLC loop shared-memory planning attributes (#3302)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -854,6 +854,13 @@ struct HoistTMEMAlloc
         if (!alloc || alloc->getParentRegion() != mmaOp->getParentRegion()) {
           continue;
         }
+        // An MMA that does not use its accumulator fully overwrites this TMEM
+        // allocation on every iteration.  Keep that scratch allocation scoped
+        // to the loop instead of turning it into loop-carried state; hoisting
+        // several such temporaries can make their otherwise disjoint TMEM
+        // lifetimes overlap after software pipelining.
+        if (isConstBool(mmaOp.useAccumulator(), false))
+          continue;
         hoistTMEMAlloc(alloc, forOp);
       }
     }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -986,6 +986,18 @@ scf::ForOp lowerMMA(ttng::MMAv5OpInterface mma, scf::ForOp forOp,
     tmemUseNumStages += 1;
   }
 
+  // A scratch accumulator (useAccumulator=false) is overwritten every
+  // iteration.  When it remains inside a software-pipelined loop, different
+  // iterations can still be in flight even if its producer and consumer are
+  // assigned to the same coarse stage.  Give it one TMEM slice per pipeline
+  // stage so the next iteration cannot overwrite a pending result.
+  auto useAcc = mma.useAccumulator().getDefiningOp<arith::ConstantOp>();
+  bool fullyOverwritesAccumulator =
+      useAcc && cast<BoolAttr>(useAcc.getValueAttr()).getValue() == false;
+  if (alloc.getDefiningOp<ttng::TMEMAllocOp>() &&
+      fullyOverwritesAccumulator)
+    tmemUseNumStages = std::max(tmemUseNumStages, schedule.getNumStages());
+
   // If the accumulator needs to be double-buffered but we can't find the alloc
   // op, then bail out.
   if (tmemUseNumStages > 1 && !alloc.getDefiningOp<ttng::TMEMAllocOp>())

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1838,10 +1838,61 @@ void replaceUsesAndPropagateType(
   OpBuilder::InsertionGuard guard(builder);
   SmallVector<Operation *> opsToDelete;
   SmallVector<OpOperand *> operandsToReplace;
+  ttg::MemDescType oldType;
+  if (oldUse->getNumResults() == 1)
+    oldType = dyn_cast<ttg::MemDescType>(oldUse->getResult(0).getType());
+  auto newType = dyn_cast<ttg::MemDescType>(val.getType());
+  bool changesOnlyMutability =
+      oldType && newType && oldType.getShape() == newType.getShape() &&
+      oldType.getElementType() == newType.getElementType() &&
+      oldType.getEncoding() == newType.getEncoding() &&
+      oldType.getMemorySpace() == newType.getMemorySpace() &&
+      oldType.getAllocShape() == newType.getAllocShape() &&
+      oldType.getMutableMemory() != newType.getMutableMemory();
+  DenseSet<Value> visitedViews;
+  auto propagateViewTypes = [&](auto &&self, Value source) -> void {
+    if (!visitedViews.insert(source).second)
+      return;
+    auto sourceType = dyn_cast<ttg::MemDescType>(source.getType());
+    if (!sourceType)
+      return;
+    for (Operation *user : source.getUsers()) {
+      if (!user->hasTrait<OpTrait::MemDescViewTrait>())
+        continue;
+      for (Value result : user->getResults()) {
+        auto resultType = dyn_cast<ttg::MemDescType>(result.getType());
+        if (!resultType)
+          continue;
+        result.setType(ttg::MemDescType::get(
+            resultType.getShape(), resultType.getElementType(),
+            resultType.getEncoding(), resultType.getMemorySpace(),
+            sourceType.getMutableMemory(), resultType.getAllocShape()));
+        self(self, result);
+      }
+    }
+  };
 
   // Save the operand to replace / delete later (avoid iterator invalidation).
   // TODO: can we use an early_inc iterator?
   for (OpOperand &use : oldUse->getUses()) {
+    // A pipelined value may be carried through an scf.for. If lowering changes
+    // a memdesc from immutable to mutable, keep every value tied to the yield
+    // operand type-consistent. The init value and result can be defined/used
+    // outside the loop, so updating only the yield and region argument leaves
+    // invalid control-flow edges.
+    if (auto yieldOp = dyn_cast<scf::YieldOp>(use.getOwner());
+        changesOnlyMutability && yieldOp) {
+      if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
+        unsigned index = use.getOperandNumber();
+        forOp.getInitArgs()[index].setType(val.getType());
+        forOp.getRegionIterArg(index).setType(val.getType());
+        forOp.getResult(index).setType(val.getType());
+        propagateViewTypes(propagateViewTypes, forOp.getInitArgs()[index]);
+        propagateViewTypes(propagateViewTypes, forOp.getRegionIterArg(index));
+        propagateViewTypes(propagateViewTypes, forOp.getResult(index));
+      }
+    }
+
     // Propagate through `ttg.warp_specialize`.
     if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(use.getOwner())) {
       for (Region &region : wsOp.getPartitionRegions())

--- a/test/Hopper/WarpSpecialization/ws_memory_planner_epilogue_multicopy.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_epilogue_multicopy.mlir
@@ -2,6 +2,7 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-memory-planner="num-buffers=3 smem-alloc-algo=1 smem-budget=200000" | FileCheck %s --check-prefix=TIGHT
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-memory-planner="num-buffers=3 smem-alloc-algo=1 smem-budget=250000" | FileCheck %s --check-prefix=FULL
 // RUN: triton-opt %s -split-input-file --nvgpu-test-ws-memory-planner="num-buffers=3 smem-alloc-algo=1 smem-budget=220000 smem-plan-search" | FileCheck %s --check-prefix=SEARCH
+// RUN: sed -e '/%%0 = scf.for %%iv = %%c0 to %%c10 step %%c1 iter_args(%%arg0 = %%c0)/c\    %%0 = scf.while (%%arg0 = %%c0) : (i32) -> i32 { scf.condition(%%true) %%arg0 : i32 } do { ^bb0(%%arg0: i32):' -e 's/} {async_task_id = array<i32: 0, 1, 2>, tt.warp_specialize}/} attributes {async_task_id = array<i32: 0, 1, 2>, tt.smem_budget = 200000 : i32, tt.warp_specialize}/' %s | triton-opt - -split-input-file --nvgpu-test-ws-memory-planner="num-buffers=3 smem-alloc-algo=1 smem-budget=220000" | FileCheck %s --check-prefix=WHILE-BUDGET
 
 // Test: TMA-fed MMA operands keep their configured pipeline depth before
 // Phase 3.7 reserves fused epilogue copies from the remaining budget.
@@ -42,6 +43,12 @@
 // SEARCH-LABEL: @epilogue_multicopy
 // SEARCH: ttg.local_alloc {buffer.copy = 3 : i32{{.*}}128x64xf16
 // SEARCH: ttg.local_alloc {buffer.copy = 3 : i32{{.*}}64x256xf16
+
+// A CLC-style scf.while must honor its 200000-byte per-loop override rather
+// than the pass-level 220000-byte budget, leaving one fused epilogue copy.
+// WHILE-BUDGET-LABEL: @epilogue_multicopy
+// WHILE-BUDGET: ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = [[WHILE_ID:[0-9]+]] : i32}{{.*}}128x128xf16
+// WHILE-BUDGET: ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = [[WHILE_ID]] : i32}{{.*}}128x128xf16
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation.mlir
@@ -92,6 +92,31 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // A collective bounds guard must be evaluated by every task that has work in
+  // its body. Scalar address/load chains are replicated instead of lowered to
+  // unsupported scalar communication channels.
+  // CHECK-LABEL: @collective_if_scalar_load
+  // CHECK: tt.addptr {{.*}} {async_task_id = array<i32: 0, 1>}
+  // CHECK: tt.load {{.*}} {async_task_id = array<i32: 0, 1>}
+  // CHECK: arith.cmpi {{.*}} {async_task_id = array<i32: 0, 1>}
+  // CHECK: scf.if
+  // CHECK: } {async_task_id = array<i32: 0, 1>}
+  tt.func public @collective_if_scalar_load(%lengths: !tt.ptr<i32>, %idx: i32,
+                                            %out0: !tt.ptr<i32>, %out1: !tt.ptr<i32>) {
+    %ptr = tt.addptr %lengths, %idx {async_task_id = array<i32: 0>} : !tt.ptr<i32>, i32
+    %length = tt.load %ptr {async_task_id = array<i32: 0>} : !tt.ptr<i32>
+    %valid = arith.cmpi sgt, %length, %idx : i32
+    scf.if %valid {
+      tt.store %out0, %length {async_task_id = array<i32: 0>} : !tt.ptr<i32>
+      tt.store %out1, %length {async_task_id = array<i32: 1>} : !tt.ptr<i32>
+    }
+    tt.return
+  }
+}
+
+// -----
+
 // Test that nested for loop constant bounds get allTasks after propagation.
 // The inner loop body only contains ops with tasks 1 and 2, while task 0 ops
 // are in the outer loop epilogue. The solver's backward propagation only sees

--- a/test/TritonGPU/hoist-tmem-alloc.mlir
+++ b/test/TritonGPU/hoist-tmem-alloc.mlir
@@ -126,6 +126,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @sink_alloc_to_mma_use_acc_false
+  // CHECK: %[[SCRATCH:.*]], %[[SCRATCH_TOKEN:.*]] = ttng.tmem_alloc : ()
+  // CHECK: scf.for {{.*}} iter_args(%[[LOOP_TOKEN:.*]] = %[[SCRATCH_TOKEN]])
+  // CHECK:   ttng.tc_gen5_mma {{.*}}, {{.*}}, %[[SCRATCH]][%[[LOOP_TOKEN]]]
   // POST-PIPELINE-LABEL: @sink_alloc_to_mma_use_acc_false
   // POST-PIPELINE: scf.for
   // POST-PIPELINE:   %[[ACC_TM:.*]], %[[ALLOC_TOK:.*]] = ttng.tmem_alloc : ()

--- a/test/TritonGPU/loop-pipeline-blackwell.mlir
+++ b/test/TritonGPU/loop-pipeline-blackwell.mlir
@@ -59,6 +59,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // A useAccumulator=false MMA produces per-iteration scratch. With two
+  // software-pipeline stages, it needs two TMEM slices even when its producer
+  // and consumer occupy the same coarse stage.
+  // CHECK-LABEL: @multibuffer_overwrite_only_tmem
+  // CHECK: scf.for
+  // CHECK:   %[[SCRATCH:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32
+  // CHECK:   %[[SLICE:.*]] = ttg.memdesc_index %[[SCRATCH]]{{.*}} : !ttg.memdesc<2x128x128xf32
+  // CHECK:   ttng.tc_gen5_mma {{.*}}, {{.*}}, %[[SLICE]], %false
+  tt.func public @multibuffer_overwrite_only_tmem(
+      %a: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
+      %b: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>,
+      %init: tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>>,
+      %iters: index) -> tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>> {
+    %false = arith.constant false
+    %true = arith.constant true
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %out = scf.for %i = %c0 to %iters step %c1 iter_args(%unused = %init) -> (tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>>) {
+      %scratch, %alloc_tok = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %mma_tok = ttng.tc_gen5_mma %a, %b, %scratch[%alloc_tok], %false, %true : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %result, %load_tok = ttng.tmem_load %scratch[%mma_tok] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>>
+      scf.yield %result : tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>>
+    } {tt.num_stages = 2 : i32}
+    tt.return %out : tensor<128x128xf32, #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>>
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/test/TritonGPU/partition-scheduling.mlir
+++ b/test/TritonGPU/partition-scheduling.mlir
@@ -96,7 +96,7 @@ tt.func public @attention_forward(
 
     // CHECK-NEXT: scf.yield {ttg.partition = array<i32: 0, 1, 2, 3>}
     scf.yield %next_l_i, %O, %row_max, %next_e_i : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
-    // CHECK-NEXT: ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0>, array<i32: 0>, array<i32: 1>, array<i32: 2>, array<i32: 1>]
+    // CHECK-NEXT: ttg.partition = array<i32: 0, 1, 2, 3>, ttg.partition.outputs = [array<i32: 0>, array<i32: 0>, array<i32: 1>, array<i32: 1>]
   } {tt.warp_specialize}
 
   "use"(%loop_outs#0, %loop_outs#1, %loop_outs#2) : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256x64xf32, #blocked>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> ()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -1402,18 +1402,17 @@ getStaggeredAccumCnt(OpBuilderWithAsyncTaskIds &builder, Operation *op,
   if (reuseGroupIdx < 0)
     return accumCnt;
   // op is a user of the channel. accumCnt is the corresponding argument of the
-  // parentForOp.
-  // Go through chList in the parentForOp, assume ch is directly in parentForOp.
-  // FIXME: handle the case where ch is inside in IfOp.
+  // enclosing control region. Order reuse members in the nearest control
+  // region so channels directly inside a collective IfOp are not collapsed to
+  // the IfOp entry in an enclosing loop's channel list.
   SmallVector<Operation *> chList;
-  // The enclosing loop holding the reuse-group channels can be an scf.for or,
-  // for a static persistent while-loop kernel, an scf.while (the channels live
-  // directly in the while's after region). Using getParentOfType<scf::ForOp>()
-  // alone would be null for the while case and crash getReuseChannels.
-  Operation *parentLoop = op->getParentOfType<scf::ForOp>();
-  if (!parentLoop)
-    parentLoop = op->getParentOfType<scf::WhileOp>();
-  getReuseChannels(config->getGroup(reuseGroupIdx), parentLoop, chList);
+  // The enclosing region holding the reuse-group channels can be an scf.for,
+  // scf.if, or scf.while.
+  Operation *parentRegion = op->getParentOp();
+  while (parentRegion &&
+         !isa<scf::ForOp, scf::IfOp, scf::WhileOp>(parentRegion))
+    parentRegion = parentRegion->getParentOp();
+  getReuseChannels(config->getGroup(reuseGroupIdx), parentRegion, chList);
   assert(chList.size() >= 1);
 
   // When multiple channels in the reuse group share the same getDstOp() but

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -406,9 +406,12 @@ class OpCategorizer {
 public:
   OpCategorizer(LoopLikeOpInterface mainLoop, ArrayRef<Operation *> mmaOps)
       : mainLoop(mainLoop), mmas(mmaOps.begin(), mmaOps.end()) {
-    // Collect all loops (nested + main)
-    for (auto nestedLoop : getLoopBodyBlock(mainLoop)->getOps<scf::ForOp>())
-      loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
+    // Keep the same nearest-loop traversal used by getInitialSchedule so
+    // collective control flow does not hide an immediately nested loop.
+    getLoopBodyRegion(mainLoop).walk([&](scf::ForOp nestedLoop) {
+      if (getEnclosingSupportedLoop(nestedLoop) == mainLoop)
+        loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
+    });
     loops.push_back(mainLoop);
   }
 
@@ -517,7 +520,12 @@ private:
 
     SmallVector<Operation *> loopMmas;
     for (auto mmaOp : mmas) {
-      if (mmaOp->getParentOp() == innermostLoop.getOperation())
+      // Collective control flow, such as a per-tile bounds guard, does not
+      // introduce a new scheduling scope.  Select MMAs by their nearest
+      // enclosing loop so MMAs nested in an scf.if still participate in the
+      // enclosing loop's data partitioning, while MMAs in a nested loop do
+      // not.
+      if (getEnclosingSupportedLoop(mmaOp) == innermostLoop)
         loopMmas.push_back(mmaOp);
     }
 
@@ -1323,11 +1331,12 @@ schedulePostLoopOps(LoopLikeOpInterface loop, PartitionSet &schedule,
 
   SmallVector<OpOperand *> uses;
   // For persistent kernels, seed from nested inner loop results.
-  for (auto &op : *getLoopBodyBlock(loop))
-    if (auto innerLoop = dyn_cast<scf::ForOp>(op))
+  getLoopBodyRegion(loop).walk([&](scf::ForOp innerLoop) {
+    if (getEnclosingSupportedLoop(innerLoop) == loop)
       for (OpResult result : innerLoop.getResults())
         for (OpOperand &use : result.getUses())
           uses.push_back(&use);
+  });
   for (OpResult result : loop->getResults())
     for (OpOperand &use : result.getUses())
       uses.push_back(&use);
@@ -1450,10 +1459,15 @@ getInitialSchedule(LoopLikeOpInterface mainLoop,
     return std::nullopt;
   }
 
-  // Collect all loops (nested + main)
+  // Collect loops immediately nested in the main scheduling scope, including
+  // loops wrapped in collective control flow such as a per-tile bounds guard.
+  // Use nearest-loop ownership so loops nested in another loop are still
+  // handled only by that loop's schedule.
   SmallVector<LoopLikeOpInterface> loops;
-  for (scf::ForOp nestedLoop : getLoopBodyBlock(mainLoop)->getOps<scf::ForOp>())
-    loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
+  getLoopBodyRegion(mainLoop).walk([&](scf::ForOp nestedLoop) {
+    if (getEnclosingSupportedLoop(nestedLoop) == mainLoop)
+      loops.push_back(cast<LoopLikeOpInterface>(nestedLoop.getOperation()));
+  });
   loops.push_back(mainLoop);
 
   // Collect all MMAs

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/TaskIdPropagation.cpp
@@ -126,16 +126,19 @@ LogicalResult TaskIdBackwardPropagation::visitOperation(
   // need to dump the task ids into the IR.
   auto taskIdAttr = op->getAttrOfType<DenseI32ArrayAttr>(kAsyncTaskIdAttrName);
 
-  // An op is a non-anchor (allows backward propagation to flow through) only
-  // if it is a scalar arithmetic/math op. These ops compute shared addresses
-  // or indices used across tasks and need the union of consumer task IDs.
+  // An op is a non-anchor (allows backward propagation to flow through) when
+  // it is a replicable scalar computation. These ops compute shared addresses,
+  // indices, or control predicates used across tasks and need the union of
+  // consumer task IDs. Scalar loads are safe to repeat and avoid introducing
+  // an unsupported scalar communication channel for a collective predicate.
   // All other annotated ops (Triton ops, tensor ops, control flow) are anchors
   // whose task IDs define the computation partition and must not be overridden.
-  bool isScalarArithOrMath =
-      isa<arith::ArithDialect, math::MathDialect>(op->getDialect()) &&
+  bool isScalarReplicable =
+      (isa<arith::ArithDialect, math::MathDialect>(op->getDialect()) ||
+       isa<triton::AddPtrOp, triton::LoadOp>(op)) &&
       llvm::none_of(op->getResultTypes(),
                     [](Type t) { return isa<RankedTensorType>(t); });
-  bool isAnchor = taskIdAttr && !isScalarArithOrMath;
+  bool isAnchor = taskIdAttr && !isScalarReplicable;
 
   auto propagateTaskToOperandsAndParent = [&](const TaskId &taskId) {
     for (auto operandLattice : operands) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -4,6 +4,7 @@
 #include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -5607,20 +5608,19 @@ LogicalResult doMemoryPlanner(triton::FuncOp funcOp, unsigned numBuffers,
   unsigned effectiveSmemBudget = smemBudget;
   bool effectiveSmemCircularReuse = options.smemCircularReuse;
   bool hasSmemAllocAlgoAttr = false;
-  funcOp->walk([&](scf::ForOp forOp) {
-    if (!forOp->hasAttr("tt.warp_specialize"))
+  funcOp->walk([&](LoopLikeOpInterface wsLoop) {
+    if (!wsLoop->hasAttr(tt::kWarpSpecializeAttrName))
       return;
-    // Walk from the WS ForOp up through parent ForOps, collecting
-    // attributes. The innermost (WS) loop has highest priority.
-    SmallVector<scf::ForOp> loopChain;
-    loopChain.push_back(forOp);
-    for (auto parent = forOp->getParentOfType<scf::ForOp>(); parent;
-         parent = parent->getParentOfType<scf::ForOp>()) {
-      loopChain.push_back(parent);
-    }
+    // Walk from the WS loop up through parent loops, collecting attributes.
+    // CLC persistent loops remain scf.while here, while countable loops are
+    // commonly represented as scf.for. The innermost WS loop has priority.
+    SmallVector<Operation *> loopChain;
+    for (Operation *loop = wsLoop; loop; loop = loop->getParentOp())
+      if (isa<LoopLikeOpInterface>(loop))
+        loopChain.push_back(loop);
     // Apply from outermost to innermost (innermost wins).
     for (auto it = loopChain.rbegin(); it != loopChain.rend(); ++it) {
-      auto loop = *it;
+      Operation *loop = *it;
       if (auto attr = loop->getAttrOfType<IntegerAttr>("tt.smem_alloc_algo")) {
         effectiveSmemAllocAlgo = attr.getInt();
         hasSmemAllocAlgoAttr = true;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -4,6 +4,7 @@
 #include "WarpSpecializationPipeline.h"
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -5598,20 +5599,19 @@ LogicalResult doMemoryPlanner(triton::FuncOp funcOp, unsigned numBuffers,
   unsigned effectiveSmemBudget = smemBudget;
   bool effectiveSmemCircularReuse = options.smemCircularReuse;
   bool hasSmemAllocAlgoAttr = false;
-  funcOp->walk([&](scf::ForOp forOp) {
-    if (!forOp->hasAttr("tt.warp_specialize"))
+  funcOp->walk([&](LoopLikeOpInterface wsLoop) {
+    if (!wsLoop->hasAttr(tt::kWarpSpecializeAttrName))
       return;
-    // Walk from the WS ForOp up through parent ForOps, collecting
-    // attributes. The innermost (WS) loop has highest priority.
-    SmallVector<scf::ForOp> loopChain;
-    loopChain.push_back(forOp);
-    for (auto parent = forOp->getParentOfType<scf::ForOp>(); parent;
-         parent = parent->getParentOfType<scf::ForOp>()) {
-      loopChain.push_back(parent);
-    }
+    // Walk from the WS loop up through parent loops, collecting attributes.
+    // CLC persistent loops remain scf.while here, while countable loops are
+    // commonly represented as scf.for. The innermost WS loop has priority.
+    SmallVector<Operation *> loopChain;
+    for (Operation *loop = wsLoop; loop; loop = loop->getParentOp())
+      if (isa<LoopLikeOpInterface>(loop))
+        loopChain.push_back(loop);
     // Apply from outermost to innermost (innermost wins).
     for (auto it = loopChain.rbegin(); it != loopChain.rend(); ++it) {
-      auto loop = *it;
+      Operation *loop = *it;
       if (auto attr = loop->getAttrOfType<IntegerAttr>("tt.smem_alloc_algo")) {
         effectiveSmemAllocAlgo = attr.getInt();
         hasSmemAllocAlgoAttr = true;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTaskIdPropagate.cpp
@@ -280,11 +280,12 @@ LogicalResult doTaskIdPropagate(triton::FuncOp funcOp) {
     }
     // TODO(Arda): Ideally front-end should not allow constant ops to be
     // annotated. Anchor constants cause problems.
-    bool isScalarArithOrMath =
-        isa<arith::ArithDialect, math::MathDialect>(op->getDialect()) &&
+    bool isScalarReplicable =
+        (isa<arith::ArithDialect, math::MathDialect>(op->getDialect()) ||
+         isa<triton::AddPtrOp, triton::LoadOp>(op)) &&
         llvm::none_of(op->getResultTypes(),
                       [](Type t) { return isa<RankedTensorType>(t); });
-    bool isAnchor = !isScalarArithOrMath && op->hasAttr("async_task_id");
+    bool isAnchor = !isScalarReplicable && op->hasAttr("async_task_id");
     if (!taskIds.isUninitialized() &&
         (isa<arith::ConstantOp>(op) || !isAnchor)) {
       // For non-anchor ops with existing annotations, merge the lattice

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodeSpecialization.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/CodeSpecialization.md
@@ -63,7 +63,17 @@ after-region arguments, `scf.condition` forwarded values, and after-region
 #### `SpecializeIfOp`
 
 Similarly, `scf::IfOp` regions are cloned with reduced result sets — only
-results used by the partition are kept.
+results used by the partition are kept. Both the then and else regions and
+their trimmed yields are cloned.
+
+Non-trivial else regions are eligible only when task-ID propagation proves the
+complete `scf.if` is contained in one task. The top-level warp-specialization
+pass therefore performs this check after `doTaskIdPropagate`: a singleton union
+from `getNestedAsyncTaskIds(ifOp)` is accepted, while a multi-task else region
+still causes a graceful AutoWS bailout because code partitioning does not yet
+support communication channels in both sides of an `scf.if`. An else region
+containing only `scf.yield` retains the pre-existing behavior and does not need
+the singleton restriction.
 
 ### Step 4: Handle Captures
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DynamicPersistentAutoWSGaps.md
@@ -108,6 +108,25 @@ round-tripping, CLC-shaped ordered-subset carry, condition/task replication,
 warp-budget cleanup, and graceful rejection of reordered or computed
 condition forwarding.
 
+### Collective per-tile guards
+
+A CLC body may be wrapped in a zero-result bounds guard such as
+`if start_n < seq_len`. AutoWS treats this as collective control flow:
+
+- nearest-loop discovery crosses the `scf.if`, so the guarded K-loop remains
+  the persistent loop's compute loop;
+- scalar address/load chains feeding the condition are replicated into every
+  participating task, and each specialized partition clones the same `if`;
+- post-compute epilogue propagation crosses the guard, preserving accumulator
+  channels and dK/dV stores; and
+- reuse-group ordering uses the nearest enclosing `for`/`if`/`while`, so
+  guarded channels use the same accumulation counter and staging rotation.
+
+This requires a collective predicate: all partitions must compute the same
+boolean. It permits rectangular CLC scheduling for jagged inputs, where an
+invalid tail tile skips the complete partitioned body in every task without
+changing cross-partition barrier cadence.
+
 The atomic-broadcast half of the outer-while path is now also validated in
 isolation (`ws_atomic_broadcast_from_psm.mlir`): starting from an
 **unpartitioned** dynamic-persistent GEMM `scf.while` with a scalar

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -193,6 +193,7 @@ def run_accuracy(shapes):
 _PERF_ENV = {
     "triton": {},
     "tlx": {},
+    "tlx_raw": {},
     "autows": {
         "HSTU_SELF_AUTOWS": "1",
         "HSTU_SELF_DQ_REDUCE": "1",
@@ -264,6 +265,43 @@ def _clc_bwd(q, k, v, do, so, asc, L, num_targets):
     return bwd
 
 
+def _tlx_raw_bwd(q, k, v, do, so, asc, L, num_targets):
+    """Backward-only closure for the TLX baseline: call the hand-written TLX
+    backward wrapper directly so both TLX and CLC variants are compared at the
+    same boundary -- prepared inputs and gradient buffers, without forward or
+    autograd dispatch.
+
+    SiLU TLX does not consume M/Delta, but its common wrapper requires pointer
+    arguments. Keep stable dummy buffers outside the timed call."""
+    dq = torch.empty_like(q, dtype=torch.float32)
+    dk, dv = torch.empty_like(k), torch.empty_like(v)
+    M = torch.empty((1, ), device=q.device, dtype=torch.float32)
+    Delta = torch.empty((1, ), device=q.device, dtype=torch.float32)
+
+    def bwd():
+        T.tlx_hstu_attention_bwd(
+            dout=do,
+            q=q,
+            k=k,
+            v=v,
+            dq=dq,
+            dk=dk,
+            dv=dv,
+            seq_offsets=so,
+            attn_scale=asc,
+            max_seq_len=L,
+            alpha=1.0 / D,
+            M=M,
+            Delta=Delta,
+            stride_mm=1,
+            num_softmax_heads=0,
+            num_targets=num_targets,
+            causal=True,
+        )
+
+    return bwd
+
+
 def _time_variant(variant, L, Z, nrep, run, kw, tensors, mode):
     """Compile, warm and time fwd+bwd for ONE variant inside the caller's knobs
     scope. `mode` selects the work done after the warm-up backward: "bench"
@@ -273,8 +311,11 @@ def _time_variant(variant, L, Z, nrep, run, kw, tensors, mode):
     q, k, v, do, so, asc = tensors
     warmup = int(os.environ.get("BENCH_WARMUP", "25"))
     rep = int(os.environ.get("BENCH_REP", "100"))
-    if variant == "autows_clc":
-        bwd = _clc_bwd(q, k, v, do, so, asc, L, kw.get("num_targets"))
+    if variant in ("autows_clc", "tlx_raw"):
+        # Compare backward wrappers at the same boundary: prepared inputs and
+        # gradient buffers, without forward or autograd dispatch.
+        bwd = (_tlx_raw_bwd if variant == "tlx_raw" else _clc_bwd)(q, k, v, do, so, asc, L,
+                                                                   kw.get("num_targets"))
         fwd_s = [float("nan")] * nrep
     else:
         fwd = lambda: run(q, k, v, so, L, asc, **kw)  # noqa: E731
@@ -304,7 +345,7 @@ def _time_variant(variant, L, Z, nrep, run, kw, tensors, mode):
     logger.info("%s backward-ready", variant)
     bwd_s = [triton.testing.do_bench(bwd, warmup=warmup, rep=rep) for _ in range(nrep)]
     fm, bm = statistics.mean(fwd_s), statistics.mean(bwd_s)
-    fsd = (float("nan") if variant == "autows_clc" else (statistics.stdev(fwd_s) if len(fwd_s) > 1 else 0.0))
+    fsd = (float("nan") if variant in ("autows_clc", "tlx_raw") else (statistics.stdev(fwd_s) if len(fwd_s) > 1 else 0.0))
     bsd = statistics.stdev(bwd_s) if len(bwd_s) > 1 else 0.0
     print(f"PERF {variant} L={L} Z={Z} fwd={fm:.4f} fwd_sd={fsd:.4f} bwd={bm:.4f} bwd_sd={bsd:.4f}")
 
@@ -416,8 +457,10 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--perf", action="store_true", help="run the fwd/bwd latency benchmark")
     ap.add_argument("--acc", action="store_true", help="run the accuracy check (default)")
-    ap.add_argument("--nrep", type=int, default=1, help="do_bench repetitions per point; >1 reports mean + std")
-    ap.add_argument("--variants", default="autows,tlx,triton", help="comma subset of autows,tlx,triton (perf)")
+    ap.add_argument("--nrep", type=int, default=1,
+                    help="do_bench repetitions per point; >1 reports mean + std")
+    ap.add_argument("--variants", default="autows,tlx,triton",
+                    help="comma subset of autows,autows_clc,tlx,tlx_raw,triton (perf)")
     ap.add_argument("--seqlens", default=None, help="comma L list, e.g. 256,512,1024,4096")
     ap.add_argument("--batch", type=int, default=None, help="batch Z (default 2)")
     ap.add_argument("--heads", type=int, default=None, help="num heads H (perf; default 2)")

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -2337,6 +2337,7 @@ def _hstu_attn_bwd_clc(  # noqa C901
     DQ_ITERS: tl.constexpr,
     DQ_REUSE: tl.constexpr,
     DKDV_SUBTILE: tl.constexpr,
+    HAS_TILE_IDS: tl.constexpr,
     CLC_SMEM_ALGO: tl.constexpr,
 ):
     tl.static_assert(ENABLE_TMA)
@@ -2382,7 +2383,10 @@ def _hstu_attn_bwd_clc(  # noqa C901
             tmem_alloc_algo=2,
             smem_alloc_algo=CLC_SMEM_ALGO,
     ):
-        tile_id = tl.load(TILE_IDS + sched.tile_id[0])
+        if HAS_TILE_IDS:
+            tile_id = tl.load(TILE_IDS + sched.tile_id[0])
+        else:
+            tile_id = sched.tile_id[0]
         off_hz = tile_id // num_n_tiles
         start_n = (tile_id % num_n_tiles) * BLOCK_N
         off_z = off_hz // H
@@ -2403,7 +2407,7 @@ def _hstu_attn_bwd_clc(  # noqa C901
         dk_base = DK + seq_start_kv * stride_dkn
         dv_base = DV + seq_start_kv * stride_dvn
 
-        if tl.constexpr(True):
+        if start_n < seq_len_kv:
             _hstu_attn_bwd_one_col_block(
                 start_n=start_n,
                 desc_row_q=seq_start_q,
@@ -2599,40 +2603,24 @@ def triton_hstu_attention_bwd(
     assert _AUTOWS_CFG.dkdv_subtile == 1 or _AUTOWS_CFG.clc, (
         "dkdv_subtile > 1 requires the CLC backward (HSTU_SELF_AUTOWS_CLC=1)")
     clc_kwargs = {}
+    has_tile_ids = False
     if _AUTOWS_CFG.clc:
         assert enable_tma and _AUTOWS_CFG.autows and _AUTOWS_CFG.dq_reduce
         assert sort_by_length_indices is None
-        # Compact the rectangular max-length grid to valid jagged tiles. Empty
-        # tail tiles cannot enter the partitioned body: their divergent inner
-        # loop trip counts break cross-partition barrier cadence.
-        #
-        # num_n_tiles is the radix of the tile_id encoding below, and the kernel
-        # decodes with tl.cdiv(max_q_len, BLOCK_N). Both sides must use the same
-        # (length, block) pair or tile_id // and % yield different (off_hz,
-        # start_n) pairs, so use max_q_len here too -- it is also the bound that
-        # matches seq_offsets_q, which blocks_per_seq is derived from. BLOCK_N
-        # agrees because the CLC path asserts _AUTOWS_CFG.autows above, and
-        # _get_bw_configs() then pins the single config to BLOCK_N = bwd_bn.
+        # V8 collective-guard schedule: run the full rectangular grid for
+        # both dense and jagged inputs. Invalid tail tiles skip the
+        # partitioned body inside the kernel (see `if start_n < seq_len_kv`
+        # in _hstu_attn_bwd_clc), so no compact TILE_IDS list is built.
         block_n = _AUTOWS_CFG.bwd_bn
         num_n_tiles = triton.cdiv(max_q_len, block_n)
-        seq_lens = seq_offsets_q[1:] - seq_offsets_q[:-1]
-        blocks_per_seq = torch.div(seq_lens + block_n - 1, block_n, rounding_mode="floor")
-        counts = blocks_per_seq.repeat_interleave(H)
-        tile_count = int(counts.sum().item())
-        tile_starts = torch.cumsum(counts, dim=0) - counts
-        compact_ids = torch.arange(tile_count, device=q.device, dtype=torch.int64)
-        off_hz = torch.repeat_interleave(torch.arange(Z * H, device=q.device, dtype=torch.int64), counts)
-        local_n = compact_ids - torch.repeat_interleave(tile_starts, counts)
-        tile_ids = (off_hz * num_n_tiles + local_n).to(torch.int32)
-        # 1D by construction: the CLC tile scheduler hands out a linear tile id
-        # that indexes the compacted TILE_IDS list, which then decodes to
-        # (off_hz, start_n) in the kernel. The compacted list is ragged across
-        # heads/batches, so the (Z * H, n_tiles) rectangle the non-CLC path
-        # launches cannot express it without re-introducing the empty tiles.
+        tile_count = Z * H * num_n_tiles
+        # The partitioned kernel evaluates the same jagged bounds guard in
+        # every task. Keep TILE_IDS pointer-typed; HAS_TILE_IDS removes the load.
+        tile_ids = seq_offsets
         grid = lambda meta: (  # noqa E731
             tile_count, )
         bwd_kernel = _hstu_attn_bwd_clc
-        clc_kwargs = {"TILE_IDS": tile_ids, "CLC_SMEM_ALGO": _AUTOWS_CFG.clc_smem_algo}
+        clc_kwargs = {"CLC_SMEM_ALGO": _AUTOWS_CFG.clc_smem_algo}
     else:
         grid = lambda meta: (  # noqa E731
             Z * H,
@@ -2651,7 +2639,7 @@ def triton_hstu_attention_bwd(
     HAS_NUM_TARGETS = num_targets is not None
     HAS_MAX_ATTN_LEN = max_attn_len != 0
     HAS_CONTEXTUAL_SEQ_LEN = contextual_seq_len != 0
-    bwd_kernel[grid](
+    launch_args = dict(
         Q=q,
         K=k,
         V=v,
@@ -2705,6 +2693,23 @@ def triton_hstu_attention_bwd(
         DKDV_SUBTILE=_AUTOWS_CFG.dkdv_subtile,
         **clc_kwargs,
     )
+    if _AUTOWS_CFG.clc:
+        bwd_kernel[grid](
+            **launch_args,
+            TILE_IDS=tile_ids,
+            HAS_TILE_IDS=has_tile_ids,
+        )
+    elif _AUTOWS_CFG.autows and not _AUTOWS_CFG.dq_reduce:
+        # Direct dQ RMW uses a program-wide lock and is not partition-safe. The
+        # default configuration still exercises AutoWS forward, but compile its
+        # backward with the ordinary pipeline instead of feeding an unannotated
+        # direct-RMW schedule to MetaWS.
+        launch_args["AUTOWS"] = False
+        with triton.knobs.nvidia.scope():
+            triton.knobs.nvidia.use_meta_ws = False
+            bwd_kernel[grid](**launch_args)
+    else:
+        bwd_kernel[grid](**launch_args)
 
     return dq, dk, dv
 

--- a/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/triton_hstu_attention.py
@@ -75,6 +75,7 @@ class HSTUAutoWSConfig:
     sp: bool = False  # bwd SEQUENCE_PARALLEL
     clc: bool = False  # bwd CLC-persistent flattened tile loop
     clc_smem_algo: int = 1  # CLC outer-loop SMEM allocation algorithm
+    mask_if: bool = False  # runtime masked/unmasked branch inside the bwd loop
     pin: bool = False  # pin autotune to one config (fast compile)
 
     @classmethod
@@ -97,6 +98,7 @@ class HSTUAutoWSConfig:
             sp=g("HSTU_SELF_AUTOWS_SP") == "1",
             clc=g("HSTU_SELF_AUTOWS_CLC") == "1",
             clc_smem_algo=int(g("HSTU_SELF_AUTOWS_CLC_SMEM_ALGO", "1")),
+            mask_if=g("HSTU_SELF_AUTOWS_MASK_IF") == "1",
             pin=g("HSTU_SELF_PIN") == "1",
         )
 
@@ -660,10 +662,25 @@ def backward_activation(qk_trans, alpha, scale, valid_mask_trans, k):
 
 
 @triton.jit
+def backward_activation_unmasked(qk_trans, alpha, scale, k):
+    qk_trans = qk_trans * alpha
+    half_qk = qk_trans * 0.5
+    one_plus_tanh = _fma_f32(tanh_approx_fp32(half_qk), 1.0, 1.0)
+    sig_trans = one_plus_tanh * 0.5
+    act_qk_trans = (half_qk * one_plus_tanh * scale).to(k.dtype)
+    return qk_trans, sig_trans, act_qk_trans
+
+
+@triton.jit
 def backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans):
     dqk_trans = dact_qk_trans * sig_trans * (1 + qk_trans * (1 - sig_trans)) * scale
     dqk_trans = tl.where(valid_mask_trans, dqk_trans, 0)
     return dqk_trans
+
+
+@triton.jit
+def backward_d_activation_unmasked(dact_qk_trans, sig_trans, qk_trans, scale):
+    return dact_qk_trans * sig_trans * (1 + qk_trans * (1 - sig_trans)) * scale
 
 
 @triton.jit
@@ -994,6 +1011,7 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
     DQ_REDUCE: tl.constexpr = False,
     DQ_ITERS: tl.constexpr = 1,
     DQ_REUSE: tl.constexpr = False,
+    MASK_IF: tl.constexpr = False,
 ):
     offs_m = offs_m + start_m
     # Keep the integer KV-index/mask chain inside the warp-specialized loop.
@@ -1030,28 +1048,63 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
         allow_tf32=ALLOW_TF32,
         attrs=({"stage": "0", "order": "0", "channels": ["opndD,tmem,1,2"]} if DQ_REUSE else None),
     )
-    valid_mask_trans = backward_valid_mask(
-        offs_m,
-        pos_offs_n,
-        offs_n,
-        max_ids,
-        contextual_seq_len,
-        max_attn_len,
-        HAS_CONTEXTUAL_SEQ_LEN,
-        HAS_NUM_TARGETS,
-        HAS_MAX_ATTN_LEN,
-    )
-    # The prescaled path folds alpha and the 0.5 into its inputs, so its first two
-    # results are NOT the non-reuse quantities: half_qk is qk*alpha/2 rather than
-    # qk*alpha, and one_plus_tanh is 1+tanh(half_qk) rather than the sigmoid (it is
-    # 2x it). backward_d_activation_prescaled is written against those meanings, so
-    # bind them under their real names instead of reusing qk_trans/sig_trans, which
-    # would read as the non-reuse quantities to anyone adding code below.
-    if DQ_REUSE:
-        half_qk, one_plus_tanh, act_qk_trans = backward_activation_prescaled(qk_trans, alpha, scale, valid_mask_trans,
-                                                                             k)
+    if MASK_IF:
+        valid_mask_trans = tl.full((BLOCK_N, BLOCK_M), True, tl.int1)
+        apply_mask = start_m < start_n + BLOCK_N
+        if HAS_MAX_ATTN_LEN:
+            apply_mask = True
+            if HAS_NUM_TARGETS:
+                apply_mask = start_m < seq_len_q - n_targets
+        if HAS_CONTEXTUAL_SEQ_LEN:
+            apply_mask = True
+        if apply_mask:
+            valid_mask_trans = backward_valid_mask(
+                offs_m,
+                pos_offs_n,
+                offs_n,
+                max_ids,
+                contextual_seq_len,
+                max_attn_len,
+                HAS_CONTEXTUAL_SEQ_LEN,
+                HAS_NUM_TARGETS,
+                HAS_MAX_ATTN_LEN,
+            )
+            if DQ_REUSE:
+                half_qk, one_plus_tanh, act_qk_trans = backward_activation_prescaled(
+                    qk_trans, alpha, scale, valid_mask_trans, k
+                )
+            else:
+                qk_trans, sig_trans, act_qk_trans = backward_activation(
+                    qk_trans, alpha, scale, valid_mask_trans, k
+                )
+        else:
+            if DQ_REUSE:
+                half_qk, one_plus_tanh, act_qk_trans = backward_activation_prescaled_unmasked(
+                    qk_trans, alpha, scale, k
+                )
+            else:
+                qk_trans, sig_trans, act_qk_trans = backward_activation_unmasked(qk_trans, alpha, scale, k)
     else:
-        qk_trans, sig_trans, act_qk_trans = backward_activation(qk_trans, alpha, scale, valid_mask_trans, k)
+        valid_mask_trans = backward_valid_mask(
+            offs_m,
+            pos_offs_n,
+            offs_n,
+            max_ids,
+            contextual_seq_len,
+            max_attn_len,
+            HAS_CONTEXTUAL_SEQ_LEN,
+            HAS_NUM_TARGETS,
+            HAS_MAX_ATTN_LEN,
+        )
+        # The prescaled path folds alpha and the 0.5 into its inputs, so its first two
+        # results are NOT the non-reuse quantities: half_qk is qk*alpha/2 rather than
+        # qk*alpha, and one_plus_tanh is 1+tanh(half_qk) rather than the sigmoid (it is
+        # 2x it). backward_d_activation_prescaled is written against those meanings, so
+        # bind them under their real names instead of reusing qk_trans/sig_trans, which
+        # would read as the non-reuse quantities to anyone adding code below.
+        if DQ_REUSE:
+            half_qk, one_plus_tanh, act_qk_trans = backward_activation_prescaled(qk_trans, alpha, scale, valid_mask_trans,
+                                                                                 k)
     # compute dv
     if ENABLE_TMA:
         do = device_desc_do.load([(desc_row_q + start_m).to(tl.int32), (off_h * stride_doh).to(tl.int32)])
@@ -1075,14 +1128,37 @@ def _hstu_attn_bwd_one_block_0(  # noqa C901
         act_qk_trans,
         do,
         allow_tf32=ALLOW_TF32,
-        attrs=({"stage": "0", "order": "2", "channels": ["opndA,tmem,1,2", "opndD,tmem,1,7"]} if DQ_REUSE else None),
+        attrs=(
+            {
+                "stage": "0",
+                "order": "2",
+                "channels": [
+                    "opndA,tmem,1,2",
+                    "opndD,tmem,1,7",
+                ],
+            }
+            if DQ_REUSE
+            else None
+        ),
     )
 
     # compute dk and dq
-    if DQ_REUSE:
-        dqk_trans = backward_d_activation_prescaled(dact_qk_trans, one_plus_tanh, half_qk, scale)
+    if MASK_IF:
+        if apply_mask:
+            if DQ_REUSE:
+                dqk_trans = backward_d_activation_prescaled(dact_qk_trans, one_plus_tanh, half_qk, scale)
+            else:
+                dqk_trans = backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans)
+        else:
+            if DQ_REUSE:
+                dqk_trans = backward_d_activation_prescaled(dact_qk_trans, one_plus_tanh, half_qk, scale)
+            else:
+                dqk_trans = backward_d_activation_unmasked(dact_qk_trans, sig_trans, qk_trans, scale)
     else:
-        dqk_trans = backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans)
+        if DQ_REUSE:
+            dqk_trans = backward_d_activation_prescaled(dact_qk_trans, one_plus_tanh, half_qk, scale)
+        else:
+            dqk_trans = backward_d_activation(dact_qk_trans, sig_trans, qk_trans, scale, valid_mask_trans)
     dqk_trans = dqk_trans.to(k.dtype)
 
     if DQ_REDUCE and ENABLE_TMA:
@@ -1785,6 +1861,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
     ATOMIC_ADD: tl.constexpr,
     ENABLE_TMA: tl.constexpr,
     AUTOWS: tl.constexpr = False,
+    MASK_IF: tl.constexpr = False,
     DQ_REDUCE: tl.constexpr = False,
     DQ_ITERS: tl.constexpr = 1,
     DQ_REUSE: tl.constexpr = False,
@@ -1863,6 +1940,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
                 DQ_REDUCE=DQ_REDUCE,
                 DQ_ITERS=DQ_ITERS,
                 DQ_REUSE=DQ_REUSE,
+                MASK_IF=MASK_IF,
             )
     if HAS_NUM_TARGETS:
         low = start_n
@@ -1944,6 +2022,7 @@ def _hstu_attn_bwd_one_col_block(  # noqa C901
             DQ_REDUCE=DQ_REDUCE,
             DQ_ITERS=DQ_ITERS,
             DQ_REUSE=DQ_REUSE,
+            MASK_IF=MASK_IF,
         )
     # write-back
     dk = dk * alpha
@@ -2032,6 +2111,7 @@ def _hstu_attn_bwd(  # noqa C901
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
     ENABLE_TMA: tl.constexpr,
     AUTOWS: tl.constexpr = False,
+    MASK_IF: tl.constexpr = False,
     DQ_REDUCE: tl.constexpr = False,
     DQ_ITERS: tl.constexpr = 1,
     DQ_REUSE: tl.constexpr = False,
@@ -2204,6 +2284,7 @@ def _hstu_attn_bwd(  # noqa C901
             ATOMIC_ADD=True,
             ENABLE_TMA=ENABLE_TMA,
             AUTOWS=AUTOWS,
+            MASK_IF=MASK_IF,
             DQ_REDUCE=DQ_REDUCE,
             DQ_ITERS=DQ_ITERS,
             DQ_REUSE=DQ_REUSE,
@@ -2268,6 +2349,7 @@ def _hstu_attn_bwd(  # noqa C901
                 ATOMIC_ADD=False,
                 ENABLE_TMA=ENABLE_TMA,
                 AUTOWS=AUTOWS,
+                MASK_IF=MASK_IF,
                 DQ_REDUCE=DQ_REDUCE,
                 DQ_ITERS=DQ_ITERS,
                 DQ_REUSE=DQ_REUSE,
@@ -2333,6 +2415,7 @@ def _hstu_attn_bwd_clc(  # noqa C901
     HAS_SORT_BY_LENGTH_INDICES: tl.constexpr,
     ENABLE_TMA: tl.constexpr,
     AUTOWS: tl.constexpr,
+    MASK_IF: tl.constexpr,
     DQ_REDUCE: tl.constexpr,
     DQ_ITERS: tl.constexpr,
     DQ_REUSE: tl.constexpr,
@@ -2465,6 +2548,7 @@ def _hstu_attn_bwd_clc(  # noqa C901
                 ATOMIC_ADD=False,
                 ENABLE_TMA=True,
                 AUTOWS=False,
+                MASK_IF=MASK_IF,
                 DQ_REDUCE=DQ_REDUCE,
                 DQ_ITERS=DQ_ITERS,
                 DQ_REUSE=DQ_REUSE,
@@ -2687,6 +2771,7 @@ def triton_hstu_attention_bwd(
         HAS_SORT_BY_LENGTH_INDICES=sort_by_length_indices is not None,
         ENABLE_TMA=enable_tma,
         AUTOWS=_AUTOWS_CFG.autows,
+        MASK_IF=_AUTOWS_CFG.mask_if,
         DQ_REDUCE=_AUTOWS_CFG.dq_reduce,
         DQ_ITERS=_AUTOWS_CFG.dq_iters,
         DQ_REUSE=_AUTOWS_CFG.dq_reduce and _AUTOWS_CFG.dq_reuse,

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -8,7 +8,7 @@ gradients match a torch-autograd float causal-SiLU reference.
 
 Four configs are covered:
 - The DEFAULT autoWS config (in-process): `test_self_attention_fwd_autows`.
-- The TLX-matching dq-reduce config (BM=BN=128, num_stages=2, TMEM reuse, dsT in
+- The non-CLC dq-reduce config (BM=64, BN=128, num_stages=2, TMEM reuse, dsT in
   SMEM): `test_self_attention_bwd_autows_dqreduce`. Its flags
   (HSTU_SELF_DQ_REDUCE / HSTU_SELF_DQ_REUSE / the BWD tile knobs) are baked as
   tl.constexpr / read into the autotune configs AT IMPORT, so they can't coexist
@@ -53,7 +53,7 @@ import hstu_autows_config as _C  # noqa: E402
 
 # DEFAULT autoWS config (in-process fwd+grads test).
 _DEFAULT_CFG = dict(autows=True, dp=1, pin=True)
-# TLX-matching dq-reduce config: BM=BN=128, num_stages=2 (annotation-driven SWP),
+# Non-CLC dq-reduce config: BM=64, BN=128, num_stages=2 (annotation-driven SWP),
 # FA-style TMEM reuse (id2={qk,act}, id5={dp,dq}, id7=dv, id10=dk) with dsT pinned
 # to SMEM, dq via TMA reduce-add subtiled x4 -- final ttgir matches the hand-written
 # TLX bwd and its grads match torch/TLX numerics.
@@ -62,7 +62,7 @@ _DQREDUCE_CFG = dict(
     dq_reduce=True,
     dq_reuse=True,
     dp=1,
-    bwd_bm=128,
+    bwd_bm=64,
     bwd_bn=128,
     bwd_stages=2,
     warps=4,
@@ -82,7 +82,7 @@ _COMPILER_DP2_CFG = dict(autows=True, dp=2, warps=4, pin=True)
 
 # The dq-reduce / fadp / compiler-dp2 cases re-invoke this file as a subprocess;
 # select the config (before the kernel import below) from argv.
-if "--run-clc" in sys.argv:
+if "--run-clc" in sys.argv or "--run-clc-jagged" in sys.argv:
     _C.set_config(**_CLC_CFG)
     os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 elif "--run-dqreduce" in sys.argv:
@@ -138,14 +138,18 @@ def _rel_l2(a, b):
     return (torch.norm(a.float() - b.float()) / (torch.norm(b.float()) + 1e-12)).item()
 
 
-def _run_autows_bwd(L, Z):
+def _run_autows_bwd(L, Z, jagged=False):
     """Run the (already-imported) autoWS kernel fwd+bwd and return the grads plus
     the torch-float reference grads. Config is whatever env was baked at import."""
     torch.manual_seed(0)
-    t = Z * L
+    lens = [L] * Z
+    if jagged:
+        assert Z == 2
+        lens[-1] = L - 65
+    t = sum(lens)
     g = lambda: torch.randn(t, H, D, device="cuda", dtype=torch.bfloat16)  # noqa: E731
     q, k, v = g().requires_grad_(True), g().requires_grad_(True), g().requires_grad_(True)
-    so = torch.arange(0, t + 1, L, device="cuda", dtype=torch.int64)
+    so = torch.tensor([0, *torch.tensor(lens).cumsum(0).tolist()], device="cuda", dtype=torch.int64)
     asc = torch.tensor(1.0 / L, device="cuda", dtype=torch.float32)
     do = g()
 
@@ -224,7 +228,7 @@ def test_self_attention_fwd_autows(L, Z):
 @pytest.mark.parametrize("L,Z", [(256, 2)])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU for TMEM reuse")
 def test_self_attention_bwd_autows_dqreduce(L, Z):
-    """TLX-matching dq-reduce config (BM=BN=128, ns=2, TMEM reuse, dsT-in-SMEM).
+    """Non-CLC dq-reduce config (BM=64, BN=128, ns=2, TMEM reuse, dsT-in-SMEM).
 
     Runs in a SUBPROCESS because its flags are constexpr-baked at import and
     cannot share an interpreter with the default config above. Asserts the bwd
@@ -265,6 +269,22 @@ def test_self_attention_bwd_autows_clc(L, Z):
     sys.stdout.write(r.stdout)
     sys.stderr.write(r.stderr)
     assert r.returncode == 0, (f"CLC autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}")
+
+
+def test_self_attention_bwd_autows_clc_jagged_production():
+    """Production shape exercises the collective jagged-tail guard."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    L, Z = 4096, 2
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-clc-jagged", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"jagged production CLC autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
 
 
 @pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
@@ -326,14 +346,20 @@ if __name__ == "__main__":
     # Subprocess entry point for the dq-reduce config. _DQREDUCE_CFG was applied
     # via set_config() at the top of this file (argv --run-dqreduce) before the
     # kernel import, so the dq-reduce constexprs / autotune config are baked on.
-    if len(sys.argv) >= 4 and sys.argv[1] in ("--run-dqreduce", "--run-clc"):
+    bwd_modes = ("--run-dqreduce", "--run-clc", "--run-clc-jagged")
+    if len(sys.argv) >= 4 and sys.argv[1] in bwd_modes:
         _L, _Z = int(sys.argv[2]), int(sys.argv[3])
         assert bool(A._AUTOWS_CFG.dq_reduce and A._AUTOWS_CFG.dq_reuse), "dq-reduce reuse flag not baked on"
-        assert A._AUTOWS_CFG.clc == (sys.argv[1] == "--run-clc")
-        (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(_L, _Z)
-        rls = {n: _rel_l2(g_, w) for n, g_, w in (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv))}
-        print(f"REL_L2 dq/dk/dv = {rls['dq']:.2e} / {rls['dk']:.2e} / {rls['dv']:.2e} "
-              f"(L={_L} Z={_Z})")
+        assert A._AUTOWS_CFG.clc == (sys.argv[1] in ("--run-clc", "--run-clc-jagged"))
+        (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(
+            _L, _Z, jagged=sys.argv[1] == "--run-clc-jagged"
+        )
+        rls = {n: _rel_l2(g_, w) for n, g_, w in
+               (("dq", dq, rq), ("dk", dk, rk), ("dv", dv, rv))}
+        print(
+            f"REL_L2 dq/dk/dv = {rls['dq']:.2e} / {rls['dk']:.2e} / {rls['dv']:.2e} "
+            f"(L={_L} Z={_Z})"
+        )
         bad = {n: v for n, v in rls.items() if not (v < 1e-2)}
         if bad:
             print(f"FAIL: rel-L2 too high: {bad}")
@@ -367,4 +393,4 @@ if __name__ == "__main__":
         print("OK")
         sys.exit(0)
     sys.exit("usage: test_self_attention_autows.py "
-             "--run-dqreduce|--run-clc|--run-fadp|--run-fwd L Z")
+             "--run-dqreduce|--run-clc|--run-clc-jagged|--run-fadp|--run-fwd L Z")

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -73,6 +73,7 @@ _CLC_CFG = dict(
     _DQREDUCE_CFG, clc=True, bwd_bm=64, bwd_bn=128,
     bwd_stages=2, dkdv_subtile=2, clc_smem_algo=2,
 )
+_CLC_MASK_IF_CFG = dict(_CLC_CFG, bwd_stages=2, mask_if=True)
 # Manual data-partition fwd: split BLOCK_M=256 into two 128-row halves
 # sharing one K/V load, warp-specialized (load + 2 MMA groups).
 _MANUAL_DP_CFG = dict(autows=True, manual_dp=True, dp=2, warps=4, pin=True)
@@ -82,7 +83,10 @@ _COMPILER_DP2_CFG = dict(autows=True, dp=2, warps=4, pin=True)
 
 # The dq-reduce / fadp / compiler-dp2 cases re-invoke this file as a subprocess;
 # select the config (before the kernel import below) from argv.
-if "--run-clc" in sys.argv or "--run-clc-jagged" in sys.argv:
+if "--run-clc-mask-if" in sys.argv:
+    _C.set_config(**_CLC_MASK_IF_CFG)
+    os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
+elif "--run-clc" in sys.argv or "--run-clc-jagged" in sys.argv:
     _C.set_config(**_CLC_CFG)
     os.environ["TRITON_WS_SMEM_PLAN_SEARCH"] = "1"
 elif "--run-dqreduce" in sys.argv:
@@ -287,6 +291,22 @@ def test_self_attention_bwd_autows_clc_jagged_production():
     )
 
 
+@pytest.mark.parametrize("L,Z", [(256, 2)])
+def test_self_attention_bwd_autows_clc_mask_if(L, Z):
+    """Runtime masked/unmasked branch compiles and matches the torch reference."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    r = subprocess.run(
+        [sys.executable, __file__, "--run-clc-mask-if", str(L), str(Z)],
+        env=dict(os.environ), capture_output=True, text=True, timeout=900,
+    )
+    sys.stdout.write(r.stdout)
+    sys.stderr.write(r.stderr)
+    assert r.returncode == 0, (
+        f"CLC mask-if autoWS bwd failed (L={L} Z={Z}):\n{r.stdout}\n{r.stderr}"
+    )
+
+
 @pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
 @pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell GPU")
 def test_self_attention_fwd_autows_fadp(L, Z):
@@ -346,11 +366,11 @@ if __name__ == "__main__":
     # Subprocess entry point for the dq-reduce config. _DQREDUCE_CFG was applied
     # via set_config() at the top of this file (argv --run-dqreduce) before the
     # kernel import, so the dq-reduce constexprs / autotune config are baked on.
-    bwd_modes = ("--run-dqreduce", "--run-clc", "--run-clc-jagged")
+    bwd_modes = ("--run-dqreduce", "--run-clc", "--run-clc-jagged", "--run-clc-mask-if")
     if len(sys.argv) >= 4 and sys.argv[1] in bwd_modes:
         _L, _Z = int(sys.argv[2]), int(sys.argv[3])
         assert bool(A._AUTOWS_CFG.dq_reduce and A._AUTOWS_CFG.dq_reuse), "dq-reduce reuse flag not baked on"
-        assert A._AUTOWS_CFG.clc == (sys.argv[1] in ("--run-clc", "--run-clc-jagged"))
+        assert A._AUTOWS_CFG.clc == (sys.argv[1] in ("--run-clc", "--run-clc-jagged", "--run-clc-mask-if"))
         (dq, dk, dv), (rq, rk, rv) = _run_autows_bwd(
             _L, _Z, jagged=sys.argv[1] == "--run-clc-jagged"
         )


### PR DESCRIPTION
Summary:

WSMemoryPlanner read per-loop tt.smem_budget and allocation attributes only from scf.for, so a CLC persistent scf.while silently ignored them. Read them from both loop forms, preserving outer-to-inner override precedence.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 80aef5fd1 on the MetaMain2 fork.

Reviewed By: njriasan

Differential Revision: D116999556


