### PR TITLE
[triton][beta] Fix lit RUN lines for the internal shell (env prefix, subshell)

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_npot.mlir
+++ b/test/Conversion/tritongpu_to_llvm_npot.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 | FileCheck %s
+// RUN: env TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file --allocate-shared-memory-nv=compute-capability=90 --convert-triton-gpu-to-llvm=compute-capability=90 | FileCheck %s
 //
 // NPOT (non-power-of-2) elementwise lowering. A non-power-of-2 out-dim builds a
 // modular LinearLayout, so the per-element index arithmetic uses ADD + a modulo

--- a/test/Hopper/TwoCTA/pipeline_bwd_bm128_gemm_only.mlir
+++ b/test/Hopper/TwoCTA/pipeline_bwd_bm128_gemm_only.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s '-tritongpu-schedule-loops=use-meta-ws=true num-stages=2' '--tritongpu-pipeline=num-stages=2' | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s '-tritongpu-schedule-loops=use-meta-ws=true num-stages=2' '--tritongpu-pipeline=num-stages=2' | FileCheck %s
 // Regression: warp-specialized loops containing a peer gather or TMA reduction
 // must use lockstep epilogue peeling. Generic epilogue predication cannot mask
 // the gather and independently predicating the reduction desynchronizes sibling

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-causal-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-causal-attention.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue separate-epilogue-store" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue separate-epilogue-store" | FileCheck %s
 
 // Tests that causal flash attention with map_elementwise masking inside scf.if
 // gets exactly two computation partitions. Without the forward-set fix in

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-fa-bwd.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue-to-computation" | FileCheck %s
 
 // Tests that the full FA BWD persistent kernel (bwd.part.prior) gets the correct
 // 4-partition layout: reduction + gemm + load + computation.

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-flex-attention.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-epilogue" | FileCheck %s
 
 // Tests that flex attention (dpFactor=2, no epilogue stores, scf.if masking)
 // gets two separate computation partitions with symmetric split.

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-merge-reduction.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-merge-reduction.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-reduction merge-epilogue-to-computation" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta="merge-reduction merge-epilogue-to-computation" | FileCheck %s
 // XFAIL: *
 
 // Regression test for B-3-F1 / T273467650.

--- a/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
+++ b/test/Hopper/WarpSpecialization/partition-scheduling-meta-shared-accumulator-dp.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta | FileCheck %s
 
 // Test for the accumulator-chain data-partition grouping.
 //

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_from_psm.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_from_psm.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-test-taskid-propagate=num-warp-groups=2 --nvgpu-test-ws-atomic-broadcast | FileCheck %s --check-prefix=BCAST
 // RUN: triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta --nvgpu-test-taskid-propagate=num-warp-groups=2 --nvgpu-test-ws-atomic-broadcast=tile-prefetch-depth=2 | FileCheck %s --check-prefix=DEPTH2
-// RUN: TRITON_USE_META_WS=1 triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000 tile-prefetch-depth=2' | FileCheck %s --check-prefix=FULL
-// RUN: TRITON_USE_META_WS=1 triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000 tile-prefetch-depth=2' '--tritongpu-pipeline=num-stages=3' 2>&1 | FileCheck %s --check-prefix=PIPELINE
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000 tile-prefetch-depth=2' | FileCheck %s --check-prefix=FULL
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s -split-input-file --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000 tile-prefetch-depth=2' '--tritongpu-pipeline=num-stages=3' 2>&1 | FileCheck %s --check-prefix=PIPELINE
 
 // Dynamic-persistent GEMM: an outer scf.while claims each tile with a scalar
 // atomic, starting UNPARTITIONED. This exercises the full front half of the

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_reject.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
 
 // Case 3 (graceful reject): the persistent scf.while's tile counter is claimed
 // by a NON-scalar (scatter) tt.atomic_rmw replicated across partitions. AutoWS

--- a/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transform.mlir
+++ b/test/Hopper/WarpSpecialization/ws_atomic_broadcast_transform.mlir
@@ -1,5 +1,5 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448 tile-prefetch-depth=2" | FileCheck %s --check-prefix=DEPTH2
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-warp-specialization="capability=100 num-stages=3 smem-budget=232448 tile-prefetch-depth=2" | FileCheck %s --check-prefix=DEPTH2
 
 // Case 2 (transform): a dynamic-persistent matmul whose persistent scf.while
 // claims its next tile via a scalar, loop-carried tt.atomic_rmw replicated to

