### PR TITLE
[AMD][TLX] Add packed variable-length D128 attention backward

### DIFF
--- a/python/test/unit/language/test_tlx_amd_fa_bwd.py
+++ b/python/test/unit/language/test_tlx_amd_fa_bwd.py
@@ -1,4 +1,4 @@
-"""Focused integration tests for the D64 AMD FA backward routes."""
+"""Focused integration tests for AMD FlashAttention backward routes."""
 
 import math
 import re
@@ -7,7 +7,7 @@ import pytest
 import torch
 import triton
 
-from triton.language.extra.tlx.tutorials import amd_fa_bwd
+from triton.language.extra.tlx.tutorials import amd_fa_bwd, amd_fa_varlen_bwd
 from triton.language.extra.tlx.tutorials.amd_fa_bwd import (
     ReferenceCase,
     _D64DQLaunch,
@@ -348,3 +348,239 @@ def test_d64_causal_gqa8_codegen_is_scratch_free_gfx950(monkeypatch):
         for compiled in compiled_objects:
             _assert_scratch_free(kernel.fn.__name__, compiled)
             assert not re.search(r"\b\w*atomic\w*\b", compiled.asm["amdgcn"])
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_plan_owns_offsets_and_compact_schedules():
+    cu_q = torch.tensor([0, 17, 48, 88], dtype=torch.int32, device="cuda")
+    cu_kv = torch.tensor([0, 33, 162, 169], dtype=torch.int32, device="cuda")
+
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+    assert plan.batch == 3
+    assert plan.total_q == 88
+    assert plan.total_kv == 169
+    assert plan.max_q == 40
+    assert plan.q_block_sequence.tolist() == [0, 0, 1, 1, 2, 2, 2]
+    assert plan.q_block_start.tolist() == [0, 16, 0, 16, 0, 16, 32]
+    assert plan.kv_block_sequence.tolist() == [0, 1, 1, 2]
+    assert plan.kv_block_start.tolist() == [0, 0, 128, 0]
+
+    cu_q.fill_(0)
+    cu_kv.fill_(0)
+    assert plan.cu_seqlens_q.tolist() == [0, 17, 48, 88]
+    assert plan.cu_seqlens_k.tolist() == [0, 33, 162, 169]
+
+
+def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, heads, seed):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    total_q = sum(q_lengths)
+    total_kv = sum(kv_lengths)
+    scale = 128**-0.5
+    q = torch.randn((total_q, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    k = torch.randn((total_kv, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    v = torch.randn((total_kv, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    do = torch.randn((total_q, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    out = torch.empty_like(q)
+    lse = torch.empty((heads, total_q), dtype=torch.float32, device="cuda")
+    expected_dq = torch.empty_like(q)
+    expected_dk = torch.empty_like(k)
+    expected_dv = torch.empty_like(v)
+
+    q_begin = 0
+    kv_begin = 0
+    for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True):
+        q_end = q_begin + q_length
+        kv_end = kv_begin + kv_length
+        for head in range(heads):
+            q_tile = q[q_begin:q_end, head].float()
+            k_tile = k[kv_begin:kv_end, head].float()
+            v_tile = v[kv_begin:kv_end, head].float()
+            do_tile = do[q_begin:q_end, head].float()
+            scores = q_tile @ k_tile.mT * scale
+            lse_tile = torch.logsumexp(scores, dim=1)
+            p = torch.exp(scores - lse_tile[:, None])
+            out_tile = (p @ v_tile).to(torch.bfloat16)
+            delta = torch.sum(out_tile.float() * do_tile, dim=1)
+            dp = do_tile @ v_tile.mT
+            ds = (p * (dp - delta[:, None])).to(torch.bfloat16).float()
+            out[q_begin:q_end, head] = out_tile
+            lse[head, q_begin:q_end] = lse_tile
+            expected_dq[q_begin:q_end, head] = (ds @ k_tile * scale).to(torch.bfloat16)
+            expected_dk[kv_begin:kv_end, head] = (ds.mT @ q_tile * scale).to(torch.bfloat16)
+            expected_dv[kv_begin:kv_end, head] = (p.to(torch.bfloat16).float().mT @ do_tile).to(torch.bfloat16)
+        q_begin = q_end
+        kv_begin = kv_end
+
+    cu_q = torch.tensor([0, *torch.tensor(q_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
+    cu_kv = torch.tensor([0, *torch.tensor(kv_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
+    return q, k, v, out, do, lse, cu_q, cu_kv, scale, (expected_dq, expected_dk, expected_dv)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_interleaved_mixed_lengths_gfx950():
+    case = _make_varlen_d128_reference_case([7, 31, 65], [33, 257, 7], heads=2, seed=401)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+    actual = amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+
+    for name, result, reference in zip(("dq", "dk", "dv"), actual, expected, strict=True):
+        assert torch.isfinite(result).all(), name
+        relative_l2 = torch.linalg.vector_norm(result.float() - reference.float()) / torch.linalg.vector_norm(
+            reference.float())
+        assert relative_l2.item() < 1e-2, (name, relative_l2.item())
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_runtime_totals_reuse_specialization_gfx950():
+    kernels = (
+        amd_fa_varlen_bwd._varlen_bwd_interleaved_kernel,
+        amd_fa_varlen_bwd._varlen_dq_convert_kernel,
+    )
+    for kernel in kernels:
+        kernel.device_caches.clear()
+
+    for q_length in (17, 33):
+        case = _make_varlen_d128_reference_case([q_length], [128], heads=1, seed=419 + q_length)
+        q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+        plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+        amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+        torch.cuda.synchronize()
+
+    device = torch.cuda.current_device()
+    for kernel in kernels:
+        assert len(kernel.device_caches[device][0]) == 1, kernel.fn.__name__
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_plan_rejects_invalid_offsets():
+    valid = torch.tensor([0, 16, 48], dtype=torch.int32, device="cuda")
+    cases = (
+        (torch.tensor([1, 17, 49], dtype=torch.int32, device="cuda"), valid, "must start at zero"),
+        (torch.tensor([0, 16, 16], dtype=torch.int32, device="cuda"), valid, "must be strictly increasing"),
+        (valid, torch.tensor([0, 32], dtype=torch.int32, device="cuda"), "must describe the same batch"),
+    )
+    for cu_q, cu_kv, message in cases:
+        with pytest.raises(ValueError, match=message):
+            amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+
+def test_varlen_d128_address_space_requires_i32_offsets():
+    # One D128 BF16 head fits at most 2**30 elements in the signed i32
+    # byte-offset range used by AMD buffer instructions.
+    max_tokens = 2**23
+
+    amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+        total_q=max_tokens - 15,
+        total_kv=max_tokens,
+        batch=1,
+        heads=1,
+    )
+
+    with pytest.raises(ValueError, match="KV tensor size exceeds the signed 32-bit byte-offset range"):
+        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+            total_q=1,
+            total_kv=max_tokens + 1,
+            batch=1,
+            heads=1,
+        )
+    with pytest.raises(ValueError, match="padded dQ size exceeds the signed 32-bit byte-offset range"):
+        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+            total_q=max_tokens - 14,
+            total_kv=1,
+            batch=1,
+            heads=1,
+        )
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_backward_rejects_unsupported_signature():
+    case = _make_varlen_d128_reference_case([16], [128], heads=1, seed=407)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+    with pytest.raises(ValueError, match="q must be contiguous bfloat16 THD"):
+        amd_fa_varlen_bwd.fa_varlen_backward(q.float(), k, v, out, do, lse, plan, scale)
+    with pytest.raises(ValueError, match="head dimension 128"):
+        amd_fa_varlen_bwd.fa_varlen_backward(
+            q[..., :64],
+            k[..., :64],
+            v[..., :64],
+            out[..., :64],
+            do[..., :64],
+            lse,
+            plan,
+            scale,
+        )
+    with pytest.raises(ValueError, match="positive head count"):
+        amd_fa_varlen_bwd.fa_varlen_backward(
+            q[:, :0],
+            k[:, :0],
+            v[:, :0],
+            out[:, :0],
+            do[:, :0],
+            lse[:0],
+            plan,
+            scale,
+        )
+    with pytest.raises(ValueError, match="sm_scale must be finite"):
+        amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, float("nan"))
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_backward_rejects_gqa():
+    case = _make_varlen_d128_reference_case([16], [128], heads=2, seed=411)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+    gqa_k = k[:, :1].contiguous()
+    gqa_v = v[:, :1].contiguous()
+
+    with pytest.raises(ValueError, match="equal Q and KV head counts"):
+        amd_fa_varlen_bwd.fa_varlen_backward(q, gqa_k, gqa_v, out, do, lse, plan, scale)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_backward_rejects_noncontiguous_lse():
+    case = _make_varlen_d128_reference_case([16], [128], heads=2, seed=413)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+    lse_storage = torch.empty((2, 32), dtype=torch.float32, device="cuda")
+    strided_lse = lse_storage[:, ::2]
+    assert strided_lse.shape == lse.shape
+    assert not strided_lse.is_contiguous()
+
+    with pytest.raises(ValueError, match="lse must be contiguous FP32"):
+        amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, strided_lse, plan, scale)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
+    case = _make_varlen_d128_reference_case([16], [128], heads=1, seed=409)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+    kernels = (
+        amd_fa_varlen_bwd._varlen_bwd_preprocess,
+        amd_fa_varlen_bwd._varlen_bwd_interleaved_kernel,
+        amd_fa_varlen_bwd._varlen_dq_convert_kernel,
+    )
+    for kernel in kernels:
+        kernel.device_caches.clear()
+
+    amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+    torch.cuda.synchronize()
+
+    device = torch.cuda.current_device()
+    expected_shared = (256, 64_640, 0)
+    for kernel, shared in zip(kernels, expected_shared, strict=True):
+        compiled_objects = tuple(kernel.device_caches[device][0].values())
+        assert len(compiled_objects) == 1
+        compiled = compiled_objects[0]
+        _assert_scratch_free(kernel.fn.__name__, compiled)
+        assert compiled.metadata.num_warps == 4
+        assert compiled.metadata.shared == shared
+
+    interleaved = tuple(kernels[1].device_caches[device][0].values())[0]
+    assert "buffer_atomic_pk_add_bf16" in interleaved.asm["amdgcn"]

--- a/python/test/unit/language/test_tlx_amd_fa_bwd.py
+++ b/python/test/unit/language/test_tlx_amd_fa_bwd.py
@@ -363,7 +363,8 @@ def test_varlen_d128_plan_owns_offsets_and_compact_schedules():
     assert plan.max_q == 40
     assert plan.q_block_sequence.tolist() == [0, 0, 1, 1, 2, 2, 2]
     assert plan.q_block_start.tolist() == [0, 16, 0, 16, 0, 16, 32]
-    assert plan.kv_block_sequence.tolist() == [0, 1, 1, 2]
+    assert plan.num_full_kv_blocks == 1
+    assert plan.kv_block_sequence.tolist() == [1, 0, 1, 2]
     assert plan.kv_block_start.tolist() == [0, 0, 128, 0]
 
     cu_q.fill_(0)
@@ -418,9 +419,17 @@ def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, heads, seed):
     return q, k, v, out, do, lse, cu_q, cu_kv, scale, (expected_dq, expected_dk, expected_dv)
 
 
+@pytest.mark.parametrize(
+    ("q_lengths", "kv_lengths"),
+    (
+        pytest.param([7, 31, 65], [33, 257, 7], id="mixed-full-tail"),
+        pytest.param([1, 17], [1, 127], id="all-tail"),
+        pytest.param([16, 32], [128, 256], id="all-full"),
+    ),
+)
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_varlen_d128_interleaved_mixed_lengths_gfx950():
-    case = _make_varlen_d128_reference_case([7, 31, 65], [33, 257, 7], heads=2, seed=401)
+def test_varlen_d128_interleaved_mixed_lengths_gfx950(q_lengths, kv_lengths):
+    case = _make_varlen_d128_reference_case(q_lengths, kv_lengths, heads=2, seed=401)
     q, k, v, out, do, lse, cu_q, cu_kv, scale, expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
@@ -558,7 +567,7 @@ def test_varlen_d128_backward_rejects_noncontiguous_lse():
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
-    case = _make_varlen_d128_reference_case([16], [128], heads=1, seed=409)
+    case = _make_varlen_d128_reference_case([16], [129], heads=1, seed=409)
     q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
     kernels = (
@@ -574,13 +583,14 @@ def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
 
     device = torch.cuda.current_device()
     expected_shared = (256, 64_640, 0)
-    for kernel, shared in zip(kernels, expected_shared, strict=True):
+    expected_specializations = (1, 2, 1)
+    for kernel, shared, specialization_count in zip(kernels, expected_shared, expected_specializations, strict=True):
         compiled_objects = tuple(kernel.device_caches[device][0].values())
-        assert len(compiled_objects) == 1
-        compiled = compiled_objects[0]
-        _assert_scratch_free(kernel.fn.__name__, compiled)
-        assert compiled.metadata.num_warps == 4
-        assert compiled.metadata.shared == shared
+        assert len(compiled_objects) == specialization_count
+        for compiled in compiled_objects:
+            _assert_scratch_free(kernel.fn.__name__, compiled)
+            assert compiled.metadata.num_warps == 4
+            assert compiled.metadata.shared == shared
 
-    interleaved = tuple(kernels[1].device_caches[device][0].values())[0]
-    assert "buffer_atomic_pk_add_bf16" in interleaved.asm["amdgcn"]
+    for interleaved in kernels[1].device_caches[device][0].values():
+        assert "buffer_atomic_pk_add_bf16" in interleaved.asm["amdgcn"]

--- a/third_party/tlx/tutorials/README.md
+++ b/third_party/tlx/tutorials/README.md
@@ -1,4 +1,6 @@
-# Adaptive FlashAttention tutorial
+# AMD attention tutorials
+
+## Adaptive FlashAttention
 
 [`amd_fa_adaptive.py`](amd_fa_adaptive.py) implements adaptive and
 fixed-reference non-causal FlashAttention for BF16 tensors on gfx950.  Its
@@ -8,7 +10,7 @@ contracts, pipeline structure, and detailed variant guidance.
 The general TLX APIs used to express its register ownership and uniform votes
 are documented in the repository [root README](../../../README.md#other-operations).
 
-## API
+### API
 
 ```python
 from third_party.tlx.tutorials.amd_fa_adaptive import attention
@@ -27,3 +29,28 @@ adaptive reference tracking; the bounded specialization is not a performance
 shortcut unless measurements on the exact target prove otherwise.  Run
 `python third_party/tlx/tutorials/amd_fa_adaptive_bench.py --help` for the
 correctness/performance driver.
+
+## Packed variable-length FlashAttention backward
+
+[`amd_fa_varlen_bwd.py`](amd_fa_varlen_bwd.py) provides a gfx950 specialization
+for packed BF16 THD, non-causal MHA backward with head dimension 128.  Prepare a
+plan once for immutable cumulative sequence offsets, then reuse it for every
+backward invocation with the same packing:
+
+```python
+from triton.language.extra.tlx.tutorials.amd_fa_varlen_bwd import (
+    fa_varlen_backward,
+    prepare_varlen_backward,
+)
+
+plan = prepare_varlen_backward(cu_seqlens_q, cu_seqlens_k)
+dq, dk, dv = fa_varlen_backward(q, k, v, out, do, lse, plan, sm_scale)
+```
+
+Plan preparation validates and copies `cu_seqlens_q` and `cu_seqlens_k` to the
+host once to build compact BM16/BN128 schedules, then owns cloned device
+offsets.  The frozen plan prevents field rebinding, but its PyTorch tensors are
+still mutable; treat every plan-owned offset and schedule tensor as immutable
+after preparation.  Keep plan construction outside the timed or repeated
+execution path.  Every sequence must have at least one query and one key/value
+token.  `lse` is contiguous FP32 with shape `(heads, total_q)`.

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -48,6 +48,7 @@ class VarlenBackwardPlan:
     total_q: int
     total_kv: int
     max_q: int
+    num_full_kv_blocks: int
 
 
 def _copy_and_validate_cu_seqlens(name: str, value: torch.Tensor) -> tuple[torch.Tensor, list[int]]:
@@ -79,6 +80,27 @@ def _make_block_schedule(lengths: list[int], block: int, device: torch.device) -
     )
 
 
+def _make_partitioned_block_schedule(lengths: list[int], block: int,
+                                     device: torch.device) -> tuple[torch.Tensor, torch.Tensor, int]:
+    full_sequences: list[int] = []
+    full_starts: list[int] = []
+    tail_sequences: list[int] = []
+    tail_starts: list[int] = []
+    for sequence, length in enumerate(lengths):
+        full_end = length // block * block
+        for start in range(0, full_end, block):
+            full_sequences.append(sequence)
+            full_starts.append(start)
+        if full_end < length:
+            tail_sequences.append(sequence)
+            tail_starts.append(full_end)
+    return (
+        torch.tensor(full_sequences + tail_sequences, dtype=torch.int32, device=device),
+        torch.tensor(full_starts + tail_starts, dtype=torch.int32, device=device),
+        len(full_sequences),
+    )
+
+
 def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tensor) -> VarlenBackwardPlan:
     """Prepare reusable compact schedules for immutable packed offsets."""
     if cu_seqlens_q.device != cu_seqlens_k.device:
@@ -91,7 +113,8 @@ def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tens
     q_lengths = [end - begin for begin, end in zip(q_offsets, q_offsets[1:])]
     k_lengths = [end - begin for begin, end in zip(k_offsets, k_offsets[1:])]
     q_block_sequence, q_block_start = _make_block_schedule(q_lengths, _BLOCK_M, cu_seqlens_q.device)
-    kv_block_sequence, kv_block_start = _make_block_schedule(k_lengths, _BLOCK_N, cu_seqlens_q.device)
+    kv_block_sequence, kv_block_start, num_full_kv_blocks = _make_partitioned_block_schedule(
+        k_lengths, _BLOCK_N, cu_seqlens_q.device)
 
     return VarlenBackwardPlan(
         cu_seqlens_q=owned_q,
@@ -104,6 +127,7 @@ def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tens
         total_q=q_offsets[-1],
         total_kv=k_offsets[-1],
         max_q=max(q_lengths),
+        num_full_kv_blocks=num_full_kv_blocks,
     )
 
 
@@ -225,6 +249,7 @@ def _varlen_bwd_interleaved_kernel(
     DQ_ACC,
     DK,
     DV,
+    TASK_OFFSET,
     SM_SCALE: tl.constexpr,
     TOTAL_Q,
     TOTAL_Q_PADDED,
@@ -232,13 +257,14 @@ def _varlen_bwd_interleaved_kernel(
     D: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    FULL_KV_TILE: tl.constexpr,
 ):
     """Compute current dK/dV while consuming the preceding dS phase for dQ."""
     tl.static_assert(D == 128)
     tl.static_assert(BLOCK_M == 16)
     tl.static_assert(BLOCK_N == 128)
 
-    task = tl.program_id(0)
+    task = tl.program_id(0) + TASK_OFFSET
     head = tl.program_id(1)
     batch = tl.load(KVBlockSequence + task)
     n0 = tl.load(KVBlockStart + task)
@@ -299,8 +325,11 @@ def _varlen_bwd_interleaved_kernel(
     offs_d = tl.arange(0, D)
     global_n = kv_start + offs_n
     kv_offsets = (global_n[:, None] * HEADS + head) * D + offs_d[None, :]
-    kv_mask = offs_n[:, None] < kv_len
-    k_token = tlx.async_load(K + kv_offsets, tlx.local_view(k_buffer, 0), mask=kv_mask, other=0.0)
+    if FULL_KV_TILE:
+        k_token = tlx.async_load(K + kv_offsets, tlx.local_view(k_buffer, 0))
+    else:
+        kv_mask = offs_n[:, None] < kv_len
+        k_token = tlx.async_load(K + kv_offsets, tlx.local_view(k_buffer, 0), mask=kv_mask, other=0.0)
     tlx.async_load_commit_group([k_token])
     _issue_qdo_async(
         tlx.local_view(q_buffers, 0),
@@ -319,9 +348,12 @@ def _varlen_bwd_interleaved_kernel(
     tl.debug_barrier()
 
     v_offsets = tlx.require_layout(kv_offsets.to(tl.int32), k_nm_layout, pin=False)
-    v_valid = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), k_nm_layout, pin=False)
-    v_zero = tlx.zeros((BLOCK_N, D), tl.bfloat16, layout=k_nm_layout)
-    v_tile = tlx.buffer_load(V, v_offsets, mask=v_valid, other=v_zero)
+    if FULL_KV_TILE:
+        v_tile = tlx.buffer_load(V, v_offsets)
+    else:
+        v_valid = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), k_nm_layout, pin=False)
+        v_zero = tlx.zeros((BLOCK_N, D), tl.bfloat16, layout=k_nm_layout)
+        v_tile = tlx.buffer_load(V, v_offsets, mask=v_valid, other=v_zero)
     v_tile = tlx.require_layout(v_tile, k_nm_layout, pin=False)
     dk = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
     dv = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
@@ -373,7 +405,10 @@ def _varlen_bwd_interleaved_kernel(
             pin=False,
         )
         scores_t = scores_t * score_scale - lse_full
-        valid = (offs_n[:, None] < kv_len) & (rows[None, :] < q_len)
+        if FULL_KV_TILE:
+            valid = tl.broadcast_to(rows[None, :] < q_len, (BLOCK_N, BLOCK_M))
+        else:
+            valid = (offs_n[:, None] < kv_len) & (rows[None, :] < q_len)
         valid = tlx.require_layout(valid, mma_nm, pin=False)
         p_t = tlx.require_layout(tl.where(valid, tl.math.exp2(scores_t), 0.0), mma_nm, pin=False)
         dp_acc = tlx.zeros((BLOCK_N, BLOCK_M), tl.float32, layout=mma_nm)
@@ -431,9 +466,13 @@ def _varlen_bwd_interleaved_kernel(
     dk_scale = tlx.require_layout(tl.full((BLOCK_N, D), SM_SCALE, dtype=tl.float32), mma_nd, pin=False)
     dk *= dk_scale
     output_offsets = tlx.require_layout(kv_offsets.to(tl.int32), mma_nd, pin=False)
-    output_mask = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), mma_nd, pin=False)
-    tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets, mask=output_mask)
-    tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets, mask=output_mask)
+    if FULL_KV_TILE:
+        tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets)
+        tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets)
+    else:
+        output_mask = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), mma_nd, pin=False)
+        tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets, mask=output_mask)
+        tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets, mask=output_mask)
 
 
 @triton.jit
@@ -541,31 +580,40 @@ def fa_varlen_backward(q, k, v, o, do, lse, plan, sm_scale):
         BLOCK_M=64,
         num_warps=4,
     )
-    _varlen_bwd_interleaved_kernel[(plan.kv_block_sequence.numel(), heads)](
-        q,
-        k,
-        v,
-        do,
-        lse,
-        delta,
-        plan.cu_seqlens_q,
-        plan.cu_seqlens_k,
-        plan.kv_block_sequence,
-        plan.kv_block_start,
-        dq_acc,
-        dk,
-        dv,
-        SM_SCALE=sm_scale,
-        TOTAL_Q=total_q,
-        TOTAL_Q_PADDED=total_q_padded,
-        HEADS=heads,
-        D=head_dim,
-        BLOCK_M=_BLOCK_M,
-        BLOCK_N=_BLOCK_N,
-        num_warps=4,
-        num_stages=1,
-        matrix_instr_nonkdim=16,
+    kv_launches = (
+        (0, plan.num_full_kv_blocks, True),
+        (plan.num_full_kv_blocks, plan.kv_block_sequence.numel() - plan.num_full_kv_blocks, False),
     )
+    for task_offset, task_count, full_kv_tile in kv_launches:
+        if task_count == 0:
+            continue
+        _varlen_bwd_interleaved_kernel[(task_count, heads)](
+            q,
+            k,
+            v,
+            do,
+            lse,
+            delta,
+            plan.cu_seqlens_q,
+            plan.cu_seqlens_k,
+            plan.kv_block_sequence,
+            plan.kv_block_start,
+            dq_acc,
+            dk,
+            dv,
+            task_offset,
+            SM_SCALE=sm_scale,
+            TOTAL_Q=total_q,
+            TOTAL_Q_PADDED=total_q_padded,
+            HEADS=heads,
+            D=head_dim,
+            BLOCK_M=_BLOCK_M,
+            BLOCK_N=_BLOCK_N,
+            FULL_KV_TILE=full_kv_tile,
+            num_warps=4,
+            num_stages=1,
+            matrix_instr_nonkdim=16,
+        )
     _varlen_dq_convert_kernel[(plan.q_block_sequence.numel(), heads)](
         dq_acc,
         plan.cu_seqlens_q,

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -1,0 +1,582 @@
+"""Packed variable-length BF16 D128 attention backward for gfx950.
+
+Each workgroup owns one 128-row KV tile and walks the corresponding sequence
+in 16-row query phases.  The current phase accumulates dK/dV and publishes dS
+through LDS; the preceding dS phase is consumed for dQ.  Independent KV owners
+combine their dQ contributions with BF16 atomics in a guarded native layout,
+followed by a conversion to packed THD order.
+
+Call :func:`prepare_varlen_backward` once and reuse the resulting plan with
+:func:`fa_varlen_backward`.  Plan creation performs one device-to-host
+synchronization to construct compact schedules; execution itself does not copy
+offsets to the host.  Treat every plan-owned offset and schedule tensor as
+immutable after preparation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+_BLOCK_M = 16
+_BLOCK_N = 128
+_HEAD_DIM = 128
+_I32_BUFFER_BF16_ELEMENTS = 1 << 30
+
+
+@dataclass(frozen=True)
+class VarlenBackwardPlan:
+    """Reusable launch metadata whose tensor contents are caller-immutable.
+
+    ``frozen=True`` prevents field rebinding, but PyTorch tensors remain
+    mutable.  Do not modify any plan-owned offset or schedule tensor after
+    preparation.
+    """
+
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: torch.Tensor
+    q_block_sequence: torch.Tensor
+    q_block_start: torch.Tensor
+    kv_block_sequence: torch.Tensor
+    kv_block_start: torch.Tensor
+    batch: int
+    total_q: int
+    total_kv: int
+    max_q: int
+
+
+def _copy_and_validate_cu_seqlens(name: str, value: torch.Tensor) -> tuple[torch.Tensor, list[int]]:
+    if value.ndim != 1 or value.numel() < 2:
+        raise ValueError(f"{name} must be a rank-1 tensor with at least two elements")
+    if value.dtype is not torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32")
+    if value.device.type != "cuda":
+        raise ValueError(f"{name} must be on a CUDA device")
+    owned = value.detach().clone(memory_format=torch.contiguous_format)
+    offsets = owned.cpu().tolist()
+    if offsets[0] != 0:
+        raise ValueError(f"{name} must start at zero")
+    if any(end <= begin for begin, end in zip(offsets, offsets[1:])):
+        raise ValueError(f"{name} must be strictly increasing")
+    return owned, offsets
+
+
+def _make_block_schedule(lengths: list[int], block: int, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    sequences: list[int] = []
+    starts: list[int] = []
+    for sequence, length in enumerate(lengths):
+        for start in range(0, length, block):
+            sequences.append(sequence)
+            starts.append(start)
+    return (
+        torch.tensor(sequences, dtype=torch.int32, device=device),
+        torch.tensor(starts, dtype=torch.int32, device=device),
+    )
+
+
+def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tensor) -> VarlenBackwardPlan:
+    """Prepare reusable compact schedules for immutable packed offsets."""
+    if cu_seqlens_q.device != cu_seqlens_k.device:
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must be on the same device")
+    owned_q, q_offsets = _copy_and_validate_cu_seqlens("cu_seqlens_q", cu_seqlens_q)
+    owned_k, k_offsets = _copy_and_validate_cu_seqlens("cu_seqlens_k", cu_seqlens_k)
+    if len(q_offsets) != len(k_offsets):
+        raise ValueError("cu_seqlens_q and cu_seqlens_k must describe the same batch")
+
+    q_lengths = [end - begin for begin, end in zip(q_offsets, q_offsets[1:])]
+    k_lengths = [end - begin for begin, end in zip(k_offsets, k_offsets[1:])]
+    q_block_sequence, q_block_start = _make_block_schedule(q_lengths, _BLOCK_M, cu_seqlens_q.device)
+    kv_block_sequence, kv_block_start = _make_block_schedule(k_lengths, _BLOCK_N, cu_seqlens_q.device)
+
+    return VarlenBackwardPlan(
+        cu_seqlens_q=owned_q,
+        cu_seqlens_k=owned_k,
+        q_block_sequence=q_block_sequence,
+        q_block_start=q_block_start,
+        kv_block_sequence=kv_block_sequence,
+        kv_block_start=kv_block_start,
+        batch=len(q_lengths),
+        total_q=q_offsets[-1],
+        total_kv=k_offsets[-1],
+        max_q=max(q_lengths),
+    )
+
+
+def _validate_i32_buffer_offsets(*, total_q: int, total_kv: int, batch: int, heads: int) -> None:
+    if total_kv * heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
+        raise ValueError("KV tensor size exceeds the signed 32-bit byte-offset range")
+    total_q_padded = total_q + batch * (_BLOCK_M - 1)
+    if total_q_padded * heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
+        raise ValueError("padded dQ size exceeds the signed 32-bit byte-offset range")
+
+
+@triton.jit
+def _varlen_bwd_preprocess(
+    O,
+    DO,
+    Delta,
+    CuQ,
+    HEADS: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // HEADS
+    head = batch_head % HEADS
+    q_start = tl.load(CuQ + batch).to(tl.int64)
+    q_end = tl.load(CuQ + batch + 1).to(tl.int64)
+    q_len = q_end - q_start
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, D)
+    mask = offs_m[:, None] < q_len
+    token = q_start + offs_m
+    offsets = (token[:, None] * HEADS + head) * D + offs_d[None, :]
+    o = tl.load(O + offsets, mask=mask, other=0.0).to(tl.float32)
+    do = tl.load(DO + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(Delta + token * HEADS + head, tl.sum(o * do, axis=1), mask=offs_m < q_len)
+
+
+@triton.jit
+def _issue_qdo_async(
+    q_dst,
+    do_dst,
+    Q,
+    DO,
+    q_start,
+    q_len,
+    head,
+    step,
+    HEADS: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    rows = step * BLOCK_M + tl.arange(0, BLOCK_M)
+    dims = tl.arange(0, D)
+    global_rows = q_start + rows
+    offsets = (global_rows[:, None] * HEADS + head) * D + dims[None, :]
+    valid = rows[:, None] < q_len
+    q_token = tlx.async_load(Q + offsets, q_dst, mask=valid, other=0.0)
+    do_token = tlx.async_load(DO + offsets, do_dst, mask=valid, other=0.0)
+    tlx.async_load_commit_group([q_token, do_token])
+
+
+@triton.jit
+def _store_dq_native(
+    dq,
+    DQ_ACC,
+    dq_base,
+    q_len,
+    step,
+    SM_SCALE: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    MMA_MD: tl.constexpr,
+):
+    dq = tlx.require_layout(dq, MMA_MD, pin=False)
+    scale = tlx.require_layout(
+        tl.full((BLOCK_M, D), SM_SCALE, dtype=tl.float32),
+        MMA_MD,
+        pin=False,
+    )
+    dq *= scale
+    dq_row_remat_group: tl.constexpr = 40
+    dq_column_remat_group: tl.constexpr = 41
+    local_m = tlx.rematerialized_range(0, BLOCK_M, dq_row_remat_group, placement=step)
+    offs_d = tlx.rematerialized_range(0, D, dq_column_remat_group, placement=step)
+    valid = tl.broadcast_to((step * BLOCK_M + local_m < q_len)[:, None], (BLOCK_M, D))
+    valid = tlx.require_layout(valid, MMA_MD, pin=False)
+    d_swizzled = ((offs_d & 1)
+                  | ((offs_d & 2) << 6)
+                  | ((offs_d & 12) << 3)
+                  | ((offs_d & 48) << 5)
+                  | ((offs_d & 64) << 2))
+    tile_offset = step * BLOCK_M * D
+    offsets = dq_base + tile_offset + ((local_m[:, None] << 1) | d_swizzled[None, :])
+    offsets = tl.max_contiguous(offsets.to(tl.int32), [1, 2])
+    offsets = tlx.require_layout(offsets, MMA_MD, pin=False)
+    tlx.buffer_atomic_add(
+        DQ_ACC,
+        offsets,
+        dq.to(tl.bfloat16),
+        mask=valid,
+        sem="relaxed",
+        contiguity=2,
+    )
+
+
+@triton.jit
+def _varlen_bwd_interleaved_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    Delta,
+    CuQ,
+    CuKV,
+    KVBlockSequence,
+    KVBlockStart,
+    DQ_ACC,
+    DK,
+    DV,
+    SM_SCALE: tl.constexpr,
+    TOTAL_Q,
+    TOTAL_Q_PADDED,
+    HEADS: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Compute current dK/dV while consuming the preceding dS phase for dQ."""
+    tl.static_assert(D == 128)
+    tl.static_assert(BLOCK_M == 16)
+    tl.static_assert(BLOCK_N == 128)
+
+    task = tl.program_id(0)
+    head = tl.program_id(1)
+    batch = tl.load(KVBlockSequence + task)
+    n0 = tl.load(KVBlockStart + task)
+    q_start = tl.load(CuQ + batch).to(tl.int64)
+    q_end = tl.load(CuQ + batch + 1).to(tl.int64)
+    kv_start = tl.load(CuKV + batch).to(tl.int64)
+    kv_end = tl.load(CuKV + batch + 1).to(tl.int64)
+    q_len = (q_end - q_start).to(tl.int32)
+    kv_len = (kv_end - kv_start).to(tl.int32)
+
+    qdo_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 32)],
+        [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [8, 0], [1, 0], [2, 0], [4, 0]],
+        [BLOCK_M, D],
+    )
+    k_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 32)],
+        [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64], [16, 0], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0],
+         [8, 0]],
+        [BLOCK_N, D],
+    )
+    ds_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 16)],
+        [[1, 0], [2, 0], [0, 1], [0, 2], [4, 0], [0, 8], [8, 0], [0, 32], [0, 16], [0, 4], [0, 64]],
+        [BLOCK_M, BLOCK_N],
+    )
+    mma_md: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    mma_nm: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[4, 1],
+    )
+    mma_nd: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[2, 2],
+    )
+    k_nm_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_nm, k_width=8)
+    qt_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_nm, k_width=8)
+    p_nd_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_nd, k_width=8)
+    q_nd_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_nd, k_width=8)
+    ds_md_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_md, k_width=8)
+    k_md_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_md, k_width=8)
+
+    k_buffer = tlx.local_alloc((BLOCK_N, D), tl.bfloat16, 1, layout=k_layout)
+    q_buffers = tlx.local_alloc((BLOCK_M, D), tl.bfloat16, 2, layout=qdo_layout)
+    do_buffers = tlx.local_alloc((BLOCK_M, D), tl.bfloat16, 2, layout=qdo_layout)
+    ds_buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.bfloat16, 2, layout=ds_layout)
+
+    offs_n = n0 + tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, D)
+    global_n = kv_start + offs_n
+    kv_offsets = (global_n[:, None] * HEADS + head) * D + offs_d[None, :]
+    kv_mask = offs_n[:, None] < kv_len
+    k_token = tlx.async_load(K + kv_offsets, tlx.local_view(k_buffer, 0), mask=kv_mask, other=0.0)
+    tlx.async_load_commit_group([k_token])
+    _issue_qdo_async(
+        tlx.local_view(q_buffers, 0),
+        tlx.local_view(do_buffers, 0),
+        Q,
+        DO,
+        q_start,
+        q_len,
+        head,
+        0,
+        HEADS,
+        D,
+        BLOCK_M,
+    )
+    initial_wait = tlx.async_load_wait_group(0)
+    tl.debug_barrier()
+
+    v_offsets = tlx.require_layout(kv_offsets.to(tl.int32), k_nm_layout, pin=False)
+    v_valid = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), k_nm_layout, pin=False)
+    v_zero = tlx.zeros((BLOCK_N, D), tl.bfloat16, layout=k_nm_layout)
+    v_tile = tlx.buffer_load(V, v_offsets, mask=v_valid, other=v_zero)
+    v_tile = tlx.require_layout(v_tile, k_nm_layout, pin=False)
+    dk = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
+    dv = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
+    q_blocks = (q_len + BLOCK_M - 1) // BLOCK_M
+    q_scratch_start = q_start + batch.to(tl.int64) * (BLOCK_M - 1)
+    dq_acc_base = ((head.to(tl.int64) * TOTAL_Q_PADDED + q_scratch_start) * D).to(tl.int32)
+    log2e: tl.constexpr = 1.4426950408889634
+
+    for step in tl.range(0, q_blocks, num_stages=1):
+        current_slot = step % 2
+        next_slot = 1 - current_slot
+        _issue_qdo_async(
+            tlx.local_view(q_buffers, next_slot),
+            tlx.local_view(do_buffers, next_slot),
+            Q,
+            DO,
+            q_start,
+            q_len,
+            head,
+            step + 1,
+            HEADS,
+            D,
+            BLOCK_M,
+        )
+        tlx.async_load_wait_group(1)
+        tl.debug_barrier()
+
+        q_view = tlx.local_view(q_buffers, current_slot)
+        do_view = tlx.local_view(do_buffers, current_slot)
+        q_tile = tlx.local_load(q_view, layout=q_nd_layout)
+        q_t = tlx.local_load(tlx.local_trans(q_view), layout=qt_layout)
+        do_tile = tlx.local_load(do_view, layout=q_nd_layout)
+        do_t = tlx.local_load(tlx.local_trans(do_view), layout=qt_layout)
+        k_tile = tlx.local_load(tlx.local_view(k_buffer, 0), token=initial_wait, layout=k_nm_layout)
+        score_acc = tlx.zeros((BLOCK_N, BLOCK_M), tl.float32, layout=mma_nm)
+        scores_t = tl.dot(k_tile, q_t, acc=score_acc, out_dtype=score_acc.dtype)
+        rows = step * BLOCK_M + tl.arange(0, BLOCK_M)
+        global_m = q_start + rows
+        lse = tl.load(LSE + head * TOTAL_Q + global_m, mask=rows < q_len, other=0.0)
+        delta = tl.load(Delta + global_m * HEADS + head, mask=rows < q_len, other=0.0)
+        score_scale = tlx.require_layout(
+            tl.full((BLOCK_N, BLOCK_M), SM_SCALE * log2e, tl.float32),
+            mma_nm,
+            pin=False,
+        )
+        lse_full = tlx.require_layout(
+            tl.broadcast_to((lse * log2e)[None, :], (BLOCK_N, BLOCK_M)),
+            mma_nm,
+            pin=False,
+        )
+        scores_t = scores_t * score_scale - lse_full
+        valid = (offs_n[:, None] < kv_len) & (rows[None, :] < q_len)
+        valid = tlx.require_layout(valid, mma_nm, pin=False)
+        p_t = tlx.require_layout(tl.where(valid, tl.math.exp2(scores_t), 0.0), mma_nm, pin=False)
+        dp_acc = tlx.zeros((BLOCK_N, BLOCK_M), tl.float32, layout=mma_nm)
+        dp_t = tl.dot(v_tile, do_t, acc=dp_acc, out_dtype=dp_acc.dtype)
+        delta_full = tlx.require_layout(
+            tl.broadcast_to(delta[None, :], (BLOCK_N, BLOCK_M)),
+            mma_nm,
+            pin=False,
+        )
+        ds_t = p_t * (dp_t - delta_full)
+        ds_bf16 = ds_t.to(tl.bfloat16)
+        current_ds = tlx.local_view(ds_buffers, current_slot)
+        tlx.local_store(current_ds, tl.trans(ds_bf16))
+        p_nd = tlx.require_layout(p_t.to(tl.bfloat16), p_nd_layout, pin=False)
+        ds_nd = tlx.require_layout(ds_bf16, p_nd_layout, pin=False)
+        dv = tl.dot(p_nd, do_tile, acc=dv, out_dtype=dv.dtype)
+        dk = tl.dot(ds_nd, q_tile, acc=dk, out_dtype=dk.dtype)
+
+        if step > 0:
+            previous_ds = tlx.local_load(tlx.local_view(ds_buffers, 1 - current_slot), layout=ds_md_layout)
+            k_for_dq = tlx.local_load(tlx.local_view(k_buffer, 0), token=initial_wait, layout=k_md_layout)
+            dq_acc = tlx.zeros((BLOCK_M, D), tl.float32, layout=mma_md)
+            dq_part = tl.dot(previous_ds, k_for_dq, acc=dq_acc, out_dtype=dq_acc.dtype)
+            _store_dq_native(
+                dq_part,
+                DQ_ACC,
+                dq_acc_base,
+                q_len,
+                step - 1,
+                SM_SCALE,
+                D,
+                BLOCK_M,
+                mma_md,
+            )
+        tl.debug_barrier()
+
+    tlx.async_load_wait_group(0)
+    tl.debug_barrier()
+    last_ds = tlx.local_load(tlx.local_view(ds_buffers, (q_blocks - 1) % 2), layout=ds_md_layout)
+    k_for_dq = tlx.local_load(tlx.local_view(k_buffer, 0), layout=k_md_layout)
+    dq_acc = tlx.zeros((BLOCK_M, D), tl.float32, layout=mma_md)
+    dq_part = tl.dot(last_ds, k_for_dq, acc=dq_acc, out_dtype=dq_acc.dtype)
+    _store_dq_native(
+        dq_part,
+        DQ_ACC,
+        dq_acc_base,
+        q_len,
+        q_blocks - 1,
+        SM_SCALE,
+        D,
+        BLOCK_M,
+        mma_md,
+    )
+
+    dk_scale = tlx.require_layout(tl.full((BLOCK_N, D), SM_SCALE, dtype=tl.float32), mma_nd, pin=False)
+    dk *= dk_scale
+    output_offsets = tlx.require_layout(kv_offsets.to(tl.int32), mma_nd, pin=False)
+    output_mask = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), mma_nd, pin=False)
+    tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets, mask=output_mask)
+    tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets, mask=output_mask)
+
+
+@triton.jit
+def _varlen_dq_convert_kernel(
+    DQ_ACC,
+    CuQ,
+    QBlockSequence,
+    QBlockStart,
+    DQ,
+    TOTAL_Q_PADDED,
+    HEADS: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    task = tl.program_id(0)
+    head = tl.program_id(1)
+    batch = tl.load(QBlockSequence + task)
+    start_m = tl.load(QBlockStart + task)
+    q_start = tl.load(CuQ + batch).to(tl.int64)
+    q_end = tl.load(CuQ + batch + 1).to(tl.int64)
+    q_len = (q_end - q_start).to(tl.int32)
+
+    local_m = tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, D)
+    d_swizzled = ((offs_d & 1)
+                  | ((offs_d & 2) << 6)
+                  | ((offs_d & 12) << 3)
+                  | ((offs_d & 48) << 5)
+                  | ((offs_d & 64) << 2))
+    native_offsets = ((local_m[:, None] << 1) | d_swizzled[None, :]).to(tl.int32)
+    native_offsets = tl.max_contiguous(native_offsets, [1, 2])
+    valid = tl.broadcast_to((start_m + local_m < q_len)[:, None], (BLOCK_M, D))
+    q_scratch_start = q_start + batch.to(tl.int64) * (BLOCK_M - 1)
+    native_base = (head.to(tl.int64) * TOTAL_Q_PADDED + q_scratch_start + start_m) * D
+    values = tl.load(DQ_ACC + native_base + native_offsets, mask=valid, other=0.0)
+
+    global_m = q_start + start_m + local_m
+    output_offsets = (global_m[:, None] * HEADS + head) * D + offs_d[None, :]
+    tl.store(DQ + output_offsets, values, mask=valid)
+
+
+def _validate_backward_inputs(q, k, v, o, do, lse, plan, sm_scale):
+    if not isinstance(plan, VarlenBackwardPlan):
+        raise TypeError("plan must be a VarlenBackwardPlan")
+    if not math.isfinite(float(sm_scale)):
+        raise ValueError("sm_scale must be finite")
+    if q.ndim != 3 or k.ndim != 3:
+        raise ValueError("q and k must be rank-3 packed THD tensors")
+    total_q, heads, head_dim = q.shape
+    total_kv, kv_heads, kv_dim = k.shape
+    if (total_q, total_kv) != (plan.total_q, plan.total_kv):
+        raise ValueError("q and k token counts must match the prepared plan")
+    if heads != kv_heads:
+        raise ValueError("packed D128 backward currently requires equal Q and KV head counts")
+    if heads == 0:
+        raise ValueError("packed backward requires a positive head count")
+    if head_dim != 128 or kv_dim != 128:
+        raise ValueError("packed backward currently requires head dimension 128")
+    _validate_i32_buffer_offsets(
+        total_q=total_q,
+        total_kv=total_kv,
+        batch=plan.batch,
+        heads=heads,
+    )
+    q_tensors = {"q": q, "o": o, "do": do}
+    for name, tensor in q_tensors.items():
+        if tensor.shape != q.shape or tensor.device != q.device:
+            raise ValueError(f"{name} must match q shape and device")
+        if tensor.dtype is not torch.bfloat16 or not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous bfloat16 THD")
+    for name, tensor in {"k": k, "v": v}.items():
+        if tensor.shape != k.shape or tensor.device != q.device:
+            raise ValueError(f"{name} must match k shape and q device")
+        if tensor.dtype is not torch.bfloat16 or not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous bfloat16 THD")
+    if plan.cu_seqlens_q.device != q.device or plan.cu_seqlens_k.device != q.device:
+        raise ValueError("the prepared plan and inputs must be on the same device")
+    if lse.shape != (heads, total_q) or lse.device != q.device or lse.dtype is not torch.float32:
+        raise ValueError("lse must be contiguous FP32 with shape (heads, total_q)")
+    if not lse.is_contiguous():
+        raise ValueError("lse must be contiguous FP32 with shape (heads, total_q)")
+    arch = torch.cuda.get_device_properties(q.device).gcnArchName
+    if not arch.startswith("gfx950"):
+        raise ValueError(f"gfx950 is required, got {arch}")
+
+
+def fa_varlen_backward(q, k, v, o, do, lse, plan, sm_scale):
+    """Run packed BF16 D128 non-causal MHA backward using a prepared plan."""
+    _validate_backward_inputs(q, k, v, o, do, lse, plan, sm_scale)
+    total_q, heads, head_dim = q.shape
+    total_q_padded = total_q + plan.batch * (_BLOCK_M - 1)
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(v)
+    delta = torch.empty((total_q, heads), dtype=torch.float32, device=q.device)
+    dq_acc = torch.zeros((heads, total_q_padded, head_dim), dtype=torch.bfloat16, device=q.device)
+
+    _varlen_bwd_preprocess[(triton.cdiv(plan.max_q, 64), plan.batch * heads)](
+        o,
+        do,
+        delta,
+        plan.cu_seqlens_q,
+        HEADS=heads,
+        D=head_dim,
+        BLOCK_M=64,
+        num_warps=4,
+    )
+    _varlen_bwd_interleaved_kernel[(plan.kv_block_sequence.numel(), heads)](
+        q,
+        k,
+        v,
+        do,
+        lse,
+        delta,
+        plan.cu_seqlens_q,
+        plan.cu_seqlens_k,
+        plan.kv_block_sequence,
+        plan.kv_block_start,
+        dq_acc,
+        dk,
+        dv,
+        SM_SCALE=sm_scale,
+        TOTAL_Q=total_q,
+        TOTAL_Q_PADDED=total_q_padded,
+        HEADS=heads,
+        D=head_dim,
+        BLOCK_M=_BLOCK_M,
+        BLOCK_N=_BLOCK_N,
+        num_warps=4,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+    )
+    _varlen_dq_convert_kernel[(plan.q_block_sequence.numel(), heads)](
+        dq_acc,
+        plan.cu_seqlens_q,
+        plan.q_block_sequence,
+        plan.q_block_start,
+        dq,
+        TOTAL_Q_PADDED=total_q_padded,
+        HEADS=heads,
+        D=head_dim,
+        BLOCK_M=_BLOCK_M,
+        num_warps=4,
+        matrix_instr_nonkdim=16,
+    )
+    return dq, dk, dv


### PR DESCRIPTION
## Summary

This PR adds a gfx950 specialization for packed BF16 THD, non-causal MHA backward with head dimension 128. It extends the KV-owner interleaving from #2709 to variable sequence lengths using compact per-sequence schedules and public Triton/TLX operations only.

The caller prepares a reusable plan from cumulative Q/KV offsets. Plan construction validates and owns the offsets, performs one host synchronization, and builds compact BM16/BN128 launch metadata outside the repeated execution path. The KV schedule is partitioned into full BN128 tiles and partial tails so full tiles use a mask-free specialization while tails retain boundary masking.

## Implementation

- Each workgroup owns one `(sequence, head, BN128 KV tile)` and walks the sequence in BM16 query phases.
- The current phase accumulates dK/dV and publishes dS through LDS while the preceding phase consumes dS for dQ.
- Full KV tiles omit K/V, probability, and dK/dV boundary masks; partial tail tiles use the masked specialization.
- Independent KV owners accumulate dQ with native-layout packed BF16 atomics. Guard rows isolate partial query tiles, and a final kernel converts the native image to packed THD order.
- Launcher validation restricts the path to contiguous BF16 MHA tensors, contiguous FP32 `(heads, total_q)` LSE, nonempty sequences, D128, gfx950, and the signed-i32 byte range required by AMD buffer operations.

Both core specializations use four warps and 64,640 bytes of LDS with no spills or scratch. No compiler changes, inline assembly, thread-ID access, custom LLVM attributes, or scheduled-MFMA operations are introduced.

## Performance on MI350X

BF16, 15 warmups and 100 HIP-event samples per provider. TLX time includes output and workspace allocation, preprocessing, attention kernels, dQ scratch initialization, and native-to-packed conversion; plan construction is excluded. Speedup is reference latency divided by TLX latency.

| Config `(total_q,total_kv,max_q,max_kv)` | TLX ms / TFLOP/s | AITER ASM v3 ms / speedup | CK ms / speedup |
| --- | ---: | ---: | ---: |
| `(62780,946279,300,3200)` | 1.813 / 219.71 | 2.011 / **1.1093x** | 2.981 / **1.6448x** |
| `(80900,940737,300,3200)` | 2.016 / 252.63 | 2.194 / **1.0880x** | 3.219 / **1.5966x** |
| `(88660,944840,300,3200)` | 2.178 / 257.28 | 2.336 / **1.0726x** | 3.411 / **1.5660x** |
| `(101900,946104,300,3200)` | 2.367 / 272.29 | 2.493 / **1.0535x** | 3.604 / **1.5229x** |
| `(84880,945242,400,3200)` | 2.043 / 263.24 | 2.298 / **1.1247x** | 3.264 / **1.5977x** |
| **Geometric-mean speedup** | | **1.0893x** | **1.5851x** |

The minimum dQ SNR versus CK was 46.46 dB.

## Testing

```text
PYTHONPATH=python TRITON_BACKENDS_IN_TREE=1 \
  python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_amd_fa_bwd.py
# 34 passed

pre-commit run --files \
  third_party/tlx/tutorials/amd_fa_varlen_bwd.py \
  python/test/unit/language/test_tlx_amd_fa_bwd.py \
  third_party/tlx/tutorials/README.md
```

Coverage includes schedule ownership and full/tail partitioning, invalid offsets and signatures, GQA and non-contiguous-LSE rejection, the signed-i32 byte boundary, mixed/all-tail/all-full packed boundaries, multiple KV owners contributing to dQ, end-to-end gradients, cache reuse across runtime token counts, the packed BF16 atomic opcode, and scratch/LDS resources for both core specializations.

## Limitations

- No causal attention, GQA, empty sequences, other dtypes, head dimensions, or architectures.
- Plan construction synchronizes once to copy offsets to the host and should be reused for calls with the same packing.
- BF16 dQ atomic accumulation is nondeterministic and uses an internal padded scratch tensor.
