### PR TITLE
[triton][beta] Move subtiled region pass to Hopper

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -225,29 +225,6 @@ def TritonNvidiaGPUInterleaveTMemPass : Pass<"triton-nvidia-interleave-tmem", "m
   }];
 }
 
-def TritonNvidiaGPUTestGenerateSubtiledRegionPass
-    : Pass<"triton-nvidia-gpu-test-generate-subtiled-region", "mlir::ModuleOp"> {
-  let summary = "Test pass: generate subtiled_region ops from split patterns";
-
-  let description = [{
-    This pass finds the GEMM epilogue subtiling pattern:
-      tmem_load -> reshape -> trans{[0,2,1]} -> split
-    followed by per-tile code (truncf, convert_layout, TMA store), and wraps
-    it in a `ttng.subtiled_region` op.
-
-    The pass runs after the memory planner and before code partition in the WS
-    pipeline. It captures the setup chain (tmem_load through split) in the
-    setup region and the per-tile code in the tile region body.
-  }];
-
-  let dependentDialects = [
-    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
-    "mlir::arith::ArithDialect"
-  ];
-}
-
-
-
 def TritonNvidiaGPURemoveTMEMTokensPass : Pass<"triton-nvidia-gpu-remove-tmem-tokens", "mlir::ModuleOp"> {
   let summary = "remove TMEM tokens";
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -6,7 +6,6 @@ add_triton_library(TritonNvidiaGPUTransforms
   ConSanNVIDIA.cpp
   FenceInsertion.cpp
   FuseTMemLoadReduce.cpp
-  GenerateSubtiledRegion.cpp
   InterleaveTMem.cpp
   MMALowering.cpp
   OptimizeDescriptorEncoding.cpp

--- a/test/Hopper/WarpSpecialization/generate_subtiled_region_dp1.mlir
+++ b/test/Hopper/WarpSpecialization/generate_subtiled_region_dp1.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-test-generate-subtiled-region | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-test-generate-subtiled-region | FileCheck %s
 
 // Test: DP=1 epilogue subtiling with convert_layout in chain.
 // The split feeds into truncf → convert_layout → local_store for each tile.

--- a/test/Hopper/WarpSpecialization/generate_subtiled_region_multi_task.mlir
+++ b/test/Hopper/WarpSpecialization/generate_subtiled_region_multi_task.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-test-generate-subtiled-region | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-test-generate-subtiled-region | FileCheck %s
 
 // Test: multi-task chain produces two SubtiledRegionOps.
 // Compute ops (truncf + local_store) have task [3], TMA copy has task [4].

--- a/test/Hopper/WarpSpecialization/generate_subtiled_region_ntile.mlir
+++ b/test/Hopper/WarpSpecialization/generate_subtiled_region_ntile.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s --triton-nvidia-gpu-test-generate-subtiled-region | FileCheck %s
+// RUN: triton-opt %s --nvgpu-test-generate-subtiled-region | FileCheck %s
 
 // Note: N-tile tests are in a separate file from the 2-tile tests to avoid
 // heap corruption from split-input-file when inner splits are erased.

--- a/test/Hopper/WarpSpecialization/generate_subtiled_region_same_task_interleave.mlir
+++ b/test/Hopper/WarpSpecialization/generate_subtiled_region_same_task_interleave.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-test-generate-subtiled-region | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-test-generate-subtiled-region | FileCheck %s
 
 // Test: SAME-TASK epilogue subtiling (separate_epilogue_store=False).
 // The per-tile truncf -> local_store -> async_tma_copy_local_to_global ->

--- a/test/Hopper/WarpSpecialization/generate_subtiled_region_tmem_split.mlir
+++ b/test/Hopper/WarpSpecialization/generate_subtiled_region_tmem_split.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --triton-nvidia-gpu-test-generate-subtiled-region --triton-nvidia-optimize-tmem-layouts | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-test-generate-subtiled-region --triton-nvidia-optimize-tmem-layouts | FileCheck %s
 
 // Test: multi-task chain with pre-hoisted allocs — OptimizeTMemLayouts
 // converts the split to tmem_subslice + tmem_load before the

--- a/third_party/nvidia/hopper/include/Transforms/Passes.td
+++ b/third_party/nvidia/hopper/include/Transforms/Passes.td
@@ -46,6 +46,28 @@ def NVGPUWarpSpecialization : Pass<"nvgpu-warp-specialization", "mlir::ModuleOp"
     ];
 }
 
