### PR TITLE
[doc] Document AutoWS 2CTA backward scheduling (#3320)

### DIFF
--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -220,6 +220,18 @@
 - **Fix**: before converting each descriptor load, recursively erase only dead `convert_layout`/`broadcast`/`expand_dims` rematerialization chains, then derive consumer task IDs from the remaining users. Whole-function DCE is intentionally avoided because test/debug IR may contain unrelated dead consumers.
 - **Regression**: `ws_code_partition.mlir` pins the alloc set after the dead chain is erased. The `ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir` assertion that both rank-1 statistic `local_load`s belong only to computation task 0 is added with that fixture, which a later commit introduces.
 
+### 31. BM128 2-CTA FA-bwd single-copy qT load-order cycle (2026-07-28, fixed in kernel)
+- **Symptom**: Pinning qT from two 16 KiB copies to one makes the persistent BM128 2-CTA backward kernel fit Blackwell SMEM, but the kernel deadlocks. The two-copy configuration launches.
+- **Root cause**: Program order put the q load before qT in the shared load partition. On reuse, q waits for its empty barrier from the late dK MMA, while the GEMM partition waits for the next qT at the early qK MMA. With one qT slot this is a cycle; a second qT slot masks it. TLX explicitly issues qT before the previous q load.
+- **Fix**: In the kernel's 2-CTA branch, issue `desc_qt.load` before `desc_q.load` and pin qT with `opndB,smem,1,1`. No compiler change is required because the final AutoWS partition preserves source load order.
+- **Validation**: The pinned `N_CTX=512`, two-stage kernel launches with one qT copy and fits SMEM. Its initially independent dQ unload issue is fixed in #32.
+
+### 32. BM128 2-CTA FA-bwd dQ epilogue duplicates H halves (2026-07-28, fixed in kernel)
+- **Symptom**: The kernel launches, dK/dV are correct, but dQ has max error 1.82-2.24 and correlation near zero. The generated output has bit-identical H columns `0:64` and `64:128`.
+- **Root cause**: The epilogue slices the logical `[64,128]` dQ accumulator. `TwoCTA_RHS` stores that logical tensor physically as `[128,64]`, so logical H slicing reads the same CTA-local physical TMEM bank twice. TLX instead unloads a physical `[128,64]` alias and uses a packed global descriptor.
+- **Fix**: In the BM128 `TLX_DQ_LAYOUT` path, reshape dQ to physical `[BLOCK_M1, HEAD_DIM/2]`, reduce four physical H slices, and address dQ through `[2*N_CTX, HEAD_DIM/2]` with doubled packed-row coordinates.
+- **Validation**: `N_CTX=256` dQ/dK/dV max errors are at most `2.93e-3`. Four `N_CTX=512` persistent launches report dQ/dK `1.953e-3`, dV `1.465e-3`, and zero run-to-run variation. `Z=2`, `H=2`, `N_CTX=256` also passes within `2.93e-3`.
+
 ## Debugging Workflow
 - `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
@@ -234,6 +234,16 @@ subtiled region resolves its counter to the nearest real counter-bearing region
 (e.g. the persistent while's after region) rather than to the subtiled region
 itself.
 
+## Direct-grid nonempty loops
+
+For direct-grid inner-loop specialization, the explicit zero store can dominate
+the MMA loop rather than share an enclosing persistent loop with it. A kernel
+may mark that loop `tt.assume_nonempty`; `removeRedundantTmemZeroStores` then
+uses dominance to remove the store because the first MMA iteration is
+guaranteed to execute and initialize operand D. This contract is undefined if
+the loop is empty. The full BM128 pre-pass regression is
+`test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir`.
+
 ## Interaction with Reuse Groups
 
 When channels share a reuse group (same `buffer.id`), they share a single

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -69,6 +69,8 @@ not disable early TMA store lowering.
 when AutoWS assigns registers to non-tensor and tensor partitions. If either
 knob is provided from the Python frontend, its value must be divisible by 8 so
 the emitted register allocation matches the backend warp-group granularity.
+Typed one-warp 2-CTA relay partitions use 40 registers independently of those
+global bounds, matching their wait/fence/publication-only role.
 
 ## Persistent loops (`scf.for` and `scf.while`)
 
@@ -93,7 +95,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes), including ordered-subset-carry `scf.while`. See [PartitionSchedulingMeta.md](PartitionSchedulingMeta.md); downstream dynamic/CLC validation is tracked in [WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md) |
 | `Analyze2CTADependencies.cpp` | `nvgpu-analyze-2cta-dependencies` | Classifies dependent 2-CTA MMA operand chains as collective contractions or peer gathers before AutoWS; see [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
 | `Plan2CTAExchange.cpp` | `nvgpu-plan-2cta-exchange` | Inserts an abstract peer-gather SSA dependency before AutoWS scheduling and memory planning |
-| `Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining to local stores and async peer stores completed on the existing AutoWS full barrier |
+| `Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining; BM64 completes on the existing AutoWS full barrier, while BM128 uses the relay design documented in [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
 | (frontend) | `tl.range` / `tl.condition` → `tt.*` loop attrs | The user-facing AutoWS/pipelining annotations, their IR attributes and consumers, and what works on `scf.while` today: [AutoWSAnnotations.md](AutoWSAnnotations.md) |
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -95,6 +95,7 @@ Epilogue store ops are independent of these knobs — they always go to
 |------|-------|------------|
 | Blackwell FA fwd | mergeEpilogue + separateEpilogueStore | correction, gemm, load, epilogue_store, comp×2 |
 | Blackwell FA bwd | mergeEpilogueToComputation (merge_epilogue=true) | reduction, gemm, load, computation |
+| Blackwell FA bwd, dependent 2-CTA | mergeEpilogueToComputation + relay | computation(default), reduction, gemm, load, relay |
 | Blackwell flex fwd | mergeEpilogue | correction, gemm, load, comp×2 |
 | Hopper FA fwd | mergeCorrection + mergeEpilogue | load, comp×2 |
 | Simple GEMM | separateEpilogueStore | gemm, load, epilogue, epilogue_store |


### PR DESCRIPTION
Summary:

Record the BM128 two-CTA accumulation-counter and partition-scheduler invariants discovered while matching TLX. Keep AutoWS2CTABackwardPlan.md as the standalone source for relay design and validation, and link it directly from the corrected overview.

Reviewed By: jdonald

Differential Revision: D114617486


