### PR TITLE
[AutoWS] Partition collective forward operands consistently

### DIFF
--- a/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
+++ b/include/triton/Dialect/Triton/IR/DiscardableAttributes.h
@@ -26,6 +26,11 @@ inline constexpr StringLiteral kAutoWSStageKey = "stage";
 inline constexpr StringLiteral kAutoWSOrderKey = "order";
 inline constexpr StringLiteral kAutoWSChannelsKey = "channels";
 inline constexpr StringLiteral kAutoWSOperandDTag = "opndD";
+// Set by the frontend on each 2-CTA FA forward contraction ("qk" or "pv") so
+// WSDataPartition can give the two data partitions distinct stage/order once
+// each contraction has a concrete partition index.
+inline constexpr StringLiteral kAutoWSTwoCTAInterleaveRoleKey =
+    "two_cta_interleave_role";
 
 // Each entry of the "channels" array is a comma-separated string laid out as
 //   operand,memory,copies,bufferId[,extra]

--- a/test/Hopper/WarpSpecialization/blackwell_ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_ws_data_partition.mlir
@@ -62,16 +62,24 @@ module attributes {ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i
         // data partition 1 begins. Interleaving the two independent correction
         // chains doubles their live ranges and spills both accumulator halves.
         // CHECK: ttng.tc_gen5_mma
+        // CHECK-SAME: \22order\22:\220\22
+        // CHECK-SAME: \22stage\22:\220\22
         // CHECK: ttng.tmem_load
         // CHECK: ttng.tmem_load
         // CHECK: ttng.tmem_store
         // CHECK: ttng.tc_gen5_mma
+        // CHECK-SAME: \22order\22:\223\22
+        // CHECK-SAME: \22stage\22:\220\22
         // CHECK: ttng.tc_gen5_mma
+        // CHECK-SAME: \22order\22:\222\22
+        // CHECK-SAME: \22stage\22:\220\22
         // CHECK: ttng.tmem_load
         // CHECK: ttng.tmem_load
         // CHECK: ttng.tmem_store
         // CHECK: ttng.tc_gen5_mma
-        %qk_20 = ttng.tc_gen5_mma %q_i_load_5, %permute_19, %qk[%qk_16], %false, %true : !ttg.memdesc<256x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xbf16, #shared3, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        // CHECK-SAME: \22order\22:\221\22
+        // CHECK-SAME: \22stage\22:\221\22
+        %qk_20 = ttng.tc_gen5_mma %q_i_load_5, %permute_19, %qk[%qk_16], %false, %true {tt.autows = "{\22two_cta_interleave_role\22:\22qk\22}"} : !ttg.memdesc<256x128xbf16, #shared2, #smem>, !ttg.memdesc<128x128xbf16, #shared3, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
         %qk_21, %qk_22 = ttng.tmem_load %qk[%qk_20] : !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<256x128xf32, #blocked>
         %amax = "tt.reduce"(%qk_21) <{axis = 1 : i32}> ({
         ^bb0(%amax_36: f32, %amax_37: f32):
@@ -110,11 +118,22 @@ module attributes {ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i
         %v_13 = arith.truncf %v_10 : tensor<256x128xf32, #blocked> to tensor<256x128xbf16, #blocked>
         %acc_33 = ttng.tmem_alloc %v_13 : (tensor<256x128xbf16, #blocked>) -> !ttg.memdesc<256x128xbf16, #tmem1, #ttng.tensor_memory>
         %acc_34 = ttng.tmem_store %inline_triton_result_3_32, %acc[%acc_27], %true : tensor<256x128xf32, #blocked> -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
-        %acc_35 = ttng.tc_gen5_mma %acc_33, %v_j_load_18, %acc[%acc_34], %true, %true : !ttg.memdesc<256x128xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %acc_35 = ttng.tc_gen5_mma %acc_33, %v_j_load_18, %acc[%acc_34], %true, %true {tt.autows = "{\22two_cta_interleave_role\22:\22pv\22}"} : !ttg.memdesc<256x128xbf16, #tmem1, #ttng.tensor_memory>, !ttg.memdesc<128x128xbf16, #shared2, #smem>, !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
         %v_14 = arith.mulf %arg8, %v_12 : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
         %v_3 = arith.addf %v_14, %l_ij : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
         scf.yield %v_6, %v_3, %qk_22, %acc_35 : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>, !ttg.async.token, !ttg.async.token
       } {tt.disallow_acc_multi_buffer}
+      // The post-loop epilogue is also group-major even though it shares the
+      // outer loop body with the inner KV loop: complete DP0's stats/output
+      // stores before loading DP1's accumulator.
+      // CHECK: symbol = "__nv_log2f"
+      // CHECK: ttng.tmem_load
+      // CHECK: tt.descriptor_store
+      // CHECK: tt.descriptor_store
+      // CHECK: symbol = "__nv_log2f"
+      // CHECK: ttng.tmem_load
+      // CHECK: tt.descriptor_store
+      // CHECK: tt.descriptor_store
       %v_16 = tt.extern_elementwise %acc_9#1 {libname = "", libpath = "", pure = true, symbol = "__nv_log2f"} : (tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>) -> tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
       %v_17 = arith.addf %acc_9#0, %v_16 : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>>
       %subscript_1 = tt.expand_dims %acc_9#1 {axis = 1 : i32} : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256x1xf32, #blocked>
@@ -123,12 +142,10 @@ module attributes {ttg.max_reg_auto_ws = 152 : i32, ttg.min_reg_auto_ws = 24 : i
       %v_18_12 = arith.divf %acc_10, %v_18 : tensor<256x128xf32, #blocked>
       %subscript_2 = ttg.convert_layout %v_17 : tensor<256xf32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<256xf32, #ttg.slice<{dim = 0, parent = #blocked1}>>
       %subscript_2_13 = tt.expand_dims %subscript_2 {axis = 0 : i32} : tensor<256xf32, #ttg.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x256xf32, #blocked1>
-      // CHECK-COUNT-2: tt.descriptor_store
       tt.descriptor_store %lse_desc_4[%pid_1, %offset_0], %subscript_2_13 : !tt.tensordesc<1x256xf32, #shared1>, tensor<1x256xf32, #blocked1>
       %subscript_3 = ttg.convert_layout %v_18_12 : tensor<256x128xf32, #blocked> -> tensor<256x128xf32, #ttg.slice<{dim = 0, parent = #blocked5}>>
       %subscript_3_14 = tt.expand_dims %subscript_3 {axis = 0 : i32} : tensor<256x128xf32, #ttg.slice<{dim = 0, parent = #blocked5}>> -> tensor<1x256x128xf32, #blocked5>
       %v_19 = arith.truncf %subscript_3_14 : tensor<1x256x128xf32, #blocked5> to tensor<1x256x128xbf16, #blocked5>
-      // CHECK-COUNT-2: tt.descriptor_store
       tt.descriptor_store %o_desc[%pid_1, %offset_0, %c0_i32], %v_19 : !tt.tensordesc<1x256x128xbf16, #shared>, tensor<1x256x128xbf16, #blocked5>
     } {tt.warp_specialize}
     tt.return

--- a/test/Hopper/WarpSpecialization/ws_data_partition.mlir
+++ b/test/Hopper/WarpSpecialization/ws_data_partition.mlir
@@ -42,8 +42,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
       %5 = arith.truncf %4#0 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf32, #mma> to tensor<128x256xf16, #mma>
       %6 = ttg.convert_layout %5 {async_task_id = array<i32: 1, 2>} : tensor<128x256xf16, #mma> -> tensor<128x256xf16, #blocked1>
       %7 = tt.splat %arg2 {async_task_id = array<i32: 1, 2>} : !tt.ptr<f16> -> tensor<128x256x!tt.ptr<f16>, #blocked1>
-     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
-     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, #blocked1>
+     // Post-loop epilogue is serialized per partition too (truncf/convert/store,
+     // then the same for the other half). The printed layout alias depends on
+     // first-use order, so match either numbering.
+     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, {{#blocked[0-9]*}}>
+     // CHECK: tt.store {{.*}} : tensor<64x256x!tt.ptr<f16>, {{#blocked[0-9]*}}>
      tt.store %7, %6 {async_task_id = array<i32: 1, 2>} : tensor<128x256x!tt.ptr<f16>, #blocked1>
     } {tt.data_partition_factor = 2 : i32}
     tt.return

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -26,8 +26,8 @@ namespace mlir {
 static const char *kDataPartitionAttrName = "tt.data_partition_factor";
 static const char *kDataPartitionIdAttrName = "tt.data_partition_id";
 
-static void remapAutoWSBufferIds(Operation *op, unsigned partition,
-                                 unsigned numPartitions) {
+static void remapAutoWSAnnotations(Operation *op, unsigned partition,
+                                   unsigned numPartitions) {
   auto attr = op->getAttrOfType<StringAttr>(kAutoWSAnnotationAttrName);
   if (!attr)
     return;
@@ -37,35 +37,57 @@ static void remapAutoWSBufferIds(Operation *op, unsigned partition,
     return;
   }
   auto *object = parsed->getAsObject();
-  auto *channels = object ? object->getArray(kAutoWSChannelsKey) : nullptr;
-  if (!channels)
+  if (!object)
     return;
 
   bool changed = false;
-  for (llvm::json::Value &channel : *channels) {
-    auto channelString = channel.getAsString();
-    if (!channelString)
-      continue;
-    SmallVector<StringRef, 5> fields;
-    StringRef(*channelString).split(fields, ',');
-    if (fields.size() != kAutoWSChannelMinFields &&
-        fields.size() != kAutoWSChannelMaxFields)
-      continue;
-    unsigned oldId;
-    if (fields[kAutoWSChannelBufferIdField].getAsInteger(10, oldId))
-      continue;
-    SmallVector<std::string, 5> remappedFields;
-    remappedFields.reserve(fields.size());
-    for (auto [index, field] : llvm::enumerate(fields)) {
-      if (index == kAutoWSChannelBufferIdField)
-        remappedFields.push_back(
-            std::to_string(oldId * numPartitions + partition));
-      else
-        remappedFields.push_back(field.str());
+  if (auto *channels = object->getArray(kAutoWSChannelsKey)) {
+    for (llvm::json::Value &channel : *channels) {
+      auto channelString = channel.getAsString();
+      if (!channelString)
+        continue;
+      SmallVector<StringRef, 5> fields;
+      StringRef(*channelString).split(fields, ',');
+      if (fields.size() != kAutoWSChannelMinFields &&
+          fields.size() != kAutoWSChannelMaxFields)
+        continue;
+      unsigned oldId;
+      if (fields[kAutoWSChannelBufferIdField].getAsInteger(10, oldId))
+        continue;
+      SmallVector<std::string, 5> remappedFields;
+      remappedFields.reserve(fields.size());
+      for (auto [index, field] : llvm::enumerate(fields)) {
+        if (index == kAutoWSChannelBufferIdField)
+          remappedFields.push_back(
+              std::to_string(oldId * numPartitions + partition));
+        else
+          remappedFields.push_back(field.str());
+      }
+      channel = llvm::join(remappedFields, ",");
+      changed = true;
     }
-    channel = llvm::join(remappedFields, ",");
-    changed = true;
   }
+
+  // A two-group FA forward pipeline alternates the single-buffer QK tiles:
+  // QK0(next), PV1(previous), QK1(next), PV0(current).  The frontend marks
+  // each contraction's role before data partitioning; once each contraction
+  // has a concrete partition index, materialize its distinct stage/order.
+  // This mirrors the hand-written TLX schedule without affecting other
+  // data-partitioned kernels.
+  if (numPartitions == 2) {
+    if (auto role = object->getString(kAutoWSTwoCTAInterleaveRoleKey)) {
+      if (*role == "qk") {
+        (*object)[kAutoWSStageKey] = "0";
+        (*object)[kAutoWSOrderKey] = partition == 0 ? "0" : "2";
+        changed = true;
+      } else if (*role == "pv") {
+        (*object)[kAutoWSStageKey] = partition == 0 ? "0" : "1";
+        (*object)[kAutoWSOrderKey] = partition == 0 ? "3" : "1";
+        changed = true;
+      }
+    }
+  }
+
   if (!changed)
     return;
 
@@ -1329,7 +1351,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     setAsyncTaskIds(newOp, sliceTaskIds);
     newOp->setAttr(kDataPartitionIdAttrName, builder.getI32IntegerAttr(offset));
     if (numOfPartitions > 1 && isDotOrMMAv5Op(newOp))
-      remapAutoWSBufferIds(newOp, offset, numOfPartitions);
+      remapAutoWSAnnotations(newOp, offset, numOfPartitions);
     if (numOfPartitions > 1 && isa<LocalAllocOp, ttng::TMEMAllocOp>(newOp)) {
       newOp->setLoc(appendToNameLoc(
           newOp->getLoc(), "_" + std::to_string(offset), op->getContext()));
@@ -2335,103 +2357,110 @@ static void reorderLoadsToFirstUse(triton::FuncOp &funcOp) {
 // operation identities.  This matches TLX's complete DP0-then-DP1 execution.
 static void serializeDataPartitionedOps(triton::FuncOp &funcOp) {
   funcOp.walk([&](Block *block) {
-    // Do not move a region-owning control-flow operation relative to values
-    // used only inside its nested regions: those captures are not explicit
-    // SSA operands of the parent op.  The profitable FA correction block has
-    // only straight-line tensor operations (tt.reduce regions are explicit
-    // dataflow ops), while entry/outer blocks contain scf control flow.
-    if (llvm::any_of(*block, [](Operation &op) {
-          return isa<LoopLikeOpInterface, scf::IfOp>(&op);
-        }))
-      return;
+    auto serializeSegment = [&](SmallVector<Operation *> &candidates) {
+      if (candidates.empty())
+        return;
 
-    DenseMap<Operation *, unsigned> originalOrder;
-    DenseMap<Operation *, int64_t> partitionId;
-    unsigned index = 0;
-    for (Operation &op : *block) {
-      originalOrder[&op] = index++;
-      if (auto id = op.getAttrOfType<IntegerAttr>(kDataPartitionIdAttrName))
-        partitionId[&op] = id.getInt();
-    }
+      DenseMap<Operation *, unsigned> originalOrder;
+      DenseMap<Operation *, int64_t> partitionId;
+      for (auto [index, op] : llvm::enumerate(candidates)) {
+        originalOrder[op] = index;
+        if (auto id = op->getAttrOfType<IntegerAttr>(kDataPartitionIdAttrName))
+          partitionId[op] = id.getInt();
+      }
 
-    DenseSet<int64_t> ids;
-    for (auto [op, id] : partitionId)
-      ids.insert(id);
-    if (ids.size() < 2)
-      return;
+      DenseSet<int64_t> ids;
+      for (auto [op, id] : partitionId)
+        ids.insert(id);
+      if (ids.size() < 2)
+        return;
 
-    // Auxiliary layout conversions are sometimes built explicitly instead of
-    // through cloneAndSetResultType.  Infer their partition from a unique
-    // marked operand so users move with their producer.
-    bool changed = true;
-    while (changed) {
-      changed = false;
-      for (Operation &blockOp : *block) {
-        Operation *op = &blockOp;
-        if (partitionId.count(op) || op->hasTrait<OpTrait::IsTerminator>())
-          continue;
-        std::optional<int64_t> inferred;
-        bool conflicting = false;
-        for (Value operand : op->getOperands()) {
-          Operation *def = operand.getDefiningOp();
-          auto it = def ? partitionId.find(def) : partitionId.end();
-          if (it == partitionId.end())
+      // Auxiliary layout conversions are sometimes built explicitly instead
+      // of through cloneAndSetResultType. Infer their partition from a unique
+      // marked operand so users move with their producer.
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (Operation *op : candidates) {
+          if (partitionId.count(op))
             continue;
-          if (inferred && *inferred != it->second) {
-            conflicting = true;
-            break;
+          std::optional<int64_t> inferred;
+          bool conflicting = false;
+          for (Value operand : op->getOperands()) {
+            Operation *def = operand.getDefiningOp();
+            auto it = def ? partitionId.find(def) : partitionId.end();
+            if (it == partitionId.end())
+              continue;
+            if (inferred && *inferred != it->second) {
+              conflicting = true;
+              break;
+            }
+            inferred = it->second;
           }
-          inferred = it->second;
-        }
-        if (inferred && !conflicting) {
-          partitionId[op] = *inferred;
-          changed = true;
+          if (inferred && !conflicting) {
+            partitionId[op] = *inferred;
+            changed = true;
+          }
         }
       }
-    }
 
-    // Rebuild the whole block, not just marked operations.  Region-bearing
-    // operations such as tt.reduce and shared scalar/layout adapters can be
-    // definitions or users of a marked value.  Keeping them in the
-    // topological schedule guarantees SSA dominance while the partition id is
-    // still the primary ordering key whenever dependencies permit it.
-    SmallVector<Operation *> candidates;
-    for (Operation &op : *block) {
-      if (!op.hasTrait<OpTrait::IsTerminator>())
-        candidates.push_back(&op);
-    }
-    DenseSet<Operation *> candidateSet(candidates.begin(), candidates.end());
-    DenseSet<Operation *> emitted;
-    SmallVector<Operation *> ordered;
-    ordered.reserve(candidates.size());
-    while (ordered.size() != candidates.size()) {
-      Operation *best = nullptr;
-      auto key = [&](Operation *op) {
-        int64_t id = partitionId.count(op) ? partitionId.lookup(op) : -1;
-        return std::pair(id, originalOrder.lookup(op));
-      };
-      for (Operation *candidate : candidates) {
-        if (emitted.contains(candidate))
-          continue;
-        bool ready = llvm::all_of(candidate->getOperands(), [&](Value operand) {
-          Operation *def = operand.getDefiningOp();
-          return !def || !candidateSet.contains(def) || emitted.contains(def);
-        });
-        if (ready && (!best || key(candidate) < key(best)))
-          best = candidate;
+      // Rebuild the straight-line segment, not just marked operations.
+      // Region-bearing dataflow operations such as tt.reduce can be
+      // definitions or users of a marked value. Keeping them in the
+      // topological schedule guarantees SSA dominance while the partition id
+      // remains the primary ordering key whenever dependencies permit it.
+      DenseSet<Operation *> candidateSet(candidates.begin(), candidates.end());
+      DenseSet<Operation *> emitted;
+      SmallVector<Operation *> ordered;
+      ordered.reserve(candidates.size());
+      while (ordered.size() != candidates.size()) {
+        Operation *best = nullptr;
+        auto key = [&](Operation *op) {
+          int64_t id = partitionId.count(op) ? partitionId.lookup(op) : -1;
+          return std::pair(id, originalOrder.lookup(op));
+        };
+        for (Operation *candidate : candidates) {
+          if (emitted.contains(candidate))
+            continue;
+          bool ready =
+              llvm::all_of(candidate->getOperands(), [&](Value operand) {
+                Operation *def = operand.getDefiningOp();
+                return !def || !candidateSet.contains(def) ||
+                       emitted.contains(def);
+              });
+          if (ready && (!best || key(candidate) < key(best)))
+            best = candidate;
+        }
+        assert(best && "cycle while serializing data-partition operations");
+        emitted.insert(best);
+        ordered.push_back(best);
       }
-      assert(best && "cycle while serializing data-partition operations");
-      emitted.insert(best);
-      ordered.push_back(best);
-    }
 
-    Operation *anchor = candidates.back()->getNextNode();
-    for (Operation *op : ordered) {
-      if (anchor)
-        op->moveBefore(anchor);
-      else
-        op->moveBefore(block, block->end());
+      Operation *anchor = candidates.back()->getNextNode();
+      for (Operation *op : ordered) {
+        if (anchor)
+          op->moveBefore(anchor);
+        else
+          op->moveBefore(block, block->end());
+      }
+    };
+
+    // Control-flow operations may capture values in nested regions without
+    // listing those captures as parent-op operands. Keep each such operation
+    // fixed and independently serialize the straight-line segments around it.
+    // This covers both the body of a partitioned loop and the post-loop FA
+    // epilogue without moving the loop itself.
+    SmallVector<Operation *> segment;
+    for (Operation &op : llvm::make_early_inc_range(*block)) {
+      if (op.hasTrait<OpTrait::IsTerminator>() ||
+          isa<LoopLikeOpInterface, scf::IfOp>(&op)) {
+        serializeSegment(segment);
+        segment.clear();
+        continue;
+      }
+      segment.push_back(&op);
     }
+    serializeSegment(segment);
   });
 
   funcOp.walk([&](Operation *op) { op->removeAttr(kDataPartitionIdAttrName); });

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DataPartition.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/DataPartition.md
@@ -250,6 +250,27 @@ Data partitioning operates **after** task ID assignment. The offset parameter
 selects which task ID from the original array. This is how N consumer warp
 groups each get their slice of the data.
 
+### Partition-aware contraction schedules
+
+Most `tt.autows` annotations are cloned unchanged, except for channel buffer
+IDs, which are remapped to keep partitions disjoint. A two-group FA forward
+pipeline additionally needs a partition-aware contraction order to safely
+reuse its single-buffer QK tiles while overlapping adjacent iterations. The
+frontend marks QK and PV contractions with `two_cta_interleave_role`; after
+slicing gives each clone a concrete partition index, data partitioning emits:
+
+```text
+QK partition 0: stage 0, order 0
+PV partition 1: stage 1, order 1
+QK partition 1: stage 0, order 2
+PV partition 0: stage 0, order 3
+```
+
+This puts `QK0`, `QK1`, and `PV0` in the prologue, matches TLX's steady-state
+`QK0(next) -> PV1(previous) -> QK1(next) -> PV0(current)` issue order, and
+leaves `PV1` in the epilogue. The rewrite is opt-in and only applies when there
+are exactly two data partitions.
+
 ## Regression Tests
 
 - `test/Hopper/WarpSpecialization/ws_data_partition_inplace_acc_token.mlir`


### PR DESCRIPTION
Summary:
Give collective 2-CTA forward operands a consistent partition assignment. Remap per-partition AutoWS buffer annotations when a contraction is cloned; materialize the distinct stage and order of a two-group FA forward pipeline -- QK0(next), PV1(previous), QK1(next), PV0(current) -- once each contraction has a concrete partition index; infer a partition for auxiliary layout conversions built outside cloneAndSetResultType from their unique marked operand so users move with their producer; and rebuild whole straight-line segments, including region-bearing dataflow ops such as tt.reduce, so SSA dominance holds while the DP id remains the primary ordering key. Control-flow ops stay fixed and the segments around them are serialized independently, because nested captures are not listed as parent-op operands.

Split out of the unlanded 2-CTA Flash Attention forward stack so it can be reviewed and landed independently of the kernel work. Cherry-picked from 305f4c638 on the MetaMain2 fork.

Depends on D114254019

Reviewed By: njriasan

Differential Revision: D116999605


