### PR TITLE
[triton][beta] Split cross-CTA sync along the logical/physical cluster seam (#3314)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -33,7 +33,15 @@ static bool hasTCGen5CommitCrossCTA(Operation *op) {
   return !ttng::getCTABroadcastMasks(ttng::getModuleTwoCTAs(op), descs).empty();
 }
 
-bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+// An op reaches another CTA for one of two unrelated reasons, and which reasons
+// are even possible depends on which cluster model the kernel uses (see
+// `triton::gpu::isPhysicalCluster`). Keeping the two apart is what lets the two
+// passes below agree about the same op.
+
+// Reaches another CTA because a distributed tensor layout spreads the operand
+// over the logical `num_ctas` cluster. Necessarily false under `ctas_per_cga`,
+// where `num_ctas` is one and every tensor is CTA-local.
+static bool opCrossesCTAsByLayout(Operation *op, bool isRead) {
   if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
     if (!isRead)
       return false;
@@ -50,14 +58,52 @@ bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
     auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
     return splitNum[reduce.getAxis()] > 1;
   }
-  if (isa<ttng::CLCTryCancelOp, ttng::AsyncSharedStoreOp>(op)) {
+  // `async_shared_store` writes a distributed tensor, so like the two above it
+  // reaches another CTA only when the logical cluster spreads that tensor.
+  if (isa<ttng::AsyncSharedStoreOp>(op))
     return ttg::lookupNumCTAs(op) > 1;
-  } else if (isa<ttng::TMEMCopyOp>(op)) {
+  return false;
+}
+
+// Reaches another CTA because the op says so -- a `two_ctas` or multicast
+// attribute, a non-zero `ctaMask`, or a remote buffer operand. These are the
+// only cross-CTA ops reachable under the physical model, and they cross under
+// the logical model too.
+static bool opCrossesCTAsByConstruction(Operation *op) {
+  if (isa<ttng::TMEMCopyOp>(op))
     return ttng::getModuleTwoCTAs(op);
-  } else if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
+  // Checked ahead of the generic interface below: only this op carries an
+  // explicit `multicastTargets` mask, which the interface cannot express.
+  if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op))
+    return tma.getMulticast() || tma.getMulticastTargets();
+  if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op))
     return tma.getMulticast();
-  }
-  return hasTCGen5CommitCrossCTA(op);
+  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op))
+    return arrive.isMulticast();
+  if (hasTCGen5CommitCrossCTA(op))
+    return true;
+  return isa<ttng::CLCTryCancelOp, ttng::MapToRemoteBufferOp>(op);
+}
+
+bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+  return opCrossesCTAsByLayout(op, isRead) || opCrossesCTAsByConstruction(op);
+}
+
+// The shared entry condition for both passes. `lookupPhysicalNumCTAs` is the
+// no-cluster test under either model, so the model is only consulted where it
+// changes the answer: a physical cluster reaches other CTAs solely through ops
+// that say so, and a kernel with none of them needs no cluster sync at all.
+static bool clusterCanCrossCTAs(ModuleOp mod) {
+  if (ttg::lookupPhysicalNumCTAs(mod) == 1)
+    return false;
+  if (!ttg::isPhysicalCluster(mod))
+    return true;
+  return mod
+      ->walk([](Operation *op) {
+        return opCrossesCTAsByConstruction(op) ? WalkResult::interrupt()
+                                               : WalkResult::advance();
+      })
+      .wasInterrupted();
 }
 
 namespace {
@@ -72,7 +118,13 @@ static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
          allocation->isExplicitBuffer(bufferId);
 }
 
-static bool isCrossCTAMBarrier(ttng::InitBarrierOp initBarrierOp, int numCTAs) {
+// Under the logical model a barrier array carries one slot per CTA, so a size
+// that deviates from `num_ctas` means the barrier is not the plain per-CTA one.
+// That is a statement about the barrier's layout and carries no information
+// under `ctas_per_cga`, where a CTA-local barrier and a remotely completed one
+// are both size one.
+static bool mbarrierShapeDeviatesFromNumCTAs(ttng::InitBarrierOp initBarrierOp,
+                                             int numCTAs) {
   auto barrierTy = cast<ttg::MemDescType>(initBarrierOp.getAlloc().getType());
   return barrierTy.getShape()[0] != numCTAs;
 }
@@ -103,6 +155,12 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   if (auto commit = dyn_cast<ttng::TCGen5CommitOp>(op)) {
     return hasTCGen5CommitCrossCTA(op) && aliasesTracked(commit.getBarrier());
   }
+  // Checked ahead of the generic interface below: only this op carries an
+  // explicit `multicastTargets` mask, which the interface cannot express.
+  if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    return (tma.getMulticast() || tma.getMulticastTargets()) &&
+           aliasesTracked(tma.getBarrier());
+  }
   if (auto tma = dyn_cast<ttng::TMALoadLikeOpInterface>(op)) {
     return tma.getMulticast() && aliasesTracked(tma.getBarrier());
   }
