### PR TITLE
[triton][beta] TMemBarrierInsertion: account for view offsets in TMEM aliasing

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMemBarrierInsertion.cpp
@@ -6,6 +6,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -82,13 +83,29 @@ static bool isTensorMemory(Value value) {
          isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace());
 }
 
-static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
+// Offset of a view relative to the root allocation, in physical TMEM
+// coordinates (rows, 32-bit columns).
+struct TMemViewOffset {
+  int64_t row = 0;
+  int64_t col = 0;
+  bool known = true;
+};
+
+// A root allocation reached from a view, together with the view's offset
+// within it. Two views of one allocation can be physically disjoint, so the
+// offset is what lets the interval model tell them apart.
+struct RootAlloc {
+  TMEMAllocOp alloc;
+  TMemViewOffset offset;
+};
+
+static void appendRootAllocs(Value value, SmallVectorImpl<RootAlloc> &allocs,
                              bool &unknown) {
   DenseSet<Value> seen;
-  SmallVector<Value> worklist{value};
+  SmallVector<std::pair<Value, TMemViewOffset>> worklist{{value, {}}};
 
   while (!worklist.empty()) {
-    Value current = worklist.pop_back_val();
+    auto [current, offset] = worklist.pop_back_val();
     if (!seen.insert(current).second)
       continue;
 
@@ -108,25 +125,27 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
               std::distance(branch->getSuccessors().begin(), it);
           SuccessorOperands args = branch.getSuccessorOperands(successorIndex);
           worklist.push_back(
-              args.getForwardedOperands()[arg.getArgNumber() -
-                                          args.getProducedOperandCount()]);
+              {args.getForwardedOperands()[arg.getArgNumber() -
+                                           args.getProducedOperandCount()],
+               offset});
         }
         continue;
       }
 
       if (auto ws = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-        worklist.push_back(ws.getExplicitCaptures()[arg.getArgNumber()]);
+        worklist.push_back(
+            {ws.getExplicitCaptures()[arg.getArgNumber()], offset});
       } else if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
         unsigned idx = arg.getArgNumber() - 1;
-        worklist.push_back(forOp.getYieldedValues()[idx]);
-        worklist.push_back(forOp.getInits()[idx]);
+        worklist.push_back({forOp.getYieldedValues()[idx], offset});
+        worklist.push_back({forOp.getInits()[idx], offset});
       } else if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp)) {
         unsigned idx = arg.getArgNumber();
         if (arg.getParentRegion() == &whileOp.getAfter()) {
-          worklist.push_back(whileOp.getConditionOp().getArgs()[idx]);
+          worklist.push_back({whileOp.getConditionOp().getArgs()[idx], offset});
         } else {
-          worklist.push_back(whileOp.getYieldedValues()[idx]);
-          worklist.push_back(whileOp.getInits()[idx]);
+          worklist.push_back({whileOp.getYieldedValues()[idx], offset});
+          worklist.push_back({whileOp.getInits()[idx], offset});
         }
       } else {
         unknown = true;
@@ -141,23 +160,55 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
     }
 
     unsigned resultIndex = cast<OpResult>(current).getResultNumber();
