### PR TITLE
[kernel] Enable direct-grid BM128 2CTA AutoWS backward

### DIFF
--- a/.llms/rules/partition-scheduler-bugs.md
+++ b/.llms/rules/partition-scheduler-bugs.md
@@ -220,6 +220,18 @@
 - **Fix**: before converting each descriptor load, recursively erase only dead `convert_layout`/`broadcast`/`expand_dims` rematerialization chains, then derive consumer task IDs from the remaining users. Whole-function DCE is intentionally avoided because test/debug IR may contain unrelated dead consumers.
 - **Regression**: `ws_code_partition.mlir` pins the alloc set after the dead chain is erased. The `ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir` assertion that both rank-1 statistic `local_load`s belong only to computation task 0 is added with that fixture, which a later commit introduces.
 
+### 31. BM128 2-CTA FA-bwd single-copy qT load-order cycle (2026-07-28, fixed in kernel)
+- **Symptom**: Pinning qT from two 16 KiB copies to one makes the persistent BM128 2-CTA backward kernel fit Blackwell SMEM, but the kernel deadlocks. The two-copy configuration launches.
+- **Root cause**: Program order put the q load before qT in the shared load partition. On reuse, q waits for its empty barrier from the late dK MMA, while the GEMM partition waits for the next qT at the early qK MMA. With one qT slot this is a cycle; a second qT slot masks it. TLX explicitly issues qT before the previous q load.
+- **Fix**: In the kernel's 2-CTA branch, issue `desc_qt.load` before `desc_q.load` and pin qT with `opndB,smem,1,1`. No compiler change is required because the final AutoWS partition preserves source load order.
+- **Validation**: The pinned `N_CTX=512`, two-stage kernel launches with one qT copy and fits SMEM. Its initially independent dQ unload issue is fixed in #32.
+
+### 32. BM128 2-CTA FA-bwd dQ epilogue duplicates H halves (2026-07-28, fixed in kernel)
+- **Symptom**: The kernel launches, dK/dV are correct, but dQ has max error 1.82-2.24 and correlation near zero. The generated output has bit-identical H columns `0:64` and `64:128`.
+- **Root cause**: The epilogue slices the logical `[64,128]` dQ accumulator. `TwoCTA_RHS` stores that logical tensor physically as `[128,64]`, so logical H slicing reads the same CTA-local physical TMEM bank twice. TLX instead unloads a physical `[128,64]` alias and uses a packed global descriptor.
+- **Fix**: In the BM128 `TLX_DQ_LAYOUT` path, reshape dQ to physical `[BLOCK_M1, HEAD_DIM/2]`, reduce four physical H slices, and address dQ through `[2*N_CTX, HEAD_DIM/2]` with doubled packed-row coordinates.
+- **Validation**: `N_CTX=256` dQ/dK/dV max errors are at most `2.93e-3`. Four `N_CTX=512` persistent launches report dQ/dK `1.953e-3`, dV `1.465e-3`, and zero run-to-run variation. `Z=2`, `H=2`, `N_CTX=256` also passes within `2.93e-3`.
+
 ## Debugging Workflow
 - `t.dump` captures IR after each WarpSpec pass (doTaskIdPropagate → doBufferAllocation → doMemoryPlanner → doCodePartition → ...)
 - IR after PartitionSchedulingMeta uses `ttg.partition = array<i32: N>` attributes (not `async_task_id`)

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/AccumulationCounters.md
@@ -234,6 +234,16 @@ subtiled region resolves its counter to the nearest real counter-bearing region
 (e.g. the persistent while's after region) rather than to the subtiled region
 itself.
 
+## Direct-grid nonempty loops
+
+For direct-grid inner-loop specialization, the explicit zero store can dominate
+the MMA loop rather than share an enclosing persistent loop with it. A kernel
+may mark that loop `tt.assume_nonempty`; `removeRedundantTmemZeroStores` then
+uses dominance to remove the store because the first MMA iteration is
+guaranteed to execute and initialize operand D. This contract is undefined if
+the loop is empty. The full BM128 pre-pass regression is
+`test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir`.
+
 ## Interaction with Reuse Groups
 
 When channels share a reuse group (same `buffer.id`), they share a single

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -69,6 +69,9 @@ not disable early TMA store lowering.
 when AutoWS assigns registers to non-tensor and tensor partitions. If either
 knob is provided from the Python frontend, its value must be divisible by 8 so
 the emitted register allocation matches the backend warp-group granularity.
+Relay partitions contain no register-resident tensors, so they use the same
+`minRegAutoWS` budget as other non-tensor partitions. A separate relay-specific
+tuning knob can be added if future performance measurements justify one.
 
 ## Persistent loops (`scf.for` and `scf.while`)
 
@@ -93,7 +96,7 @@ recognizes the `scf.while` outer loop (same doc).
 | `PartitionSchedulingMeta.cpp` | `nvgpu-partition-scheduling-meta` | Partition scheduling for Blackwell (assigns `ttg.partition` attributes), including ordered-subset-carry `scf.while`. See [PartitionSchedulingMeta.md](PartitionSchedulingMeta.md); downstream dynamic/CLC validation is tracked in [WarpSpecializeWhileLoops.md](WarpSpecializeWhileLoops.md) |
 | `Analyze2CTADependencies.cpp` | `nvgpu-analyze-2cta-dependencies` | Classifies dependent 2-CTA MMA operand chains as collective contractions or peer gathers before AutoWS; see [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
 | `Plan2CTAExchange.cpp` | `nvgpu-plan-2cta-exchange` | Inserts an abstract peer-gather SSA dependency before AutoWS scheduling and memory planning |
-| `Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining to local stores and async peer stores completed on the existing AutoWS full barrier |
+| `Materialize2CTAExchange.cpp` | `nvgpu-materialize-2cta-exchange` | Lowers planned peer gathers after pipelining; BM64 completes on the existing AutoWS full barrier, while BM128 uses the relay design documented in [AutoWS2CTABackwardPlan.md](AutoWS2CTABackwardPlan.md) |
 | (frontend) | `tl.range` / `tl.condition` → `tt.*` loop attrs | The user-facing AutoWS/pipelining annotations, their IR attributes and consumers, and what works on `scf.while` today: [AutoWSAnnotations.md](AutoWSAnnotations.md) |
 | `WSTaskPartition.cpp` | `doTaskPartition` | Assigns `async_task_id` to anchor ops (loads, dots, stores) — Hopper only |
 | `TaskIdPropagation.cpp` | — | `TaskIdBackwardPropagation` sparse dataflow analysis |

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/PartitionSchedulingMeta.md
@@ -95,6 +95,7 @@ Epilogue store ops are independent of these knobs — they always go to
 |------|-------|------------|
 | Blackwell FA fwd | mergeEpilogue + separateEpilogueStore | correction, gemm, load, epilogue_store, comp×2 |
 | Blackwell FA bwd | mergeEpilogueToComputation (merge_epilogue=true) | reduction, gemm, load, computation |
+| Blackwell FA bwd, dependent 2-CTA | mergeEpilogueToComputation + relay | computation(default), reduction, gemm, load, relay |
 | Blackwell flex fwd | mergeEpilogue | correction, gemm, load, comp×2 |
 | Hopper FA fwd | mergeCorrection + mergeEpilogue | load, comp×2 |
 | Simple GEMM | separateEpilogueStore | gemm, load, epilogue, epilogue_store |

--- a/third_party/tlx/tutorials/accuracy_bench_bwd_autows_vs_tlx.py
+++ b/third_party/tlx/tutorials/accuracy_bench_bwd_autows_vs_tlx.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 import torch
+import triton
 
 TUT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, TUT)
@@ -32,6 +33,11 @@ SM_SCALE = 0.5
 DTYPE = torch.float16
 RUNS = int(os.environ.get("BENCH_RUNS", 5))
 SEED = int(os.environ.get("BENCH_SEED", 20))
+MODE = os.environ.get("BENCH_MODE", "accuracy")
+IMPL = os.environ.get("BENCH_IMPL", "")
+WARMUP_MS = int(os.environ.get("BENCH_WARMUP_MS", 500))
+REP_MS = int(os.environ.get("BENCH_REP_MS", 500))
+SCOPE = os.environ.get("BENCH_SCOPE", "full")
 
 # baseVariant: "ws_persistent" (failing) or "ws" (passing). Default to the
 # failing persistent path under investigation.
@@ -41,7 +47,26 @@ BWD_IDX = int(os.environ.get("BENCH_BWD_IDX", 4))
 
 def pin_autows_config():
     kern = aws._attn_bwd_persist if AWS_VARIANT == "ws_persistent" else aws._attn_bwd
-    kern.configs = [aws.configs_bwd_persist[BWD_IDX]]
+    cfg = aws.configs_bwd_persist[BWD_IDX]
+    if "BENCH_EPILOGUE_SUBTILE" in os.environ or "BENCH_NUM_STAGES" in os.environ:
+        cfg = triton.Config(
+            {
+                **cfg.kwargs,
+                "EPILOGUE_SUBTILE":
+                int(os.environ.get("BENCH_EPILOGUE_SUBTILE", cfg.kwargs["EPILOGUE_SUBTILE"])),
+            },
+            num_warps=cfg.num_warps,
+            num_stages=int(os.environ.get("BENCH_NUM_STAGES", cfg.num_stages)),
+            pre_hook=cfg.pre_hook,
+            ctas_per_cga=cfg.ctas_per_cga,
+            allowDependentTwoCTA=cfg.allowDependentTwoCTA,
+            # The BM128 2-CTA entry sets this; dropping it here would silently
+            # benchmark a different kernel than the pinned autotune config.
+            generate_subtiled_region=cfg.generate_subtiled_region,
+        )
+        cfg.minRegAutoWS = aws.configs_bwd_persist[BWD_IDX].minRegAutoWS
+        cfg.maxRegAutoWS = aws.configs_bwd_persist[BWD_IDX].maxRegAutoWS
+    kern.configs = [cfg]
     kern.cache = {}
 
 
@@ -104,7 +129,55 @@ def maxabs(a, b):
     return (a.float() - b.float()).abs().max().item()
 
 
+def perf_main():
+    assert IMPL in ("autows", "tlx"), "BENCH_IMPL must be autows or tlx in perf mode"
+    if IMPL == "autows":
+        pin_autows_config()
+        attention = lambda q, k, v: aws.attention(  # noqa: E731
+            q, k, v, CAUSAL, SM_SCALE, AWS_VARIANT, False, 0, False)
+        kern = aws._attn_bwd_persist if AWS_VARIANT == "ws_persistent" else aws._attn_bwd
+        cfg = kern.configs[0]
+    else:
+        pin_tlx_config()
+        attention = lambda q, k, v: tlx.attention(q, k, v, SM_SCALE, CAUSAL)  # noqa: E731
+        cfg = tlx._attn_bwd_ws.configs[0]
+
+    q, k, v, dout = make_inputs(SEED)
+    q.requires_grad_()
+    k.requires_grad_()
+    v.requires_grad_()
+
+    assert SCOPE in ("full", "bwd"), "BENCH_SCOPE must be full or bwd"
+    if SCOPE == "full":
+        # Match test_blackwell_fa_perf.py: include a fresh forward graph in
+        # every timed iteration so backward does not depend on retained state.
+        def fn():
+            q.grad = k.grad = v.grad = None
+            out = attention(q, k, v).half()
+            out.backward(dout)
+    else:
+        out = attention(q, k, v).half()
+
+        def fn():
+            q.grad = k.grad = v.grad = None
+            out.backward(dout, retain_graph=True)
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=[0.5, 0.2, 0.8], warmup=WARMUP_MS, rep=REP_MS)
+    flops_per_matmul = 2.0 * Z * H * N_CTX * N_CTX * HEAD_DIM
+    total_flops = 5.0 * flops_per_matmul
+    tflops = lambda latency_ms: total_flops * 1e-12 / (latency_ms * 1e-3)  # noqa: E731
+    print(f"impl={IMPL} scope={SCOPE} Z={Z} H={H} N_CTX={N_CTX} "
+          f"d={HEAD_DIM} causal={CAUSAL}")
+    print(f"config={cfg}")
+    print(f"latency_ms median={ms:.4f} p20={min_ms:.4f} p80={max_ms:.4f}")
+    print(f"tflops median={tflops(ms):.2f} p20={tflops(max_ms):.2f} "
+          f"p80={tflops(min_ms):.2f}")
+
+
 def main():
+    if MODE == "perf":
+        perf_main()
+        return
     pin_autows_config()
     pin_tlx_config()
     q, k, v, dout = make_inputs(SEED)

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -1,11 +1,19 @@
+import contextlib
 import copy
 import json
+import os
+
 import pytest
 import torch
 
 import triton
 import triton.language as tl
-from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _reduce_fadd2
+from triton.language.extra.cuda.inline_ptx_lib import (
+    _fma_f32x2,
+    _mul_f32x2,
+    _reduce_fadd2,
+    _sub_f32x2,
+)
 from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
@@ -603,6 +611,21 @@ _DEFAULT_BWD_DOT_ATTRS = FrozenDotAttrs({
     "dk": {"stage": "1", "order": "1", "channels": ["opndD,tmem,1,10"]},
 })
 
+# BM128 2-CTA uses TLX's qK -> dK -> dP -> dQ -> dV dot order. dK reads
+# dS from the reused dP slot before the next dP write. dQ reuses qK's lower
+# 64 columns, while P stays live for dV in qK's upper 64 columns.
+_BWD_DOT_ATTRS_BM128_2CTA = FrozenDotAttrs({
+    "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,1,1", "opndD,tmem,1,2"]},
+    "dpT": {"stage": "0", "order": "1", "channels": ["opndA,smem,1,3", "opndB,smem,1,4", "opndD,tmem,1,5"]},
+    "dv": {"stage": "0", "order": "3", "channels": ["opndA,tmem,1,2,64", "opndD,tmem,1,7"]},
+    "dk": {"stage": "1", "order": "0", "channels": ["opndD,tmem,1,10"]},
+    "dq": {"stage": "1", "order": "2", "channels": ["opndA,smem,1,8", "opndD,tmem,1,2"]},
+    # Load-only schedule anchors. These order metadata relative to the MMA
+    # operand prefetch wavefront without changing the dot execution order.
+    "m_load": {"stage": "0", "order": "2"},
+    "delta_load": {"stage": "0", "order": "4"},
+})
+
 # For BM of 128: dpT share with dq, qk share with ppT, dsT share with dpT.
 _BWD_DOT_ATTRS_TMEM = FrozenDotAttrs({
     "qkT": {"stage": "0", "order": "0", "channels": ["opndA,smem,1,0", "opndB,smem,2,1", "opndD,tmem,1,2"]},
@@ -707,13 +730,17 @@ def _attn_bwd_dkdv_inner(
     LN2: tl.constexpr,
     RESCHED: tl.constexpr,
     TWO_CTAS: tl.constexpr = False,
+    TLX_DQ_LAYOUT: tl.constexpr = False,
     BWD_DOT_ATTRS: tl.constexpr = None,
 ):
-    q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
     if TWO_CTAS:
+        # Keep qT ahead of q in the load partition. With one qT slot, loading q
+        # first can wait on the late dK consumer while qK waits for the next qT.
         qt = desc_qt.load([(off_bh + curr_m).to(tl.int32), 0])
         qT = tl.trans(qt)
+        q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
     else:
+        q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
         qT = tl.trans(q)
     offs_m_start = off_chz + curr_m
     m = desc_m.load([offs_m_start.to(tl.int32)])
@@ -721,7 +748,7 @@ def _attn_bwd_dkdv_inner(
         qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"), two_ctas=TWO_CTAS)
     else:
         qkT = tl.dot(k, qT)
-    pT = tl.math.exp2(qkT - m[None, :])
+    pT = tl.math.exp2(_sub_f32x2(qkT, m[None, :]))
     if MASK:
         offs_m = curr_m + tl.arange(0, BLOCK_M1)
         mask = offs_m[None, :] >= offs_n[:, None]
@@ -741,7 +768,7 @@ def _attn_bwd_dkdv_inner(
         dv += tl.dot(ppT, do)
         Di = desc_delta.load([offs_m_start.to(tl.int32)])
         dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
-    dsT = pT * (dpT - Di[None, :])
+    dsT = _mul_f32x2(pT, _sub_f32x2(dpT, Di[None, :]))
     dsT = dsT.to(dtype)
     if RESCHED:
         # dk reads dsT from the reused TMEM buffer-5; dq writes the same buffer.
@@ -749,20 +776,36 @@ def _attn_bwd_dkdv_inner(
         # blackwell_fa_ws_pipelined_persistent: "dk must read dsT_tmem BEFORE
         # dq writes ... same TMEM slot"). Emit dk first.
         dk += tl.dot(dsT, q, attrs=BWD_DOT_ATTRS.get("dk"), two_ctas=TWO_CTAS)
-        dq = tl.dot(tl.trans(dsT), kt, attrs=BWD_DOT_ATTRS.get("dq"), two_ctas=TWO_CTAS)
+        if TLX_DQ_LAYOUT:
+            # Physical BM128 2-CTA dQ. The compiler peer-gather rewrite replaces
+            # this local packed view with the rank-owned M half from both CTA N
+            # domains: [64, 256] @ [256, 64] -> [64, 128].
+            dsT_dq = tl.reshape(tl.trans(dsT), (BLOCK_M1 // 2, dsT.shape[0] * 2))
+            dq = tl.dot(dsT_dq, kt, attrs=BWD_DOT_ATTRS.get("dq"), two_ctas=TWO_CTAS)
+        else:
+            dq = tl.dot(tl.trans(dsT), kt, attrs=BWD_DOT_ATTRS.get("dq"), two_ctas=TWO_CTAS)
     else:
         dk += tl.dot(dsT, tl.trans(qT))
         dq = tl.dot(tl.trans(dsT), k)
     slice_size: tl.constexpr = HEAD_DIM // DQ_SUBTILE
     if TWO_CTAS:
-        # TwoCTA_RHS distributes the accumulator's M dimension across the
-        # cluster.  Each CTA exposes its local half at the first logical half;
-        # the cluster rank selects the corresponding output rows.
         cluster_cta_rank = tl.program_id(0) % 2
-        dq_local = _take_m_half_2D(dq, cluster_cta_rank)
-        dqs = _split_n_2D(dq_local, DQ_SUBTILE)
-        dq_row = off_bh + curr_m + cluster_cta_rank * (BLOCK_M1 // 2)
-        for slice_id in tl.static_range(0, DQ_SUBTILE):
+        if TLX_DQ_LAYOUT:
+            # TwoCTA_RHS stores logical [BM/2, H] as physical [BM, H/2].
+            # Load/store that physical view directly; slicing the logical H
+            # dimension makes both halves address the same local TMEM bank.
+            dq_local = tl.reshape(dq, (BLOCK_M1, HEAD_DIM // 2))
+            dq_subtiles: tl.constexpr = DQ_SUBTILE // 2
+            dqs = _split_n_2D(dq_local, dq_subtiles)
+            dq_row = 2 * (off_bh + curr_m + cluster_cta_rank * (BLOCK_M1 // 2))
+        else:
+            # Native two-CTA dQ retains the full logical M extent; select the
+            # rank-owned half for the global update.
+            dq_local = _take_m_half_2D(dq, cluster_cta_rank)
+            dq_subtiles: tl.constexpr = DQ_SUBTILE
+            dqs = _split_n_2D(dq_local, dq_subtiles)
+            dq_row = off_bh + curr_m + cluster_cta_rank * (BLOCK_M1 // 2)
+        for slice_id in tl.static_range(0, dq_subtiles):
             dqN = dqs[slice_id] * LN2
             desc_dq.atomic_add([dq_row.to(tl.int32), slice_id * slice_size], dqN)
     else:
@@ -811,6 +854,7 @@ def _attn_bwd_dkdv(
     BWD_DOT_ATTRS: tl.constexpr = None,
     SMEM_BUDGET: tl.constexpr = 200000,
     TWO_CTAS: tl.constexpr = False,
+    TLX_DQ_LAYOUT: tl.constexpr = False,
 ):
     offs_n = start_n + tl.arange(0, BLOCK_N1)
 
@@ -857,6 +901,7 @@ def _attn_bwd_dkdv(
                 LN2,
                 True,
                 TWO_CTAS,
+                TLX_DQ_LAYOUT,
                 BWD_DOT_ATTRS,
             )
     else:
@@ -888,6 +933,7 @@ def _attn_bwd_dkdv(
                 LN2,
                 True,
                 TWO_CTAS,
+                TLX_DQ_LAYOUT,
                 BWD_DOT_ATTRS,
             )
 
@@ -902,6 +948,14 @@ def _bwd_host_descriptor_pre_hook(nargs):
     # DQ_SUBTILE controls dq atomic_add staging only; defaults to
     # EPILOGUE_SUBTILE so existing configs continue to behave the same.
     DQ_SUBTILE = nargs.get("DQ_SUBTILE", EPILOGUE_SUBTILE)
+    NUM_CTAS = nargs.get("NUM_CTAS", 1)
+    # BM128 2-CTA assigns adjacent N tiles to the CTA pair. Keep this initial
+    # implementation to complete pairs: a CTA cannot independently skip a
+    # collective MMA when the sequence has an odd trailing N tile.
+    if NUM_CTAS == 2 and BLOCK_M1 == 128:
+        N_CTX = nargs["N_CTX"]
+        if N_CTX % (BLOCK_N1 * NUM_CTAS) != 0:
+            raise ValueError("BM128 2-CTA requires N_CTX divisible by 2 * BLOCK_N1")
     if not isinstance(nargs["desc_q"], TensorDescriptor):
         return
 
@@ -916,12 +970,23 @@ def _bwd_host_descriptor_pre_hook(nargs):
     nargs["desc_do"].block_shape = [BLOCK_M1, HEAD_DIM]
     if "desc_dot" in nargs:
         nargs["desc_dot"].block_shape = [BLOCK_M1, HEAD_DIM]
-    dq_rows = BLOCK_M1 // nargs.get("NUM_CTAS", 1)
+    packed_dq = NUM_CTAS == 2 and BLOCK_M1 == 128
+    if packed_dq:
+        N_CTX = nargs["N_CTX"]
+        nargs["desc_dq"].shape = [2 * nargs["BATCH"] * nargs["H"] * N_CTX, HEAD_DIM // 2]
+        nargs["desc_dq"].strides = [HEAD_DIM // 2, 1]
+    else:
+        nargs["desc_dq"].shape = [nargs["BATCH"] * nargs["H"] * nargs["N_CTX"], HEAD_DIM]
+        nargs["desc_dq"].strides = [HEAD_DIM, 1]
+    dq_rows = BLOCK_M1 if packed_dq else BLOCK_M1 // NUM_CTAS
     nargs["desc_dq"].block_shape = [dq_rows, HEAD_DIM // DQ_SUBTILE]
     nargs["desc_v"].block_shape = [BLOCK_N1, HEAD_DIM]
     nargs["desc_k"].block_shape = [BLOCK_N1, HEAD_DIM]
     if "desc_kt" in nargs:
-        nargs["desc_kt"].block_shape = [BLOCK_N1, HEAD_DIM]
+        if NUM_CTAS == 2 and BLOCK_M1 == 128:
+            nargs["desc_kt"].block_shape = [BLOCK_N1 * NUM_CTAS, HEAD_DIM]
+        else:
+            nargs["desc_kt"].block_shape = [BLOCK_N1, HEAD_DIM]
     nargs["desc_dv"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
     nargs["desc_dk"].block_shape = [BLOCK_N1, HEAD_DIM // EPILOGUE_SUBTILE]
     nargs["desc_m"].block_shape = [BLOCK_M1]
@@ -1037,6 +1102,33 @@ configs_bwd_persist = [
         ctas_per_cga=(2, 1, 1),
         allowDependentTwoCTA=True,
     ),
+    triton.Config(  # BM128 2-CTA: adjacent N tiles per CTA cluster.
+        {
+            "BLOCK_M1": 128,
+            "BLOCK_N1": 128,
+            "BLOCK_M2": 128,
+            "BLOCK_N2": 128,
+            "EPILOGUE_SUBTILE": 8,
+            "DQ_SUBTILE": 8,
+            # Permit the allocated dQ reduction staging group to use two slots
+            # (224004 + 8192 = 232196 physical bytes). Fully reused dK/dV
+            # staging groups remain at one slot in the memory planner.
+            "SMEM_BUDGET": 230400,
+            "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM128_2CTA,
+            "NUM_CTAS": 2,
+        },
+        # Match TLX: the default computation/epilogue group starts with eight
+        # warps; AutoWS specializes reduction, GEMM, load, and relay from it.
+        num_warps=8,
+        num_stages=2,
+        # minRegAutoWS/maxRegAutoWS are deliberately not set here: the loop
+        # below assigns them for every config and would overwrite anything
+        # given at construction. Keep one source of truth.
+        pre_hook=_bwd_host_descriptor_pre_hook,
+        ctas_per_cga=(2, 1, 1),
+        allowDependentTwoCTA=True,
+        generate_subtiled_region=True,
+    ),
     triton.Config(
         {
             "BLOCK_M1": 64,
@@ -1080,6 +1172,15 @@ configs_bwd_persist = [
         pre_hook=_bwd_host_descriptor_pre_hook,
     ),
 ]
+
+# Keep register options config-owned so the autotuner passes each option once.
+# Existing configs retain the historical 24/192 bounds; the dedicated BM128
+# 2-CTA config uses the TLX-aligned 88-register budget. Environment overrides
+# remain global and are applied uniformly for debugging sweeps.
+for _config in configs_bwd_persist:
+    _is_bm128_2cta = (_config.kwargs.get("NUM_CTAS", 1) == 2 and _config.kwargs["BLOCK_M1"] == 128)
+    _config.minRegAutoWS = int(os.environ.get("AUTOWS_BWD_MIN_REG", "88" if _is_bm128_2cta else "24"))
+    _config.maxRegAutoWS = int(os.environ.get("AUTOWS_BWD_MAX_REG", "88" if _is_bm128_2cta else "192"))
 
 
 @triton.jit
@@ -1125,13 +1226,16 @@ def _attn_bwd_core(
 
     start_n = pid * BLOCK_N1
     start_m = 0
+    TLX_DQ_LAYOUT: tl.constexpr = TWO_CTAS and BLOCK_M1 == 128
+    cluster_cta_rank = tl.program_id(0) % 2 if TWO_CTAS else 0
 
     k = desc_k.load([(off_bh + start_n).to(tl.int32), 0])
+    v = desc_v.load([(off_bh + start_n).to(tl.int32), 0])
     if TWO_CTAS:
-        kt = desc_kt.load([(off_bh + start_n).to(tl.int32), 0])
+        kt_start_n = start_n - cluster_cta_rank * BLOCK_N1 if TLX_DQ_LAYOUT else start_n
+        kt = desc_kt.load([(off_bh + kt_start_n).to(tl.int32), 0])
     else:
         kt = k
-    v = desc_v.load([(off_bh + start_n).to(tl.int32), 0])
     num_steps = (N_CTX - start_m) // BLOCK_M1
     dk, dv = _attn_bwd_dkdv(  #
         dk,
@@ -1167,6 +1271,7 @@ def _attn_bwd_core(
         BWD_DOT_ATTRS=BWD_DOT_ATTRS,
         SMEM_BUDGET=SMEM_BUDGET,
         TWO_CTAS=TWO_CTAS,
+        TLX_DQ_LAYOUT=TLX_DQ_LAYOUT,
     )
 
     dvs = _split_n_2D(dv, EPILOGUE_SUBTILE)
@@ -1260,6 +1365,7 @@ def _attn_bwd(
         DQ_SUBTILE,
         BWD_DOT_ATTRS,
         SMEM_BUDGET,
+        NUM_CTAS == 2,
     )
 
 
@@ -1302,9 +1408,14 @@ def _attn_bwd_persist(
     NUM_CTAS: tl.constexpr = 1,
 ):
     n_tile_num = tl.cdiv(N_CTX, BLOCK_N1)
+    cluster_rank = tl.program_id(0) % NUM_CTAS
     prog_id = tl.program_id(0) // NUM_CTAS
     num_progs = tl.num_programs(0) // NUM_CTAS
-    total_tiles = n_tile_num * BATCH * H
+    # BM64 retains its validated same-N direct protocol. BM128 matches TLX
+    # ownership: one persistent cluster tile covers two adjacent N tiles.
+    ADJACENT_N: tl.constexpr = NUM_CTAS == 2 and BLOCK_M1 == 128
+    scheduled_n_tiles = n_tile_num // NUM_CTAS if ADJACENT_N else n_tile_num
+    total_tiles = scheduled_n_tiles * BATCH * H
 
     tiles_per_sm = total_tiles // num_progs
     if prog_id < total_tiles % num_progs:
@@ -1359,7 +1470,7 @@ def _attn_bwd_persist(
         desc_kt,
         shape=[y_dim, HEAD_DIM],
         strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N1, HEAD_DIM],
+        block_shape=[BLOCK_N1 * NUM_CTAS if NUM_CTAS == 2 and BLOCK_M1 == 128 else BLOCK_N1, HEAD_DIM],
     )
     desc_dv = _maybe_make_tensor_desc(
         desc_dv,
@@ -1395,8 +1506,9 @@ def _attn_bwd_persist(
             smem_alloc_algo=1,
             smem_budget=SMEM_BUDGET,
     ):
-        pid = tile_idx % n_tile_num
-        bhid = tile_idx // n_tile_num
+        scheduled_pid = tile_idx % scheduled_n_tiles
+        bhid = tile_idx // scheduled_n_tiles
+        pid = scheduled_pid * NUM_CTAS + cluster_rank if ADJACENT_N else scheduled_pid
         _attn_bwd_core(
             desc_q,
             desc_qt,
@@ -1485,7 +1597,8 @@ class _attention_opt(torch.autograd.Function):
         with triton.knobs.nvidia.scope():
             triton.knobs.nvidia.use_meta_ws = True
             triton.knobs.nvidia.use_meta_partition = True
-            triton.knobs.nvidia.disable_wsbarrier_reorder = True
+            triton.knobs.nvidia.disable_wsbarrier_reorder = (os.environ.get("AUTOWS_ENABLE_WSBARRIER_REORDER", "0")
+                                                             != "1")
             if persistent:
                 _attn_fwd_persist[grid_persist](
                     sm_scale,
@@ -1654,8 +1767,13 @@ class _attention_opt(torch.autograd.Function):
         )
 
         def grid(meta):
+            num_ctas = meta.get("NUM_CTAS") or 1
+            n_tiles = triton.cdiv(N_CTX, meta["BLOCK_N1"])
+            if num_ctas == 2:
+                assert meta["BLOCK_M1"] == 128
+                assert n_tiles % num_ctas == 0
             return (
-                triton.cdiv(N_CTX, meta["BLOCK_N1"]),  # tiles along N (K/V)
+                n_tiles,
                 1,  # (or cdiv over M if you need)
                 BATCH * N_HEAD,
             )  # batch*heads
@@ -1665,8 +1783,15 @@ class _attention_opt(torch.autograd.Function):
 
             def grid_persist_bwd(meta):
                 num_ctas = meta.get("NUM_CTAS") or 1
-                total_tiles = triton.cdiv(N_CTX, meta["BLOCK_N1"]) * BATCH * N_HEAD
-                num_clusters = min(NUM_SMS // num_ctas, total_tiles)
+                n_tiles = triton.cdiv(N_CTX, meta["BLOCK_N1"])
+                if num_ctas == 2 and meta["BLOCK_M1"] == 128:
+                    assert n_tiles % num_ctas == 0
+                    n_tiles //= num_ctas
+                total_tiles = n_tiles * BATCH * N_HEAD
+                if os.environ.get("AUTOWS_BWD_FULL_GRID", "0") == "1":
+                    num_clusters = total_tiles
+                else:
+                    num_clusters = min(NUM_SMS // num_ctas, total_tiles)
                 return (
                     num_clusters * num_ctas,
                     1,
@@ -1676,7 +1801,8 @@ class _attention_opt(torch.autograd.Function):
         with triton.knobs.nvidia.scope():
             triton.knobs.nvidia.use_meta_ws = True
             triton.knobs.nvidia.use_meta_partition = True
-            triton.knobs.nvidia.disable_wsbarrier_reorder = True
+            triton.knobs.nvidia.disable_wsbarrier_reorder = (os.environ.get("AUTOWS_ENABLE_WSBARRIER_REORDER", "0")
+                                                             != "1")
             if ctx.persistent:
                 _attn_bwd_persist[grid_persist_bwd](
                     desc_q,
@@ -1703,7 +1829,6 @@ class _attention_opt(torch.autograd.Function):
                     HEAD_DIM=ctx.HEAD_DIM,  #
                     dtype=torch_dtype_to_triton(q.dtype),
                     warp_specialize=warp_specialize,
-                    maxRegAutoWS=192,
                 )
             else:
                 _attn_bwd[grid](
@@ -1731,7 +1856,6 @@ class _attention_opt(torch.autograd.Function):
                     HEAD_DIM=ctx.HEAD_DIM,  #
                     dtype=torch_dtype_to_triton(q.dtype),
                     warp_specialize=warp_specialize,
-                    maxRegAutoWS=192,
                 )
 
         return dq, dk, dv, None, None, None, None, None, None, None
@@ -1794,11 +1918,17 @@ def test_op(
     # (dedicated coverage: test_bwd_tmem_dsT_reuse_3group / _persistent).
     if mode == "bwd":
         chosen_cfg = configs_bwd_persist[bwd_config_idx]
-        # The 2-CTA backward is still being built out over the following
-        # commits; it is exercised by its own dedicated tests until it is
-        # numerically correct, not through this autotune matrix.
-        if chosen_cfg.kwargs.get("NUM_CTAS", 1) == 2:
-            pytest.skip("2-CTA backward is under construction")
+        cfg_num_ctas = chosen_cfg.kwargs.get("NUM_CTAS", 1)
+        cfg_block_m1 = chosen_cfg.kwargs["BLOCK_M1"]
+        # The 2-CTA backward only implements the BM128 adjacent-N-tile grid on
+        # the non-persistent path -- grid() asserts BLOCK_M1 == 128 there --
+        # so BM64 2-CTA is persistent-only.
+        if cfg_num_ctas == 2 and cfg_block_m1 != 128 and baseVariant == "ws":
+            pytest.skip("BM64 2-CTA backward is persistent-only")
+        # BM128 2-CTA packs dQ as [2 * N_CTX, HEAD_DIM // 2] and subtiles the
+        # epilogue by 8, which is only defined for HEAD_DIM=128.
+        if cfg_num_ctas == 2 and cfg_block_m1 == 128 and HEAD_DIM == 64:
+            pytest.skip("BM128 2-CTA backward requires HEAD_DIM=128")
         # Optional per-test SMEM budget override (e.g. force depth-2 early-TMA
         # store staging for the T277224987 regression). Copy so we never mutate
         # the shared global config.
@@ -1936,6 +2066,69 @@ def test_bwd_bm64_1cta_persistent_store_wait_drain():
         _attn_bwd_persist.cache = old_autows_cache
         tlx._attn_bwd_ws.configs = old_tlx_configs
         tlx._attn_bwd_ws.cache = old_tlx_cache
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_bm128_2cta_packed_dq():
+    # TwoCTA_RHS stores logical [64,128] dQ as physical [128,64]. Loading the
+    # logical H slices duplicates the local physical bank into both H halves.
+    idx = next(i for i, config in enumerate(configs_bwd_persist)
+               if config.kwargs.get("NUM_CTAS") == 2 and config.kwargs.get("BLOCK_M1") == 128)
+    test_op(
+        Z=2,
+        H=2,
+        N_CTX=256,
+        HEAD_DIM=128,
+        causal=False,
+        mode="bwd",
+        baseVariant="ws_persistent",
+        provider="triton-fp16",
+        SUBTILING=False,
+        VECT_MUL=0,
+        FADD2_REDUCE=False,
+        bwd_config_idx=idx,
+    )
+
+
+@contextlib.contextmanager
+def _temporarily_appended_bwd_config(config):
+    """Append a config to configs_bwd_persist for the duration of a test.
+
+    configs_bwd_persist is bound into @triton.autotune on _attn_bwd_persist and
+    is read at import time by parametrize(). A bare append/pop leaves the list
+    inconsistent if the body raises between them in a way finally cannot see,
+    or if two callers interleave. Snapshot and restore the whole list instead.
+    """
+    saved = list(configs_bwd_persist)
+    configs_bwd_persist.append(config)
+    try:
+        yield len(configs_bwd_persist) - 1
+    finally:
+        configs_bwd_persist[:] = saved
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
+def test_bwd_bm128_2cta_nonpersistent():
+    idx = next(i for i, config in enumerate(configs_bwd_persist)
+               if config.kwargs.get("NUM_CTAS") == 2 and config.kwargs.get("BLOCK_M1") == 128)
+    config = copy.copy(configs_bwd_persist[idx])
+    config.kwargs = dict(config.kwargs)
+    config.kwargs["EPILOGUE_SUBTILE"] = 2
+    with _temporarily_appended_bwd_config(config) as _idx:
+        test_op(
+            Z=2,
+            H=2,
+            N_CTX=256,
+            HEAD_DIM=128,
+            causal=False,
+            mode="bwd",
+            baseVariant="ws",
+            provider="triton-fp16",
+            SUBTILING=False,
+            VECT_MUL=0,
+            FADD2_REDUCE=False,
+            bwd_config_idx=_idx,
+        )
 
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) for the device-TMA bwd kernel")
@@ -2155,8 +2348,7 @@ def test_bwd_bm128_memtype_only():
             "SMEM_BUDGET": 220000,
             "BWD_DOT_ATTRS": _BWD_DOT_ATTRS_BM128_MEMTYPE,
         }, num_warps=4, num_stages=2, pre_hook=_bwd_host_descriptor_pre_hook)
-    configs_bwd_persist.append(cfg)
-    try:
+    with _temporarily_appended_bwd_config(cfg) as _idx:
         test_op(
             Z=8,
             H=16,
@@ -2169,10 +2361,8 @@ def test_bwd_bm128_memtype_only():
             SUBTILING=False,
             VECT_MUL=0,
             FADD2_REDUCE=False,
-            bwd_config_idx=len(configs_bwd_persist) - 1,
+            bwd_config_idx=_idx,
         )
-    finally:
-        configs_bwd_persist.pop()
 
 
 try:


### PR DESCRIPTION
Summary: Add the non-persistent BM128 two-CTA AutoWS configuration, dot scheduling metadata, descriptor handling, and benchmark selection using the independently tested nonempty-loop contract.

Reviewed By: njriasan

Differential Revision: D114617478


