### PR TITLE
Add nonempty loop assumption (#3318)

### DIFF
--- a/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
+++ b/lib/Dialect/Triton/IR/DiscardableAttributes.cpp
@@ -25,6 +25,10 @@ static constexpr AutoWSLoopAttrInfo kAutoWSLoopAttrs[] = {
     {"tt.smem_alloc_algo", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
     {"tt.smem_budget", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
     {"tt.smem_circular_reuse", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
+    // Forwarded: the consumer reads it off the MMA's immediate parent
+    // scf.for, so an annotated scheduler while must hand it to the inner
+    // compute loop or the elision silently does not happen.
+    {"tt.assume_nonempty", AutoWSLoopAttrPropagation::ForwardToInnerLoop},
 };
 
 ArrayRef<AutoWSLoopAttrInfo> getAutoWSLoopAttrs() { return kAutoWSLoopAttrs; }

--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -6,6 +6,38 @@ import re
 from triton.compiler import ASTSource
 
 
+@pytest.mark.parametrize("assume_nonempty, expect_attr", [(True, True), (False, False), (None, False)])
+def test_range_assume_nonempty_attr(assume_nonempty, expect_attr) -> None:
+    # Assert both presence and absence. A presence-only check cannot tell a
+    # correctly wired kwarg from a string that shows up in the TTIR regardless.
+
+    if assume_nonempty is None:
+
+        @triton.jit
+        def kernel(out, n: tl.constexpr):
+            for i in tl.range(0, n):
+                tl.store(out + i, i)
+    else:
+
+        @triton.jit
+        def kernel(out, n: tl.constexpr, flag: tl.constexpr):
+            for i in tl.range(0, n, assume_nonempty=flag):
+                tl.store(out + i, i)
+
+    signature = {"out": "*i32", "n": "constexpr"}
+    constexprs = {"n": 4}
+    if assume_nonempty is not None:
+        signature["flag"] = "constexpr"
+        constexprs["flag"] = assume_nonempty
+
+    src = ASTSource(fn=kernel, signature=signature, constexprs=constexprs)
+    compiled = triton.compile(src, target=GPUTarget("cuda", 100, 32))
+    if expect_attr:
+        assert "tt.assume_nonempty" in compiled.asm["ttir"]
+    else:
+        assert "tt.assume_nonempty" not in compiled.asm["ttir"]
+
+
 def test_compile_only_sm100() -> None:
 
     @triton.jit

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -4129,6 +4129,7 @@ class AutoWSLoopOptions(base_value):
                                                         metadata=_loop_attr("tt.disallow_acc_multi_buffer", "unit"))
     flatten: bool | constexpr = field(default=False, metadata=_loop_attr("tt.flatten", "unit"))
     warp_specialize: bool | constexpr = field(default=False, metadata=_loop_attr("tt.warp_specialize", "unit"))
+    assume_nonempty: bool | constexpr = field(default=False, metadata=_loop_attr("tt.assume_nonempty", "unit"))
     multi_cta: bool | constexpr = field(default=False, metadata=_loop_attr("tt.multi_cta", "unit"))
     disable_licm: bool | constexpr = field(default=False, metadata=_loop_attr("llvm.loop_annotation", "licm"))
     data_partition_factor: int | constexpr | None = field(default=None,
@@ -4185,6 +4186,12 @@ class range(AutoWSLoopOptions):
         The compiler will attempt to partition memory, MMA, and vector
         operations in the loop into separate async partitions. This will
         increase the total number of warps required by the kernel.
+    :param assume_nonempty: Promise that the loop executes at least once. This
+        is an unchecked assumption, not a runtime assertion. It permits AutoWS
+        to remove an explicit accumulator initialization when the first MMA
+        iteration initializes the same accumulator itself. The option must be
+        placed on the loop that contains the MMA, since that is the loop the
+        consumer inspects. Violating this contract produces undefined results.
     :param multi_cta: Enable multi-CTA reduction on the loop. The compiler
         will partition loop iterations across CTAs in a cluster and
         automatically generate cross-CTA reduction (via Distributed Shared

--- a/test/Triton/simplify-single-trip-while.mlir
+++ b/test/Triton/simplify-single-trip-while.mlir
@@ -114,7 +114,8 @@ tt.func @computed_condition(%arg0: i32) -> i32 {
 // CHECK-NOT: scf.while
 // CHECK: scf.if
 // CHECK: scf.for
-// CHECK: } {tt.data_partition_factor = 2 : i32
+// CHECK: } {tt.assume_nonempty
+// CHECK-SAME: tt.data_partition_factor = 2 : i32
 // CHECK-SAME: tt.disallow_acc_multi_buffer
 // CHECK-SAME: tt.mem_plan_pick = 3 : i32
 // CHECK-SAME: tt.merge_correction = true
@@ -162,7 +163,7 @@ tt.func @forwards_autows(%arg0: i32) -> i32 {
         scf.yield %acc : i32
       }
       scf.yield %false, %inner : i1, i32
-    } attributes {tt.warp_specialize, tt.num_stages = 3 : i32, tt.loop_unroll_factor = 4 : i32, tt.disallow_acc_multi_buffer, tt.flatten, tt.multi_cta, llvm.loop_annotation = true, tt.data_partition_factor = 2 : i32, tt.list_schedule_pick = 1 : i32, tt.mem_plan_pick = 3 : i32, tt.merge_epilogue = true, tt.merge_epilogue_to_computation = true, tt.merge_correction = true, tt.separate_epilogue_store = true, tt.tmem_alloc_algo = 2 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 65536 : i32, tt.smem_circular_reuse = true}
+    } attributes {tt.assume_nonempty, tt.warp_specialize, tt.num_stages = 3 : i32, tt.loop_unroll_factor = 4 : i32, tt.disallow_acc_multi_buffer, tt.flatten, tt.multi_cta, llvm.loop_annotation = true, tt.data_partition_factor = 2 : i32, tt.list_schedule_pick = 1 : i32, tt.mem_plan_pick = 3 : i32, tt.merge_epilogue = true, tt.merge_epilogue_to_computation = true, tt.merge_correction = true, tt.separate_epilogue_store = true, tt.tmem_alloc_algo = 2 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 65536 : i32, tt.smem_circular_reuse = true}
     scf.yield %while_result : i32
   } else {
     scf.yield %arg0 : i32

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AutoWSAnnotations.md
@@ -50,6 +50,7 @@ AutoWS inventory.
 | `loop_unroll_factor` | `tt.loop_unroll_factor` | `LoopUnroll` (TTIR) | IR-level unroll |
 | `flatten` | `tt.flatten` | `FuseNestedLoops` | flatten a loop nest |
 | `disallow_acc_multi_buffer` | `tt.disallow_acc_multi_buffer` | pipeliner | keep acc single-buffered |
+| `assume_nonempty` | `tt.assume_nonempty` | `WSCodePartition` (`removeRedundantTmemZeroStores`) | promise the loop runs at least once; must be on the loop containing the MMA |
 | `multi_cta` | `tt.multi_cta` | multi-CTA reduction | cluster-level reduction |
 | `merge_epilogue` / `merge_epilogue_to_computation` / `merge_correction` | `tt.merge_*` | `PartitionSchedulingMeta` (`SchedulingOptions`) | epilogue/correction routing |
 | `separate_epilogue_store` | `tt.separate_epilogue_store` | `PartitionSchedulingMeta` | epilogue store gets own partition |


### PR DESCRIPTION
Summary:

Expose tt.assume_nonempty through tl.range so AutoWS can elide redundant accumulator initialization when the first iteration initializes the accumulator. Add compile-only TTIR coverage for the attribute.

Differential Revision: D114617482