--- a/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_empty_producer_guard.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization="capability=100" | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization="capability=100" | FileCheck %s
 
 // Regression guard for the empty-producer assertion (bug #7 in
 // .llms/rules/partition-scheduler-bugs.md): the `producerTaskIds.size() == 1`

--- a/test/Hopper/WarpSpecialization/ws_lower_token_coalesce_init_barriers.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_token_coalesce_init_barriers.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization | FileCheck %s
 
 // Regression guard for token-initialization barrier coalescing in
 // WSLowerToken.cpp. Lowering emits one CTA barrier after initializing each

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagate_no_mma_reduction.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagate_no_mma_reduction.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta --nvgpu-warp-specialization | FileCheck %s
 
 // Regression guard for the no-MMA reduction materialization crash: the
 // `attr.size() == 1 && "expected exactly 1 partition element"` assertion in

--- a/test/Hopper/WarpSpecialization/ws_task_id_propagation_no_tasks.mlir
+++ b/test/Hopper/WarpSpecialization/ws_task_id_propagation_no_tasks.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000' | FileCheck %s
+// RUN: env TRITON_USE_META_WS=1 triton-opt %s --nvgpu-partition-scheduling-meta '--nvgpu-warp-specialization=capability=90 num-stages=3 smem-budget=200000' | FileCheck %s
 
 // A while with no partition anchors has no task union. It must pass through
 // task propagation without materializing an unknown task attribute.

--- a/test/LLVMIR/di-local-variable-with-callsite-loc.mlir
+++ b/test/LLVMIR/di-local-variable-with-callsite-loc.mlir
@@ -1,4 +1,4 @@
-// RUN: LLVM_EXTRACT_DI_LOCAL_VARIABLES=1 triton-opt %s -o - --mlir-print-debuginfo --mlir-use-nameloc-as-prefix --enable-line-info --extract-variable-info | \
+// RUN: env LLVM_EXTRACT_DI_LOCAL_VARIABLES=1 triton-opt %s -o - --mlir-print-debuginfo --mlir-use-nameloc-as-prefix --enable-line-info --extract-variable-info | \
 // RUN: mlir-translate --mlir-to-llvmir | FileCheck %s
 
 // Regression test for a crash when CallSiteLoc operations coexist with

--- a/test/Plugins/test-dialect-plugin.mlir
+++ b/test/Plugins/test-dialect-plugin.mlir
@@ -1,4 +1,4 @@
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libMLIRDialectPlugin.so \
 // RUN: triton-opt \
 // RUN: -split-input-file --convert-plugin-gpu-to-llvm --convert-triton-gpu-to-llvm %s | \

--- a/test/Plugins/test-plugin.mlir
+++ b/test/Plugins/test-plugin.mlir
@@ -1,9 +1,9 @@
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libTritonPluginsTestLib.so \
 // RUN: triton-opt \
 // RUN: -split-input-file -tritongpu-plugin %s | FileCheck %s --check-prefix=CHECK-PLUGIN
 
-// RUN: LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
+// RUN: env LD_PRELOAD=%shlibdir/../plugins/libtriton.so \
 // RUN: TRITON_PLUGIN_PATHS=%shlibdir/../plugins/libTritonPluginsTestLib.so \
 // RUN: triton-opt \
 // RUN: -split-input-file %s | FileCheck %s -allow-unused-prefixes --check-prefix=CHECK-NOFLAG

--- a/test/TritonGPU/amd/amd-decompose-mode.mlir
+++ b/test/TritonGPU/amd/amd-decompose-mode.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule="mode=decompose" 2>&1 \
 // RUN:   | FileCheck %s --implicit-check-not="amd-modulo: DDG"
 //

--- a/test/TritonGPU/amd/amd-early-lower.mlir
+++ b/test/TritonGPU/amd/amd-early-lower.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_AMD_EARLY_LOWER=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_AMD_EARLY_LOWER=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 \
 // RUN:   | FileCheck %s --implicit-check-not="tt.load"
 //

--- a/test/TritonGPU/amd/amd-modulo-async-classify.mlir
+++ b/test/TritonGPU/amd/amd-modulo-async-classify.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // AMDLatencyModel must classify the lowered staged global load

--- a/test/TritonGPU/amd/amd-modulo-expand.mlir
+++ b/test/TritonGPU/amd/amd-modulo-expand.mlir
@@ -1,7 +1,7 @@
-// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=SCHEDULE
-// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>/dev/null \
 // RUN:   | triton-opt -split-input-file -tritonamdgpu-pipeline 2>&1 \
 // RUN:   | FileCheck %s

