### PR TITLE
[AutoWS] Generalize 2-CTA forward partition scheduling

### DIFF
--- a/python/test/unit/language/test_dot_2cta.py
+++ b/python/test/unit/language/test_dot_2cta.py
@@ -52,6 +52,57 @@ def _tl_dot_2cta_data_partition_kernel(
         c_desc.store([offs_m, offs_n], acc.to(tl.bfloat16))
 
 
+@triton.jit
+def _tl_dot_2cta_sliced_dependent_chain_kernel(q_ptr, k_ptr, v_ptr, o_ptr):
+    q_desc = tl.make_tensor_descriptor(q_ptr, [256, 128], [128, 1], [256, 128])
+    k_desc = tl.make_tensor_descriptor(k_ptr, [128, 128], [128, 1], [128, 128])
+    v_desc = tl.make_tensor_descriptor(v_ptr, [128, 128], [128, 1], [64, 128])
+    o_desc = tl.make_tensor_descriptor(o_ptr, [256, 128], [128, 1], [256, 128])
+
+    q = q_desc.load([0, 0])
+    k = k_desc.load([0, 0])
+    v0 = v_desc.load([0, 0])
+    v1 = v_desc.load([64, 0])
+    qk = tl.dot(q, k.T, two_ctas=True).to(tl.bfloat16)
+
+    p0, p1 = qk.reshape([256, 2, 64]).permute(0, 2, 1).split()
+    acc = tl.zeros([256, 128], tl.float32)
+    acc = tl.dot(p0, v0, acc, two_ctas=True)
+    acc = tl.dot(p1, v1, acc, two_ctas=True)
+    o_desc.store([0, 0], acc.to(tl.bfloat16))
+
+
+@triton.jit
+def _tl_dot_2cta_sliced_dependent_chain_ws_kernel(q_ptr, k_ptr, v_ptr, o_ptr):
+    q_desc = tl.make_tensor_descriptor(q_ptr, [256, 128], [128, 1], [256, 128])
+    k_desc = tl.make_tensor_descriptor(k_ptr, [256, 128], [128, 1], [128, 128])
+    v_desc = tl.make_tensor_descriptor(v_ptr, [256, 128], [128, 1], [64, 128])
+    o_desc = tl.make_tensor_descriptor(o_ptr, [256, 128], [128, 1], [256, 128])
+
+    start_pid = tl.program_id(0) // 2
+    for _ in tl.range(
+            start_pid,
+            1,
+            1,
+            warp_specialize=True,
+            data_partition_factor=1,
+            smem_alloc_algo=1,
+    ):
+        q = q_desc.load([0, 0])
+        acc = tl.zeros([256, 128], tl.float32)
+        for ki in tl.range(0, 256, 128):
+            k = k_desc.load([ki, 0])
+            v0 = v_desc.load([ki, 0])
+            v1 = v_desc.load([ki + 64, 0])
+            qk = tl.dot(q, k.T, two_ctas=True).to(tl.bfloat16)
+
+            p0, p1 = qk.reshape([256, 2, 64]).permute(0, 2, 1).split()
+            acc = acc * 0.5
+            acc = tl.dot(p0, v0, acc, two_ctas=True)
+            acc = tl.dot(p1, v1, acc, two_ctas=True)
+        o_desc.store([0, 0], acc.to(tl.bfloat16))
+
+
 @pytest.mark.parametrize("DATA_PARTITION_FACTOR", [2])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tl_dot_2cta_data_partition(DATA_PARTITION_FACTOR, device):
@@ -226,3 +277,72 @@ def test_tl_dot_2cta_persistent_meta_ws(DATA_PARTITION_FACTOR, m, device):
     ttgir = kernel.asm["ttgir"]
     assert "ttg.warp_specialize" in ttgir
     assert "two_ctas" in ttgir
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tl_dot_2cta_sliced_dependent_chain(device):
+    torch.manual_seed(0)
+    q = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
+    k = torch.randn((128, 128), device=device, dtype=torch.bfloat16)
+    v = torch.randn((128, 128), device=device, dtype=torch.bfloat16)
+    o = torch.empty((256, 128), device=device, dtype=torch.bfloat16)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    compiled = _tl_dot_2cta_sliced_dependent_chain_kernel[(2, )](
+        q,
+        k,
+        v,
+        o,
+        num_warps=4,
+        num_stages=2,
+        ctas_per_cga=(2, 1, 1),
+        allowDependentTwoCTA=True,
+    )
+    qk = torch.matmul(q.float(), k.float().T).to(torch.bfloat16)
+    reference = torch.matmul(qk.float(), v.float()).to(torch.bfloat16)
+    torch.testing.assert_close(o, reference, atol=1.0, rtol=2e-2)
+
+    ttgir = compiled.asm["ttgir"]
+    assert ttgir.count('ttng.two_cta_dependency = "collective_contraction"') == 2
+    assert 'ttng.two_cta_dependency = "requires_peer_gather"' not in ttgir
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tl_dot_2cta_sliced_dependent_chain_ws(device):
+    torch.manual_seed(0)
+    q = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
+    k = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
+    v = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
+    o = torch.empty((256, 128), device=device, dtype=torch.bfloat16)
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        triton.knobs.nvidia.use_meta_partition = True
+        compiled = _tl_dot_2cta_sliced_dependent_chain_ws_kernel[(2, )](
+            q,
+            k,
+            v,
+            o,
+            num_warps=4,
+            num_stages=2,
+            ctas_per_cga=(2, 1, 1),
+            allowDependentTwoCTA=True,
+        )
+    qk0 = torch.matmul(q.float(), k[:128].float().T).to(torch.bfloat16)
+    qk1 = torch.matmul(q.float(), k[128:].float().T).to(torch.bfloat16)
+    reference = 0.5 * torch.matmul(qk0.float(), v[:128].float())
+    reference += torch.matmul(qk1.float(), v[128:].float())
+    reference = reference.to(torch.bfloat16)
+    torch.testing.assert_close(o, reference, atol=1.0, rtol=2e-2)
+
+    ttgir = compiled.asm["ttgir"]
+    assert "ttg.warp_specialize" in ttgir
+    assert ttgir.count('ttng.two_cta_dependency = "collective_contraction"') >= 4
+    assert 'ttng.two_cta_dependency = "requires_peer_gather"' not in ttgir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -531,17 +531,6 @@ private:
       mmaToSlice[mmaOp] = collectMMABackwardSlice(innermostLoop, mmaOp);
     }
 
