### PR TITLE
[TritonGPU] Fold conditional accumulator initialization (#3303)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h
@@ -1,0 +1,24 @@
+#ifndef TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_
+#define TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_
+
+#include "mlir/IR/Operation.h"
+
+// Helpers that interpret the contents of an inline-PTX asm block well enough to
+// answer a specific structural question about it. The instruction mnemonics
+// recognized here are NVIDIA-specific; the callers live in target-independent
+// TritonGPU transforms, which is why these are declared alongside them rather
+// than in third_party/nvidia.
+
+namespace mlir {
+
+// Return true if the op multiplies its two operands and does nothing else, so
+// that a zero operand forces a zero result. Covers arith.mulf and the packed
+// mul.f32x2 emitted as elementwise inline PTX (see
+// third_party/nvidia/language/cuda/inline_ptx_lib.py). Callers depend on the
+// zero-propagation property, so an asm block that multiplies and then performs
+// further arithmetic must NOT match.
+bool isMulOp(Operation *op);
+
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_triton_library(TritonGPUTransforms
   Pipeliner/PipeliningUtility.cpp
   Pipeliner/Schedule.cpp
   Prefetch.cpp
+  PtxInterpUtils.cpp
   RemoveLayoutConversions.cpp
   ReorderInstructions.cpp
   CoalesceAsyncCopy.cpp

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -3,6 +3,7 @@
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -133,7 +134,12 @@ std::optional<std::pair<Operation *, int>>
 findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
   Value v = accUse;
   if (auto arg = dyn_cast<BlockArgument>(v)) {
-    assert(arg.getOwner() == forOp.getBody());
+    // A zero-preserving op can also consume a value captured from an outer
+    // block (for example the scale operand of a packed multiply).  Such a
+    // value is not the accumulator loop argument and does not establish a
+    // zero origin.
+    if (arg.getOwner() != forOp.getBody())
+      return std::nullopt;
     if (isConstantZeroTensor(forOp.getInitArgs()[arg.getArgNumber() - 1])) {
       loopArgIsZero = true;
     }
@@ -145,6 +151,37 @@ findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
     return std::nullopt;
   }
   if (auto selOp = dyn_cast<arith::SelectOp>(defOp)) {
+    // A select can preserve the same zero-initialized loop accumulator along
+    // both arms without either arm being a literal zero.  Attention's
+    // conditional rescale is the canonical example:
+    //
+    //   scaled = acc * alpha
+    //   acc = select should_rescale, scaled, acc
+    //
+    // Both arms are zero on the first iteration, so the first MMA can
+    // initialize operand D directly.  Trace the arms independently: sharing
+    // loopArgIsZero while visiting the first arm would otherwise make an
+    // unsupported second arm look zero-preserving.
+    bool trueLoopArgIsZero = false;
+    bool falseLoopArgIsZero = false;
+    auto trueOrigin =
+        findZeroInitOp(selOp.getTrueValue(), forOp, trueLoopArgIsZero);
+    auto falseOrigin =
+        findZeroInitOp(selOp.getFalseValue(), forOp, falseLoopArgIsZero);
+    if (!trueOrigin && !falseOrigin && trueLoopArgIsZero &&
+        falseLoopArgIsZero) {
+      loopArgIsZero = true;
+      return std::nullopt;
+    }
+    // The asymmetric case is deliberately not propagated: one arm preserving
+    // the zero loop arg says nothing about the other, so the select as a whole
+    // is not zero-preserving. Discarding the per-arm flags and falling through
+    // to the scalar-condition path below is the conservative choice.
+
+    // Rewriting a conditional zero into a scalar use-accumulator flag requires
+    // a scalar condition.  Tensor conditions are nevertheless safe in the
+    // both-arms-preserve-zero case handled above because the condition itself
+    // does not affect first-iteration initialization.
     if (!selOp.getCondition().getType().isInteger(1))
       return std::nullopt;
     if (isConstantZeroTensor(selOp.getTrueValue()) ||
@@ -166,7 +203,7 @@ findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
       return std::make_pair(ifOp, resultIndex);
     }
   }
-  if (auto multOp = dyn_cast<arith::MulFOp>(defOp)) {
+  if (isMulOp(defOp)) {
     auto output1 = findZeroInitOp(defOp->getOperand(0), forOp, loopArgIsZero);
     if (output1.has_value()) {
       return output1;

--- a/lib/Dialect/TritonGPU/Transforms/PtxInterpUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/PtxInterpUtils.cpp
@@ -1,0 +1,62 @@
+#include "triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+
+using namespace triton;
+
+// Is this PTX instruction only moving data around, rather than computing?
+// Register declarations and moves cannot change a zero into a non-zero.
+static bool isPtxDataMovement(StringRef instr) {
+  // Match "mov." rather than "mov" so a future mnemonic that merely starts
+  // with those three letters is treated as arithmetic (and so rejected) rather
+  // than silently assumed zero-preserving. Every real PTX mov variant is
+  // dotted: mov.b64, mov.u32, ...
+  return instr.starts_with(".reg") || instr.starts_with("mov.");
+}
+
+// Recognize a packed mul.f32x2 written as elementwise inline PTX. The kernels
+// emit it as a small block, e.g.
+//
+//   { .reg .b64 ra, rb, rc;
+//     mov.b64 ra, { $2, $3 };
+//     mov.b64 rb, { $4, $5 };
+//     mul.f32x2 rc, ra, rb;
+//     mov.b64 { $0, $1 }, rc; }
+//
+// so a single-instruction match is too strict (it would reject every real
+// producer) and a substring match is too loose: a block that multiplies and
+// then adds still contains "mul.f32x2" but does not propagate zero. Split the
+// block into instructions and require that the multiply is the ONLY arithmetic
+// performed; everything else must be a declaration or a data move.
+static bool isPackedF32Mul(Operation *op) {
+  auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op);
+  if (!inlineAsm || !inlineAsm.getPure() || inlineAsm.getPackedElement() != 2 ||
+      op->getNumOperands() != 2 || op->getNumResults() != 1)
+    return false;
+
+  SmallVector<StringRef> instrs;
+  inlineAsm.getAsmString().split(instrs, ';');
+  bool sawMul = false;
+  for (StringRef instr : instrs) {
+    // Strip the block braces and surrounding whitespace/newlines so the
+    // matching is insensitive to how the asm was indented in Python.
+    instr = instr.trim(" \t\n\r{}");
+    if (instr.empty())
+      continue;
+    if (isPtxDataMovement(instr))
+      continue;
+    if (!instr.starts_with("mul.f32x2") || sawMul)
+      return false;
+    sawMul = true;
+  }
+  return sawMul;
+}
+
+bool isMulOp(Operation *op) {
+  return isa<arith::MulFOp>(op) || isPackedF32Mul(op);
+}
+
+} // namespace mlir

--- a/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero.mlir
+++ b/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero.mlir
@@ -39,7 +39,8 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     %n_tile_num = arith.constant 127 : i32
     %c64_i32 = arith.constant 64 : i32
     %true = arith.constant true
-    %cst_28 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %cst_28 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_28_layout = ttg.convert_layout %cst_28 : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blocked1>
     %n_tile_num_29 = arith.addi %N_CTX, %n_tile_num : i32
     %n_tile_num_30 = arith.divsi %n_tile_num_29, %c128_i32 : i32
     %prog_id = tt.get_program_id x : i32
@@ -88,8 +89,8 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       %dv, %dv_50 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
       %dq, %dq_51 = ttng.tmem_alloc {ttg.partition = array<i32: 0>} : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token)
       %dk, %dk_52 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
-      %dk_53 = ttng.tmem_store %cst_28, %dk[%dk_52], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
-      %dv_54 = ttng.tmem_store %cst_28, %dv[%dv_50], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %dk_53 = ttng.tmem_store %cst_28_layout, %dk[%dk_52], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %dv_54 = ttng.tmem_store %cst_28_layout, %dv[%dv_50], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
       %curr_m:7 = scf.for %curr_m_68 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg47 = %c0_i32, %arg48 = %false, %qkT_69 = %qkT_48, %dpT_70 = %dpT_49, %dv_71 = %dv_54, %dq_72 = %dq_51, %dk_73 = %dk_53) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
         %q = arith.extsi %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : i32 to i64
         %q_74 = arith.addi %off_bh_40, %q {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : i64

--- a/test/TritonGPU/accumulator-init.mlir
+++ b/test/TritonGPU/accumulator-init.mlir
@@ -311,6 +311,87 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return %17 : tensor<128x16xf32, #mma1>
   }
 
+// CHECK-LABEL: @packed_mul_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: tt.elementwise_inline_asm {{.*}} %[[ACC]], {{.*}}
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %[[USE_ACC]]
+  tt.func @packed_mul_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// CHECK-LABEL: @select_preserves_packed_mul_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: %[[SCALED:.+]] = tt.elementwise_inline_asm {{.*}} %[[ACC]], {{.*}}
+// CHECK: %[[SELECTED:.+]] = arith.select {{.*}}, %[[SCALED]], %[[ACC]]
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, %[[SELECTED]], %[[USE_ACC]]
+  tt.func @select_preserves_packed_mul_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>, %condition: tensor<128x16xi1, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %selected = arith.select %condition, %scaled, %acc : tensor<128x16xi1, #mma1>, tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %selected : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// The packed mul as the kernels actually emit it: movs around a single
+// mul.f32x2 (see inline_ptx_lib.py _mul_f32x2). Zero still propagates, so the
+// init must fold -- a matcher insisting on one instruction would reject every
+// real producer and silently disable this optimization.
+// CHECK-LABEL: @packed_mul_block_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %[[USE_ACC]]
+  tt.func @packed_mul_block_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "{\0A  .reg .b64 ra, rb, rc;\0A  mov.b64 ra, { $2, $3 };\0A  mov.b64 rb, { $4, $5 };\0A  mul.f32x2 rc, ra, rb;\0A  mov.b64 { $0, $1 }, rc;\0A}" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// This asm multiplies and THEN adds, so 0 * scale + 1.0 = 1.0 and the zero is
+// NOT preserved. It still contains the mul.f32x2 token and satisfies every
+// structural check, so a substring match would wrongly fold the init and
+// corrupt the first iteration. The accumulator must stay explicit: no
+// use-accumulator flag is threaded through the loop.
+// CHECK-LABEL: @packed_mul_then_add_no_zero_init
+// CHECK-NOT: arith.constant false
+// CHECK: scf.for {{.*}} iter_args({{.*}}) ->
+// CHECK: ttng.warp_group_dot
+  tt.func @packed_mul_then_add_no_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;\0Aadd.f32x2 $0, $0, $0;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
 // CHECK-LABEL: @if_defines_alternative
 // CHECK: %[[ACC_NEXT:.+]] = ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %arg{{.*}} : !ttg.memdesc
   tt.func @if_defines_alternative(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = 16 : i32}) -> tensor<128x16xf32, #mma1> {


### PR DESCRIPTION
Summary:

Teach accumulator-init analysis that select(acc * alpha, acc) preserves a zero-initialized loop accumulator along both arms -- attention's conditional rescale -- so the first MMA can initialize operand D directly. The arms are traced independently so an unsupported second arm cannot inherit the first's zero. Look through a narrowly recognized pure packed mul.f32x2 inline asm exactly as through arith.mulf. Also return cleanly instead of asserting when a zero-preserving op consumes a value captured from an outer block, such as the scale operand of a packed multiply.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from b8049352e on the MetaMain2 fork.

Reviewed By: njriasan

Differential Revision: D116999744