--- a/test/TritonGPU/amd/amd-modulo-lds-capacity.mlir
+++ b/test/TritonGPU/amd/amd-modulo-lds-capacity.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 \
 // RUN:   TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //

--- a/test/TritonGPU/amd/amd-modulo-pipeline.mlir
+++ b/test/TritonGPU/amd/amd-modulo-pipeline.mlir
@@ -1,10 +1,10 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
-// RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule 2>/dev/null \
 // RUN:   | triton-opt -tritonamdgpu-pipeline | FileCheck %s --check-prefix=EXPAND
-// RUN: TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 TRITON_AMD_MODULO_SERIALIZE=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule 2>/dev/null \
 // RUN:   | triton-opt -tritonamdgpu-schedule-loops="num_stages=2" \
 // RUN:   | FileCheck %s --check-prefix=PRESERVE

--- a/test/TritonGPU/amd/amd-modulo-scaffold.mlir
+++ b/test/TritonGPU/amd/amd-modulo-scaffold.mlir
@@ -1,6 +1,6 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
-// RUN: TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_USE_MODULO_SCHEDULE=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule=mode=modulo 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=RETRY
 //

--- a/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
+++ b/test/TritonGPU/amd/amd-modulo-warp-pipeline-partition.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_AMD_MODULO=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // Steps 4.7 + 4.8: AMD warp-pipeline cluster partitioning and s_setprio

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase0-noop.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase0-noop.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // Phase 0 of the TTGIR-level SCHED pass: walks the module, identifies inner

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase1a-plan.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase1a-plan.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // Phase 1a of the TTGIR-level SCHED pass: detect M-split partition plans

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase1b-bwd.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase1b-bwd.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // Phase 1b of the TTGIR-level SCHED pass: backward walker reports how many

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase1c-fwd.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase1c-fwd.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 | FileCheck %s
 //
 // Phase 1c of the TTGIR-level SCHED pass: forward walker reports how many

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase1d-apply.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase1d-apply.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 triton-opt %s \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule \
 // RUN:   2>&1 | FileCheck %s
 //

--- a/test/TritonGPU/amd/amd-ttgir-sched-phase3-barrier.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-phase3-barrier.mlir
@@ -1,13 +1,13 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 triton-opt %s \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule \
 // RUN:   2>&1 | FileCheck %s --check-prefix=DEFAULT
 //
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
 // RUN:   TRITON_TTGIR_SCHED_BARRIER_STRIDE=0 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule \
 // RUN:   2>&1 | FileCheck %s --check-prefix=DISABLED
 //
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
 // RUN:   TRITON_TTGIR_SCHED_BARRIER_STRIDE=1 triton-opt %s \
 // RUN:   -split-input-file -tritonamdgpu-dot-decompose-and-schedule \
 // RUN:   2>&1 | FileCheck %s --check-prefix=PERDOT

--- a/test/TritonGPU/amd/amd-ttgir-sched-slice-global-loads.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-slice-global-loads.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 \
 // RUN:   TRITON_TTGIR_SCHED_SLICE_LOADS=1 TRITON_TTGIR_SCHED_SLICE_GLOBAL_LOADS=1 \
 // RUN:   triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 \

--- a/test/TritonGPU/amd/amd-ttgir-sched-slice-loads.mlir
+++ b/test/TritonGPU/amd/amd-ttgir-sched-slice-loads.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 TRITON_TTGIR_SCHED_SLICE_LOADS=1 \
+// RUN: env TRITON_ENABLE_TTGIR_SCHED=1 TRITON_TTGIR_SCHED_APPLY=1 TRITON_TTGIR_SCHED_SLICE_LOADS=1 \
 // RUN:   triton-opt %s -split-input-file \
 // RUN:   -tritonamdgpu-dot-decompose-and-schedule 2>&1 \
 // RUN:   | FileCheck %s --implicit-check-not="tensor<64x64xf16" \

--- a/test/TritonGPU/coalesce-npot-atomic.mlir
+++ b/test/TritonGPU/coalesce-npot-atomic.mlir
@@ -1,4 +1,4 @@
-// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -tritongpu-coalesce -verify-diagnostics
+// RUN: env TRITON_ALLOW_NPOT=1 triton-opt %s -tritongpu-coalesce -verify-diagnostics
 
 // A modular layout may map multiple physical slots to one logical element.
 // Atomics must reject until lowering predicates one canonical representative;

