### PR TITLE
[kernel] Reuse FA output staging under CLC (#3326)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -2,6 +2,7 @@
 #define TRITON_TRITONGPU_TRANSFORMS_PIPELINER_PIPELINING_UTILITY_H_
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Dominance.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/DiscardableAttributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
@@ -192,6 +193,14 @@ getLastUseOfPipelinedOp(ArrayRef<Operation *> ops, scf::ForOp forOp,
 
 // Clean up attributes passing over schedules across stages in pipelining
 void removePipeliningAttributes(ModuleOp moduleOp);
+
+// True when an `llvm.assume` dominating `loop` proves its trip count is at
+// least one, by asserting `ub > lb` (or the equivalent `lb < ub`) on the
+// loop's own bound values. Matches `tl.assume(hi > lo)` in the frontend.
+// `domInfo` is required because an assume only states a fact at its own
+// program point: one sitting after the loop, or in a region that does not
+// dominate it, proves nothing about the trip count.
+bool isLoopTripCountKnownPositive(scf::ForOp loop, DominanceInfo &domInfo);
 } // namespace triton
 } // namespace mlir
 

--- a/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/FuseNestedLoops.cpp
@@ -1112,30 +1112,6 @@ static void optimizeEpilogueDependencies(scf::ForOp outerLoop,
           {outerLoop.getBody()->begin(), innerLoop->getIterator()}, inEpilogue);
 }
 
-// Crudely match llvm.assume(ub > lb) or llvm.assume(lb < ub).
-static LogicalResult matchPositiveTripCount(scf::ForOp loop) {
-  for (Operation *user : loop.getUpperBound().getUsers()) {
-    if (auto cmp = dyn_cast<arith::CmpIOp>(user)) {
-      if (llvm::none_of(cmp->getUsers(),
-                        [](Operation *op) { return isa<LLVM::AssumeOp>(op); }))
-        continue;
-      if (cmp.getPredicate() == (loop.getUnsignedCmp()
-                                     ? arith::CmpIPredicate::ugt
-                                     : arith::CmpIPredicate::sgt) &&
-          cmp.getLhs() == loop.getUpperBound() &&
-          cmp.getRhs() == loop.getLowerBound())
-        return success();
-      if (cmp.getPredicate() == (loop.getUnsignedCmp()
-                                     ? arith::CmpIPredicate::ult
-                                     : arith::CmpIPredicate::slt) &&
-          cmp.getLhs() == loop.getLowerBound() &&
-          cmp.getRhs() == loop.getUpperBound())
-        return success();
-    }
-  }
-  return failure();
-}
-
 // Speculate the length of the inner loop such that the loop is known to execute
 // at least once. This way, the inner loop body does not have to be placed
 // inside a conditional in the fused loop, which interacts better with the
@@ -1147,7 +1123,7 @@ static LogicalResult speculateInnerLoopLength(scf::ForOp outerLoop,
   ImplicitLocOpBuilder b(loc, outerLoop);
 
   // Check if the inner loop is known to execute at least once.
-  if (succeeded(matchPositiveTripCount(innerLoop))) {
+  if (triton::isLoopTripCountKnownPositive(innerLoop, domInfo)) {
     innerLoop->setAttr(kMustExecuteAttrName, b.getUnitAttr());
     return success();
   }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -865,3 +865,34 @@ void triton::removePipeliningAttributes(ModuleOp moduleOp) {
     op->removeAttr(mlir::triton::kScheduledMaxStageAttrName);
   });
 }
+
+bool triton::isLoopTripCountKnownPositive(scf::ForOp loop,
+                                          DominanceInfo &domInfo) {
+  // Crudely match llvm.assume(ub > lb) or llvm.assume(lb < ub), the form
+  // tl.assume(hi > lo) lowers to. Kept deliberately syntactic: the assume
+  // must reference the loop's own bound SSA values, and must dominate the
+  // loop -- an assume placed after it, or under a sibling branch, asserts
+  // nothing at the point the trip count is taken.
+  auto isDominatingAssume = [&](Operation *op) {
+    return isa<LLVM::AssumeOp>(op) && domInfo.properlyDominates(op, loop);
+  };
+  for (Operation *user : loop.getUpperBound().getUsers()) {
+    auto cmp = dyn_cast<arith::CmpIOp>(user);
+    if (!cmp)
+      continue;
+    if (llvm::none_of(cmp->getUsers(), isDominatingAssume))
+      continue;
+    bool unsignedCmp = loop.getUnsignedCmp();
+    if (cmp.getPredicate() ==
+            (unsignedCmp ? arith::CmpIPredicate::ugt : arith::CmpIPredicate::sgt) &&
+        cmp.getLhs() == loop.getUpperBound() &&
+        cmp.getRhs() == loop.getLowerBound())
+      return true;
+    if (cmp.getPredicate() ==
+            (unsignedCmp ? arith::CmpIPredicate::ult : arith::CmpIPredicate::slt) &&
+        cmp.getLhs() == loop.getLowerBound() &&
+        cmp.getRhs() == loop.getUpperBound())
+      return true;
+  }
+  return false;
+}

