### PR TITLE
[CPU] Export NativeRT launcher and avoid SLEEF runtime dependency

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -593,7 +593,11 @@ class CompiledKernel:
         device = active_driver.get_current_device()
         utils = active_driver.utils
         # create launcher
-        self._run = active_driver.launcher_cls(self.src, self.metadata)
+        run = active_driver.launcher_cls(self.src, self.metadata)
+        if hasattr(run, "launcher_bytes") and run.launcher_bytes is not None:
+            # Used by external runtimes such as NativeRT.
+            self.asm["launcher.so"] = run.launcher_bytes
+        self._run = run
         # not enough shared memory to run the kernel
         max_shared = _max_shared_mem(device, utils)
         if self.metadata.shared > max_shared:

--- a/third_party/cpu/backend/build.py
+++ b/third_party/cpu/backend/build.py
@@ -134,7 +134,7 @@ def compile_launcher_from_src(src, name):
             spec = importlib.util.spec_from_file_location(name, cache_path)
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
-            return mod
+            return mod, cache_path
         except ImportError:
             logging.getLogger(__name__).warning("Cached CPU launcher could not be loaded; rebuilding it")
             cache_path = None
@@ -157,7 +157,7 @@ def compile_launcher_from_src(src, name):
     spec = importlib.util.spec_from_file_location(name, cache_path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return mod
+    return mod, cache_path
 
 
 def build_kernel_from_asm(src_path, srcdir):

--- a/third_party/cpu/backend/compiler.py
+++ b/third_party/cpu/backend/compiler.py
@@ -52,7 +52,8 @@ class CPUOptions:
     enable_tree_reduction: bool = False
     max_num_imprecise_acc_default: int = 0
     enable_fast_math: bool = True
-    vec_lib: Optional[str] = 'libsleef'
+    # For now, don't use libsleef to avoid library-not-found issues.
+    vec_lib: Optional[str] = None
     # TODO: Try to enable it.
     sanitize_overflow: bool = False
     instrumentation_mode: str = ""

--- a/third_party/cpu/backend/driver.py
+++ b/third_party/cpu/backend/driver.py
@@ -123,6 +123,14 @@ def make_launcher(constants, signature, ids):
     kernel_fn_args_list = ', '.join(f"arg{i}" for i in kernel_fn_args)
     kernel_fn_arg_types = ', '.join([f"{ty_to_cpp(signature[i])}" for i in kernel_fn_args] + ["uint32_t"] * 6)
 
+    kernel_fn_arg_decls = ""
+    for i, ty in signature_without_constexprs.items():
+        if ty[0] == "*":
+            kernel_fn_arg_decls += f"    auto arg{i} = args[{i}];\n"
+        else:
+            ty_str = ty_to_cpp(ty) + "*"
+            kernel_fn_arg_decls += f"    auto& arg{i} = *reinterpret_cast<{ty_str}>(args[{i}]);\n"
+
     # generate glue code
     src = f"""
 #include <algorithm>
@@ -355,6 +363,24 @@ PyMODINIT_FUNC PyInit___triton_cpu_launcher(void) {{
   PyModule_AddFunctions(m, ModuleMethods);
   return m;
 }}
+
+extern "C" void run_from_nativert(
+    uint32_t gridX,
+    uint32_t gridY,
+    uint32_t gridZ,
+    int num_cpu_threads,
+    void** args,
+    kernel_ptr_t kernel_ptr) {{
+
+{kernel_fn_arg_decls}
+    run_omp_kernels(
+        gridX,
+        gridY,
+        gridZ,
+        num_cpu_threads,
+        kernel_ptr{(',' if len(signature_without_constexprs) > 0 else '')}
+        {', '.join([f"arg{i}" for i in signature_without_constexprs])});
+}}
 """
     return src
 
@@ -368,8 +394,10 @@ class CPULauncher(object):
         constants = {cst_key(key): value for key, value in constants.items()}
         signature = {cst_key(key): value for key, value in src.signature.items()}
         src = make_launcher(constants, signature, ids)
-        mod = compile_launcher_from_src(src, "__triton_cpu_launcher")
+        mod, launcher_path = compile_launcher_from_src(src, "__triton_cpu_launcher")
         self.launch = mod.launch
+        with open(launcher_path, "rb") as f:
+            self.launcher_bytes = f.read()
 
     def __call__(self, *args, **kwargs):
         self.launch(*args, **kwargs)


### PR DESCRIPTION
## Summary

This follow-up to #2981 adds support for consuming compiled CPU kernels from external runtimes.

- Export `run_from_nativert`, which accepts arguments through `void **` and reuses the existing OpenMP launch path.
- Store the compiled launcher in `CompiledKernel.asm["launcher.so"]`.
- Disable SLEEF vector lowering by default to avoid unavailable runtime-library dependencies.
- Correctly forward specialized arguments through the launcher helper.

## Testing

- Python syntax checks passed.
- Generated launcher C++ compiled successfully.
- Verified that the resulting shared object exports `run_from_nativert`.
- `git diff --check` passed.