--- a/test/TritonGPU/coalesce-npot.mlir
+++ b/test/TritonGPU/coalesce-npot.mlir
@@ -5,7 +5,7 @@
 // a non-pow2 factor that does not tile the 64-lane warp and is rejected by
 // BlockedEncodingAttr::verify. warpSize is 64 (CDNA).
 //
-// RUN: TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file -tritongpu-coalesce | FileCheck %s
+// RUN: env TRITON_ALLOW_NPOT=1 triton-opt %s -split-input-file -tritongpu-coalesce | FileCheck %s
 
 // N=48 contiguous, 8 elems/thread (dot A-operand style). This is the exact case
 // that produced the invalid threadsPerWarp = [10, 6]: the NPOT lane factor

--- a/test/TritonGPU/modulo-exhaustive-fa-bwd-bm64-tmem.mlir
+++ b/test/TritonGPU/modulo-exhaustive-fa-bwd-bm64-tmem.mlir
@@ -6,31 +6,31 @@
 // matched by its NAME location (q/k/do/qk_trans/dq/dk/...) alongside its
 // loop.stage/loop.cluster, across the top-4 picks.
 
-// RUN: STANDALONE_MODULO=1 TRITON_USE_MODULO_SCHEDULE=contracted \
+// RUN: env STANDALONE_MODULO=1 TRITON_USE_MODULO_SCHEDULE=contracted \
 // RUN:   TRITON_MODULO_TOPK=5 TRITON_MODULO_PICK=1 \
 // RUN:   triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule \
 // RUN:   -mlir-print-debuginfo -mlir-print-local-scope | FileCheck %s --check-prefix=CONTRACTED \
 // RUN:       --implicit-check-not=tt.autows --implicit-check-not=tt.modulo_ii --implicit-check-not=ttg.partition
 
-// RUN: STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
+// RUN: env STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
 // RUN:   TRITON_USE_MODULO_SCHEDULE=exhaustive TRITON_MODULO_TOPK=4 TRITON_MODULO_PICK=0 \
 // RUN:   triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule \
 // RUN:   -mlir-print-debuginfo -mlir-print-local-scope | FileCheck %s --check-prefix=P0 \
 // RUN:       --implicit-check-not=tt.autows --implicit-check-not=tt.modulo_ii --implicit-check-not=ttg.partition
 
-// RUN: STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
+// RUN: env STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
 // RUN:   TRITON_USE_MODULO_SCHEDULE=exhaustive TRITON_MODULO_TOPK=4 TRITON_MODULO_PICK=1 \
 // RUN:   triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule \
 // RUN:   -mlir-print-debuginfo -mlir-print-local-scope | FileCheck %s --check-prefix=P1 \
 // RUN:       --implicit-check-not=tt.autows --implicit-check-not=tt.modulo_ii --implicit-check-not=ttg.partition
 
-// RUN: STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
+// RUN: env STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
 // RUN:   TRITON_USE_MODULO_SCHEDULE=exhaustive TRITON_MODULO_TOPK=4 TRITON_MODULO_PICK=2 \
 // RUN:   triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule \
 // RUN:   -mlir-print-debuginfo -mlir-print-local-scope | FileCheck %s --check-prefix=P2 \
 // RUN:       --implicit-check-not=tt.autows --implicit-check-not=tt.modulo_ii --implicit-check-not=ttg.partition
 
-// RUN: STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
+// RUN: env STANDALONE_MODULO=1 STANDALONE_MODULO_MAX_STAGE_DIFF=2 \
 // RUN:   TRITON_USE_MODULO_SCHEDULE=exhaustive TRITON_MODULO_TOPK=4 TRITON_MODULO_PICK=3 \
 // RUN:   triton-opt %s -allow-unregistered-dialect -nvgpu-modulo-schedule \
 // RUN:   -mlir-print-debuginfo -mlir-print-local-scope | FileCheck %s --check-prefix=P3 \

