### PR TITLE
[triton][beta] Unify Triton and TLX cluster predicates (#3313)

### DIFF
--- a/docs/design/2cta-autoWS-sync.md
+++ b/docs/design/2cta-autoWS-sync.md
@@ -725,11 +725,26 @@ In WS mode, worker warps sit in a switch loop and never execute main code.
 If the main code contains `barrier.cluster.arrive/wait`, worker warps must
 still participate or the cluster barrier deadlocks.
 
-`ConvertWarpSpecializeToLLVM.cpp` emits a predicated
-`@!isDefault barrier.cluster.arrive.aligned` at kernel entry for worker warps.
-This is gated on `tlxIsClustered(func) || getModuleTwoCTAs(func)` — covering
-both TLX and autoWS 2-CTA kernels. The arrive-once pattern assumes the main
-code has at most one cluster barrier per kernel invocation.
+Rather than have each pass rediscover whether a kernel needs that entry sync,
+the pass that inserts it stamps a marker and the others read it:
+
+1. `maybeInsertClusterSync` (`TritonGPUToLLVM.cpp`) decides. It runs only for a
+   physical cluster (`triton::gpu::isPhysicalCluster`) that contains a remote
+   barrier or a multicast arrive, inserts the kernel-entry cluster sync, and
+   records `tlx.cluster_sync_kernel_init` on the module.
+2. `ConvertWarpSpecializeToLLVM.cpp` reads that marker and emits a predicated
+   `@!isDefault barrier.cluster.arrive.relaxed.aligned` in the entry header, so
+   the worker warps join the barrier the default warps are waiting on.
+3. `ClusterOpsToLLVM.cpp` (`lowerClusterSyncForAllWarps`) reads the same marker
+   and skips its all-warps wrapping for that sync. Wrapping it there as well
+   would add a second worker arrive, imbalancing the barrier.
+
+The arrive-once pattern assumes the main code has at most one cluster barrier
+per kernel invocation.
+
+Note this path is physical-cluster only: a logical `num_ctas > 1` kernel never
+reaches step 1, so its cross-CTA barrier initialization is handled entirely by
+`runCrossCTAMBarrierInitSyncInsertion`.
 
 ### Bugs Fixed for Auto-WS + 2-CTA
 

--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -78,6 +78,24 @@ int lookupThreadsPerWarp(OpBuilder &rewriter);
 int lookupNumCTAs(OpBuilder &rewriter);
 int lookupNumCTAs(Operation *op);
 
+// A cluster is requested either logically, through `num_ctas` (tensors are
+// distributed across the CTAs and one program spans them all), or physically,
+// through `ctas_per_cga` (each CTA is its own program and only explicit ops
+// cross between them). The two are mutually exclusive; `CUDAOptions` rejects
+// setting both.
+
+// True when the kernel runs on a physical `ctas_per_cga` cluster, i.e. the
+// `ttg.cluster-dim-*` product exceeds one. Note this asks which *model* is in
+// use; for the CTA count under either model, use `lookupPhysicalNumCTAs`.
+bool isPhysicalCluster(ModuleOp mod);
+bool isPhysicalCluster(Operation *op);
+
+// The number of CTAs actually in a cluster, whichever model requested it.
+// Equals `lookupNumCTAs` unless the kernel uses `ctas_per_cga`. `op` may be the
+// module itself.
+int lookupPhysicalNumCTAs(Operation *op);
+int lookupPhysicalNumCTAs(OpBuilder &rewriter);
+
 // Record/query whether the module contains exactly one `ttg.warp_specialize`
 // op via the `ttg.single-warp-specialize` module attribute. `hasSingle...`
 // returns false when the attribute is absent.

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/Dialect.h
@@ -81,6 +81,9 @@ unsigned getPackedArithFp4Axis(PackedArithOp op);
 constexpr static char AttrTwoCTAsName[] = "ttng.two-ctas";
 constexpr static char AttrTwoCTALoadName[] = "two_cta_load";
 
+/// Whether the kernel issues paired-CTA (`cta_group::2`) MMA. This is not the
+/// same question as whether it runs on a cluster, which is
+/// `triton::gpu::isPhysicalCluster`.
 inline bool getModuleTwoCTAs(ModuleOp mod) {
   auto attr = mod->getAttrOfType<BoolAttr>(AttrTwoCTAsName);
   return attr ? attr.getValue() : false;
@@ -88,21 +91,6 @@ inline bool getModuleTwoCTAs(ModuleOp mod) {
 
 inline bool getModuleTwoCTAs(Operation *op) {
   return getModuleTwoCTAs(op->getParentOfType<ModuleOp>());
-}
-
-/// Check if any cluster dimension >= 2 (2-CTA mode).
-inline bool is2CTA(ModuleOp mod) {
-  for (auto name :
-       {"ttg.cluster-dim-x", "ttg.cluster-dim-y", "ttg.cluster-dim-z"}) {
-    if (auto attr = mod->getAttrOfType<IntegerAttr>(name))
-      if (attr.getInt() >= 2)
-        return true;
-  }
-  return false;
-}
-
-inline bool is2CTA(Operation *op) {
-  return is2CTA(op->getParentOfType<ModuleOp>());
 }
 
 // Returns the required ordering of repeated TMEM scale blocks for one

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4495,6 +4495,34 @@ int triton::gpu::lookupNumCTAs(OpBuilder &rewriter) {
   return triton::gpu::TritonGPUDialect::getNumCTAs(cast<ModuleOp>(op));
 }
 
+bool triton::gpu::isPhysicalCluster(ModuleOp mod) {
+  auto dims = TritonGPUDialect::getClusterDims(mod);
+  return dims[0] * dims[1] * dims[2] > 1;
+}
+
+bool triton::gpu::isPhysicalCluster(Operation *op) {
+  auto mod = dyn_cast<ModuleOp>(op);
+  if (!mod)
+    mod = op->getParentOfType<ModuleOp>();
+  return mod && isPhysicalCluster(mod);
+}
+
+int triton::gpu::lookupPhysicalNumCTAs(Operation *op) {
+  auto mod = dyn_cast<ModuleOp>(op);
+  if (!mod)
+    mod = op->getParentOfType<ModuleOp>();
+  if (!mod)
+    return lookupNumCTAs(op);
+  auto dims = TritonGPUDialect::getClusterDims(mod);
+  int physicalNumCTAs = dims[0] * dims[1] * dims[2];
+  return physicalNumCTAs > 1 ? physicalNumCTAs : lookupNumCTAs(op);
+}
+
+int triton::gpu::lookupPhysicalNumCTAs(OpBuilder &rewriter) {
+  assert(rewriter.getInsertionBlock() && "expected an insertion point");
+  return lookupPhysicalNumCTAs(rewriter.getInsertionBlock()->getParentOp());
+}
+
 bool triton::gpu::areLayoutsEquivalent(ArrayRef<int64_t> shape,
                                        LayoutEncodingTrait lhs,
                                        LayoutEncodingTrait rhs) {

--- a/python/test/unit/language/test_tlx_cluster.py
+++ b/python/test/unit/language/test_tlx_cluster.py
@@ -55,6 +55,41 @@ def test_cluster_dims(device):
 
 
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper/Blackwell for clusters")
+def test_ctas_per_cga_regroups_grid_without_multiplying(device):
+    """`ctas_per_cga` groups CTAs the grid already has; `num_ctas` spawns more.
+
+    A grid of GRID with a 2-CTA physical cluster must still launch GRID thread
+    blocks -- GRID // 2 clusters -- where the same grid with `num_ctas=2`
+    launches 2 * GRID. Normalizing `ctas_per_cga` to `num_ctas == 1` is what
+    keeps the launcher's `gridX * num_ctas` from multiplying the request, so
+    this pins the launch geometry rather than only the recorded metadata.
+    """
+
+    @triton.jit
+    def count_kernel(counter_ptr):
+        tl.atomic_add(counter_ptr, 1)
+
+    GRID = 1000
+
+    counter = torch.zeros(1, dtype=torch.int32, device=device)
+    physical = count_kernel[(GRID, )](counter, ctas_per_cga=(2, 1, 1))
+    torch.cuda.synchronize()
+    assert counter.item() == GRID, "ctas_per_cga must regroup the grid, not multiply it"
+    assert physical.metadata.num_ctas == 1
+    assert tuple(physical.metadata.cluster_dims) == (2, 1, 1)
+
+    # The contrasting model is asserted through metadata only. Under `num_ctas`
+    # the cluster's CTAs cooperate on a single program, so a scalar atomic runs
+    # once per program rather than once per thread block: the counter reads GRID
+    # under both models and cannot see the extra CTAs. It is a valid probe above
+    # precisely because `ctas_per_cga` pins `num_ctas == 1`, which makes programs
+    # and thread blocks coincide.
+    logical = count_kernel[(GRID, )](counter, num_ctas=2)
+    assert logical.metadata.num_ctas == 2
+    assert tuple(logical.metadata.cluster_dims) == (1, 1, 1)
+
+
+@pytest.mark.skipif(not is_hopper_or_newer(), reason="Need Hopper/Blackwell for clusters")
 def test_cluster_size_1d(device):
 
     @triton.jit

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -260,16 +260,27 @@ class CUDAOptions:
         _check_reg_auto_ws_alignment("minRegAutoWS", self.minRegAutoWS)
         _check_reg_auto_ws_alignment("maxRegAutoWS", self.maxRegAutoWS)
 
-        # If ctas_per_cga is set, it overrides cluster_dims with CUDA semantics:
-        # ctas_per_cga defines the cluster shape for regrouping grid CTAs.
-        # num_ctas must be 1 when using ctas_per_cga since it's incompatible with
-        # the multiplicative semantics of num_ctas.
-        if self.ctas_per_cga is not None:
-            # Ensure cluster_dims is all 1s to prevent conflicting cluster specifications.
-            assert (self.cluster_dims == (1, 1, 1) or self.cluster_dims == self.ctas_per_cga), (
-                f"When using ctas_per_cga, cluster_dims must be default (1,1,1) or match ctas_per_cga to avoid conflicting "
-                f"cluster specifications. Got cluster_dims={self.cluster_dims}")
+        # num_ctas and ctas_per_cga are alternative cluster models, not two dials
+        # on one. Under num_ctas the CTAs share a program and its tensors are
+        # distributed across them; under ctas_per_cga each CTA is its own program
+        # and only explicit ops cross between them. The compiler decides which
+        # model a kernel uses by inspecting these, so requesting a cluster more
+        # than one way has no well-defined answer. cluster_dims is the
+        # module-level spelling of the ctas_per_cga shape, so those two may
+        # coexist only when they agree.
+        cluster_shape = self.ctas_per_cga if self.ctas_per_cga is not None else self.cluster_dims
+        mirrors_agree = self.ctas_per_cga is None or self.cluster_dims in ((1, 1, 1), self.ctas_per_cga)
+        if not mirrors_agree or (self.num_ctas > 1 and cluster_shape != (1, 1, 1)):
+            raise ValueError(
+                "a cluster must be requested exactly one way: either num_ctas, or ctas_per_cga "
+                f"(optionally mirrored in cluster_dims). Got num_ctas={self.num_ctas}, "
+                f"ctas_per_cga={self.ctas_per_cga}, cluster_dims={self.cluster_dims}")
 
+        # ctas_per_cga regroups grid CTAs rather than spawning them, so it is
+        # incompatible with the multiplicative semantics of num_ctas. Mirror it
+        # into cluster_dims, which is what reaches the module as
+        # ttg.cluster-dim-*.
+        if self.ctas_per_cga is not None:
             object.__setattr__(self, "cluster_dims", self.ctas_per_cga)
             object.__setattr__(self, "num_ctas", 1)
 

--- a/third_party/nvidia/hopper/lib/Transforms/Analyze2CTADependencies.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Analyze2CTADependencies.cpp
@@ -91,7 +91,7 @@ public:
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    if (!ttng::is2CTA(module) || module->hasAttr("tlx.has_tlx_ops"))
+    if (!ttg::isPhysicalCluster(module) || module->hasAttr("tlx.has_tlx_ops"))
       return;
 
     module.walk([&](ttng::TCGen5MMAOp mma) {

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -176,7 +176,7 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    if (!ttng::is2CTA(moduleOp))
+    if (!ttg::isPhysicalCluster(moduleOp))
       return;
 
     // Skip TLX kernels — they manage their own cross-CTA sync via

--- a/third_party/nvidia/hopper/lib/Transforms/Plan2CTAExchange.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Plan2CTAExchange.cpp
@@ -140,7 +140,7 @@ public:
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    if (!ttng::is2CTA(module) || module->hasAttr("tlx.has_tlx_ops"))
+    if (!ttg::isPhysicalCluster(module) || module->hasAttr("tlx.has_tlx_ops"))
       return;
 
     WalkResult result = module.walk([&](ttng::TCGen5MMAOp mma) {

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -182,7 +182,7 @@ struct Transform2CTALoads
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
 
-    if (!ttng::is2CTA(moduleOp))
+    if (!ttg::isPhysicalCluster(moduleOp))
       return;
 
     // TLX kernels manage their own 2-CTA load splitting and synchronization.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -68,10 +68,10 @@ Value emitRedundantThreadPredicate(
   Value zero = b.i32_val(0);
   auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
 
-  // In TLX clustered kernels, always use zero for blockId instead of cluster
-  // CTA ID This ensures operations execute based on the CTA-local thread ID,
-  // not cluster position
-  bool isClusteredKernel = op && tlx::tlxIsClustered(op);
+  // On a physical `ctas_per_cga` cluster each CTA is its own program, so the
+  // layout's block dimension must index CTA-locally rather than by cluster
+  // rank.
+  bool isClusteredKernel = op && triton::gpu::isPhysicalCluster(op);
 
   Value blockId = (freeVarMasks.lookup(kBlock) == 0 || isClusteredKernel)
                       ? zero

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -248,9 +248,8 @@ struct ConvertTritonGPUToLLVM
     if (failed(applyPartialConversion(mod, cfTarget, std::move(cfPatterns))))
       return signalPassFailure();
 
-    // Fold CTAId when there is only 1 CTA.
-    int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
-    if (numCTAs == 1 && !tlx::tlxIsClustered(mod)) {
+    // Fold CTAId when there is only 1 CTA, under either cluster model.
+    if (triton::gpu::lookupPhysicalNumCTAs(mod) == 1) {
       mod.walk([](triton::nvgpu::ClusterCTAIdOp id) {
         OpBuilder b(id);
         Value zero = LLVM::createConstantI32(id->getLoc(), b, 0);
@@ -453,7 +452,7 @@ private:
   // If the kernel is clustered, insert cluster sync properly to
   // bootstrap remote bars or tmem
   LogicalResult maybeInsertClusterSync(ModuleOp &mod) {
-    if (!tlx::tlxIsClustered(mod)) {
+    if (!triton::gpu::isPhysicalCluster(mod)) {
       return success();
     }
 

--- a/third_party/tlx/dialect/include/IR/Dialect.h
+++ b/third_party/tlx/dialect/include/IR/Dialect.h
@@ -74,10 +74,6 @@ void setClusterSyncKernelCleanupOnMod(Operation *op, bool value);
 bool hasUserPostWsSync(Operation *op);
 void setUserPostWsSyncOnMod(Operation *op, bool value);
 
-// Returns true if the kernel uses clusters (clusterDims product > 1).
-// Subsumes tlxEnablePairedMMA: paired CTA MMA always implies clustering.
-bool tlxIsClustered(Operation *op);
-
 // Get element size in bytes for a type, handling pointer types (8 bytes)
 // and using ceiling division for sub-byte types.
 inline int64_t getElementBytes(mlir::Type elemType) {

--- a/third_party/tlx/dialect/lib/IR/Dialect.cpp
+++ b/third_party/tlx/dialect/lib/IR/Dialect.cpp
@@ -539,16 +539,3 @@ void mlir::triton::tlx::setUserPostWsSyncOnMod(Operation *op, bool value) {
   module->setAttr(AttrUserPostWsSyncName,
                   BoolAttr::get(module->getContext(), value));
 }
-
-bool mlir::triton::tlx::tlxIsClustered(Operation *op) {
-  assert(op != nullptr && "expecting nonnull op for checking cluster dims");
-  auto moduleOp = getModuleOp(op);
-  assert(moduleOp != nullptr &&
-         "expecting op nested in a module for checking cluster dims");
-  const SmallVector<int> clusterDims =
-      triton::gpu::TritonGPUDialect::getClusterDims(moduleOp);
-  int clusterSize = 1;
-  for (int d : clusterDims)
-    clusterSize *= d;
-  return clusterSize > 1;
-}


### PR DESCRIPTION
Summary:

Triton has two ways to request a cluster and three names for asking whether one
exists. `num_ctas` distributes one program's tensors across CTAs; `ctas_per_cga`
keeps `num_ctas == 1` and gives each CTA its own program, with cross-CTA traffic
only through explicit ops. `tlx::tlxIsClustered` and `ttng::is2CTA` both test the
second case -- identical predicates modulo phrasing -- and neither name says so.
The first implies the property is TLX-specific when core NVIDIA lowering relies
on it; the second reads as a question about paired-CTA MMA.

Replace both with `triton::gpu::isPhysicalCluster`, next to a new
`lookupPhysicalNumCTAs` that answers the separate question of how many CTAs a
cluster holds under either model. `getModuleTwoCTAs` is deliberately untouched:
whether a kernel issues `cta_group::2` MMA is a different fact.

The two models are only mutually exclusive by convention today. `CUDAOptions`
forces `num_ctas = 1` when `ctas_per_cga` is set, but nothing rejects
`cluster_dims` alongside `num_ctas > 1`, which leaves the model ambiguous and
makes the new predicate's name a lie. Reject that combination.

Also corrects the "Entry Cluster Barrier for Worker Warps" section of
`2cta-autoWS-sync.md`, which documented a gate that does not exist. The entry
sync is a marker handshake: `maybeInsertClusterSync` decides and stamps
`tlx.cluster_sync_kernel_init`, and `ConvertWarpSpecializeToLLVM` and
`ClusterOpsToLLVM` read it.

No behavior change apart from the new `ValueError`.

Authored with AI assistance from Claude.

Reviewed By: htyu

Differential Revision: D117590331