+def NVGPUTestGenerateSubtiledRegion
+    : Pass<"nvgpu-test-generate-subtiled-region", "mlir::ModuleOp"> {
+  let summary = "Test pass: generate subtiled_region ops from split patterns";
+
+  let description = [{
+    This pass finds the GEMM epilogue subtiling pattern:
+      tmem_load -> reshape -> trans{[0,2,1]} -> split
+    followed by per-tile code (truncf, convert_layout, TMA store), and wraps
+    it in a `ttng.subtiled_region` op.
+
+    The pass runs after the memory planner and before code partition in the WS
+    pipeline. It captures the setup chain (tmem_load through split) in the
+    setup region and the per-tile code in the tile region body.
+  }];
+
+  let dependentDialects = [
+    "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+    "mlir::triton::nvws::NVWSDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def NVGPUTestWSTaskPartition : Pass<"nvgpu-test-ws-task-partition", "mlir::ModuleOp"> {
   let summary = "test warp specialization task partition";
 

--- a/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
+++ b/third_party/nvidia/hopper/lib/Transforms/CMakeLists.txt
@@ -38,6 +38,7 @@ add_triton_library(NVHopperTransforms
   MultiCTAReduction.cpp
   WarpSpecialization.cpp
   WarpSpecialization/CodePartitionUtility.cpp
+  WarpSpecialization/GenerateSubtiledRegion.cpp
   WarpSpecialization/WSAtomicBroadcast.cpp
   WarpSpecialization/PingPong.cpp
   WarpSpecialization/TaskIdPropagation.cpp

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -16,7 +16,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/Schedule.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Tools/Sys/Dump.h"
 #include "llvm/Support/LogicalResult.h"
 
@@ -86,8 +85,7 @@ void doLowerRemainingSubtiledRegions(triton::FuncOp funcOp) {
 void doGenerateSubtiledRegion(triton::FuncOp funcOp) {
   auto moduleOp = funcOp->getParentOfType<ModuleOp>();
   PassManager pm(moduleOp.getContext());
-  pm.addPass(triton::nvidia_gpu::
-                 createTritonNvidiaGPUTestGenerateSubtiledRegionPass());
+  pm.addPass(createNVGPUTestGenerateSubtiledRegion());
   // OptimizeTMemLayouts runs later via add_optimize_tmem_layouts in
   // compiler.py. This avoids transforming bare splits into tmem_subslice
   // ops that lack async_task_id and would crash createAllocChannel.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/GenerateSubtiledRegion.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/GenerateSubtiledRegion.cpp
@@ -2,19 +2,21 @@
 // META_WS_ONLY
 #include "lib/Dialect/TritonGPU/Transforms/WarpSpecialization/PartitionAttrs.h"
 #include "mlir/IR/IRMapping.h"
+#include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
-#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
 
 namespace mlir {
+
+#define GEN_PASS_DEF_NVGPUTESTGENERATESUBTILEDREGION
+#include "nvidia/hopper/include/Transforms/Passes.h.inc"
+
 namespace triton {
 namespace nvidia_gpu {
-
-#define GEN_PASS_DEF_TRITONNVIDIAGPUTESTGENERATESUBTILEDREGIONPASS
-#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
 
 namespace {
 
@@ -1378,70 +1380,75 @@ bool tryGenerateForSplit(triton::SplitOp splitOp) {
   return true;
 }
 
-namespace {
-
-class TritonNvidiaGPUTestGenerateSubtiledRegionPass
-    : public impl::TritonNvidiaGPUTestGenerateSubtiledRegionPassBase<
-          TritonNvidiaGPUTestGenerateSubtiledRegionPass> {
-public:
-  using TritonNvidiaGPUTestGenerateSubtiledRegionPassBase::
-      TritonNvidiaGPUTestGenerateSubtiledRegionPassBase;
-
-  void runOnOperation() override {
-    // Collect root splits (those tracing to tmem_load) in function bodies.
-    // Process them one at a time, re-walking after each success to avoid
-    // dangling pointers from erased inner splits. Track failed splits to
-    // avoid infinite loops on splits that can't be processed (e.g.,
-    // multi-task N-tile).
-    DenseSet<Operation *> failedSplits;
-    bool changed = true;
-    while (changed) {
-      changed = false;
-      SmallVector<triton::SplitOp> splitOps;
-      auto feedsIntoSubtiledRegion = [](triton::SplitOp splitOp) {
-        SmallVector<Value> worklist;
-        for (Value r : splitOp->getResults())
-          worklist.push_back(r);
-        DenseSet<Value> visited;
-        while (!worklist.empty()) {
-          Value v = worklist.pop_back_val();
-          if (!visited.insert(v).second)
-            continue;
-          for (Operation *user : v.getUsers()) {
-            if (isa<SubtiledRegionOp>(user))
-              return true;
-            for (Value r : user->getResults())
-              worklist.push_back(r);
-          }
-        }
-        return false;
-      };
-      getOperation().walk([&](triton::SplitOp splitOp) {
-        if (failedSplits.contains(splitOp.getOperation()))
-          return;
-        if (splitOp->getParentOfType<SubtiledRegionOp>())
-          return;
-        if (feedsIntoSubtiledRegion(splitOp))
-          return;
-        splitOps.push_back(splitOp);
-      });
-      for (auto splitOp : splitOps) {
-        auto tmemLoad = traceSetupChain(splitOp);
-        if (!tmemLoad)
+static void generateSubtiledRegions(ModuleOp moduleOp) {
+  // Collect root splits (those tracing to tmem_load) in function bodies.
+  // Process them one at a time, re-walking after each success to avoid
+  // dangling pointers from erased inner splits. Track failed splits to avoid
+  // infinite loops on splits that can't be processed (e.g., multi-task
+  // N-tile).
+  DenseSet<Operation *> failedSplits;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<triton::SplitOp> splitOps;
+    auto feedsIntoSubtiledRegion = [](triton::SplitOp splitOp) {
+      SmallVector<Value> worklist;
+      for (Value r : splitOp->getResults())
+        worklist.push_back(r);
+      DenseSet<Value> visited;
+      while (!worklist.empty()) {
+        Value v = worklist.pop_back_val();
+        if (!visited.insert(v).second)
           continue;
-        if (tryGenerateForSplit(splitOp)) {
-          changed = true;
-        } else {
-          failedSplits.insert(splitOp);
+        for (Operation *user : v.getUsers()) {
+          if (isa<SubtiledRegionOp>(user))
+            return true;
+          for (Value r : user->getResults())
+            worklist.push_back(r);
         }
-        break;
       }
+      return false;
+    };
+    moduleOp.walk([&](triton::SplitOp splitOp) {
+      if (failedSplits.contains(splitOp.getOperation()))
+        return;
+      if (splitOp->getParentOfType<SubtiledRegionOp>())
+        return;
+      if (feedsIntoSubtiledRegion(splitOp))
+        return;
+      splitOps.push_back(splitOp);
+    });
+    for (auto splitOp : splitOps) {
+      auto tmemLoad = traceSetupChain(splitOp);
+      if (!tmemLoad)
+        continue;
+      if (tryGenerateForSplit(splitOp)) {
+        changed = true;
+      } else {
+        failedSplits.insert(splitOp);
+      }
+      break;
     }
   }
-};
-
-} // anonymous namespace
+}
 
 } // namespace nvidia_gpu
 } // namespace triton
+
+namespace {
+
+class NVGPUTestGenerateSubtiledRegionPass
+    : public impl::NVGPUTestGenerateSubtiledRegionBase<
+          NVGPUTestGenerateSubtiledRegionPass> {
+public:
+  using impl::NVGPUTestGenerateSubtiledRegionBase<
+      NVGPUTestGenerateSubtiledRegionPass>::NVGPUTestGenerateSubtiledRegionBase;
+
+  void runOnOperation() override {
+    triton::nvidia_gpu::generateSubtiledRegions(getOperation());
+  }
+};
+
+} // namespace
+
 } // namespace mlir

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SubtileOperator.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/SubtileOperator.md
@@ -59,8 +59,8 @@ Defined in `include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td`.
 ### Passes
 
 #### 1. GenerateSubtiledRegion
-**File:** `lib/Dialect/TritonNvidiaGPU/Transforms/GenerateSubtiledRegion.cpp`
-**Pass:** `triton-nvidia-gpu-test-generate-subtiled-region`
+**File:** `third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/GenerateSubtiledRegion.cpp`
+**Pass:** `nvgpu-test-generate-subtiled-region`
 
 Finds `tmem_load → reshape → trans{[0,2,1]} → split` patterns and wraps the
 per-tile chains into `SubtiledRegionOp`s.


### PR DESCRIPTION
Summary:
Move the `GenerateSubtiledRegion` implementation, pass registration, and lit tests from the generic TritonNvidiaGPU tree into `third_party/nvidia/hopper`. Update the warp-specialization pipeline, documentation, CMake ownership, and generated BUCK metadata while preserving the pass behavior.

Rename the internal test flag to `--nvgpu-test-generate-subtiled-region` and make the CMake-to-Buck generator drop the non-target `Python::Interpreter` alias so the generated BUCK remains reproducible.

Authored with Claude.

Differential Revision: D117739507