+    // The view ops that carry an offset must be matched before the generic
+    // MemDescViewTrait branch below, which would otherwise shadow them and
+    // discard the offset.
     if (auto alloc = dyn_cast<TMEMAllocOp>(defOp)) {
-      allocs.push_back(alloc);
-    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
-      worklist.push_back(defOp->getOperand(0));
+      allocs.push_back({alloc, offset});
+    } else if (auto index = dyn_cast<ttg::MemDescIndexOp>(defOp)) {
+      // Multi-buffered views advance the base pointer by one buffer's worth of
+      // 32-bit columns, matching MemDescIndexOpConversion.
+      APInt indexValue;
+      TMemViewOffset next = offset;
+      if (matchPattern(index.getIndex(), m_ConstantInt(&indexValue)))
+        next.col += indexValue.getSExtValue() *
+                    getTmemAllocSizes(index.getType()).numCols;
+      else
+        next.known = false;
+      worklist.push_back({index.getSrc(), next});
     } else if (auto slice = dyn_cast<TMEMSubSliceOp>(defOp)) {
-      worklist.push_back(slice.getSrc());
+      // getTMemSubSliceOffset packs the column offset in the low 16 bits and
+      // the row offset in the high 16 bits, as TMEMSubSliceOpConversion does.
+      // This tree's tmem_subslice predates upstream's (offset, dim) form: it
+      // carries a single $N and can only slice the inner (column) dimension,
+      // which is exactly upstream's dim=1 default.
+      uint32_t packed =
+          getTMemSubSliceOffset(slice.getSrc().getType(), slice.getN());
+      TMemViewOffset next = offset;
+      next.col += packed & 0xffff;
+      next.row += packed >> 16;
+      worklist.push_back({slice.getSrc(), next});
+    } else if (isa<ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+                   ttg::MemDescReshapeOp>(defOp)) {
+      // Pure reinterpretations do not move the base pointer.
+      worklist.push_back({defOp->getOperand(0), offset});
+    } else if (defOp->hasTrait<OpTrait::MemDescViewTrait>()) {
+      // Keep walking to the root, but do not pretend the offset is known.
+      TMemViewOffset next = offset;
+      next.known = false;
+      worklist.push_back({defOp->getOperand(0), next});
     } else if (auto selectOp = dyn_cast<arith::SelectOp>(defOp)) {
-      worklist.push_back(selectOp.getTrueValue());
-      worklist.push_back(selectOp.getFalseValue());
+      worklist.push_back({selectOp.getTrueValue(), offset});
+      worklist.push_back({selectOp.getFalseValue(), offset});
     } else if (auto ifOp = dyn_cast<scf::IfOp>(defOp)) {
-      worklist.push_back(ifOp.thenYield().getOperand(resultIndex));
-      worklist.push_back(ifOp.elseYield().getOperand(resultIndex));
+      worklist.push_back({ifOp.thenYield().getOperand(resultIndex), offset});
+      worklist.push_back({ifOp.elseYield().getOperand(resultIndex), offset});
     } else if (auto forOp = dyn_cast<scf::ForOp>(defOp)) {
-      worklist.push_back(forOp.getYieldedValues()[resultIndex]);
-      worklist.push_back(forOp.getInits()[resultIndex]);
+      worklist.push_back({forOp.getYieldedValues()[resultIndex], offset});
+      worklist.push_back({forOp.getInits()[resultIndex], offset});
     } else if (auto whileOp = dyn_cast<scf::WhileOp>(defOp)) {
-      worklist.push_back(whileOp.getConditionOp().getArgs()[resultIndex]);
+      worklist.push_back(
+          {whileOp.getConditionOp().getArgs()[resultIndex], offset});
     } else {
       unknown = true;
     }
@@ -165,46 +216,54 @@ static void appendRootAllocs(Value value, SmallVectorImpl<TMEMAllocOp> &allocs,
 }
 
 static SmallVector<AllocationSlice> getTMemSlices(Value value) {
-  SmallVector<TMEMAllocOp> allocs;
+  SmallVector<RootAlloc> allocs;
   bool unknown = false;
   appendRootAllocs(value, allocs, unknown);
 
   SmallVector<AllocationSlice> slices;
-  if (unknown || allocs.empty()) {
+  auto everything = [&]() -> SmallVector<AllocationSlice> {
+    slices.clear();
     slices.emplace_back(
         Interval<size_t>(0, std::numeric_limits<size_t>::max()));
     return slices;
-  }
+  };
 
-  for (TMEMAllocOp alloc : allocs) {
+  if (unknown || allocs.empty())
+    return everything();
+
+  // The accessed extent is the view's own footprint, not the whole allocation.
+  auto viewTy = dyn_cast<ttg::MemDescType>(value.getType());
+  if (!viewTy)
+    return everything();
+  TMemAllocation viewSize = getTmemAllocSizes(viewTy);
+
+  for (RootAlloc &root : allocs) {
     auto colAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_col_offset");
     auto rowAttr =
-        alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
-    if (!colAttr || !rowAttr) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        root.alloc->getAttrOfType<IntegerAttr>("tensor_memory_row_offset");
+    if (!colAttr || !rowAttr)
+      return everything();
 
-    int64_t colOffset = colAttr.getInt();
-    int64_t rowOffset = rowAttr.getInt();
-    TMemAllocation allocSize = getTmemAllocSizes(alloc.getType());
+    TMemAllocation allocSize = getTmemAllocSizes(root.alloc.getType());
+    // Fall back to the whole allocation when the view offset is not statically
+    // known, so an unresolved view can never look narrower than it is.
+    bool useView = root.offset.known;
+    int64_t colOffset = colAttr.getInt() + (useView ? root.offset.col : 0);
+    int64_t rowOffset = rowAttr.getInt() + (useView ? root.offset.row : 0);
+    int64_t numRows = useView ? viewSize.numRows : allocSize.numRows;
+    int64_t numCols = useView ? viewSize.numCols : allocSize.numCols;
+
     if (rowOffset % kRowOffsetGranularity != 0 ||
-        allocSize.numRows % kAllocRowGranularity != 0) {
-      slices.clear();
-      slices.emplace_back(
-          Interval<size_t>(0, std::numeric_limits<size_t>::max()));
-      return slices;
-    }
+        numRows % kAllocRowGranularity != 0)
+      return everything();
 
     int64_t rowGroup = rowOffset / kRowOffsetGranularity;
-    int64_t numRowGroups = allocSize.numRows / kAllocRowGranularity;
+    int64_t numRowGroups = numRows / kAllocRowGranularity;
     for (int64_t row = 0; row < numRowGroups; ++row) {
       size_t start = static_cast<size_t>(rowGroup + row) * kFlattenedRowStride +
                      static_cast<size_t>(colOffset);
-      slices.emplace_back(Interval<size_t>(start, start + allocSize.numCols));
+      slices.emplace_back(Interval<size_t>(start, start + numCols));
     }
   }
   return slices;

--- a/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
+++ b/test/TritonNvidiaGPU/tmem_barrier_insertion.mlir
@@ -8,6 +8,7 @@
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[16, 0], [32, 0]], block = []}>
 #tmem128 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
 #tmem64 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1>
