### PR TITLE
[triton][tlx] Round-trip barrier arrive count and predicate in TTGIR-to-TLX (#3307)

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-barriers.mlir
+++ b/test/TLX/print-ttgir-to-tlx-barriers.mlir
@@ -80,6 +80,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
+
+  // An arrive count is an attribute, not an operand, and is emitted positionally.
+  // CHECK-LABEL: def arrive_with_count(
+  // CHECK: tlx.barrier_arrive({{.*}}, 2)
+  tt.func public @arrive_with_count() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A predicate is an optional operand and must be named, not passed
+  // positionally into the arrive_count slot.
+  // CHECK-LABEL: def arrive_with_predicate(
+  // CHECK: tlx.barrier_arrive({{.*}}, pred=
+  tt.func public @arrive_with_predicate() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %pid = tt.get_program_id x : i32
+    %pred = arith.cmpi sgt, %pid, %c0_i32 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A perThread arrive needs no keyword: barrier_arrive picks the per-thread
+  // lowering off the barrier, which alloc_warp_barrier restores.
+  // CHECK-LABEL: def per_thread_arrive(
+  // CHECK: tlx.alloc_warp_barrier(1, 4)
+  // CHECK: tlx.barrier_arrive(
+  // CHECK-NOT: per_thread=
+  tt.func public @per_thread_arrive() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 128 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {perThread} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----
@@ -124,6 +161,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %v1 = ttg.memdesc_index %bar[%c1_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %v0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %v1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A multicast arrive signals every CTA in its equivalence class; emitting it
+// as a local arrive would silently drop the multicast. It needs more than one
+// CTA and the identity CGA layout, hence a separate module.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+  // CHECK-LABEL: def multicast_arrive(
+  // CHECK: # unsupported: multicast arrive_barrier (ctaMask=1)
+  // CHECK-NOT: tlx.barrier_arrive(
+  tt.func public @multicast_arrive() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @+1 {{multicast arrive_barrier does not round-trip to TLX}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1876,6 +1876,34 @@ void printSimplifiedOp(
     return;
   }
 
+  // ttng.arrive_barrier: `count` is an attribute and `pred` an optional
+  // operand, but the generic mapping printed both positionally.
+  if (opName == "ttng.arrive_barrier") {
+    // A multicast arrive has no TLX spelling; leave a marker instead of an
+    // arrive that would look local but mean something else.
+    auto ctaMask = op->getAttrOfType<IntegerAttr>("ctaMask");
+    if (ctaMask && ctaMask.getInt() != 0) {
+      op->emitError("multicast arrive_barrier does not round-trip to TLX");
+      os << "# unsupported: multicast arrive_barrier (ctaMask="
+         << ctaMask.getInt() << ")";
+      printLocComment(op, os);
+      return;
+    }
+    os << "tlx.barrier_arrive("
+       << getValueName(op->getOperand(0), argSubstitutionMap);
+    // count is required on this op, but tolerate its absence on hand-written
+    // IR rather than crash; 1 is the value the op defaults to anyway.
+    auto countAttr = op->getAttrOfType<IntegerAttr>("count");
+    int64_t count = countAttr ? countAttr.getInt() : 1;
+    if (count != 1)
+      os << ", " << count;
+    if (op->getNumOperands() >= 2)
+      os << ", pred=" << getValueName(op->getOperand(1), argSubstitutionMap);
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
   // Get the TLX name or use original
   auto it = opNameMap.find(opName);
   StringRef tlxName = (it != opNameMap.end()) ? it->second : opName;


### PR DESCRIPTION
Summary:

`ttng.arrive_barrier` went through the generic op mapping, which prints every operand positionally. That is wrong for this op in two ways.

Its arrive count is an attribute rather than an operand, so a non-unit count was dropped and every arrive was emitted as a single arrival.

Its predicate is an optional second operand, so the generic mapping printed it positionally straight into `tlx.barrier_arrive`'s `arrive_count` slot. That slot is a constexpr, so a predicated arrive did not just round-trip incorrectly, it failed to compile.

Emit the count only when it is not the default, and the predicate as a named `pred=`.

The op's `perThread` attribute needs no keyword of its own. `tlx.barrier_arrive` selects the per-thread lowering from the barrier it is given, via `is_warp_barrier`, which `tlx.alloc_warp_barrier` sets and `tlx.local_view` propagates -- so restoring the allocation restores the arrive. Multicast arrives (a non-zero `ctaMask`) have no TLX spelling and are not round-tripped. They report a diagnostic and emit an `# unsupported: multicast arrive_barrier` marker in place of the arrive, rather than an arrive that would read as local but mean something else. That check is a plain conditional rather than an assert, so it survives release builds where `NDEBUG` is defined.

Authored with Claude.

The `perThread` attribute needs no keyword of its own: `tlx.barrier_arrive` recovers per-thread arrival from the barrier it is handed, via `is_warp_barrier`, which `tlx.alloc_warp_barrier` sets and `tlx.local_view` propagates. That leaves the attribute and the allocation coupled -- an arrive round-trips as per-thread exactly when its barrier was initialized with an arrive count that is a multiple of the warp size. Kernels in the tree satisfy that, since the warp-specialization pass marks an arrive per-thread precisely when it targets a warp barrier, and it is the same classification the allocation already uses. This is not enforced here: a check would have to drop arrives it cannot represent, and dropping an arrive deadlocks the kernel, which is worse than the mismatch it would be guarding against.

Reviewed By: manman-ren

Differential Revision: D117065919


