### PR TITLE
Fix clang C++17 build: don't capture structured bindings in lambdas

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -823,7 +823,10 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
   for (int i = 0; i < numClusters; ++i)
     clusters.push_back(schedule.clusters.newAtBack());
 
-  for (auto &[op, key] : latencySchedule) {
+  for (auto &[op, entryKey] : latencySchedule) {
+    // Copy out of the structured binding: capturing one in a lambda is a C++20
+    // extension and this file is built as C++17.
+    auto key = entryKey;
     auto cluster = llvm::find_if(prefetchClusters, [&](const auto &entry) {
       return entry.first == key;
     });

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2963,7 +2963,10 @@ void PartitionSchedulingMeta::runOnOperation() {
     }
     loops.push_back(loop);
   });
-  for (auto [idx, loop] : llvm::enumerate(loops)) {
+  for (auto [idx, enumeratedLoop] : llvm::enumerate(loops)) {
+    // Copy out of the structured binding: capturing one in a lambda is a C++20
+    // extension and this file is built as C++17.
+    LoopLikeOpInterface loop = enumeratedLoop;
     // Build SchedulingOptions from pass options and per-loop attributes.
     SchedulingOptions schedOpts;
     schedOpts.mergeEpilogue = mergeEpilogue;

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -261,9 +261,13 @@ public:
       changed = true;
     }
 
-    for (auto [index, result, init, yielded] :
+    for (auto [enumeratedIndex, enumeratedResult, init, yielded] :
          llvm::enumerate(predicateOp.getResults(), predicateOp.getInits(),
                          yieldOp.getValues())) {
+      // Copy out of the structured bindings: capturing one in a lambda is a
+      // C++20 extension and this file is built as C++17.
+      auto index = enumeratedIndex;
+      OpResult result = enumeratedResult;
       auto boundaryConvert = yielded.getDefiningOp<ttg::ConvertLayoutOp>();
       if (!boundaryConvert || !boundaryConvert->hasOneUse())
         continue;


### PR DESCRIPTION
Three commits landed on 2026-08-26 each captured a structured binding inside a lambda, which is a C++20 extension. The tree builds with -std=gnu++17 -Werror, so clang rejects it via -Wc++20-extensions (GCC accepts it silently, which is how it slipped through):

  38f543290 (#3295) lib/.../Pipeliner/ScheduleLoops.cpp        - key
  47aa63729 (#3304) third_party/nvidia/.../PartitionSchedulingMeta.cpp - loop
  4da8c06d3 (#2892) third_party/tlx/.../PropagateLayout.cpp    - index, result

Each site copies the binding into an ordinary local before the lambda. No behavior change.

Authored with Claude Code.

## Test plan

`make dev-install llvm`

`pytest python/test/unit/language/test_tlx_*.py third_party/tlx/tutorials/testing/test_correctness.py`

LIT (will fix in another PR)
```
Testing Time: 2.99s

Total Discovered Tests: 562
  Unsupported      :   4 (0.71%)
  Passed           : 508 (90.39%)
  Expectedly Failed:  14 (2.49%)
  Failed           :  36 (6.41%)
```