--- a/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner_tl_assume.mlir
+++ b/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero_bwd_bm128_inner_tl_assume.mlir
@@ -1,0 +1,214 @@
+// RUN: triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=2 smem-budget=232448" | FileCheck %s
+// CHECK-LABEL: tt.func public @_attn_bwd
+// Variant of ws_remove_redundant_tmem_zero_bwd_bm128_inner.mlir that proves the
+// loop is non-empty with tl.assume(hi > lo) instead of the tt.assume_nonempty
+// annotation. The redundant operand-D zero-store must still be removed.
+// Dead load-task rematerialization clones of m/Di must be removed before
+// descriptor conversion derives the local_load consumer set. Otherwise these
+// loads carry tasks {0, 3} and create an unsafe self-consumer TMA channel.
+// CHECK-COUNT-2: ttg.local_load {{.*}}async_task_id = array<i32: 0>{{.*}}!ttg.memdesc<128xf32
+// CHECK-NOT: ttng.tmem_store %cst
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 2, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 2, 4], threadsPerWarp = [8, 1, 4], warpsPerCTA = [8, 1, 1], order = [1, 2, 0]}>
+#blocked7 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [8, 4, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked8 = #ttg.blocked<{sizePerThread = [1, 8, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 128], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], warp = [[0, 32], [0, 64], [32, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[128, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
+#linear3 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear4 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#linear5 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [0, 64], [0, 32]], block = []}>
+#linear6 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 1, 0]], block = []}>
+#linear7 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0]], lane = [[2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0]], warp = [[64, 0, 0], [1, 0, 0], [0, 0, 1]], block = []}>
+#linear8 = #ttg.linear<{register = [[0, 0, 1], [0, 16, 0], [0, 1, 0], [0, 2, 0], [64, 0, 0]], lane = [[0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0], [4, 0, 0]], warp = [[8, 0, 0], [16, 0, 0], [32, 0, 0]], block = []}>
+#linear9 = #ttg.linear<{register = [[0, 16], [0, 1], [0, 2], [64, 0]], lane = [[0, 4], [0, 8], [1, 0], [2, 0], [4, 0]], warp = [[8, 0], [16, 0], [32, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 32, rank = 1}>
+#shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, twoCTAs = true>
+#tmem1 = #ttng.tensor_memory_encoding<blockM = 64, blockN = 128, colStride = 1, twoCTAs = true, ctaMode = twocta_rhs>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.max_reg_auto_ws = 88 : i32, ttg.min_reg_auto_ws = 88 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @_attn_bwd(%arg0: !tt.tensordesc<128x64xf16, #shared>, %arg1: i32, %arg2: i32, %arg3: i64, %arg4: i64, %arg5: !tt.tensordesc<64x128xf16, #shared>, %arg6: i32, %arg7: i32, %arg8: i64, %arg9: i64, %arg10: !tt.tensordesc<128x128xf16, #shared>, %arg11: i32, %arg12: i32, %arg13: i64, %arg14: i64, %arg15: !tt.tensordesc<256x64xf16, #shared>, %arg16: i32, %arg17: i32, %arg18: i64, %arg19: i64, %arg20: !tt.tensordesc<128x128xf16, #shared>, %arg21: i32, %arg22: i32, %arg23: i64, %arg24: i64, %arg25: f32, %arg26: !tt.tensordesc<128x64xf16, #shared>, %arg27: i32, %arg28: i32, %arg29: i64, %arg30: i64, %arg31: !tt.tensordesc<64x128xf16, #shared>, %arg32: i32, %arg33: i32, %arg34: i64, %arg35: i64, %arg36: !tt.tensordesc<128x16xf32, #shared1>, %arg37: i32, %arg38: i32, %arg39: i64, %arg40: i64, %arg41: !tt.tensordesc<128x64xf16, #shared>, %arg42: i32, %arg43: i32, %arg44: i64, %arg45: i64, %arg46: !tt.tensordesc<128x64xf16, #shared>, %arg47: i32, %arg48: i32, %arg49: i64, %arg50: i64, %arg51: !tt.tensordesc<128xf32, #shared2>, %arg52: i32, %arg53: i64, %arg54: !tt.tensordesc<128xf32, #shared2>, %arg55: i32, %arg56: i64, %arg57: i32 {tt.divisibility = 16 : i32}, %arg58: i32 {tt.divisibility = 16 : i32}, %arg59: i32 {tt.divisibility = 16 : i32}, %arg60: i32, %arg61: i32, %arg62: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %false = arith.constant false
+    %cst = arith.constant dense<0.693147182> : tensor<128x16xf32, #blocked>
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c48_i32 = arith.constant 48 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i64 = arith.constant 2 : i64
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %true = arith.constant true
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %0 = tt.get_program_id z : i32
+    %1 = tt.get_program_id x : i32
+    %2 = arith.muli %0, %arg62 : i32
+    %3 = arith.extsi %2 : i32 to i64
+    %4 = arith.remsi %0, %arg61 : i32
+    %5 = arith.muli %arg58, %4 : i32
+    %6 = arith.divsi %0, %arg61 : i32
+    %7 = arith.muli %arg57, %6 : i32
+    %8 = arith.addi %5, %7 : i32
+    %9 = arith.extsi %8 : i32 to i64
+    %10 = arith.extsi %arg59 : i32 to i64
+    %11 = arith.divsi %9, %10 : i64
+    %12 = arith.muli %1, %c128_i32 : i32
+    %13 = arith.remsi %1, %c2_i32 : i32
+    %14 = arith.extsi %12 : i32 to i64
+    %15 = arith.addi %11, %14 : i64
+    %16 = arith.trunci %15 : i64 to i32
+    %17 = tt.descriptor_load %arg10[%16, %c0_i32] {ttg.partition = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1>
+    %18 = ttg.local_alloc %17 {ttg.partition = array<i32: 3>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %19 = arith.muli %13, %c128_i32 : i32
+    %20 = arith.subi %12, %19 : i32
+    %21 = arith.extsi %20 : i32 to i64
+    %22 = arith.addi %11, %21 : i64
+    %23 = arith.trunci %22 : i64 to i32
+    %24 = nvg.cluster_id
+    %25 = arith.remsi %24, %c2_i32 : i32
+    %26 = arith.muli %25, %c64_i32 : i32
+    %27 = tt.descriptor_load %arg15[%23, %26] {ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<256x64xf16, #shared> -> tensor<256x64xf16, #blocked2>
+    %28 = ttg.local_alloc %27 {ttg.partition = array<i32: 3>} : (tensor<256x64xf16, #blocked2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+    %29 = tt.descriptor_load %arg20[%16, %c0_i32] {ttg.partition = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared> -> tensor<128x128xf16, #blocked1>
+    %30 = ttg.local_alloc %29 {ttg.partition = array<i32: 3>} : (tensor<128x128xf16, #blocked1>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
+    %31 = arith.divsi %arg62, %c128_i32 : i32
+    %32 = arith.muli %13, %c64_i32 : i32
+    %33 = arith.extsi %32 : i32 to i64
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_1, %token_2 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_3, %token_4 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_5, %token_6 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %result_7, %token_8 = ttng.tmem_alloc : () -> (!ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %34 = ttng.tmem_store %cst_0, %result_5[%token_6], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %35 = ttng.tmem_store %cst_0, %result_3[%token_4], %true {ttg.partition = array<i32: 1>} : tensor<128x128xf32, #linear> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %nonempty = arith.cmpi sgt, %31, %c0_i32 {ttg.partition = array<i32: 1>} : i32
+    llvm.intr.assume %nonempty : i1 {ttg.partition = array<i32: 1>}
+    %36:7 = scf.for %arg63 = %c0_i32 to %31 step %c1_i32 iter_args(%arg64 = %c0_i32, %arg65 = %false, %arg66 = %token, %arg67 = %token_2, %arg68 = %35, %arg69 = %34, %arg70 = %token_8) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
+      %58 = arith.extsi %arg64 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : i32 to i64
+      %59 = arith.addi %11, %58 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 1>} : i64
+      %60 = arith.trunci %59 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+      %61 = arith.addi %60, %26 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i32
+      %62 = tt.descriptor_load %arg5[%61, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1>
+      %63 = ttg.local_alloc %62 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+      %64 = ttg.memdesc_trans %63 {loop.cluster = 1 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared3, #smem>
+      %65 = tt.descriptor_load %arg0[%60, %26] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked2>
+      %66 = ttg.local_alloc %65 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %67 = arith.addi %3, %58 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64
+      %68 = arith.trunci %67 {loop.cluster = 1 : i32, loop.stage = 0 : i32} : i64 to i32
+      %69 = tt.descriptor_load %arg51[%68] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2> -> tensor<128xf32, #blocked3>
+      %70 = ttng.tc_gen5_mma %18, %64, %result[%arg66], %false, %true {loop.cluster = 1 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \220\22, \22channels\22: [\22opndA,smem,1,0\22, \22opndB,smem,1,1\22, \22opndD,tmem,1,2\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %71 = ttg.convert_layout %69 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %72 = ttg.convert_layout %69 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %73 = tt.expand_dims %71 {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %74 = tt.expand_dims %72 {axis = 0 : i32, loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %75 = tt.broadcast %73 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %result_15, %token_16 = ttng.tmem_load %result[%70] {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %76 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 4 : i32, loop.stage = 0 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %result_15, %75 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %77 = math.exp2 %76 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear>
+      %78 = tt.descriptor_load %arg26[%60, %26] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked2>
+      %79 = ttg.local_alloc %78 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %80 = tt.descriptor_load %arg31[%61, %c0_i32] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>, two_cta_b} : !tt.tensordesc<64x128xf16, #shared> -> tensor<64x128xf16, #blocked1>
+      %81 = arith.truncf %77 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %result_17 = ttng.tmem_alloc %81 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+      %82 = ttg.local_alloc %80 {loop.cluster = 4 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : (tensor<64x128xf16, #blocked1>) -> !ttg.memdesc<64x128xf16, #shared, #smem>
+      %83 = ttg.memdesc_trans %82 {loop.cluster = 4 : i32, loop.stage = 0 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<64x128xf16, #shared, #smem> -> !ttg.memdesc<128x64xf16, #shared3, #smem>
+      %84 = ttng.tc_gen5_mma %30, %83, %result_1[%arg67], %false, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,smem,1,3\22, \22opndB,smem,1,4\22, \22opndD,tmem,1,5\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, two_ctas} : !ttg.memdesc<128x128xf16, #shared, #smem>, !ttg.memdesc<128x64xf16, #shared3, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %85 = tt.descriptor_load %arg54[%68] {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 3>} : !tt.tensordesc<128xf32, #shared2> -> tensor<128xf32, #blocked3>
+      %86 = ttng.tc_gen5_mma %result_17, %79, %result_3[%arg68], %arg65, %true {loop.cluster = 4 : i32, loop.stage = 0 : i32, tt.autows = "{\22stage\22: \220\22, \22order\22: \222\22, \22channels\22: [\22opndA,tmem,1,2\22, \22opndD,tmem,1,7\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %87 = ttg.convert_layout %85 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %88 = ttg.convert_layout %85 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #blocked3> -> tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>>
+      %89 = tt.expand_dims %87 {axis = 0 : i32, loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %90 = tt.expand_dims %88 {axis = 0 : i32, loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 3>} : tensor<128xf32, #ttg.slice<{dim = 0, parent = #linear}>> -> tensor<1x128xf32, #linear>
+      %91 = tt.broadcast %89 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %result_18, %token_19 = ttng.tmem_load %result_1[%84] {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %92 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            sub.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %result_18, %91 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %93 = tt.elementwise_inline_asm "\0A        {\0A            .reg .b64 ra, rb, rc;\0A            mov.b64 ra, { $2, $3 };\0A            mov.b64 rb, { $4, $5 };\0A            mul.f32x2 rc, ra, rb;\0A            mov.b64 { $0, $1 }, rc;\0A        }\0A        " {constraints = "=r,=r,r,r,r,r", loop.cluster = 1 : i32, loop.stage = 1 : i32, packed_element = 2 : i32, pure = true, ttg.partition = array<i32: 0>} %77, %92 : tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear> -> tensor<128x128xf32, #linear>
+      %94 = arith.truncf %93 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> to tensor<128x128xf16, #linear>
+      %result_20 = ttng.tmem_alloc %94 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x128xf16, #linear>) -> !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>
+      %95 = ttng.tc_gen5_mma %result_20, %66, %result_5[%arg69], %arg65, %true {loop.cluster = 1 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \220\22, \22channels\22: [\22opndD,tmem,1,10\22]}", tt.self_latency = 0 : i32, ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "collective_contraction", two_ctas} : !ttg.memdesc<128x128xf16, #tmem, #ttng.tensor_memory>, !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %96 = ttng.two_cta_peer_gather %94 split_dim = 1 num_ctas = 2 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<64x256xf16, #linear1>
+      %97 = tt.trans %96 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 0>} : tensor<64x256xf16, #linear1> -> tensor<256x64xf16, #linear2>
+      %98 = tt.reshape %94 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x128xf16, #linear> -> tensor<128x2x64xf16, #linear3>
+      %99 = tt.trans %98 {loop.cluster = 1 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf16, #linear3> -> tensor<128x64x2xf16, #linear4>
+      %100 = ttg.convert_layout %99 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x64x2xf16, #linear4> -> tensor<128x64x2xf16, #blocked4>
+      %outLHS_21, %outRHS_22 = tt.split %100 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : tensor<128x64x2xf16, #blocked4> -> tensor<128x64xf16, #blocked5>
+      %101 = ttg.local_alloc %outLHS_21 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked5>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %102 = ttg.local_alloc %97 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 0>} : (tensor<256x64xf16, #linear2>) -> !ttg.memdesc<256x64xf16, #shared, #smem>
+      ttng.two_cta_peer_relay %101 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 4>} : <128x64xf16, #shared, #smem>
+      %103 = ttg.memdesc_trans %102 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 1, 0>, ttg.partition = array<i32: 2>} : !ttg.memdesc<256x64xf16, #shared, #smem> -> !ttg.memdesc<64x256xf16, #shared3, #smem>
+      %104 = ttng.tc_gen5_mma %103, %28, %result_7[%arg70], %false, %true {loop.cluster = 2 : i32, loop.stage = 1 : i32, tt.autows = "{\22stage\22: \221\22, \22order\22: \221\22, \22channels\22: [\22opndA,smem,1,8\22, \22opndD,tmem,1,5\22]}", ttg.partition = array<i32: 2>, ttng.two_cta_dependency = "requires_peer_gather", two_ctas} : !ttg.memdesc<64x256xf16, #shared3, #smem>, !ttg.memdesc<256x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %result_23, %token_24 = ttng.tmem_load %result_7[%104] {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.memdesc<64x128xf32, #tmem1, #ttng.tensor_memory, mutable> -> tensor<64x128xf32, #linear5>
+      %105 = tt.reshape %result_23 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<64x128xf32, #linear5> -> tensor<128x2x32xf32, #linear6>
+      %106 = tt.trans %105 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x32xf32, #linear6> -> tensor<128x32x2xf32, #linear7>
+      %107 = ttg.convert_layout %106 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32x2xf32, #linear7> -> tensor<128x32x2xf32, #linear8>
+      %outLHS_25, %outRHS_26 = tt.split %107 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32x2xf32, #linear8> -> tensor<128x32xf32, #linear9>
+      %108 = tt.reshape %outLHS_25 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked6>
+      %109 = tt.trans %108 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x16xf32, #blocked6> -> tensor<128x16x2xf32, #blocked7>
+      %outLHS_27, %outRHS_28 = tt.split %109 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16x2xf32, #blocked7> -> tensor<128x16xf32, #blocked>
+      %110 = tt.reshape %outRHS_26 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x32xf32, #linear9> -> tensor<128x2x16xf32, #blocked6>
+      %111 = tt.trans %110 {loop.cluster = 2 : i32, loop.stage = 1 : i32, order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 1>} : tensor<128x2x16xf32, #blocked6> -> tensor<128x16x2xf32, #blocked7>
+      %outLHS_29, %outRHS_30 = tt.split %111 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16x2xf32, #blocked7> -> tensor<128x16xf32, #blocked>
+      %112 = arith.addi %59, %33 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64
+      %113 = arith.muli %112, %c2_i64 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64
+      %114 = arith.mulf %outLHS_27, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %115 = arith.trunci %113 {loop.cluster = 1 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : i64 to i32
+      %116 = ttg.local_alloc %114 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %117 = ttng.async_tma_reduce add, %arg36[%115, %c0_i32] %116 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %117   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %118 = arith.mulf %outRHS_28, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %119 = ttg.local_alloc %118 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %120 = ttng.async_tma_reduce add, %arg36[%115, %c16_i32] %119 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %120   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %121 = arith.mulf %outLHS_29, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %122 = ttg.local_alloc %121 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %123 = ttng.async_tma_reduce add, %arg36[%115, %c32_i32] %122 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %123   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %124 = arith.mulf %outRHS_30, %cst {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : tensor<128x16xf32, #blocked>
+      %125 = ttg.local_alloc %124 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : (tensor<128x16xf32, #blocked>) -> !ttg.memdesc<128x16xf32, #shared1, #smem, mutable>
+      %126 = ttng.async_tma_reduce add, %arg36[%115, %c48_i32] %125 {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !tt.tensordesc<128x16xf32, #shared1>, !ttg.memdesc<128x16xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %126   {loop.cluster = 2 : i32, loop.stage = 1 : i32, ttg.partition = array<i32: 1>} : !ttg.async.token
+      %127 = arith.addi %arg64, %c128_i32 {loop.cluster = 0 : i32, loop.stage = 1 : i32} : i32
+      scf.yield %127, %true, %token_16, %token_19, %86, %95, %token_24 : i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token
+    } {tt.merge_epilogue_to_computation = true, tt.scheduled_max_stage = 1 : i32, tt.smem_alloc_algo = 1 : i32, tt.smem_budget = 180000 : i32, tt.tmem_alloc_algo = 2 : i32, tt.warp_specialize, ttg.partition.stages = [0 : i32, 0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["computation", "reduction", "gemm", "load", "relay"], ttg.warp_specialize.tag = 0 : i32}
+    %result_9, %token_10 = ttng.tmem_load %result_3[%36#4] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %result_11, %token_12 = ttng.tmem_load %result_5[%36#5] {ttg.partition = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+    %37 = tt.reshape %result_9 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+    %38 = tt.trans %37 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+    %39 = ttg.convert_layout %38 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #blocked8>
+    %outLHS, %outRHS = tt.split %39 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #blocked8> -> tensor<128x64xf32, #blocked2>
+    %40 = arith.truncf %outLHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %41 = ttg.local_alloc %40 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %42 = ttng.async_tma_copy_local_to_global %arg46[%16, %c0_i32] %41 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %42   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %43 = arith.truncf %outRHS {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %44 = ttg.local_alloc %43 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %45 = ttng.async_tma_copy_local_to_global %arg46[%16, %c64_i32] %44 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %45   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %46 = tt.reshape %result_11 {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear3>
+    %47 = tt.trans %46 {order = array<i32: 0, 2, 1>, ttg.partition = array<i32: 0>} : tensor<128x2x64xf32, #linear3> -> tensor<128x64x2xf32, #linear4>
+    %48 = ttg.convert_layout %47 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #linear4> -> tensor<128x64x2xf32, #blocked8>
+    %outLHS_13, %outRHS_14 = tt.split %48 {ttg.partition = array<i32: 0>} : tensor<128x64x2xf32, #blocked8> -> tensor<128x64xf32, #blocked2>
+    %49 = tt.splat %arg25 : f32 -> tensor<128x64xf32, #blocked2>
+    %50 = arith.mulf %outLHS_13, %49 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+    %51 = arith.truncf %50 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %52 = ttg.local_alloc %51 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %53 = ttng.async_tma_copy_local_to_global %arg41[%16, %c0_i32] %52 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %53   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    %54 = arith.mulf %outRHS_14, %49 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2>
+    %55 = arith.truncf %54 {ttg.partition = array<i32: 0>} : tensor<128x64xf32, #blocked2> to tensor<128x64xf16, #blocked2>
+    %56 = ttg.local_alloc %55 {ttg.partition = array<i32: 0>} : (tensor<128x64xf16, #blocked2>) -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+    %57 = ttng.async_tma_copy_local_to_global %arg41[%16, %c64_i32] %56 {ttg.partition = array<i32: 0>} : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+    ttng.async_tma_store_token_wait %57   {ttg.partition = array<i32: 0>} : !ttg.async.token
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -4994,8 +4994,14 @@ void removeRedundantTmemZeroStores(triton::FuncOp funcOp) {
           zeroStoreParentLoop &&
           (zeroStoreParentLoop == mmaParentLoop.getOperation() ||
            zeroStoreParentLoop->isProperAncestor(mmaParentLoop));
+      // The loop is known to run at least once either from an explicit
+      // tt.assume_nonempty annotation, or from a tl.assume(hi > lo) on its
+      // bounds, which needs no separate annotation.
+      bool knownNonEmpty =
+          mmaParentLoop->hasAttr("tt.assume_nonempty") ||
+          triton::isLoopTripCountKnownPositive(mmaParentLoop, dominance);
       bool dominatesKnownNonEmptyLoop =
-          mmaParentLoop->hasAttr("tt.assume_nonempty") &&
+          knownNonEmpty &&
           dominance.properlyDominates(zeroStoreOp, mmaParentLoop);
       if (commonOuterLoop || dominatesKnownNonEmptyLoop) {
         LLVM_DEBUG({

--- a/third_party/nvidia/hopper/run_all.sh
+++ b/third_party/nvidia/hopper/run_all.sh
@@ -54,6 +54,10 @@ pytest python/test/unit/language/test_autows_addmm.py
 pytest python/test/unit/language/test_autows_quantized_matmul.py
 pytest third_party/tlx/tutorials/testing/test_correctness_autows.py
 
+echo "Verifying repeated high-grid 2-CTA CLC FA forward"
+AUTOWS_FWD_CLC=1 AUTOWS_FWD_NUM_CTAS=2 \
+    pytest third_party/tlx/tutorials/testing/test_correctness_autows.py::test_autows_fa_rescale_opt_clc_repeated_high_grid
+
 echo "Run autoWS tutorial kernels"
 echo "Verifying correctness of FA tutorial kernels"
 pytest third_party/tlx/tutorials/fused_attention_ws_device_tma.py

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -1,5 +1,7 @@
+import os
 from enum import IntEnum
 from typing import NamedTuple
+
 import torch
 import triton
 import triton.language as tl
@@ -104,6 +106,22 @@ configs = [
         (True, True, False),
     ]
 ]
+
+_fwd_num_ctas = os.environ.get("TLX_FWD_NUM_CTAS")
+if _fwd_num_ctas is not None:
+    configs = [config for config in configs if config.kwargs.get("NUM_CTAS", 1) == int(_fwd_num_ctas)]
+
+_fwd_num_buffers_kv = os.environ.get("TLX_FWD_NUM_BUFFERS_KV")
+if _fwd_num_buffers_kv is not None:
+    configs = [config for config in configs if config.kwargs["NUM_BUFFERS_KV"] == int(_fwd_num_buffers_kv)]
+
+_fwd_rescale_opt = os.environ.get("TLX_FWD_RESCALE_OPT")
+if _fwd_rescale_opt is not None:
+    configs = [config for config in configs if config.kwargs["RESCALE_OPT"] == bool(int(_fwd_rescale_opt))]
+
+_fwd_use_where = os.environ.get("TLX_FWD_USE_WHERE")
+if _fwd_use_where is not None:
+    configs = [config for config in configs if config.kwargs["USE_WHERE"] == bool(int(_fwd_use_where))]
 
 
 def prune_configs_by_hdim(configs, named_args, **kwargs):

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -357,6 +357,8 @@ FWD_2CTA_DP_FACTOR = int(os.environ.get("AUTOWS_FWD_DP_FACTOR", "2"))
 FWD_2CTA_MMA_SLICES = int(os.environ.get("AUTOWS_FWD_MMA_SLICES", "2"))
 FWD_2CTA_KV_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_KV_NUM_STAGES", _FWD_CLC_SAFE_STAGES))
 FWD_2CTA_OUTER_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_OUTER_NUM_STAGES", "1"))
+_FWD_2CTA_SMEM_BUDGET = os.environ.get("AUTOWS_FWD_SMEM_BUDGET")
+FWD_2CTA_SMEM_BUDGET = int(_FWD_2CTA_SMEM_BUDGET) if _FWD_2CTA_SMEM_BUDGET is not None else None
 
 configs = [
     triton.Config(
@@ -384,6 +386,7 @@ configs = [
             "MMA_SLICES": FWD_2CTA_MMA_SLICES,
             "KV_NUM_STAGES": FWD_2CTA_KV_NUM_STAGES,
             "OUTER_NUM_STAGES": FWD_2CTA_OUTER_NUM_STAGES,
+            "SMEM_BUDGET": FWD_2CTA_SMEM_BUDGET,
             "RESCALE_OPT": _FWD_RESCALE_OPT,
         },
         num_stages=FWD_2CTA_NUM_STAGES,
@@ -677,6 +680,7 @@ def _attn_fwd_persist(
     KV_NUM_STAGES: tl.constexpr,
     OUTER_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    SMEM_BUDGET: tl.constexpr = None,
     USE_CLC: tl.constexpr = False,
     NUM_CTAS: tl.constexpr = 1,
     RESCALE_OPT: tl.constexpr = False,
@@ -725,6 +729,7 @@ def _attn_fwd_persist(
                 merge_epilogue=True,
                 separate_epilogue_store=True,
                 data_partition_factor=DP_FACTOR,
+                smem_budget=SMEM_BUDGET,
         ):
             # Preserve the static 2-CTA mapping: adjacent physical CTAs process
             # adjacent M tiles.  The CLC lowering adds the cluster rank to the
@@ -772,6 +777,7 @@ def _attn_fwd_persist(
                 separate_epilogue_store=True,
                 data_partition_factor=DP_FACTOR,
                 num_stages=OUTER_NUM_STAGES if NUM_CTAS == 2 else None,
+                smem_budget=SMEM_BUDGET,
         ):
             pid = tile_idx % n_tile_num
             off_hz = tile_idx // n_tile_num

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -743,7 +743,7 @@ def _attn_bwd_dkdv_inner(
         q = desc_q.load([(off_bh + curr_m).to(tl.int32), 0])
         qT = tl.trans(q)
     offs_m_start = off_chz + curr_m
-    m = desc_m.load([offs_m_start.to(tl.int32)])
+    m = desc_m.load([offs_m_start.to(tl.int32)], attrs=BWD_DOT_ATTRS.get("m_load") if RESCHED else None)
     if RESCHED:
         qkT = tl.dot(k, qT, attrs=BWD_DOT_ATTRS.get("qkT"), two_ctas=TWO_CTAS)
     else:
@@ -762,7 +762,7 @@ def _attn_bwd_dkdv_inner(
     ppT = ppT.to(dtype)
     if RESCHED:
         dpT = tl.dot(v, tl.trans(dot), attrs=BWD_DOT_ATTRS.get("dpT"), two_ctas=TWO_CTAS).to(tl.float32)
-        Di = desc_delta.load([offs_m_start.to(tl.int32)])
+        Di = desc_delta.load([offs_m_start.to(tl.int32)], attrs=BWD_DOT_ATTRS.get("delta_load"))
         dv += tl.dot(ppT, do, attrs=BWD_DOT_ATTRS.get("dv"), two_ctas=TWO_CTAS)
     else:
         dv += tl.dot(ppT, do)
@@ -865,6 +865,13 @@ def _attn_bwd_dkdv(
     curr_m = start_m
     step_m = BLOCK_M1
     if warp_specialize:
+        if TWO_CTAS and BLOCK_M1 == 128:
+            # Only the BM128 2-CTA path has a pre-hook guaranteeing a non-empty
+            # loop (it asserts N_CTX % (BLOCK_N1 * NUM_CTAS) == 0). BM64 2-CTA has
+            # no such guard, so promising non-emptiness there would be a false
+            # promise when num_steps is 0. Lets removeRedundantTmemZeroStores drop
+            # the operand-D zero-store.
+            tl.assume(num_steps > 0)
         for blk_idx in tl.range(
                 0,
                 num_steps,

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -42,6 +42,27 @@ def is_hopper():
 
 
 @triton.jit
+def _reduce_or(x, y):
+    return x | y
+
+
+@triton.jit
+def _rescale_accumulator(acc, alpha, SUBTILING: tl.constexpr, VECT_MUL: tl.constexpr):
+    BM: tl.constexpr = acc.shape[0]
+    BN: tl.constexpr = acc.shape[1]
+    if SUBTILING:
+        acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+        if VECT_MUL == 1 or VECT_MUL == 3:
+            acc0 = _mul_f32x2(acc0, alpha[:, None])
+            acc1 = _mul_f32x2(acc1, alpha[:, None])
+        else:
+            acc0 = acc0 * alpha[:, None]
+            acc1 = acc1 * alpha[:, None]
+        return tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    return acc * alpha[:, None]
+
+
+@triton.jit
 def _mask_scalar(qk, col_limit_right, s, i):
     col_lim_right_s = col_limit_right - s
     col_lim_right_cur = max(col_lim_right_s, 0)
@@ -89,6 +110,7 @@ def _attn_fwd_subtile(
     FADD2_REDUCE: tl.constexpr,
     MMA_SLICES: tl.constexpr,
     TWO_CTAS: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
 ):
     qk = tl.dot(
         q,
@@ -110,34 +132,50 @@ def _attn_fwd_subtile(
         col_limit_right = (offs_m - start_n + 1)[:, None]
         qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
 
-    m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
-
-    if VECT_MUL == 2 or VECT_MUL == 3:
-        qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+    if RESCALE_OPT:
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        alpha_ = (m_i - m_ij) * qk_scale
+        alpha = tl.math.exp2(alpha_)
+        # Skip the accumulator rescale where alpha is within 2^-8 of 1.0: below
+        # that the correction is smaller than the accumulator's fp32 precision,
+        # so paying for the TMEM read-modify-write buys nothing.
+        rescale_mask = alpha_ >= -8.0
+        alpha = tl.where(rescale_mask, 1.0, alpha)
+        m_ij = tl.where(rescale_mask, m_i, m_ij)
+        m_scaled = m_ij * qk_scale
+        if VECT_MUL == 2 or VECT_MUL == 3:
+            qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
+        else:
+            qk = qk * qk_scale - m_scaled[:, None]
     else:
-        qk = qk * qk_scale - m_ij[:, None]
+        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+        if VECT_MUL == 2 or VECT_MUL == 3:
+            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+        else:
+            qk = qk * qk_scale - m_ij[:, None]
+        alpha = tl.math.exp2(m_i - m_ij)
 
     p = tl.math.exp2(qk)
-    # -- compute correction factor
-    alpha = tl.math.exp2(m_i - m_ij)
     if not FADD2_REDUCE:
         l_ij = tl.sum(p, 1)
 
     # -- update output accumulator --
-    BM: tl.constexpr = acc.shape[0]
-    BN: tl.constexpr = acc.shape[1]
-
-    if SUBTILING:
-        acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
-        if VECT_MUL == 1 or VECT_MUL == 3:
-            acc0 = _mul_f32x2(acc0, alpha[:, None])
-            acc1 = _mul_f32x2(acc1, alpha[:, None])
-        else:
-            acc0 = acc0 * alpha[:, None]
-            acc1 = acc1 * alpha[:, None]
-        acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    if RESCALE_OPT:
+        # Derive the correction vote from the finalized alpha tile.  The
+        # correction task already consumes alpha for the accumulator multiply,
+        # so this lets AutoWS compute the vote beside that load instead of
+        # materializing a second cross-partition needs_rescale channel.
+        needs_rescale = alpha < 1.0
+        should_rescale = tl.reshape(tl.reduce(needs_rescale, axis=0, combine_fn=_reduce_or), ())
+        scaled_acc = _rescale_accumulator(acc, alpha, SUBTILING, VECT_MUL)
+        # Keep this as an eager SSA select until the accumulator is placed in
+        # TMEM. HoistTMEMAlloc first folds it into a predicated TMEM store;
+        # after AutoWS has materialized each data-partition task, the
+        # post-pipeline invocation turns that store into a side-effecting
+        # conditional load/rescale/store.
+        acc = tl.where(should_rescale, scaled_acc, acc)
     else:
-        acc = acc * alpha[:, None]
+        acc = _rescale_accumulator(acc, alpha, SUBTILING, VECT_MUL)
 
     PM: tl.constexpr = p.shape[0]
     PN: tl.constexpr = p.shape[1]
@@ -215,6 +253,7 @@ def _attn_fwd_inner_oss_dp(
     KV_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
     TWO_CTAS: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
 ):
     # range of values handled by this stage
     if STAGE == 1:  # causal = False
@@ -272,6 +311,7 @@ def _attn_fwd_inner_oss_dp(
             FADD2_REDUCE,
             MMA_SLICES,
             TWO_CTAS,
+            RESCALE_OPT,
         )
 
         offsetkv_y += BLOCK_N
@@ -305,6 +345,7 @@ elif supports_host_descriptor():
 else:
     NUM_STAGES_OPTIONS = [3]
 _FWD_USE_CLC = os.environ.get("AUTOWS_FWD_CLC", "0") == "1"
+_FWD_RESCALE_OPT = os.environ.get("AUTOWS_FWD_RESCALE_OPT", "1") == "1"
 _FWD_CLC_SAFE_STAGES = "2" if _FWD_USE_CLC else "4"
 FWD_2CTA_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_NUM_STAGES", _FWD_CLC_SAFE_STAGES))
 FWD_2CTA_BLOCK_M = int(os.environ.get("AUTOWS_FWD_BLOCK_M", "256"))
@@ -323,6 +364,7 @@ configs = [
             "MMA_SLICES": 1,
             "KV_NUM_STAGES": s,
             "OUTER_NUM_STAGES": s,
+            "RESCALE_OPT": _FWD_RESCALE_OPT,
         },
         num_stages=s,
         num_warps=w,
@@ -338,6 +380,7 @@ configs = [
             "MMA_SLICES": FWD_2CTA_MMA_SLICES,
             "KV_NUM_STAGES": FWD_2CTA_KV_NUM_STAGES,
             "OUTER_NUM_STAGES": FWD_2CTA_OUTER_NUM_STAGES,
+            "RESCALE_OPT": _FWD_RESCALE_OPT,
         },
         num_stages=FWD_2CTA_NUM_STAGES,
         num_warps=4,
@@ -412,6 +455,7 @@ def _attn_fwd_tma_dp(
     KV_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
     NUM_CTAS: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
 ):
     start_m = pid  # tl.program_id(0)
     # off_hz = tl.program_id(1)
@@ -465,6 +509,7 @@ def _attn_fwd_tma_dp(
         KV_NUM_STAGES,
         DP_FACTOR,
         NUM_CTAS == 2,
+        RESCALE_OPT,
     )
 
     if FADD2_REDUCE:
@@ -472,6 +517,8 @@ def _attn_fwd_tma_dp(
     else:
         l_i0 = l_i0_0
 
+    if RESCALE_OPT:
+        m_i0 *= qk_scale
     m_i0 += tl.math.log2(l_i0)
     if NUM_CTAS == 2:
         # Match the TLX epilogue's packed-f32 normalization. Keeping adjacent
@@ -521,6 +568,7 @@ def _attn_fwd(
     OUTER_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
     NUM_CTAS: tl.constexpr = 1,
+    RESCALE_OPT: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     off_hz = tl.program_id(1)
@@ -576,6 +624,7 @@ def _attn_fwd(
         KV_NUM_STAGES,
         DP_FACTOR,
         NUM_CTAS,
+        RESCALE_OPT,
     )
 
 
@@ -612,6 +661,7 @@ def _attn_fwd_persist(
     DP_FACTOR: tl.constexpr,
     USE_CLC: tl.constexpr = False,
     NUM_CTAS: tl.constexpr = 1,
+    RESCALE_OPT: tl.constexpr = False,
 ):
     n_tile_num = tl.cdiv(N_CTX, BLOCK_M)
     prog_id = tl.program_id(0)
@@ -691,6 +741,7 @@ def _attn_fwd_persist(
                 KV_NUM_STAGES,
                 DP_FACTOR,
                 NUM_CTAS,
+                RESCALE_OPT,
             )
             scheduler = scheduler.advance()
     else:
@@ -732,6 +783,7 @@ def _attn_fwd_persist(
                 KV_NUM_STAGES,
                 DP_FACTOR,
                 NUM_CTAS,
+                RESCALE_OPT,
             )
             tile_idx += num_progs
 

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -80,14 +80,31 @@ def _attn_fwd_subtile(
     l_i1,  # used when FADD2_REDUCE is true
     m_i,
     acc,
-    v,
+    v0,
+    v1,
     dtype: tl.constexpr,
     STAGE: tl.constexpr,
     SUBTILING: tl.constexpr,
     VECT_MUL: tl.constexpr,
     FADD2_REDUCE: tl.constexpr,
+    MMA_SLICES: tl.constexpr,
+    TWO_CTAS: tl.constexpr,
 ):
-    qk = tl.dot(q, k)
+    qk = tl.dot(
+        q,
+        k,
+        attrs=({
+            "channels": [
+                "opndA,smem,1,2",
+                "opndD,tmem,1,0",
+            ],
+            "two_cta_interleave_role": "qk" if TWO_CTAS else None,
+            "two_cta_tma_direct_wait": TWO_CTAS,
+            "two_cta_fuse_final_stats": TWO_CTAS,
+            "two_cta_fuse_acc_slices": TWO_CTAS,
+        } if MMA_SLICES == 2 else None),
+        two_ctas=TWO_CTAS,
+    )
 
     if STAGE == 3 and start_n >= start_m * BLOCK_M:
         col_limit_right = (offs_m - start_n + 1)[:, None]
@@ -133,7 +150,34 @@ def _attn_fwd_subtile(
     # prepare p and v for the dot
     p = p.to(dtype)
     # note that this non transposed v for FP8 is only supported on Blackwell
-    acc = tl.dot(p, v, acc)
+    if MMA_SLICES == 1:
+        acc = tl.dot(p, v0, acc, two_ctas=TWO_CTAS)
+    else:
+        ps = _split_n_2D(p, MMA_SLICES)
+        acc = tl.dot(
+            ps[0],
+            v0,
+            acc,
+            attrs={
+                "two_cta_interleave_role": "pv" if TWO_CTAS else None,
+                "channels": ["opndA,tmem,1,0,0"],
+            },
+            two_ctas=TWO_CTAS,
+        )
+        acc = tl.dot(
+            ps[1],
+            v1,
+            acc,
+            attrs={
+                "two_cta_interleave_role": "pv" if TWO_CTAS else None,
+                "channels": ["opndA,tmem,1,0,64"],
+                # ps[0] and ps[1] are adjacent slices of the same QK tile.
+                # The immediately preceding contraction has already
+                # rendezvoused both CTAs after that tile was produced.
+                "two_cta_sync_covered_by_prior": TWO_CTAS,
+            },
+            two_ctas=TWO_CTAS,
+        )
     # update m_i and l_i
     # place this at the end of the loop to reduce register pressure
     if not FADD2_REDUCE:
@@ -167,7 +211,10 @@ def _attn_fwd_inner_oss_dp(
     SUBTILING: tl.constexpr,
     VECT_MUL: tl.constexpr,
     FADD2_REDUCE: tl.constexpr,
+    MMA_SLICES: tl.constexpr,
+    KV_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    TWO_CTAS: tl.constexpr,
 ):
     # range of values handled by this stage
     if STAGE == 1:  # causal = False
@@ -175,6 +222,11 @@ def _attn_fwd_inner_oss_dp(
     else:  # causal = True
         lo, hi = 0, (start_m + 1) * BLOCK_M
     offsetkv_y = offset_y + lo
+
+    if TWO_CTAS:
+        # Lets removeRedundantTmemZeroStores drop the operand-D zero-store: the
+        # first MMA initializes the accumulator itself when the loop always runs.
+        tl.assume(hi > lo)
 
     # loop over k, v and update accumulator
     for start_n in tl.range(
@@ -184,13 +236,18 @@ def _attn_fwd_inner_oss_dp(
             warp_specialize=warp_specialize,
             merge_epilogue=True,
             separate_epilogue_store=True,
-            # disallow_acc_multi_buffer=True,
+            disallow_acc_multi_buffer=TWO_CTAS,
             data_partition_factor=DP_FACTOR,
+            num_stages=KV_NUM_STAGES if TWO_CTAS else None,
     ):
         start_n = tl.multiple_of(start_n, BLOCK_N)
 
         k = desc_k.load([offsetkv_y, 0]).T
-        v = desc_v.load([offsetkv_y, 0])
+        v0 = desc_v.load([offsetkv_y, 0])
+        if MMA_SLICES == 2:
+            v1 = desc_v.load([offsetkv_y + BLOCK_N // 2, 0])
+        else:
+            v1 = v0
 
         l_i0, l_i0_1, m_i0, acc0 = _attn_fwd_subtile(
             q0,
@@ -206,12 +263,15 @@ def _attn_fwd_inner_oss_dp(
             l_i0_1,
             m_i0,
             acc0,
-            v,
+            v0,
+            v1,
             dtype,
             STAGE,
             SUBTILING,
             VECT_MUL,
             FADD2_REDUCE,
+            MMA_SLICES,
+            TWO_CTAS,
         )
 
         offsetkv_y += BLOCK_N
@@ -223,13 +283,17 @@ def _host_descriptor_pre_hook(nargs):
     BLOCK_M = nargs["BLOCK_M"]
     BLOCK_N = nargs["BLOCK_N"]
     HEAD_DIM = nargs["HEAD_DIM"]
+    NUM_CTAS = nargs.get("NUM_CTAS", 1)
+    MMA_SLICES = nargs.get("MMA_SLICES", 1)
+    if NUM_CTAS == 2 and nargs["N_CTX"] % (NUM_CTAS * BLOCK_M) != 0:
+        raise ValueError("2-CTA forward requires N_CTX divisible by 2 * BLOCK_M")
     if not isinstance(nargs["desc_q"], TensorDescriptor):
         return
     nargs["desc_q"].block_shape = [BLOCK_M, HEAD_DIM]  # due to data partitioning
     if nargs["FP8_OUTPUT"]:
         nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
     else:
-        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
+        nargs["desc_v"].block_shape = [BLOCK_N // MMA_SLICES, HEAD_DIM]
     nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
     nargs["desc_o"].block_shape = [BLOCK_M, HEAD_DIM]
 
@@ -240,6 +304,12 @@ elif supports_host_descriptor():
     NUM_STAGES_OPTIONS = [3]
 else:
     NUM_STAGES_OPTIONS = [3]
+FWD_2CTA_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_NUM_STAGES", "4"))
+FWD_2CTA_BLOCK_M = int(os.environ.get("AUTOWS_FWD_BLOCK_M", "256"))
+FWD_2CTA_DP_FACTOR = int(os.environ.get("AUTOWS_FWD_DP_FACTOR", "2"))
+FWD_2CTA_MMA_SLICES = int(os.environ.get("AUTOWS_FWD_MMA_SLICES", "2"))
+FWD_2CTA_KV_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_KV_NUM_STAGES", "4"))
+FWD_2CTA_OUTER_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_OUTER_NUM_STAGES", "1"))
 
 configs = [
     triton.Config(
@@ -247,12 +317,40 @@ configs = [
             "BLOCK_M": BM,
             "BLOCK_N": BN,
             "DP_FACTOR": 2,
+            "NUM_CTAS": 1,
+            "MMA_SLICES": 1,
+            "KV_NUM_STAGES": s,
+            "OUTER_NUM_STAGES": s,
         },
         num_stages=s,
         num_warps=w,
         pre_hook=_host_descriptor_pre_hook,
     ) for BM in [256] for BN in [128] for s in NUM_STAGES_OPTIONS for w in [4]
+] + [
+    triton.Config(
+        {
+            "BLOCK_M": FWD_2CTA_BLOCK_M,
+            "BLOCK_N": 128,
+            "DP_FACTOR": FWD_2CTA_DP_FACTOR,
+            "NUM_CTAS": 2,
+            "MMA_SLICES": FWD_2CTA_MMA_SLICES,
+            "KV_NUM_STAGES": FWD_2CTA_KV_NUM_STAGES,
+            "OUTER_NUM_STAGES": FWD_2CTA_OUTER_NUM_STAGES,
+        },
+        num_stages=FWD_2CTA_NUM_STAGES,
+        num_warps=4,
+        minRegAutoWS=24,
+        maxRegAutoWS=168,
+        pre_hook=_host_descriptor_pre_hook,
+        ctas_per_cga=(2, 1, 1),
+        allowDependentTwoCTA=True,
+    )
 ]
+
+_fwd_num_ctas = os.environ.get("AUTOWS_FWD_NUM_CTAS")
+if _fwd_num_ctas is not None:
+    configs = [config for config in configs if config.kwargs.get("NUM_CTAS", 1) == int(_fwd_num_ctas)]
+configs_fwd = configs
 
 
 def keep(conf):
@@ -264,9 +362,17 @@ def keep(conf):
 
 def prune_invalid_configs(configs, named_args, **kwargs):
     N_CTX = kwargs["N_CTX"]
+    STAGE = kwargs["STAGE"]
+    FP8_OUTPUT = kwargs["FP8_OUTPUT"]
 
-    # Filter out configs where BLOCK_M > N_CTX
-    return [conf for conf in configs if conf.kwargs.get("BLOCK_M", 0) <= N_CTX]
+    # The current 2-CTA mapping gives adjacent CTAs adjacent M tiles. Keep the
+    # pair on the same head and in identical control flow; causal and FP8 paths
+    # need dedicated clustered mappings and remain 1-CTA for now.
+    return [
+        conf for conf in configs if conf.kwargs.get("BLOCK_M", 0) <= N_CTX and (
+            conf.kwargs.get("NUM_CTAS", 1) == 1 or (STAGE == 1 and not FP8_OUTPUT and N_CTX %
+                                                    (2 * conf.kwargs["BLOCK_M"]) == 0))
+    ]
 
 
 @triton.jit
@@ -300,7 +406,10 @@ def _attn_fwd_tma_dp(
     SUBTILING: tl.constexpr,
     VECT_MUL: tl.constexpr,
     FADD2_REDUCE: tl.constexpr,
+    MMA_SLICES: tl.constexpr,
+    KV_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    NUM_CTAS: tl.constexpr,
 ):
     start_m = pid  # tl.program_id(0)
     # off_hz = tl.program_id(1)
@@ -350,7 +459,10 @@ def _attn_fwd_tma_dp(
         SUBTILING,
         VECT_MUL,
         FADD2_REDUCE,
+        MMA_SLICES,
+        KV_NUM_STAGES,
         DP_FACTOR,
+        NUM_CTAS == 2,
     )
 
     if FADD2_REDUCE:
@@ -359,14 +471,25 @@ def _attn_fwd_tma_dp(
         l_i0 = l_i0_0
 
     m_i0 += tl.math.log2(l_i0)
-    acc0 = acc0 / l_i0[:, None]
+    if NUM_CTAS == 2:
+        # Match the TLX epilogue's packed-f32 normalization. Keeping adjacent
+        # output columns paired avoids scalarizing the large accumulator tile.
+        BM: tl.constexpr = acc0.shape[0]
+        BN: tl.constexpr = acc0.shape[1]
+        scale = 1.0 / l_i0
+        acc0_0, acc0_1 = acc0.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+        acc0_0 = _mul_f32x2(acc0_0, scale[:, None])
+        acc0_1 = _mul_f32x2(acc0_1, scale[:, None])
+        acc0 = tl.join(acc0_0, acc0_1).permute(0, 2, 1).reshape([BM, BN])
+    else:
+        acc0 = acc0 / l_i0[:, None]
     m_ptrs0 = M + off_hz * N_CTX + offs_m0
     tl.store(m_ptrs0, m_i0)
     desc_o.store([qo_offset_y, 0], acc0.to(dtype))
 
 
 @triton.autotune(
-    configs=list(filter(keep, configs)),
+    configs=list(filter(keep, configs_fwd)),
     key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
     prune_configs_by={"early_config_prune": prune_invalid_configs},
 )
@@ -391,7 +514,11 @@ def _attn_fwd(
     SUBTILING: tl.constexpr,
     VECT_MUL: tl.constexpr,
     FADD2_REDUCE: tl.constexpr,
+    MMA_SLICES: tl.constexpr,
+    KV_NUM_STAGES: tl.constexpr,
+    OUTER_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    NUM_CTAS: tl.constexpr = 1,
 ):
     pid = tl.program_id(0)
     off_hz = tl.program_id(1)
@@ -406,7 +533,7 @@ def _attn_fwd(
         desc_v,
         shape=[y_dim, HEAD_DIM],
         strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N, HEAD_DIM],
+        block_shape=[BLOCK_N // MMA_SLICES, HEAD_DIM],
     )
     desc_k = _maybe_make_tensor_desc(
         desc_k,
@@ -443,12 +570,15 @@ def _attn_fwd(
         SUBTILING,
         VECT_MUL,
         FADD2_REDUCE,
+        MMA_SLICES,
+        KV_NUM_STAGES,
         DP_FACTOR,
+        NUM_CTAS,
     )
 
 
 @triton.autotune(
-    configs=list(filter(keep, configs)),
+    configs=list(filter(keep, configs_fwd)),
     key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
     prune_configs_by={"early_config_prune": prune_invalid_configs},
 )
@@ -474,7 +604,11 @@ def _attn_fwd_persist(
     SUBTILING: tl.constexpr,
     VECT_MUL: tl.constexpr,
     FADD2_REDUCE: tl.constexpr,
+    MMA_SLICES: tl.constexpr,
+    KV_NUM_STAGES: tl.constexpr,
+    OUTER_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    NUM_CTAS: tl.constexpr = 1,
 ):
     n_tile_num = tl.cdiv(N_CTX, BLOCK_M)
     prog_id = tl.program_id(0)
@@ -487,25 +621,25 @@ def _attn_fwd_persist(
 
     tile_idx = prog_id
 
-    desc_q = tl.make_tensor_descriptor(
+    desc_q = _maybe_make_tensor_desc(
         desc_q,
         shape=[Z * H * N_CTX, HEAD_DIM],
         strides=[HEAD_DIM, 1],
         block_shape=[BLOCK_M, HEAD_DIM],
     )
-    desc_k = tl.make_tensor_descriptor(
+    desc_k = _maybe_make_tensor_desc(
         desc_k,
         shape=[Z * H * N_CTX, HEAD_DIM],
         strides=[HEAD_DIM, 1],
         block_shape=[BLOCK_N, HEAD_DIM],
     )
-    desc_v = tl.make_tensor_descriptor(
+    desc_v = _maybe_make_tensor_desc(
         desc_v,
         shape=[Z * H * N_CTX, HEAD_DIM],
         strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N, HEAD_DIM],
+        block_shape=[BLOCK_N // MMA_SLICES, HEAD_DIM],
     )
-    desc_o = tl.make_tensor_descriptor(
+    desc_o = _maybe_make_tensor_desc(
         desc_o,
         shape=[Z * H * N_CTX, HEAD_DIM],
         strides=[HEAD_DIM, 1],
@@ -520,6 +654,7 @@ def _attn_fwd_persist(
             merge_epilogue=True,
             separate_epilogue_store=True,
             data_partition_factor=DP_FACTOR,
+            num_stages=OUTER_NUM_STAGES if NUM_CTAS == 2 else None,
     ):
         pid = tile_idx % n_tile_num
         off_hz = tile_idx // n_tile_num
@@ -545,7 +680,10 @@ def _attn_fwd_persist(
             SUBTILING,
             VECT_MUL,
             FADD2_REDUCE,
+            MMA_SLICES,
+            KV_NUM_STAGES,
             DP_FACTOR,
+            NUM_CTAS,
         )
         tile_idx += num_progs
 
@@ -1570,14 +1708,31 @@ class _attention_opt(torch.autograd.Function):
         assert HEAD_DIM_K in {16, 32, 64, 128, 256}
         o = torch.empty_like(q)
         stage = 3 if causal else 1
+        if "AUTOWS_FWD_SUBTILING" in os.environ:
+            SUBTILING = os.environ["AUTOWS_FWD_SUBTILING"] == "1"
+        if "AUTOWS_FWD_VECT_MUL" in os.environ:
+            VECT_MUL = int(os.environ["AUTOWS_FWD_VECT_MUL"])
+        elif _fwd_num_ctas == "2":
+            VECT_MUL = 3
         extra_kern_args = {}
 
         M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
-        warp_specialize = True
-        desc_q = q
-        desc_v = v
-        desc_k = k
-        desc_o = o
+        warp_specialize = os.environ.get("AUTOWS_FWD_WARP_SPECIALIZE", "1") == "1"
+        # The non-persistent 1-CTA schedule still relies on the in-kernel
+        # descriptor creation path. Use host descriptors only for the focused
+        # 2-CTA configuration until that independent schedule is converted.
+        if supports_host_descriptor() and _fwd_num_ctas == "2":
+            y_dim = q.shape[0] * q.shape[1] * q.shape[2]
+            dummy_block = [1, 1]
+            desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+        else:
+            desc_q = q
+            desc_v = v
+            desc_k = k
+            desc_o = o
 
         def alloc_fn(size: int, align: int, _):
             return torch.empty(size, dtype=torch.int8, device="cuda")
@@ -1586,26 +1741,34 @@ class _attention_opt(torch.autograd.Function):
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
         def grid(META):
+            num_ctas = META.get("NUM_CTAS") or 1
+            m_tiles = triton.cdiv(q.shape[2], META["BLOCK_M"])
             return (
-                triton.cdiv(q.shape[2], META["BLOCK_M"]),
+                triton.cdiv(m_tiles, num_ctas) * num_ctas,
                 q.shape[0] * q.shape[1],
                 1,
             )
 
         def grid_persist(META):
+            num_ctas = META.get("NUM_CTAS") or 1
+            total_tiles = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+            # Clamp to one cluster: total_tiles // num_ctas floors to 0 when there
+            # are fewer tiles than CTAs, which would launch a (0, 1, 1) grid and
+            # silently produce no output.
+            num_clusters = max(1, min(NUM_SMS // num_ctas, total_tiles // num_ctas))
             return (
-                min(
-                    NUM_SMS,
-                    triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1],
-                ),
+                num_clusters * num_ctas,
                 1,
                 1,
             )
 
         ctx.grid = grid
         persistent = baseVariant == "persistent" or baseVariant == "ws_persistent"
-        if is_blackwell() and warp_specialize:
-            extra_kern_args["maxnreg"] = 128
+        fwd_maxnreg = os.environ.get("AUTOWS_FWD_MAXNREG")
+        if fwd_maxnreg is None and _fwd_num_ctas != "2":
+            fwd_maxnreg = "128"
+        if is_blackwell() and warp_specialize and fwd_maxnreg is not None:
+            extra_kern_args["maxnreg"] = int(fwd_maxnreg)
         with triton.knobs.nvidia.scope():
             triton.knobs.nvidia.use_meta_ws = True
             triton.knobs.nvidia.use_meta_partition = True

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -304,11 +304,13 @@ elif supports_host_descriptor():
     NUM_STAGES_OPTIONS = [3]
 else:
     NUM_STAGES_OPTIONS = [3]
-FWD_2CTA_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_NUM_STAGES", "4"))
+_FWD_USE_CLC = os.environ.get("AUTOWS_FWD_CLC", "0") == "1"
+_FWD_CLC_SAFE_STAGES = "2" if _FWD_USE_CLC else "4"
+FWD_2CTA_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_NUM_STAGES", _FWD_CLC_SAFE_STAGES))
 FWD_2CTA_BLOCK_M = int(os.environ.get("AUTOWS_FWD_BLOCK_M", "256"))
 FWD_2CTA_DP_FACTOR = int(os.environ.get("AUTOWS_FWD_DP_FACTOR", "2"))
 FWD_2CTA_MMA_SLICES = int(os.environ.get("AUTOWS_FWD_MMA_SLICES", "2"))
-FWD_2CTA_KV_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_KV_NUM_STAGES", "4"))
+FWD_2CTA_KV_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_KV_NUM_STAGES", _FWD_CLC_SAFE_STAGES))
 FWD_2CTA_OUTER_NUM_STAGES = int(os.environ.get("AUTOWS_FWD_OUTER_NUM_STAGES", "1"))
 
 configs = [
@@ -608,6 +610,7 @@ def _attn_fwd_persist(
     KV_NUM_STAGES: tl.constexpr,
     OUTER_NUM_STAGES: tl.constexpr,
     DP_FACTOR: tl.constexpr,
+    USE_CLC: tl.constexpr = False,
     NUM_CTAS: tl.constexpr = 1,
 ):
     n_tile_num = tl.cdiv(N_CTX, BLOCK_M)
@@ -646,46 +649,91 @@ def _attn_fwd_persist(
         block_shape=[BLOCK_M, HEAD_DIM],
     )
 
-    # inner loop warpspec vs. outer loop warpspec
-    for _ in tl.range(
-            0,
-            tiles_per_sm,
-            warp_specialize=warp_specialize and OUTER_LOOP,
-            merge_epilogue=True,
-            separate_epilogue_store=True,
-            data_partition_factor=DP_FACTOR,
-            num_stages=OUTER_NUM_STAGES if NUM_CTAS == 2 else None,
-    ):
-        pid = tile_idx % n_tile_num
-        off_hz = tile_idx // n_tile_num
-        _attn_fwd_tma_dp(
-            sm_scale,
-            M,
-            Z,
-            H,
-            desc_q,
-            desc_k,
-            desc_v,
-            desc_o,
-            pid,
-            off_hz,
-            N_CTX,
-            HEAD_DIM,
-            BLOCK_M,
-            BLOCK_N,
-            FP8_OUTPUT,
-            STAGE,
-            warp_specialize and not OUTER_LOOP,
-            dtype,
-            SUBTILING,
-            VECT_MUL,
-            FADD2_REDUCE,
-            MMA_SLICES,
-            KV_NUM_STAGES,
-            DP_FACTOR,
-            NUM_CTAS,
-        )
-        tile_idx += num_progs
+    if USE_CLC:
+        scheduler = tl.clc_tile_scheduler()
+        while tl.condition(
+                scheduler.is_valid(),
+                warp_specialize=warp_specialize,
+                merge_epilogue=True,
+                separate_epilogue_store=True,
+                data_partition_factor=DP_FACTOR,
+        ):
+            # Preserve the static 2-CTA mapping: adjacent physical CTAs process
+            # adjacent M tiles.  The CLC lowering adds the cluster rank to the
+            # canceled cluster's first CTA id, so tile_id is already the
+            # per-CTA tile index expected by _attn_fwd_tma_dp.
+            tile_idx = scheduler.tile_id[0]
+            pid = tile_idx % n_tile_num
+            off_hz = tile_idx // n_tile_num
+            _attn_fwd_tma_dp(
+                sm_scale,
+                M,
+                Z,
+                H,
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                pid,
+                off_hz,
+                N_CTX,
+                HEAD_DIM,
+                BLOCK_M,
+                BLOCK_N,
+                FP8_OUTPUT,
+                STAGE,
+                False,
+                dtype,
+                SUBTILING,
+                VECT_MUL,
+                FADD2_REDUCE,
+                MMA_SLICES,
+                KV_NUM_STAGES,
+                DP_FACTOR,
+                NUM_CTAS,
+            )
+            scheduler = scheduler.advance()
+    else:
+        # inner loop warpspec vs. outer loop warpspec
+        for _ in tl.range(
+                0,
+                tiles_per_sm,
+                warp_specialize=warp_specialize and OUTER_LOOP,
+                merge_epilogue=True,
+                separate_epilogue_store=True,
+                data_partition_factor=DP_FACTOR,
+                num_stages=OUTER_NUM_STAGES if NUM_CTAS == 2 else None,
+        ):
+            pid = tile_idx % n_tile_num
+            off_hz = tile_idx // n_tile_num
+            _attn_fwd_tma_dp(
+                sm_scale,
+                M,
+                Z,
+                H,
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                pid,
+                off_hz,
+                N_CTX,
+                HEAD_DIM,
+                BLOCK_M,
+                BLOCK_N,
+                FP8_OUTPUT,
+                STAGE,
+                warp_specialize and not OUTER_LOOP,
+                dtype,
+                SUBTILING,
+                VECT_MUL,
+                FADD2_REDUCE,
+                MMA_SLICES,
+                KV_NUM_STAGES,
+                DP_FACTOR,
+                NUM_CTAS,
+            )
+            tile_idx += num_progs
 
 
 def torch_dtype_to_triton(dtype):
@@ -1739,6 +1787,7 @@ class _attention_opt(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        use_clc = _FWD_USE_CLC
 
         def grid(META):
             num_ctas = META.get("NUM_CTAS") or 1
@@ -1752,6 +1801,13 @@ class _attention_opt(torch.autograd.Function):
         def grid_persist(META):
             num_ctas = META.get("NUM_CTAS") or 1
             total_tiles = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+            if use_clc:
+                # One physical CTA per M tile, matching the static 2-CTA
+                # schedule where neighboring CTAs cover neighboring M tiles.
+                assert total_tiles % num_ctas == 0, (
+                    f"CLC 2-CTA needs one physical CTA per M tile, so total_tiles "
+                    f"({total_tiles}) must be a multiple of NUM_CTAS ({num_ctas})")
+                return (total_tiles, 1, 1)
             # Clamp to one cluster: total_tiles // num_ctas floors to 0 when there
             # are fewer tiles than CTAs, which would launch a (0, 1, 1) grid and
             # silently produce no output.
@@ -1790,6 +1846,7 @@ class _attention_opt(torch.autograd.Function):
                     STAGE=stage,  #
                     warp_specialize=warp_specialize,
                     OUTER_LOOP=True,
+                    USE_CLC=use_clc,
                     dtype=torch_dtype_to_triton(q.dtype),
                     SUBTILING=SUBTILING,
                     VECT_MUL=VECT_MUL,

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -110,6 +110,7 @@ def _attn_fwd_subtile(
     FADD2_REDUCE: tl.constexpr,
     MMA_SLICES: tl.constexpr,
     TWO_CTAS: tl.constexpr,
+    INNER_WARP_SPECIALIZE: tl.constexpr,
     RESCALE_OPT: tl.constexpr,
 ):
     qk = tl.dot(
@@ -209,10 +210,12 @@ def _attn_fwd_subtile(
             attrs={
                 "two_cta_interleave_role": "pv" if TWO_CTAS else None,
                 "channels": ["opndA,tmem,1,0,64"],
-                # ps[0] and ps[1] are adjacent slices of the same QK tile.
-                # The immediately preceding contraction has already
-                # rendezvoused both CTAs after that tile was produced.
-                "two_cta_sync_covered_by_prior": TWO_CTAS,
+                # Inner-warp-specialized (non-persistent) schedules keep both
+                # slices adjacent in one partition, so the first rendezvous
+                # covers the second.  Persistent schedules pipeline the
+                # shared V allocation across iterations and need the second
+                # rendezvous before that slot can rotate.
+                "two_cta_sync_covered_by_prior": TWO_CTAS and INNER_WARP_SPECIALIZE,
             },
             two_ctas=TWO_CTAS,
         )
@@ -282,11 +285,12 @@ def _attn_fwd_inner_oss_dp(
         start_n = tl.multiple_of(start_n, BLOCK_N)
 
         k = desc_k.load([offsetkv_y, 0]).T
-        v0 = desc_v.load([offsetkv_y, 0])
+        v = desc_v.load([offsetkv_y, 0])
         if MMA_SLICES == 2:
-            v1 = desc_v.load([offsetkv_y + BLOCK_N // 2, 0])
+            v0, v1 = v.reshape([2, BLOCK_N // 2, HEAD_DIM]).permute(1, 2, 0).split()
         else:
-            v1 = v0
+            v0 = v
+            v1 = v
 
         l_i0, l_i0_1, m_i0, acc0 = _attn_fwd_subtile(
             q0,
@@ -311,6 +315,7 @@ def _attn_fwd_inner_oss_dp(
             FADD2_REDUCE,
             MMA_SLICES,
             TWO_CTAS,
+            warp_specialize,
             RESCALE_OPT,
         )
 
@@ -324,7 +329,6 @@ def _host_descriptor_pre_hook(nargs):
     BLOCK_N = nargs["BLOCK_N"]
     HEAD_DIM = nargs["HEAD_DIM"]
     NUM_CTAS = nargs.get("NUM_CTAS", 1)
-    MMA_SLICES = nargs.get("MMA_SLICES", 1)
     if NUM_CTAS == 2 and nargs["N_CTX"] % (NUM_CTAS * BLOCK_M) != 0:
         raise ValueError("2-CTA forward requires N_CTX divisible by 2 * BLOCK_M")
     if not isinstance(nargs["desc_q"], TensorDescriptor):
@@ -333,7 +337,7 @@ def _host_descriptor_pre_hook(nargs):
     if nargs["FP8_OUTPUT"]:
         nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
     else:
-        nargs["desc_v"].block_shape = [BLOCK_N // MMA_SLICES, HEAD_DIM]
+        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
     nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
     nargs["desc_o"].block_shape = [BLOCK_M, HEAD_DIM]
 
@@ -396,6 +400,15 @@ _fwd_num_ctas = os.environ.get("AUTOWS_FWD_NUM_CTAS")
 if _fwd_num_ctas is not None:
     configs = [config for config in configs if config.kwargs.get("NUM_CTAS", 1) == int(_fwd_num_ctas)]
 configs_fwd = configs
+# Keep the clustered forward path opt-in.  The production 2-CTA schedule uses
+# the persistent CLC wrapper, while the generic entry points below also cover
+# non-persistent and static-persistent schedules.  Letting their unpinned
+# autotuner select the clustered config can exercise a different rotating-V
+# lifetime and corrupt long sequences.  Explicit tests still pin the 2-CTA
+# config from configs_fwd, and AUTOWS_FWD_NUM_CTAS=2 selects it unchanged for
+# the production/performance path.
+configs_fwd_autotune = (configs_fwd if _fwd_num_ctas is not None else
+                        [config for config in configs_fwd if config.kwargs.get("NUM_CTAS", 1) == 1])
 
 
 def keep(conf):
@@ -538,7 +551,7 @@ def _attn_fwd_tma_dp(
 
 
 @triton.autotune(
-    configs=list(filter(keep, configs_fwd)),
+    configs=list(filter(keep, configs_fwd_autotune)),
     key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
     prune_configs_by={"early_config_prune": prune_invalid_configs},
 )
@@ -569,6 +582,11 @@ def _attn_fwd(
     DP_FACTOR: tl.constexpr,
     NUM_CTAS: tl.constexpr = 1,
     RESCALE_OPT: tl.constexpr = False,
+    # Unused here: the budget only drives staging reuse in the persistent CLC
+    # loop. It must still be declared, because this kernel shares
+    # configs_fwd_autotune with _attn_fwd_persist and autotune would otherwise
+    # pass an unexpected kwarg.
+    SMEM_BUDGET: tl.constexpr = None,
 ):
     pid = tl.program_id(0)
     off_hz = tl.program_id(1)
@@ -583,7 +601,7 @@ def _attn_fwd(
         desc_v,
         shape=[y_dim, HEAD_DIM],
         strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N // MMA_SLICES, HEAD_DIM],
+        block_shape=[BLOCK_N, HEAD_DIM],
     )
     desc_k = _maybe_make_tensor_desc(
         desc_k,
@@ -629,7 +647,7 @@ def _attn_fwd(
 
 
 @triton.autotune(
-    configs=list(filter(keep, configs_fwd)),
+    configs=list(filter(keep, configs_fwd_autotune)),
     key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
     prune_configs_by={"early_config_prune": prune_invalid_configs},
 )
@@ -690,7 +708,7 @@ def _attn_fwd_persist(
         desc_v,
         shape=[Z * H * N_CTX, HEAD_DIM],
         strides=[HEAD_DIM, 1],
-        block_shape=[BLOCK_N // MMA_SLICES, HEAD_DIM],
+        block_shape=[BLOCK_N, HEAD_DIM],
     )
     desc_o = _maybe_make_tensor_desc(
         desc_o,

--- a/third_party/tlx/tutorials/testing/test_correctness_autows.py
+++ b/third_party/tlx/tutorials/testing/test_correctness_autows.py
@@ -7,6 +7,8 @@ Run:
     pytest third_party/tlx/tutorials/testing/test_correctness_autows.py
 """
 
+import os
+
 import pytest
 import torch
 import triton
@@ -149,7 +151,11 @@ def test_autows_fa_non_causal(SUBTILING, VECT_MUL, FADD2_REDUCE, baseVariant):
 @pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_2cta_non_causal(baseVariant):
-    config = next(config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2)
+    config = next(
+        (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2),
+        None,
+    )
+    assert config is not None, "no forward config with NUM_CTAS=2"
     kernel = _attn_fwd_persist if baseVariant == "ws_persistent" else _attn_fwd
     old_configs = kernel.configs
     old_cache = kernel.cache
@@ -170,7 +176,11 @@ def test_autows_fa_2cta_non_causal(baseVariant):
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_2cta_persistent_multi_iteration():
     """Cover Q/output staging reuse across persistent tile iterations."""
-    config = next(config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2)
+    config = next(
+        (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2),
+        None,
+    )
+    assert config is not None, "no forward config with NUM_CTAS=2"
     old_configs = _attn_fwd_persist.configs
     old_cache = _attn_fwd_persist.cache
     _attn_fwd_persist.configs = [config]
@@ -182,6 +192,67 @@ def test_autows_fa_2cta_persistent_multi_iteration():
     try:
         actual = _autows_fa(q, k, v, False, sm_scale, "ws_persistent", True, 1, False)
         torch.testing.assert_close(actual, reference, atol=1e-2, rtol=0)
+    finally:
+        _attn_fwd_persist.configs = old_configs
+        _attn_fwd_persist.cache = old_cache
+
+
+@pytest.mark.parametrize("N_CTX", [1024, 4096])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_autows_fa_rescale_opt_long_sequence(N_CTX):
+    """Cover the optimized accumulator update at both target sequence lengths."""
+    num_ctas = int(os.environ.get("AUTOWS_FWD_NUM_CTAS", "1"))
+    config = next(
+        (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS", 1) == num_ctas),
+        None,
+    )
+    assert config is not None, f"no forward config with NUM_CTAS={num_ctas}"
+    if not config.kwargs["RESCALE_OPT"]:
+        pytest.skip("requires AUTOWS_FWD_RESCALE_OPT=1")
+
+    old_configs = _attn_fwd_persist.configs
+    old_cache = _attn_fwd_persist.cache
+    _attn_fwd_persist.configs = [config]
+    _attn_fwd_persist.cache = {}
+
+    sm_scale = 0.5
+    q, k, v = FlashAttention.create_inputs(2, 2, N_CTX, 128)
+    reference = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
+    try:
+        actual = _autows_fa(q, k, v, False, sm_scale, "ws_persistent", True, 1, False)
+        torch.testing.assert_close(actual, reference, atol=1e-2, rtol=0)
+    finally:
+        _attn_fwd_persist.configs = old_configs
+        _attn_fwd_persist.cache = old_cache
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+@pytest.mark.skipif(
+    os.environ.get("AUTOWS_FWD_CLC") != "1" or os.environ.get("AUTOWS_FWD_NUM_CTAS") != "2",
+    reason="Run with AUTOWS_FWD_CLC=1 and AUTOWS_FWD_NUM_CTAS=2",
+)
+def test_autows_fa_rescale_opt_clc_repeated_high_grid():
+    """Stress repeated 2-CTA CLC launches across many persistent tiles."""
+    config = next(
+        (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2),
+        None,
+    )
+    assert config is not None, "no forward config with NUM_CTAS=2"
+    if not config.kwargs["RESCALE_OPT"]:
+        pytest.skip("requires AUTOWS_FWD_RESCALE_OPT=1")
+
+    old_configs = _attn_fwd_persist.configs
+    old_cache = _attn_fwd_persist.cache
+    _attn_fwd_persist.configs = [config]
+    _attn_fwd_persist.cache = {}
+
+    sm_scale = 0.5
+    q, k, v = FlashAttention.create_inputs(4, 48, 1024, 128)
+    reference = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
+    try:
+        for _ in range(5):
+            actual = _autows_fa(q, k, v, False, sm_scale, "ws_persistent", True, 1, False)
+            torch.testing.assert_close(actual, reference, atol=1e-2, rtol=0)
     finally:
         _attn_fwd_persist.configs = old_configs
         _attn_fwd_persist.cache = old_cache

--- a/third_party/tlx/tutorials/testing/test_correctness_autows.py
+++ b/third_party/tlx/tutorials/testing/test_correctness_autows.py
@@ -175,7 +175,7 @@ def test_autows_fa_2cta_non_causal(baseVariant):
 
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_2cta_persistent_multi_iteration():
-    """Cover Q/output staging reuse across persistent tile iterations."""
+    """Cover persistent tile reuse and V staging-slot rotation."""
     config = next(
         (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2),
         None,
@@ -187,7 +187,7 @@ def test_autows_fa_2cta_persistent_multi_iteration():
     _attn_fwd_persist.cache = {}
 
     sm_scale = 0.5
-    q, k, v = FlashAttention.create_inputs(4, 48, 512, 128)
+    q, k, v = FlashAttention.create_inputs(4, 48, 1024, 128)
     reference = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
     try:
         actual = _autows_fa(q, k, v, False, sm_scale, "ws_persistent", True, 1, False)

--- a/third_party/tlx/tutorials/testing/test_correctness_autows.py
+++ b/third_party/tlx/tutorials/testing/test_correctness_autows.py
@@ -12,7 +12,11 @@ import torch
 import triton
 
 from triton.language.extra.tlx.tutorials.fused_attention_ws_device_tma import (
-    attention as _autows_fa, )
+    _attn_fwd,
+    _attn_fwd_persist,
+    attention as _autows_fa,
+    configs_fwd as _autows_fwd_configs,
+)
 from triton.language.extra.tlx.tutorials.fused_attention_ws_device_tma_dp import (
     attention as _autows_fa_dp, )
 
@@ -140,6 +144,47 @@ def test_autows_fa_non_causal(SUBTILING, VECT_MUL, FADD2_REDUCE, baseVariant):
         ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
         tri_out = _autows_fa(q, k, v, False, sm_scale, baseVariant, SUBTILING, VECT_MUL, FADD2_REDUCE)
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
+
+
+@pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_autows_fa_2cta_non_causal(baseVariant):
+    config = next(config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2)
+    kernel = _attn_fwd_persist if baseVariant == "ws_persistent" else _attn_fwd
+    old_configs = kernel.configs
+    old_cache = kernel.cache
+    kernel.configs = [config]
+    kernel.cache = {}
+
+    sm_scale = 0.5
+    q, k, v = FlashAttention.create_inputs(2, 2, 512, 128)
+    reference = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
+    try:
+        actual = _autows_fa(q, k, v, False, sm_scale, baseVariant, True, 1, False)
+        torch.testing.assert_close(actual, reference, atol=1e-2, rtol=0)
+    finally:
+        kernel.configs = old_configs
+        kernel.cache = old_cache
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_autows_fa_2cta_persistent_multi_iteration():
+    """Cover Q/output staging reuse across persistent tile iterations."""
+    config = next(config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2)
+    old_configs = _attn_fwd_persist.configs
+    old_cache = _attn_fwd_persist.cache
+    _attn_fwd_persist.configs = [config]
+    _attn_fwd_persist.cache = {}
+
+    sm_scale = 0.5
+    q, k, v = FlashAttention.create_inputs(4, 48, 512, 128)
+    reference = FlashAttention.get_reference(q, k, v, sm_scale, causal=False)
+    try:
+        actual = _autows_fa(q, k, v, False, sm_scale, "ws_persistent", True, 1, False)
+        torch.testing.assert_close(actual, reference, atol=1e-2, rtol=0)
+    finally:
+        _attn_fwd_persist.configs = old_configs
+        _attn_fwd_persist.cache = old_cache
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

(cherry picked from commit d98ca3ec771271cfeab175387315fe7245efaf0d)

Depends on the AutoWS 2-CTA forward compiler support, which is submitted separately
against master as the split cut: D116999883, D116999604, D116999605, D116999607,
D116999637, D116999775, D116999744, D116999847, D116999673, D116999806, D116999519,
D116999522, D116999555, D116999556. Phabricator cannot draw that edge because those
diffs are based on master while this stack sits on the unlanded 2-CTA backward work,
so the constraint is stated here: land the compiler diffs and the backward stack
before this group.

Reviewed By: njriasan

Differential Revision: D117104764


