### PR TITLE
[TritonGPU] insert terminator for the then branch

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/HoistTMEMAlloc.cpp
@@ -251,6 +251,15 @@ public:
       resultTypes.push_back(rewriter.getType<AsyncTokenType>());
     auto ifOp = scf::IfOp::create(rewriter, loc, resultTypes, condition,
                                   /*withElseRegion=*/true);
+    if (threadsToken) {
+      // scf::IfOp::build only materializes the region terminators when the op
+      // has no results; with a token result the blocks come back empty.
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointToEnd(ifOp.thenBlock());
+      scf::YieldOp::create(rewriter, loc, ValueRange{incomingToken});
+      rewriter.setInsertionPointToEnd(ifOp.elseBlock());
+      scf::YieldOp::create(rewriter, loc, ValueRange{incomingToken});
+    }
 
     auto thenYield = cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
     rewriter.setInsertionPoint(thenYield);


### PR DESCRIPTION
Caused by https://github.com/facebookexperimental/triton/pull/3273

MLIR's scf::IfOp::build only builds terminator on the then/else blocks when resultTypes is empty. With result tokens, it creates bare empty blocks and expects the caller to build the scf.yields.

At https://github.com/facebookexperimental/triton/commit/ac22092574523cab05e8285d0a634d83f9d6c2d1#diff-3d2435e5be76f348c9b04fb36c2ee93b5c14a60e67ff09c47615755a510bd5efR250, when there is a ThreadToken, resultTypes is not empty because the store threads a TMEM token.

Fixes https://github.com/facebookexperimental/triton/issues/3292