+#tmem128x64 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1>
 #tmem_scales = #ttng.tensor_memory_scales_encoding<>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
@@ -328,6 +329,113 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     ttg.barrier local
     ttng.tmem_store %arg0, %0, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     ttng.tmem_copy %arg1, %0 : !ttg.memdesc<128x128xf32, #shared_copy, #ttg.shared_memory>, !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Two multi-buffered views of one allocation that land on different physical
+  // columns do not alias, so no barrier is needed between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Same allocation, same buffer index: the views do alias and the WAR still
+  // needs ordering.
+  // CHECK-LABEL: @ld_then_st_same_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_same_buffer(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A dynamic buffer index cannot prove disjointness: stay conservative.
+  // CHECK-LABEL: @ld_then_st_dynamic_buffer
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_dynamic_buffer(%arg0: tensor<128x128xf32, #blocked>, %idx: i32) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttg.memdesc_index %0[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %0[%idx] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // tmem_subslice offsets are honoured too: two column subslices of one
+  // allocation that do not overlap need no barrier between them.
+  // CHECK-LABEL: @ld_then_st_disjoint_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_disjoint_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %wr = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // Overlapping subslices of one allocation still need the barrier.
+  // CHECK-LABEL: @ld_then_st_overlapping_subslices
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: ttng.tmem_store
+  tt.func @ld_then_st_overlapping_subslices(%arg0: tensor<128x64xf32, #blocked>) {
+    %true = arith.constant true
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %rd = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %wr = ttng.tmem_subslice %0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable> -> tensor<128x64xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x64xf32, #blocked> -> !ttg.memdesc<128x64xf32, #tmem128x64, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // memdesc_reinterpret does not move the base pointer, so the buffer offset
+  // underneath it still decides aliasing.
+  // CHECK-LABEL: @ld_then_st_reinterpret_disjoint_buffers
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
+  // CHECK-NOT: ttg.barrier
+  tt.func @ld_then_st_reinterpret_disjoint_buffers(%arg0: tensor<128x128xf32, #blocked>) {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %0 = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable>
+    ttg.barrier local
+    %v = ttg.memdesc_reinterpret %0 : !ttg.memdesc<2x128x128xi32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %rd = ttg.memdesc_index %v[%c0] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %wr = ttg.memdesc_index %v[%c1] : !ttg.memdesc<2x128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
+    %1 = ttng.tmem_load %rd : !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    ttng.tmem_store %arg0, %wr, %true : tensor<128x128xf32, #blocked> -> !ttg.memdesc<128x128xf32, #tmem128, #ttng.tensor_memory, mutable>
     tt.return
   }
 }


### PR DESCRIPTION
Summary:
`TMemBarrierInsertion` (upstream `triton-lang/triton#10263`, brought into beta
by the 56-PR backport bundle in D112855155) models tensor-memory aliasing as
flattened 1D intervals. `getTMemSlices` walks a `memdesc` value back to its root
`ttng.tmem_alloc`, but currently discards the view chain and uses the root
allocation's offset and full size.

Two views of one allocation that occupy disjoint physical columns therefore
produce identical intervals and always appear to alias. The pass then inserts a
CTA barrier between them. The clearest instance is a multi-buffered TMEM
accumulator, where accesses to distinct pipeline slots are unnecessarily
serialized.

This diff carries each view's offset back to the root and uses the view's own
extent:

- constant `ttg.memdesc_index`: add
  `index * getTmemAllocSizes(resultTy).numCols`, matching
  `MemDescIndexOpConversion`;
- `ttng.tmem_subslice`: use `getTMemSubSliceOffset(srcTy, N)`, whose low 16
  bits are the 32-bit-column offset and high 16 bits are the row offset,
  matching `TMEMSubSliceOpConversion`;
- `ttg.memdesc_reinterpret`, `memdesc_trans`, and `memdesc_reshape`: preserve
  the base address.

Anything that cannot be resolved statically falls back conservatively to the
whole allocation. A dynamic `memdesc_index`, an unmodelled `MemDescViewTrait`
operation, missing allocation-offset attributes, or an unsupported row shape
can therefore only make the analysis less precise; it cannot hide a real
alias.

This diff changes only view/address resolution. It does not change the hazard
policy for genuinely overlapping views; per-warp ownership refinement is a
separate optimization.

The order of the cases in `appendRootAllocs` matters: offset-carrying view
operations must be handled before the generic `MemDescViewTrait` branch.
`ttng.tmem_subslice` has that trait, so the generic branch would otherwise
discard its offset.

This beta tree predates upstream's `(offset, dim)` form of `tmem_subslice`: it
has one `$N` and slices the inner column dimension. The call to
`getTMemSubSliceOffset` is adapted accordingly. The upstream counterpart,
triton-lang/triton#11168, was closed; this change lives in beta and must be
carried through future backport bundles.

Performance:
Latest downstream measurements isolate this diff as P0 -> P1 on
`fbcode/stable` `c37ed00ae47c`. They comprise three independent runs (rounds
11, 12, and 16), each using a pinned config matrix on B200: profiler mode,
bf16, clocks and NUMA pinned, 6 configs x 4 sequence lengths x 5 paired
repetitions. Positive means faster. Each cell below is the median of the three
runs; `~0` means the runs disagree on the sign.

| config (`RESCALE,WHERE,WARP_BAR`) | barriers | 1024 | 2048 | 4096 | 8192 |
|---|---|---|---|---|---|
| `0,0,0` | 51 -> 43 | ~0 | +0.24% | +0.17% | +0.44% |
| `1,0,0` | 57 -> 49 | ~0 | +0.53% | +0.84% | +0.90% |
| `1,1,0` | 51 -> 43 | +0.31% | +0.34% | +0.53% | +0.44% |
| `0,0,1` | 37 -> 27 | +0.69% | +0.84% | +0.90% | +1.07% |
| **`1,0,1` (autotune winner)** | **43 -> 33** | **~0** | **+0.65%** | **+0.73%** | **+1.02%** |
| `1,1,1` | 37 -> 27 | +0.23% | +0.10% | +0.45% | +0.36% |

There is no stable negative cell in the 6 x 4 matrix. The `1,0,1` config is
the fastest config at every measured point and shape, so this diff does not
change the autotune winner. Round 15's independent, instruction-correlated NCU
analysis also finds that D114805386 reduces total stall samples in every
one-CTA config profiled; the 2-CTA sample is approximately neutral.

The original `+2.15 / +1.26 / +3.08 / +1.15%` claim is withdrawn. It does not
reproduce, and the original run did not pin the autotune config. The six configs
differ in absolute latency by up to about 14%, much more than this diff moves a
fixed config, so an unpinned A/B can primarily measure a config change.

These performance numbers are base-specific and have not yet been rerun after
the latest rebase to `fbcode/master`. The full measurement record, raw data,
and reproduction scripts are in:
https://www.internalfb.com/manifold/explorer/tritonparse/tree/example1/cutracer/case30/ai_discussions/MEASUREMENTS.md

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D114805386