--- a/test/TritonGPU/modulo-schedule-graph-budget-reduction.mlir
+++ b/test/TritonGPU/modulo-schedule-graph-budget-reduction.mlir
@@ -1,5 +1,5 @@
-// RUN: TRITON_MODULO_SMEM_BUDGET_KB=448 triton-opt %s -allow-unregistered-dialect -split-input-file -nvgpu-modulo-schedule="print-schedule-graph" 2>&1 | FileCheck %s --check-prefix=GRAPH
-// RUN: TRITON_MODULO_SMEM_BUDGET_KB=448 triton-opt %s -allow-unregistered-dialect -split-input-file -nvgpu-modulo-schedule | FileCheck %s --check-prefix=IR
+// RUN: env TRITON_MODULO_SMEM_BUDGET_KB=448 triton-opt %s -allow-unregistered-dialect -split-input-file -nvgpu-modulo-schedule="print-schedule-graph" 2>&1 | FileCheck %s --check-prefix=GRAPH
+// RUN: env TRITON_MODULO_SMEM_BUDGET_KB=448 triton-opt %s -allow-unregistered-dialect -split-input-file -nvgpu-modulo-schedule | FileCheck %s --check-prefix=IR
 
 //===----------------------------------------------------------------------===//
 // Regression tests for Step 4.6 budget reduction (reduceBufferGroup +

--- a/test/TritonGPU/pipeline-split-cluster-unscheduled-op.mlir
+++ b/test/TritonGPU/pipeline-split-cluster-unscheduled-op.mlir
@@ -1,10 +1,14 @@
-// RUN: (triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-lower-loop 2>&1 || true) | FileCheck %s
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect -tritongpu-test-pipeline-lower-loop > %t 2>&1 || :
+// RUN: FileCheck %s --input-file=%t
 
 // The diagnostic below is emitted via `op.emitError()` in LowerLoops.cpp,
 // which in an assert-enabled build is immediately followed by an assert that
 // aborts, but in an NDEBUG build (e.g. internal @mode/opt) emits cleanly and
 // returns 0. We therefore ignore triton-opt's exit status and let FileCheck
 // arbitrate on the emitted output, so the test is portable across both builds.
+// The output is staged through %t rather than a `( ... || true) | FileCheck`
+// pipeline because lit's internal shell has no subshells, and `||` binds
+// looser than `|` so the status cannot be discarded inline.
 
 // Regression test for the `CoarseSchedule::splitClusterBefore`
 // implicit-insert bug.

--- a/test/TritonGPU/verify-npot-dot-mma-layout.mlir
+++ b/test/TritonGPU/verify-npot-dot-mma-layout.mlir
@@ -1,6 +1,6 @@
 // Flag ON: NPOT dot-operand / MMA tensors PASS verifyTensorLayout and the
 // module round-trips cleanly (FileCheck the op labels are printed back).
-// RUN: TRITON_ALLOW_NPOT=1 triton-opt --split-input-file %s | FileCheck %s
+// RUN: env TRITON_ALLOW_NPOT=1 triton-opt --split-input-file %s | FileCheck %s
 //
 // Flag OFF (default): the same NPOT tensors are REJECTED by verifyTensorLayout
 // with the "not a power of two" diagnostic.


### PR DESCRIPTION
Summary:
D117481954 changed `test/lit.cfg.py` from
`ShTest(not llvm_config.use_lit_shell)` to `ShTest(False)` because LLVM 23
rejects the deprecated external-shell mode. The OSS CMake CI had been
resolving that expression to the *external* shell, so it was the only
configuration still tolerating shell syntax that lit's internal shell does
not implement. 36 of 562 lit tests now fail there with exit status 127.

Two constructs are affected:

- `VAR=1 triton-opt ...` — the internal shell has no env-assignment prefix,
  so it treats `TRITON_ALLOW_NPOT=1` as the program name:
  `'TRITON_ALLOW_NPOT=1': command not found`. Fixed by using lit's `env`
  builtin (`env VAR=1 triton-opt ...`), which is what the rest of this test
  suite already does — see `ws_memory_planner_bwd_hd64.mlir`,
  `interleave_tmem.mlir`, `consan.mlir`. For the multi-line RUN lines only
  the first line takes `env`; the continuations stay as additional
  assignments in the same argument list.

- `(triton-opt ... || true) | FileCheck %s` in
  `pipeline-split-cluster-unscheduled-op.mlir` — the internal shell has no
  subshells, so `(/path/to/triton-opt` became the program name. That test
  discards the exit status on purpose (`op.emitError()` is followed by an
  aborting assert in an assertions build but returns 0 under NDEBUG), and
  `||` binds looser than `|` so the status cannot be dropped inline. The
  output is now staged through `%t` and handed to FileCheck with
  `--input-file`, with `|| :` (lit's colon builtin) discarding the status.

No test semantics change: every rewritten RUN line runs the same command
with the same environment and the same FileCheck invocation.

Differential Revision: D117729917