@@ -112,17 +170,31 @@ usesTrackedBarrierInCrossCTAConsumerOp(Operation *op,
   if (auto store = dyn_cast<ttng::AsyncSharedStoreOp>(op)) {
     return aliasesTracked(store.getMbarrier());
   }
+  if (auto arrive = dyn_cast<ttng::ArriveBarrierOp>(op)) {
+    return arrive.isMulticast() && aliasesTracked(arrive.getAlloc());
+  }
+  // Addressing a barrier in another CTA is what makes it cluster-visible, so
+  // the mapping op counts even though the arrive lands on its result. The op is
+  // Pure, though, so a dead result is never itself found by the memory-effect
+  // use scan -- tracking one would strand the init with no insertion window.
+  if (auto remote = dyn_cast<ttng::MapToRemoteBufferOp>(op)) {
+    return !remote.getResult().use_empty() && aliasesTracked(remote.getSrc());
+  }
   return false;
 }
 
-static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
-                                             FunctionOpInterface funcOp,
-                                             Allocation *allocation,
-                                             int numCTAs) {
-  // Barrier init sync is needed for barriers that are themselves cross-CTA,
-  // and also for per-CTA barriers consumed by multi-CTA ops that multicast or
-  // otherwise fan out barrier state across the cluster.
-  if (isCrossCTAMBarrier(initBarrierOp, numCTAs))
+// Can a CTA other than the one that ran `init` complete or observe this
+// mbarrier? If so its initialization has to be made visible cluster-wide before
+// anyone touches it. The consumer walk answers this under either model; the
+// logical model additionally encodes the answer in the barrier's own shape,
+// which is why `num_ctas` appears here and nowhere else in this pass.
+static bool mbarrierIsClusterVisible(ttng::InitBarrierOp initBarrierOp,
+                                     FunctionOpInterface funcOp,
+                                     Allocation *allocation) {
+  auto mod = initBarrierOp->getParentOfType<ModuleOp>();
+  if (!ttg::isPhysicalCluster(mod) &&
+      mbarrierShapeDeviatesFromNumCTAs(initBarrierOp,
+                                       ttg::TritonGPUDialect::getNumCTAs(mod)))
     return true;
 
   Allocation::BufferIdSetT initBarrierBuffers;
@@ -132,8 +204,6 @@ static bool requiresCrossCTAMBarrierInitSync(ttng::InitBarrierOp initBarrierOp,
     initBarrierBuffers.insert(bufferId);
   }
 
-  // Or if it's used by a multi-CTA consumer that broadcasts barrier state
-  // across CTAs even though the barrier allocation itself looks per-CTA.
   return funcOp
       ->walk<WalkOrder::PreOrder>([&](Operation *op) {
         if (usesTrackedBarrierInCrossCTAConsumerOp(op, initBarrierBuffers,
@@ -181,10 +251,8 @@ static bool hasWarpSpecializeOp(FunctionOpInterface funcOp) {
       .wasInterrupted();
 }
 
-static LogicalResult
-insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
-                                          Allocation *allocation, int numCTAs,
-                                          OpBuilder &builder) {
+static LogicalResult insertCrossCTAMBarrierInitSyncForFunction(
+    FunctionOpInterface funcOp, Allocation *allocation, OpBuilder &builder) {
   if (!funcOp || funcOp->getNumRegions() != 1) {
     return funcOp.emitOpError(
         "cross-CTA mbarrier init sync insertion requires a single function "
@@ -197,8 +265,7 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
   // Find all cross-CTA mbarrier.init ops and map each
   // one to the containing top-level op that bounds the insertion window.
   funcOp.walk([&](ttng::InitBarrierOp initBarrierOp) {
-    if (!requiresCrossCTAMBarrierInitSync(initBarrierOp, funcOp, allocation,
-                                          numCTAs))
+    if (!mbarrierIsClusterVisible(initBarrierOp, funcOp, allocation))
       return;
     Operation *topLevelAnchor =
         topLevelRegion.findAncestorOpInRegion(*initBarrierOp.getOperation());
@@ -444,7 +511,7 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
   ModuleOp mod = moduleAllocation.getModuleOp();
   if (computeCapability < 90)
     return;
-  if (ttg::TritonGPUDialect::getNumCTAs(mod) == 1)
+  if (!clusterCanCrossCTAs(mod))
     return;
 
   MembarFilterFn filterFn = [](Operation *lhs, Operation *rhs, bool lhsIsRead,
@@ -469,8 +536,39 @@ runCrossCTAMBarrierInitSyncInsertion(ModuleAllocation &moduleAllocation,
   ModuleOp mod = moduleAllocation.getModuleOp();
   if (computeCapability < 90)
     return success();
-  int numCTAs = ttg::TritonGPUDialect::getNumCTAs(mod);
-  if (numCTAs == 1)
+  // This pass owns the logical model only, so bail before `clusterCanCrossCTAs`
+  // rather than after -- under `ctas_per_cga` that predicate would walk the
+  // whole module and the result would be discarded here anyway.
+  //
+  // Not threaded through the Meta warp specialization paths yet. A cluster
+  // barrier at function scope only reaches the default warps, and
+  // `ConvertWarpSpecializeToLLVM` emits exactly one compensating
+  // `@!isDefault barrier.cluster.arrive` in the function header -- which
+  // `maybeInsertClusterSync`'s entry rendezvous already claims. A second
+  // rendezvous from here is arrived at by the default warps alone and never
+  // completes.
+  //
+  // Standing down for entry-block inits alone is not enough. Narrowing this to
+  // "every classified init is in the entry block" was tried and reverted: on
+  // physical-cluster kernels whose cluster-visible init sits inside a region,
+  // this pass then runs and silently miscomputes -- 14 warp-specialized
+  // tutorial09 matmuls returned wrong results (3-11% of elements) rather than
+  // hanging or erroring. So under `ctas_per_cga` leave the sync to
+  // `maybeInsertClusterSync` unconditionally.
+  //
+  // Known gap: that pass only scans the entry block, so a cluster-visible init
+  // nested in a region now gets no sync and no diagnostic. Covering it needs a
+  // mechanism neither pass has yet.
+  //
+  // TODO: unify the two. They emit the same fence + relaxed cluster barrier and
+  // differ only in how they decide it is needed -- `maybeInsertClusterSync` on
+  // a module-wide predicate over entry-block inits, this pass on a per-barrier
+  // classification anywhere in the function. One pass should own the emission
+  // and take the decision from the other, which also removes the "exactly one
+  // rendezvous" hazard this stand-down is working around.
+  if (ttg::isPhysicalCluster(mod))
+    return success();
+  if (!clusterCanCrossCTAs(mod))
     return success();
 
   LogicalResult status = success();
@@ -481,8 +579,8 @@ runCrossCTAMBarrierInitSyncInsertion(ModuleAllocation &moduleAllocation,
           return;
         auto *allocation = moduleAllocation.getFuncData(funcOp);
         OpBuilder builder(funcOp);
-        if (failed(insertCrossCTAMBarrierInitSyncForFunction(
-                funcOp, allocation, numCTAs, builder))) {
+        if (failed(insertCrossCTAMBarrierInitSyncForFunction(funcOp, allocation,
+                                                             builder))) {
           status = failure();
         }
       });


### PR DESCRIPTION
Summary:

`ClusterBarrierInsertion` served both cluster models through one set of
predicates that mixed encoding tests with attribute tests. Under `num_ctas` a
tensor layout is what puts data in another CTA; under `ctas_per_cga` only an op
that explicitly says so can. Conflating them left `runClusterBarrierInsertion`
and `runCrossCTAMBarrierInitSyncInsertion` disagreeing about whether the same op
is cross-CTA, and left `isCrossCTAMBarrier` asking a layout question that has no
answer under `ctas_per_cga`, where a CTA-local barrier and a remotely completed
one are both size one.

Split `isDistributedMultiCTAOp` into `opCrossesCTAsByLayout` (logical only) and
`opCrossesCTAsByConstruction` (both models), so a single classification backs
both passes. Replace `isCrossCTAMBarrier`/`requiresCrossCTAMBarrierInitSync`
with `mbarrierIsClusterVisible`, which consults the barrier's shape only under
the logical model and is op-driven otherwise; `num_ctas` drops out of
`insertCrossCTAMBarrierInitSyncForFunction` entirely. Both passes now share one
entry condition, `clusterCanCrossCTAs`.

Two ops that reach other CTAs were missing from the classification and are added
here: `map_to_remote_buffer`, and `arrive_barrier` with a non-zero `ctaMask`.
Barriers reached only that way -- the CLC ready barrier and the atomic tile
scheduler's full/ready barriers -- previously depended on `maybeInsertClusterSync`
picking them up as entry-block inits.

Differential Revision: D117595536


