### PR TITLE
[triton][tlx] Round-trip Cluster Launch Control ops in TTGIR-to-TLX (#3309)

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-clc.mlir
+++ b/test/TLX/print-ttgir-to-tlx-clc.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that Cluster Launch Control ops round-trip to their TLX spellings.
+//
+// A persistent CLC kernel issues a cancel request into a response buffer,
+// waits on an mbarrier, then decodes the stolen tile out of the response.
+// None of those ops have a generic mapping: the response buffer's ui128
+// element type is unnameable in TLX, and the issue and query ops take
+// different operand orders and result counts than the printer's default.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The ui128 response buffer gets its own allocator rather than a local_alloc
+  // of an element type TLX cannot name.
+  // CHECK-LABEL: def clc_response_alloc(
+  // CHECK: tlx._alloc_clc_responses(1)
+  // CHECK-NOT: tlx.local_alloc(
+  tt.func public @clc_response_alloc() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The issue op takes (mbarrier, response) in TTGIR but (response, barrier)
+  // in TLX, so the operands are swapped rather than printed in order.
+  // Binding each name where it is defined is what makes the swap observable:
+  // the barrier is allocated first, so a call emitted in source order would
+  // read _clc_issue([[BAR]], [[RESP]]) and fail here.
+  // CHECK-LABEL: def clc_issue(
+  // CHECK: [[BAR:[a-zA-Z_0-9]+]] = tlx.alloc_barriers(1)
+  // CHECK: [[RESP:[a-zA-Z_0-9]+]] = tlx._alloc_clc_responses(1)
+  // CHECK: tlx._clc_issue([[RESP]], [[BAR]])
+  tt.func public @clc_issue() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_clc_try_cancel %bar, %resp : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The query decodes three results, which are bound as one tuple.
+  // CHECK-LABEL: def clc_query(
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = tlx._clc_query(
+  tt.func public @clc_query() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    %x, %y, %z = ttng.clc_query_cancel %resp : (!ttg.memdesc<1xui128, #shared, #smem, mutable>) -> (i32, i32, i32)
+    tt.return
+  }
+
+  // The CLC lowering replaces tl.program_id(0) with the cluster id; emitting
+  // program_id back re-derives the same value on recompile.
+  // CHECK-LABEL: def cluster_id(
+  // CHECK: tl.program_id(axis=0)
+  tt.func public @cluster_id() attributes {noinline = false} {
+    %cid = "nvg.cluster_id"() : () -> i32
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1392,6 +1392,20 @@ void printSimplifiedOp(
 
   // Special handling for local_alloc
   if (opName == "ttg.local_alloc") {
+    // A ui128 buffer is a CLC response allocation; that element type has no
+    // TLX spelling, so emit the dedicated allocator.
+    if (auto memDescType =
+            dyn_cast<ttg::MemDescType>(op->getResult(0).getType())) {
+      if (memDescType.getElementType().isUnsignedInteger(128)) {
+        os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+        int64_t num = 1;
+        for (int64_t dim : memDescType.getShape())
+          num *= dim;
+        os << "tlx._alloc_clc_responses(" << num << ")";
+        printLocComment(op, os);
+        return;
+      }
+    }
     auto it = allocInfoMap.find(op);
     if (it != allocInfoMap.end()) {
       const LocalAllocInfo &info = it->second;
@@ -1900,6 +1914,40 @@ void printSimplifiedOp(
     if (op->getNumOperands() >= 2)
       os << ", pred=" << getValueName(op->getOperand(1), argSubstitutionMap);
     os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // nvg.cluster_id: the CLC-persistent lowering replaces the source's
+  // tl.program_id(0) with the cluster id, identical for single-CTA clusters.
+  if (opName == "nvg.cluster_id") {
+    if (op->getNumResults() > 0)
+      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+    os << "tl.program_id(axis=0)";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.async_clc_try_cancel(mbar, response): TLX takes (response, barrier).
+  if (opName == "ttng.async_clc_try_cancel") {
+    os << "tlx._clc_issue("
+       << getValueName(op->getOperand(1), argSubstitutionMap) << ", "
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.clc_query_cancel(response): decodes the stolen tile's 3D CTA id,
+  // or (-1, -1, -1) when no work was claimed.
+  if (opName == "ttng.clc_query_cancel") {
+    unsigned nres = op->getNumResults();
+    for (unsigned i = 0; i < nres; ++i)
+      os << (i ? ", " : "")
+         << getValueName(op->getResult(i), argSubstitutionMap);
+    if (nres > 0)
+      os << " = ";
+    os << "tlx._clc_query("
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
     printLocComment(op, os);
     return;
   }


### PR DESCRIPTION
Summary:

A persistent CLC kernel issues a cancel request into a response buffer, waits on an mbarrier, then decodes the tile it stole out of that response. None of the ops involved survive the printer's generic mapping, which prints an op's operands positionally under a mapped name.

The response buffer is a `ttg.local_alloc` of `ui128`, an element type TLX cannot name, so it needs its own allocator rather than a `tlx.local_alloc`.

`ttng.async_clc_try_cancel` takes the mbarrier first and the response second; `tlx._clc_issue` takes them the other way around, so printing the operands in order silently swaps them.

`ttng.clc_query_cancel` returns the three CTA-id components, which have to be bound as a tuple.

`nvg.cluster_id` replaces the source kernel's `tl.program_id(0)` during the CLC-persistent lowering, and is identical to it for the single-CTA clusters these kernels launch, so emitting `tl.program_id(axis=0)` re-derives the same value on recompile.

Authored with Claude.

Reviewed By: manman-ren

Differential Revision: D117188473