-    // Find shared ops (appear in multiple slices)
-    DenseMap<Operation *, unsigned> opCount;
-    for (auto &[mma, slice] : mmaToSlice) {
-      for (Operation *op : slice)
-        opCount[op]++;
-    }
-    for (auto &[op, count] : opCount) {
-      if (count > 1)
-        sharedOps.insert(op);
-    }
-
     // Group dependent MMAs using union-find.
     // MMA B depends on MMA A if A's result feeds (directly or via iter args
     // and intermediate ops) into B's operands.
@@ -637,6 +626,22 @@ private:
         accBufToMma[buf] = i;
       else
         unite(i, it->second);
+    }
+
+    // An op is shared only when it feeds MMAs in different dependency groups.
+    // Counting raw MMA slices incorrectly marks common producers of a serial
+    // MMA chain as shared. For example, two K-sliced PV MMAs consume the same
+    // softmax P tile and accumulate into the same output; their P chain must
+    // remain local to that compute group rather than being moved to the
+    // default/correction partition and staged back through SMEM.
+    DenseMap<Operation *, unsigned> opToFirstGroup;
+    for (unsigned i = 0; i < n; ++i) {
+      unsigned group = find(i);
+      for (Operation *op : mmaToSlice[loopMmas[i]]) {
+        auto [it, inserted] = opToFirstGroup.try_emplace(op, group);
+        if (!inserted && it->second != group)
+          sharedOps.insert(op);
+      }
     }
 
     // Count distinct groups that have exclusive (non-shared) ops
@@ -1380,7 +1385,7 @@ struct ScheduleResult {
   DenseMap<unsigned, Partition *> dpIdToPartition;
   bool createComputePartitions;
   // True for no-MMA in-register reduction kernels (RMS/LayerNorm). Enables the
-  // scalar-offset partition fixup in runOnOperation; inert for MMA kernels.
+  // scalar-offset partition fixup in runOnOperation.
   bool noMMACompute = false;
 };
 
@@ -1852,26 +1857,39 @@ getInitialSchedule(LoopLikeOpInterface mainLoop,
     }
   }
 
