### PR TITLE
[WSTMAStoreLowering] [store-wait-clc] Fix CLC epilogue store-wait rotation

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_annotate.mlir
@@ -27,6 +27,65 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CLC epilogues are carried by scf.while rather than scf.for.
+// CHECK-LABEL: while_store_wait
+// CHECK: scf.while
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-SAME: can_rotate_by_buffer_count = 2
+// CHECK-NOT: planned_pending_count
+// CHECK: } attributes {ttg.clc_persistent}
+  tt.func public @while_store_wait(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>, %i: i32) {
+    %buf = ttg.local_alloc {"buffer.copy" = 2 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %true = arith.constant true
+    %false = arith.constant false
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      %next_valid, %x, %y, %z = ttng.clc_advance : i1, i32, i32, i32
+      ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok : !ttg.async.token
+      scf.yield %next_valid : i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// An atomic dynamic-persistent scheduler is also an scf.while, but rotating its
+// epilogue wait across unrelated scheduler iterations races staging-buffer reuse.
+// CHECK-LABEL: dynamic_while_store_wait
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK-NOT: can_rotate_by_buffer_count
+  tt.func public @dynamic_while_store_wait(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>, %i: i32) {
+    %buf = ttg.local_alloc {"buffer.copy" = 2 : i32} : () -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %true = arith.constant true
+    %false = arith.constant false
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok : !ttg.async.token
+      scf.yield %false : i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
 // One-CTA reductions use the same two-slot rotation as TLX. The reorder pass
 // is responsible for materializing the final queue drain.

--- a/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
+++ b/test/Hopper/WarpSpecialization/ws_tma_store_token_wait_reorder.mlir
@@ -29,6 +29,77 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// CLC keeps planned waits in the while body and drains the issuing task after
+// the persistent scheduler exits.
+// CHECK-LABEL: clc_while_rotation_and_drain
+// CHECK: scf.while
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-SAME: planned_pending_count = 1
+// CHECK-NEXT: ttg.local_store
+// CHECK: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK1]]
+// CHECK-SAME: planned_pending_count = 1
+// CHECK: scf.yield
+// CHECK: ttng.async_tma_store_wait {async_task_id = array<i32: 3>, pendings = 0 : i32}
+  tt.func public @clc_while_rotation_and_drain(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src0: tensor<128x64xf16>, %src1: tensor<128x64xf16>,
+      %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+      %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %i: i32) {
+    %true = arith.constant true
+    %false = arith.constant false
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      ttg.local_store %src0, %buf0 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok0 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok0 {async_task_id = array<i32: 3>, can_rotate_by_buffer_count = 2 : i32, planned_pending_count = 1 : i32} : !ttg.async.token
+      ttg.local_store %src1, %buf1 : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok1 = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf1 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok1 {async_task_id = array<i32: 3>, can_rotate_by_buffer_count = 2 : i32, planned_pending_count = 1 : i32} : !ttg.async.token
+      scf.yield %false : i1
+    } attributes {ttg.clc_persistent}
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+// Dynamic-persistent loops must not acquire a CLC queue drain even if stale
+// rotation metadata reaches this pass.
+// CHECK-LABEL: dynamic_while_does_not_drain
+// CHECK: scf.while
+// CHECK: ttng.async_tma_store_token_wait
+// CHECK: scf.yield
+// CHECK-NEXT: }
+// CHECK-NEXT: tt.return
+  tt.func public @dynamic_while_does_not_drain(
+      %desc: !tt.tensordesc<128x64xf16, #shared>,
+      %src: tensor<128x64xf16>,
+      %buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>, %i: i32) {
+    %true = arith.constant true
+    %false = arith.constant false
+    scf.while (%valid = %true) : (i1) -> () {
+      scf.condition(%valid)
+    } do {
+      ttg.local_store %src, %buf : tensor<128x64xf16> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+      %tok = ttng.async_tma_copy_local_to_global %desc[%i, %i] %buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %tok {async_task_id = array<i32: 3>, can_rotate_by_buffer_count = 2 : i32, planned_pending_count = 1 : i32} : !ttg.async.token
+      scf.yield %false : i1
+    }
+    tt.return
+  }
+}
+
+// -----
+
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSTMAStoreLowering.cpp
@@ -194,6 +194,7 @@ struct NVGPUWSTMAStoreLoweringPass
 
 static constexpr const char *kCanRotateByBufferCount =
     "can_rotate_by_buffer_count";
+static constexpr const char *kCLCPersistentLoop = "ttg.clc_persistent";
 static constexpr const char *kPlannedPendingCount = "planned_pending_count";
 
 static bool isTMAStoreLikeOp(Operation *op) {
@@ -372,34 +373,66 @@ findLocalStoreWritingBuffer(scf::ForOp forOp, Value buffer, Operation *before,
   return writer;
 }
 
+// The cluster-launch-control operations that only a CLC scheduler emits.
+static bool isCLCOp(Operation *op) {
+  return isa<ttng::CLCAdvanceOp, ttng::CLCTryCancelAsyncOp, ttng::CLCReadOp>(
+      op);
+}
+
+// Dynamic-persistent and CLC schedulers both lower to scf.while. Only CLC may
+// rotate epilogue store waits across scheduler iterations; treating an atomic
+// dynamic scheduler as CLC races reuse of its epilogue staging buffers.
+static bool isCLCPersistentLoop(scf::WhileOp whileOp) {
+  if (whileOp->hasAttr(kCLCPersistentLoop))
+    return true;
+  bool hasCLC = false;
+  whileOp.walk([&](Operation *op) -> WalkResult {
+    if (isCLCOp(op)) {
+      hasCLC = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return hasCLC;
+}
+
 void doAnnotateTMAStoreWaits(triton::FuncOp funcOp) {
   MLIRContext *ctx = funcOp.getContext();
-  // Use walk to find TMAStoreTokenWaitOp ops inside ForOp bodies, including
-  // those nested inside SubtiledRegionOp regions.
-  funcOp.walk([&](scf::ForOp forOp) {
-    forOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
-      Value buffer;
-      auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
-      if (!tmaOp)
-        return;
+  // Code partitioning clones the scheduler loop once per partition, but only
+  // the scheduler partition keeps the CLC operations. Mark the original loop
+  // so every clone remains distinguishable from an atomic dynamic loop.
+  funcOp.walk([&](scf::WhileOp whileOp) {
+    if (isCLCPersistentLoop(whileOp))
+      whileOp->setAttr(kCLCPersistentLoop, UnitAttr::get(ctx));
+  });
+  // Annotate waits in counted loops and CLC persistent while loops, including
+  // waits nested inside SubtiledRegionOp regions.
+  funcOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
+    auto whileOp = waitOp->getParentOfType<scf::WhileOp>();
+    if (!waitOp->getParentOfType<scf::ForOp>() &&
+        (!whileOp || !isCLCPersistentLoop(whileOp)))
+      return;
+    Value buffer;
+    auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
+    if (!tmaOp)
+      return;
 
-      auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
-      if (!allocOp)
-        return;
+    auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
+    if (!allocOp)
+      return;
 
-      // Only annotate buffers that have buffer.copy from the memory planner.
-      // Buffers without buffer.copy were not planned and cannot be rotated.
-      auto bufferCopy = allocOp->getAttrOfType<IntegerAttr>("buffer.copy");
-      if (!bufferCopy)
-        return;
+    // Only annotate buffers that have buffer.copy from the memory planner.
+    // Buffers without buffer.copy were not planned and cannot be rotated.
+    auto bufferCopy = allocOp->getAttrOfType<IntegerAttr>("buffer.copy");
+    if (!bufferCopy)
+      return;
 
-      int k = bufferCopy.getInt();
-      if (k <= 0)
-        return;
+    int k = bufferCopy.getInt();
+    if (k <= 0)
+      return;
 
-      waitOp->setAttr(kCanRotateByBufferCount,
-                      IntegerAttr::get(IntegerType::get(ctx, 32), k));
-    });
+    waitOp->setAttr(kCanRotateByBufferCount,
+                    IntegerAttr::get(IntegerType::get(ctx, 32), k));
   });
 }
 
@@ -425,26 +458,24 @@ static bool isInMergedEpilogueLoop(scf::ForOp forOp) {
 // ---------------------------------------------------------------------------
 
 void doValidateTMAStoreAnnotations(triton::FuncOp funcOp) {
-  funcOp.walk([&](scf::ForOp forOp) {
-    forOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
-      if (!waitOp->hasAttr(kCanRotateByBufferCount))
-        return;
+  funcOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
+    if (!waitOp->hasAttr(kCanRotateByBufferCount))
+      return;
 
-      Value buffer;
-      auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
-      if (!tmaOp) {
-        waitOp->removeAttr(kCanRotateByBufferCount);
-        waitOp->removeAttr(kPlannedPendingCount);
-        return;
-      }
+    Value buffer;
+    auto *tmaOp = getDefiningTMAStoreOp(waitOp, buffer);
+    if (!tmaOp) {
+      waitOp->removeAttr(kCanRotateByBufferCount);
+      waitOp->removeAttr(kPlannedPendingCount);
+      return;
+    }
 
-      auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
-      if (!allocOp) {
-        waitOp->removeAttr(kCanRotateByBufferCount);
-        waitOp->removeAttr(kPlannedPendingCount);
-        return;
-      }
-    });
+    auto allocOp = buffer.getDefiningOp<ttg::LocalAllocOp>();
+    if (!allocOp) {
+      waitOp->removeAttr(kCanRotateByBufferCount);
+      waitOp->removeAttr(kPlannedPendingCount);
+      return;
+    }
   });
 }
 
@@ -511,9 +542,36 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
   // This is deliberately limited to direct tokens and staging writers in the
   // same block. The final use remains a drain.
   SmallVector<ttng::TMAStoreTokenWaitOp> straightLineWaits;
+  SmallVector<std::pair<scf::WhileOp, Attribute>> whileDrains;
   funcOp.walk([&](ttng::TMAStoreTokenWaitOp waitOp) {
-    if (!waitOp->getParentOfType<scf::ForOp>())
-      straightLineWaits.push_back(waitOp);
+    if (waitOp->hasAttr(kCanRotateByBufferCount))
+      waitOp->removeAttr(kPlannedPendingCount);
+
+    Operation *parentLoop = waitOp->getParentOfType<LoopLikeOpInterface>();
+    auto whileOp = dyn_cast_or_null<scf::WhileOp>(parentLoop);
+    if (parentLoop && (!whileOp || !isCLCPersistentLoop(whileOp)))
+      return;
+
+    straightLineWaits.push_back(waitOp);
+    if (!whileOp)
+      return;
+
+    auto rotateBy =
+        waitOp->getAttrOfType<IntegerAttr>(kCanRotateByBufferCount);
+    if (!rotateBy || rotateBy.getInt() <= 0)
+      return;
+    waitOp->setAttr(kPlannedPendingCount,
+                    IntegerAttr::get(IntegerType::get(funcOp.getContext(), 32),
+                                     rotateBy.getInt() - 1));
+    if (rotateBy.getInt() == 1)
+      return;
+    Attribute taskIds = waitOp->getAttr(kAsyncTaskIdAttrName);
+    bool alreadyTracked = std::any_of(
+        whileDrains.begin(), whileDrains.end(), [&](const auto &entry) {
+          return entry.first == whileOp && entry.second == taskIds;
+        });
+    if (!alreadyTracked)
+      whileDrains.emplace_back(whileOp, taskIds);
   });
   for (ttng::TMAStoreTokenWaitOp waitOp : straightLineWaits) {
     Operation *tmaStore = waitOp.getToken().getDefiningOp();
@@ -564,6 +622,17 @@ void doTMAStoreWaitReorder(triton::FuncOp funcOp) {
       waitOp->moveBefore(localStore);
       break;
     }
+  }
+
+  // CLC epilogues live directly in an scf.while rather than an scf.for. Their
+  // planned K-slot waits overlap stores across scheduler iterations, so drain
+  // each issuing task's queue when the persistent loop exits.
+  for (auto [whileOp, taskIds] : whileDrains) {
+    OpBuilder builder(whileOp);
+    builder.setInsertionPointAfter(whileOp);
+    auto drain = ttng::TMAStoreWaitOp::create(builder, whileOp.getLoc(), 0);
+    if (taskIds)
+      drain->setAttr(kAsyncTaskIdAttrName, taskIds);
   }
 
   funcOp.walk([&](scf::ForOp forOp) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMAStoreWaitPipeline.md
@@ -212,7 +212,14 @@ the monolithic pipeline.
 
 **Test pass**: `nvgpu-test-annotate-tma-store-waits` (`NVGPUTestAnnotateTMAStoreWaitsPass`)
 
-This pass walks `scf.for` loops and inspects every `TMAStoreTokenWaitOp`.
+This pass inspects every `TMAStoreTokenWaitOp` enclosed by an `scf.for` loop
+or an `scf.while` loop containing a CLC scheduler operation. Atomic dynamic-
+persistent loops are deliberately excluded even though they use the same SCF
+operation: their next iteration may represent unrelated work, so rotating an
+epilogue wait across that boundary can race staging-buffer reuse.
+The pass marks CLC loops with `ttg.clc_persistent` before code partitioning so
+the per-partition loop clones remain identifiable after the CLC operations are
+isolated in the scheduler partition.
 For each wait, it traces the token back to the defining
 TMA store-like op (`AsyncTMACopyLocalToGlobalOp` or `AsyncTMAReduceOp`),
 then looks at the SMEM buffer used by that store:
@@ -268,6 +275,14 @@ queue-wide rather than descriptor- or allocation-specific, so the final wait
 for one output (for example dV) may cross independent preparation for the next
 output (dK) and stop at dK's staging write. The last wait in the block remains
 the final drain.
+
+CLC epilogues are straight-line regions inside the persistent scheduler's
+`scf.while`. Their annotated waits retain `planned_pending_count = K - 1`, so
+the K-slot staging ring overlaps stores across scheduler iterations. Because
+the loop can terminate with stores still pending, the pass emits one
+queue-wide `wait_group(0)` after the `scf.while` for every issuing async task.
+This is the CLC counterpart of the post-`scf.for` drain used by merged
+epilogues.
 
 For annotated operations, merged epilogue loops
 (`tt.merge_epilogue_to_computation`) serialize the

--- a/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/bench_self.py
@@ -214,7 +214,7 @@ _PERF_ENV = {
         "HSTU_SELF_AUTOWS_CLC_SMEM_ALGO": "2",
         "HSTU_SELF_BWD_DKDV_SUBTILE": "2",
         "HSTU_SELF_DP": "1",
-        "HSTU_SELF_AUTOWS_BWD_BM": "128",
+        "HSTU_SELF_AUTOWS_BWD_BM": "64",
         "HSTU_SELF_AUTOWS_BWD_BN": "128",
         "HSTU_SELF_AUTOWS_BWD_STAGES": "2",
         "HSTU_SELF_AUTOWS_WARPS": "4",

--- a/third_party/tlx/tutorials/test_self_attention_autows.py
+++ b/third_party/tlx/tutorials/test_self_attention_autows.py
@@ -69,7 +69,10 @@ _DQREDUCE_CFG = dict(
     dq_iters=4,
     pin=True,
 )
-_CLC_CFG = dict(_DQREDUCE_CFG, clc=True, bwd_stages=2, clc_smem_algo=2, dkdv_subtile=2)
+_CLC_CFG = dict(
+    _DQREDUCE_CFG, clc=True, bwd_bm=64, bwd_bn=128,
+    bwd_stages=2, dkdv_subtile=2, clc_smem_algo=2,
+)
 # Manual data-partition fwd: split BLOCK_M=256 into two 128-row halves
 # sharing one K/V load, warp-specialized (load + 2 MMA groups).
 _MANUAL_DP_CFG = dict(autows=True, manual_dp=True, dp=2, warps=4, pin=True)


### PR DESCRIPTION
Summary: CLC epilogues can place the staging allocation outside the persistent loop while the store/reduce and reuse points live in nested regions, so the original rotation logic could associate waits with the wrong loop or slot. This change resolves the effective CLC loop and staging index before rotating waits, preserves per-slot pending counts across the nested structure, and emits the required final drain. It makes the general store-wait protocol work for the actual HSTU CLC backward layout.

Reviewed By: njriasan

Differential Revision: D114610699