-  // Correction ops (cross-iteration MMA users) go to correction partition
-  // (which is aliased to default for fwd).
-  // Skip entirely when no correction partition is available.
-  Partition *corrDest =
+  // Correction ops (cross-iteration MMA users) normally go to the correction
+  // partition (which is aliased to default for fwd). When ordinary correction
+  // merging is requested for data-partitioned attention, keep each correction
+  // chain with the computation partition that owns its accumulator. Routing
+  // every chain through a single fallback partition both serializes independent
+  // DP groups and makes all of their full accumulator tiles live at once.
+  Partition *sharedCorrDest =
       correctionPartition ? correctionPartition : defaultPartition;
-  if (corrDest) {
-    for (auto mmaOp : mmas) {
-      for (OpOperand &use : mmaOp->getUses()) {
-        auto loop = getEnclosingSupportedLoop(mmaOp);
-        if (use.getOwner() != getLoopBodyTerminator(loop))
-          continue;
-        BlockArgument arg = getLoopCarriedBodyArg(loop, use.getOperandNumber());
-        if (!arg)
-          continue;
-        for (OpOperand &use : arg.getUses()) {
-          tryScheduleOp(corrDest, use.getOwner());
-          scheduleUsers(loop, schedule, corrDest, use.getOwner());
-        }
-        break;
+  for (auto mmaOp : mmas) {
+    Partition *corrDest = sharedCorrDest;
+    if (localSchedOpts.mergeCorrection && dataPartitionFactor > 1) {
+      unsigned dpId = categorizer.getDpId(mmaOp);
+      if (dpId != SHARED_DPID) {
+        auto it = dpIdToPartition.find(dpId);
+        if (it != dpIdToPartition.end())
+          corrDest = it->second;
       }
+    }
+    if (!corrDest)
+      continue;
+    for (OpOperand &mmaUse : mmaOp->getUses()) {
+      auto loop = getEnclosingSupportedLoop(mmaOp);
+      if (mmaUse.getOwner() != getLoopBodyTerminator(loop))
+        continue;
+      BlockArgument arg =
+          getLoopCarriedBodyArg(loop, mmaUse.getOperandNumber());
+      if (!arg)
+        continue;
+      for (OpOperand &argUse : arg.getUses()) {
+        tryScheduleOp(corrDest, argUse.getOwner());
+        scheduleUsers(loop, schedule, corrDest, argUse.getOwner());
+      }
+      break;
     }
   }
 
@@ -2462,6 +2480,41 @@ void propagatePartitions(LoopLikeOpInterface loop, PartitionSet &schedule,
         }
         continue;
       }
+
+      // A persistent outer loop can contain an inner loop whose body is
+      // already partitioned across all worker roles.  The wrapper then has
+      // multiple defining and sink partitions, but giving it a new partition
+      // only creates a wrapper-only task.  Code partitioning clones the inner
+      // loop into its body partitions and leaves that task empty; the empty
+      // task still consumes a barrier slot and a warp.  Co-own the wrapper by
+      // the partitions already present in its body instead.
+      Operation *nestedLoopOp = nullptr;
+      bool hasOtherNonScalarOp = false;
+      for (Operation *op : cluster.ops) {
+        if (isScalarOp(op) || op->hasTrait<OpTrait::IsTerminator>())
+          continue;
+        if (isa<LoopLikeOpInterface>(op) && !nestedLoopOp) {
+          nestedLoopOp = op;
+          continue;
+        }
+        hasOtherNonScalarOp = true;
+        break;
+      }
+      if (nestedLoopOp && !hasOtherNonScalarOp) {
+        SetVector<Partition *> bodyPartitions;
+        nestedLoopOp->walk([&](Operation *nestedOp) {
+          if (nestedOp == nestedLoopOp)
+            return;
+          for (int id : safeGetPartitionIds(nestedOp))
+            if (Partition *partition = schedule.getPartition(id))
+              bodyPartitions.insert(partition);
+        });
+        if (bodyPartitions.size() > 1) {
+          setPartition(nestedLoopOp, bodyPartitions);
+          continue;
+        }
+      }
+
       Partition *newPartition = schedule.addPartition(0);
       newPartition->setType("computation");
       for (Operation *op : cluster.ops) {
@@ -2949,9 +3002,38 @@ void PartitionSchedulingMeta::runOnOperation() {
     }
     {
       PartitionSet &schedule = result->schedule;
+      // Scalar index/offset ops are rematerializable, so propagatePartitions
+      // skips them. No-MMA reductions have no MMA slice to anchor them. Assign
+      // each still-unannotated value-producing op the union of its partitioned
+      // users' ids, iterating to a fixpoint so chains
+      // (muli -> addi -> descriptor_load) resolve.
+      auto fixupScalarPartitions = [&]() {
+        if (!result->noMMACompute)
+          return;
+        bool changed = true;
+        while (changed) {
+          changed = false;
+          getLoopBodyRegion(loop).walk([&](Operation *op) {
+            if (op->getNumResults() == 0 || hasPartition(op))
+              return;
+            SetVector<int> unionIds;
+            for (Operation *user : op->getUsers()) {
+              SetVector<int> userIds = safeGetPartitionIds(user);
+              unionIds.insert(userIds.begin(), userIds.end());
+            }
+            if (!unionIds.empty()) {
+              setPartition(op, unionIds);
+              changed = true;
+            }
+          });
+        }
+      };
+      fixupScalarPartitions();
+
       currentPhase = "propagate";
       propagatePartitions(loop, schedule, result->createComputePartitions,
                           result->layout.defaultPartition);
+      fixupScalarPartitions();
 
       // Assign partition to TMAStoreTokenWaitOp ops that have no partition.
       // These arise from early TMA reduce lowering: the wait's token comes
@@ -2978,37 +3060,7 @@ void PartitionSchedulingMeta::runOnOperation() {
       // propagatePartitions + optimizeSchedule) but before serialization.
       splitDataPartitionedIfOps(loop, schedule);
 
-      // No-MMA reduction kernels (RMS norm / LayerNorm) have no MMA backward
-      // slice to anchor partition assignment for scalar index/offset ops
-      // (e.g. offs_m = tile_id * 64) that feed the descriptor loads/stores.
-      // propagatePartitions skips these (isScalarOp), yet the
-      // tt.warp_specialize verifier requires every op in the loop to carry
-      // ttg.partition. Assign each still-unannotated value-producing op the
-      // union of its partitioned users' ids, iterating to a fixpoint so chains
-      // (muli -> addi -> descriptor_load) resolve. setPartition sorts/dedups
-      // and propagates to region terminators. An offset feeding both load and
-      // store gets both ids and is replicated by code partition (no
-      // cross-partition scalar channel). Gated to the no-MMA case so MMA
-      // kernels are untouched.
-      if (result->noMMACompute) {
-        bool changed = true;
-        while (changed) {
-          changed = false;
-          getLoopBodyRegion(loop).walk([&](Operation *op) {
-            if (op->getNumResults() == 0 || hasPartition(op))
-              return;
-            SetVector<int> unionIds;
-            for (Operation *user : op->getUsers()) {
-              SetVector<int> userIds = safeGetPartitionIds(user);
-              unionIds.insert(userIds.begin(), userIds.end());
-            }
-            if (!unionIds.empty()) {
-              setPartition(op, unionIds);
-              changed = true;
-            }
-          });
-        }
-      }
+      fixupScalarPartitions();
 
       // A predicated TMEM read-modify-write becomes an scf.if only after code
       // specialization. Until then, keep its predicate chain in the same


### PR DESCRIPTION
Summary:
sharedOps counted how many individual MMA backward slices contained an op before dependent MMAs were unioned. Two serial K-sliced PV contractions share P and accumulate into the same output, so P appeared in two raw slices even though both MMAs belong to one dependency group; marking it shared moved the qK/softmax/P chain to the default correction partition, staged P through SMEM into the compute tasks, and then exhausted TMEM while allocating alpha. Build sharedOps after dependency and accumulator-chain union-find and mark an op shared only when its backward-slice users belong to different final dependency groups, so common producers within one serial MMA group stay group-local. Adds test_tl_dot_2cta_sliced_dependent_chain.

Port note: the original commit also narrowed requiresPeerGather()'s tt.trans check to rank 2. That hunk is dropped here because master's landed classifier is isTransposedMemDesc() on the MMA's A memdesc, which never inspects register-level transposes, so a rank-3 static-subtiling trans cannot reach a peer-gather classification in the first place.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 868b2890e on the MetaMain2 fork.

Reviewed By: njriasan

Differential Revision: D116999883


