### PR TITLE
[TLX] Respect TLX user-pinned layouts

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -43,6 +43,26 @@ def TTG_ConvertLayoutOp
   let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
 }
 
+def TTG_RequireLayoutOp
+    : TTG_Op<"require_layout", [SameOperandsAndResultShape,
+                                SameOperandsAndResultElementType, Pure]> {
+  let summary = "preserve a user-requested layout boundary";
+
+  let description = [{
+    `ttg.require_layout` is a semantic layout boundary produced from a
+    source-level pinned layout request. Unlike `ttg.convert_layout`, it must not
+    be treated as a transparent cast by layout canonicalization or
+    rematerialization. Layout optimization may insert conversions around it, but
+    the boundary itself is retired only after those passes have run.
+  }];
+
+  let arguments = (ins TT_Tensor:$src);
+
+  let results = (outs TT_Tensor:$result);
+
+  let assemblyFormat = "$src attr-dict `:` type($src) `->` type($result)";
+}
+
 def TTG_AsyncWaitOp : TTG_Op<"async_wait", [MemWaitOpTrait]> {
   let summary = "Ensure all specified async_copy_* operations are complete.";
   let description = [{

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -47,6 +47,13 @@ Value getMemAccessPtr(Operation *op);
 // Return bitwidth of tensor element
 unsigned getElementBitWidth(RankedTensorType type);
 
+// True if `encoding` is, or nests anywhere, an encoding implementing
+// ttg::PinnedEncodingTrait. Frontends may wrap a pinned encoding in another
+// layout attribute (for example #tlx.no_verify_layout<#tlx.user_layout<...>>),
+// so callers that enforce hard user layout anchors need to recurse through the
+// attribute tree instead of checking only the top-level encoding.
+bool containsPinnedEncoding(Attribute encoding);
+
 // Calculate the optimal number of elements per thread for a given operation
 // along an axis with greatest continuity.
 unsigned

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1194,6 +1194,7 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   CastOpAxisInfoVisitor<arith::ExtUIOp>,
                   CastOpAxisInfoVisitor<arith::TruncIOp>,
                   CastOpAxisInfoVisitor<triton::gpu::ConvertLayoutOp>,
+                  CastOpAxisInfoVisitor<triton::gpu::RequireLayoutOp>,
                   CastOpAxisInfoVisitor<triton::BitcastOp>,
                   CastOpAxisInfoVisitor<triton::gluon::SetAutoLayoutOp>>();
   visitors.append<MakeRangeOpAxisInfoVisitor>();

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -11,6 +11,10 @@ add_triton_library(TritonGPUIR
   TritonGPUAttrDefsIncGen
   TritonGPUTypeInterfacesIncGen
   TritonGPUOpInterfacesIncGen
+  TLXTableGen
+  TLXTypesIncGen
+  TLXLayoutInterfaceIncGen
+  TLXAttrDefsIncGen
 
   LINK_LIBS PUBLIC
   MLIRGPUDialect

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -323,8 +323,11 @@ struct CanonicalizeConvertFromConvert
   mlir::LogicalResult
   matchAndRewrite(ConvertLayoutOp op,
                   PatternRewriter &rewriter) const override {
-    // Convert to the same layout is redundant.
+    // Convert to the same layout is redundant unless it carries a backend
+    // request that must follow the conversion surviving layout propagation.
     if (op->getResultTypes() == op->getOperandTypes()) {
+      if (op->hasAttr("tlx.rematerialize_coordinates"))
+        return failure();
       rewriter.replaceOp(op, op->getOperands());
       return success();
     }

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -69,29 +69,6 @@ static void pickDescriptorLoadStoreLayout(
   });
 }
 
-// A value pinned via tlx.require_layout(pin=True) carries a PinnedEncodingTrait
-// (#tlx.user_layout), possibly under a #tlx.no_verify_layout wrapper that
-// resolve-placeholder-layouts peels only after coalesce runs. Walk the TLX
-// wrapper chain to detect the pin (used for both a pinned load result and a
-// pinned store value operand).
-static bool hasRecursivePin(Attribute enc) {
-  for (Attribute e = enc; e && e.getDialect().getNamespace() == "tlx";) {
-    if (isa<PinnedEncodingTrait>(e))
-      return true;
-    Attribute inner;
-    e.walkImmediateSubElements(
-        [&](Attribute sub) {
-          if (!inner)
-            inner = sub;
-        },
-        [](Type) {});
-    if (!inner || inner == e)
-      break;
-    e = inner;
-  }
-  return false;
-}
-
 struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
   using impl::TritonGPUCoalesceBase<CoalescePass>::TritonGPUCoalesceBase;
 
@@ -156,7 +133,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
         // purpose. The pin (PinnedEncodingTrait) may sit under a
         // #tlx.no_verify_layout wrapper here (peeled later by
         // resolve-placeholder).
-        if (hasRecursivePin(resultType.getEncoding()))
+        if (containsPinnedEncoding(resultType.getEncoding()))
           return;
       } else {
         // Not a memory operation we handle
@@ -203,7 +180,7 @@ struct CoalescePass : public impl::TritonGPUCoalesceBase<CoalescePass> {
         if (auto store = dyn_cast<triton::StoreOp>(curr)) {
           if (auto vt =
                   dyn_cast<RankedTensorType>(store.getValue().getType())) {
-            if (hasRecursivePin(vt.getEncoding())) {
+            if (containsPinnedEncoding(vt.getEncoding())) {
               Attribute concrete = triton::unwrapTlxWrappers(vt.getEncoding());
               if (isa_and_nonnull<DistributedEncodingTrait>(concrete))
                 pinned = concrete;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -823,10 +823,9 @@ scheduleKeyOpsAnnotation(scf::ForOp forOp,
   for (int i = 0; i < numClusters; ++i)
     clusters.push_back(schedule.clusters.newAtBack());
 
-  for (auto &[op, entryKey] : latencySchedule) {
-    // Copy out of the structured binding: capturing one in a lambda is a C++20
-    // extension and this file is built as C++17.
-    auto key = entryKey;
+  for (auto &entry : latencySchedule) {
+    Operation *op = entry.first;
+    auto key = entry.second;
     auto cluster = llvm::find_if(prefetchClusters, [&](const auto &entry) {
       return entry.first == key;
     });

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -39,6 +39,16 @@ namespace mlir::triton::gpu {
 
 namespace {
 
+static bool hasPinnedEncoding(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    return containsPinnedEncoding(tensorType.getEncoding());
+  return false;
+}
+
+static bool isPinnedConvertLayout(ConvertLayoutOp op) {
+  return hasPinnedEncoding(op.getType());
+}
+
 // A layout conversion requested at the source level can acquire a short
 // elementwise/conversion suffix when pinned layouts are materialized.  Layout
 // propagation may then eliminate the marked conversion and retain a later
@@ -128,6 +138,7 @@ public:
   void rewriteWhileOp(scf::WhileOp whileOp);
   void rewriteIfOp(scf::IfOp ifOp);
   void rewriteWarpPredicateOp(WarpPredicateOp predicateOp);
+  void rewriteRequireLayoutOp(RequireLayoutOp requireOp);
   void rewriteYieldOp(scf::YieldOp yieldOp);
   void rewritePredicateYieldOp(PredicateYieldOp yieldOp);
   void rewriteConditionOp(scf::ConditionOp conditionOp);
@@ -367,27 +378,6 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 }
 // Facebook end
 
-// A frontend may defer verification by wrapping a user pin in another layout
-// attribute (for example #tlx.no_verify_layout<#tlx.user_layout<...>>).  The
-// PinnedEncodingTrait is therefore not necessarily implemented by the
-// top-level encoding.  Detect it anywhere in the attribute tree so a deferred
-// hard constraint remains a hard constraint in this pass.
-static bool containsPinnedEncoding(Attribute encoding) {
-  if (!encoding)
-    return false;
-  if (isa<PinnedEncodingTrait>(encoding))
-    return true;
-
-  bool pinned = false;
-  encoding.walkImmediateSubElements(
-      [&](Attribute nested) {
-        if (!pinned)
-          pinned = containsPinnedEncoding(nested);
-      },
-      [](Type) {});
-  return pinned;
-}
-
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
 bool isLayoutAnchor(Operation *op) {
@@ -474,7 +464,8 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
     bool hasChanged = false;
     for (auto encoding : info.encodings) {
       Attribute dstEncoding;
-      if (isa<ConvertLayoutOp>(op)) {
+      if (auto convertOp = dyn_cast<ConvertLayoutOp>(op);
+          convertOp && !isPinnedConvertLayout(convertOp)) {
         // Try to remove the convert by making the dst encoding match the source
         // encoding.
         dstEncoding = encoding;
@@ -582,10 +573,17 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
     if (auto reshapeOp = dyn_cast<ReshapeOp>(user);
         reshapeOp && reshapeOp.getEfficientLayout())
       continue;
+    if (isa<RequireLayoutOp>(user))
+      continue;
+    if (auto convertOp = dyn_cast<ConvertLayoutOp>(user)) {
+      if (!isPinnedConvertLayout(convertOp))
+        setEncoding(user->getResults(), info, changed, user);
+      continue;
+    }
     if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
         user->hasTrait<OpTrait::Elementwise>() ||
-        isa<ReduceOp, ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp,
-            ConvertLayoutOp>(user)) {
+        isa<ReduceOp, ExpandDimsOp, ReshapeOp, TransOp, JoinOp, SplitOp>(
+            user)) {
       setEncoding(user->getResults(), info, changed, user);
       continue;
     }
@@ -890,6 +888,8 @@ void LayoutPropagation::rewriteRegion(Region &region) {
         rewriteOp(&op);
         for (Region &R : op.getRegions())
           queue.push_back(&R);
+      } else if (auto requireOp = dyn_cast<RequireLayoutOp>(&op)) {
+        rewriteRequireLayoutOp(requireOp);
       } else if (auto yieldOp = dyn_cast<scf::YieldOp>(&op)) {
         rewriteYieldOp(yieldOp);
       } else if (auto yieldOp = dyn_cast<PredicateYieldOp>(&op)) {
@@ -1125,6 +1125,8 @@ void LayoutPropagation::rewriteOp(Operation *op) {
     rewriteIfOp(ifOp);
   else if (auto predicateOp = dyn_cast<WarpPredicateOp>(op))
     rewriteWarpPredicateOp(predicateOp);
+  else if (auto requireOp = dyn_cast<RequireLayoutOp>(op))
+    rewriteRequireLayoutOp(requireOp);
   else {
     Attribute encoding = *layouts[op->getResult(0)].encodings.begin();
     if (canUseResultEncoding(op, encoding)) {
@@ -1139,6 +1141,12 @@ void LayoutPropagation::rewriteOp(Operation *op) {
       llvm::report_fatal_error("unexpected op in rewrite");
     }
   }
+}
+
+void LayoutPropagation::rewriteRequireLayoutOp(RequireLayoutOp requireOp) {
+  auto resultType = cast<RankedTensorType>(requireOp.getType());
+  requireOp.getSrcMutable().assign(
+      getValueAs(requireOp.getSrc(), resultType.getEncoding()));
 }
 
 bool canBeRemat(Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -29,6 +29,22 @@ namespace mlir {
 
 using namespace triton;
 
+bool containsPinnedEncoding(Attribute encoding) {
+  if (!encoding)
+    return false;
+  if (isa<triton::gpu::PinnedEncodingTrait>(encoding))
+    return true;
+
+  bool pinned = false;
+  encoding.walkImmediateSubElements(
+      [&](Attribute nested) {
+        if (!pinned)
+          pinned = containsPinnedEncoding(nested);
+      },
+      [](Type) {});
+  return pinned;
+}
+
 SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 const ArrayRef<int64_t> &shape,
                                                 Type eltType, int numWarps) {

--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -106,6 +106,15 @@ def _row_per_thread_layout():
     return tlx.layout(shape=((32, 4), (128, )), stride=((128, 4096), (1, )))
 
 
+def _column_per_thread_layout():
+    return tlx.layout(shape=((32, 4), (128, )), stride=((1, 32), (128, )))
+
+
+_COLUMN_PER_THREAD_LINEAR = ("#ttg.linear<{register = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0]], "
+                             "lane = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], "
+                             "warp = [[0, 32], [0, 64]], block = []}>")
+
+
 @pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
 def test_pinned_layout_propagates_through_elementwise():
     """A pinned (no_verify) register layout that feeds arith/math elementwise
@@ -373,6 +382,47 @@ def test_pinned_propagates_through_cast():
     assert "no_verify_layout" not in compiled.asm["ttgir"]
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_require_layout_after_release_reanchors_layout():
+    """A release boundary should permit a later explicit pin to establish a new
+    hard layout anchor. The current layout-removal path drops that second pin
+    when its only consumer is a layout-flexible local_store."""
+
+    @triton.jit
+    def kernel(ROW: tl.constexpr, COL: tl.constexpr):
+        offs = tl.arange(0, 128)
+        x = offs[:, None].to(tl.float32) + offs[None, :].to(tl.float32)
+        row = tlx.require_layout(x, ROW)
+        col = tlx.require_layout(tlx.release_layout(row), COL)
+        out_buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1))
+        tlx.local_store(tlx.local_view(out_buf, 0), col)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), _column_per_thread_layout(), grid=(1, ), num_warps=4)
+    ttgir = compiled.asm["ttgir"]
+    assert _COLUMN_PER_THREAD_LINEAR in ttgir
+    _assert_no_layout_residue(ttgir)
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Need Blackwell")
+def test_require_layout_after_release_reanchors_tmem_store():
+    """A user pin that feeds a TMEM local_store must not be erased by the
+    convert-layout cleanup before the required TMEM-compatible store layout."""
+
+    @triton.jit
+    def kernel(ROW: tl.constexpr, COL: tl.constexpr):
+        offs = tl.arange(0, 128)
+        x = offs[:, None].to(tl.float32) + offs[None, :].to(tl.float32)
+        row = tlx.require_layout(x, ROW)
+        store_value = tlx.require_layout(tlx.release_layout(row), COL)
+        out_buf = tlx.local_alloc((128, 128), tl.float32, tl.constexpr(1), tlx.storage_kind.tmem)
+        tlx.local_store(tlx.local_view(out_buf, 0), store_value)
+
+    compiled = kernel.warmup(_row_per_thread_layout(), _column_per_thread_layout(), grid=(1, ), num_warps=4)
+    ttgir = compiled.asm["ttgir"]
+    assert _COLUMN_PER_THREAD_LINEAR in ttgir
+    _assert_no_layout_residue(ttgir)
+
+
 @pytest.mark.skipif(not is_cuda(), reason="Need CUDA")
 def test_dump_layout_cute(capfd, monkeypatch):
     """`tlx.dump_layout` prints the resolved layout in CuTe Shape:Stride form to
@@ -519,9 +569,9 @@ def test_swizzled_layout_lowers_to_swizzled_shared():
 # ---------------------------------------------------------------------------
 # "Does the compiler understand user layouts?" -- adversarial end-to-end cases.
 #
-# Every user-pinned layout rides through the pipeline as #tlx.user_layout<...>
-# and must (a) survive to the final TTGIR as the exact concrete layout the user
-# asked for, and (b) leave no #tlx.user_layout / no_verify_layout residue.
+# Every user-pinned layout must (a) survive to the final TTGIR as the exact
+# concrete layout the user asked for, and (b) leave no #tlx.user_layout,
+# no_verify_layout, or ttg.require_layout residue.
 # ---------------------------------------------------------------------------
 
 
@@ -531,6 +581,7 @@ def _assert_no_layout_residue(ttgir):
     # `tlx.user_layout` (see triton_tlx.cc), which must not trip this check.
     assert "#tlx.user_layout" not in ttgir, "user-layout wrapper encoding leaked into final IR"
     assert "#tlx.no_verify_layout" not in ttgir, "no-verify wrapper encoding leaked into final IR"
+    assert "ttg.require_layout" not in ttgir, "require_layout boundary leaked into final IR"
 
 
 @pytest.mark.skipif(not is_cuda(), reason="Need CUDA")

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -15,6 +15,14 @@ tt.func @cast() {
 
 // -----
 
+tt.func @require_layout(%arg0: tensor<128xi32> {tt.contiguity = 16 : i32, tt.divisibility = 4 : i32, tt.constancy = 2 : i32}) {
+  // expected-remark @below {{contiguity = [16], divisibility = [4], constancy = [2], constant_value = <none>}}
+  %0 = ttg.require_layout %arg0 : tensor<128xi32> -> tensor<128xi32>
+  tt.return
+}
+
+// -----
+
 tt.func @add(%arg0: tensor<128xi32> {tt.contiguity = 1 : i32, tt.divisibility = 4 : i32, tt.constancy = 2: i32}, %arg1: tensor<128xi32> {tt.contiguity = 4 : i32, tt.divisibility = 4 : i32, tt.constancy = 1: i32}) {
   // expected-remark @below {{contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>}}
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>

--- a/test/Conversion/warp_specialize_to_llvm.mlir
+++ b/test/Conversion/warp_specialize_to_llvm.mlir
@@ -49,6 +49,7 @@ llvm.func @rewrite_barriers() attributes {allocation.offset = 32 : i32} {
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#bridge = #ttg.linear<{register = [], lane = [[32], [16], [8], [4], [2], [1]], warp = [], block = []}>
 #predicate_register_order = #ttg.linear<{register = [[1], [2]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
 #carried_register_order = #ttg.linear<{register = [[2], [1]], lane = [[4], [8], [16], [32], [64], [128]], warp = [], block = []}>
 module attributes {"ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32, "ttg.target" = "hip:gfx950"} {
@@ -73,6 +74,32 @@ llvm.func @lower_warp_predicate(
   // AMD: cf.br ^[[MERGE]](%{{.*}} : !llvm.struct<(i32)>)
   // AMD: ^[[MERGE]](%{{.*}}: !llvm.struct<(i32)>):
   // AMD-NOT: ttg.warp_predicate
+  llvm.return %result_struct : !llvm.struct<(i32)>
+}
+
+// Partial conversion can add a tensor-to-tensor bridge on top of the LLVM
+// bridge when layout propagation retags a carried value. Lowering must walk the
+// complete chain to recover the false-path LLVM value.
+// AMD-LABEL: llvm.func @lower_bridged_warp_predicate
+// AMD: cf.cond_br %{{.*}}, ^[[BODY:bb[0-9]+]], ^[[MERGE:bb[0-9]+]](%{{.*}} : !llvm.struct<(i32)>)
+// AMD: ^[[BODY]]:
+// AMD: cf.br ^[[MERGE]](%{{.*}} : !llvm.struct<(i32)>)
+// AMD: ^[[MERGE]](%{{.*}}: !llvm.struct<(i32)>):
+// AMD-NOT: ttg.warp_predicate
+llvm.func @lower_bridged_warp_predicate(
+    %predicate_struct: !llvm.struct<(i1)>,
+    %init_struct: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %predicate = builtin.unrealized_conversion_cast %predicate_struct : !llvm.struct<(i1)> to tensor<64xi1, #blocked>
+  %init_bridge = builtin.unrealized_conversion_cast %init_struct : !llvm.struct<(i32)> to tensor<64xi32, #bridge>
+  %init = builtin.unrealized_conversion_cast %init_bridge : tensor<64xi32, #bridge> to tensor<64xi32, #blocked>
+  %result = ttg.warp_predicate %predicate (%init) {
+    %two = llvm.mlir.constant(2 : i32) : i32
+    %yield_undef = llvm.mlir.undef : !llvm.struct<(i32)>
+    %yield_struct = llvm.insertvalue %two, %yield_undef[0] : !llvm.struct<(i32)>
+    %yield = builtin.unrealized_conversion_cast %yield_struct : !llvm.struct<(i32)> to tensor<64xi32, #blocked>
+    ttg.predicate_yield %yield : tensor<64xi32, #blocked>
+  } : (tensor<64xi1, #blocked>, tensor<64xi32, #blocked>) -> tensor<64xi32, #blocked>
+  %result_struct = builtin.unrealized_conversion_cast %result : tensor<64xi32, #blocked> to !llvm.struct<(i32)>
   llvm.return %result_struct : !llvm.struct<(i32)>
 }
 

--- a/test/TLX/remove-layout-require-layout.mlir
+++ b/test/TLX/remove-layout-require-layout.mlir
@@ -1,0 +1,30 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions | FileCheck %s
+
+// A user layout requirement is a semantic boundary, not a transparent
+// convert_layout.  RemoveLayoutConversions may insert physical conversions on
+// either side of the boundary, but it must not propagate the TMEM-store layout
+// backward through the user requirement.
+
+#src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#user_col = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
+#tmem_compatible = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 8]], warp = [[16, 0], [32, 0], [0, 16]], block = []}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$USER_COL:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
+  // CHECK-DAG: #[[$TMEM_COMPAT:.*]] = #ttg.linear
+  // CHECK-LABEL: tt.func @require_layout_blocks_tmem_store_propagation
+  tt.func @require_layout_blocks_tmem_store_propagation(
+      %arg0: tensor<64x32xf32, #src>,
+      %acc: !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %true = arith.constant true
+    // CHECK: %[[TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf32, #{{.*}}> -> tensor<64x32xf32, #[[$USER_COL]]>
+    // CHECK: %[[REQ:.*]] = ttg.require_layout %[[TO_USER]] : tensor<64x32xf32, #[[$USER_COL]]> -> tensor<64x32xf32, #[[$USER_COL]]>
+    %required = ttg.require_layout %arg0 : tensor<64x32xf32, #src> -> tensor<64x32xf32, #user_col>
+    // CHECK: %[[TO_TMEM:.*]] = ttg.convert_layout %[[REQ]] : tensor<64x32xf32, #[[$USER_COL]]> -> tensor<64x32xf32, #[[$TMEM_COMPAT]]>
+    %for_store = ttg.convert_layout %required : tensor<64x32xf32, #user_col> -> tensor<64x32xf32, #tmem_compatible>
+    // CHECK: ttng.tmem_store %[[TO_TMEM]], %{{.*}}, %{{.*}} : tensor<64x32xf32, #[[$TMEM_COMPAT]]> -> !ttg.memdesc<64x32xf32, #{{.*}}, #ttng.tensor_memory, mutable>
+    ttng.tmem_store %for_store, %acc, %true : tensor<64x32xf32, #tmem_compatible> -> !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/remove-layout-require-layout.mlir
+++ b/test/TLX/remove-layout-require-layout.mlir
@@ -28,3 +28,392 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.thr
     tt.return
   }
 }
+
+// -----
+
+// AMD FA backward epilogues also use the opposite packing direction:
+// join two D-slices, permute the packed axis, then reshape back to 2D.  Both
+// join operands may carry user requirements and must not be rewritten to their
+// original source layouts.
+
+#join_src_piece = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#join_user_piece = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+#join_packed = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#join_trans = #ttg.blocked<{sizePerThread = [1, 2, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [4, 1, 2], order = [1, 2, 0]}>
+#join_flat = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$JOIN_USER_PIECE:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+  // CHECK-DAG: #[[$JOIN_PACKED:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_join_trans_reshape_rewrite
+  tt.func @require_layout_blocks_join_trans_reshape_rewrite(
+      %lo_src: tensor<128x64xf32, #join_src_piece>,
+      %hi_src: tensor<128x64xf32, #join_src_piece>)
+      -> tensor<128x128xf32, #join_flat> {
+    // CHECK-DAG: %[[JOIN_LO_CVT:.*]] = ttg.convert_layout %arg0 : tensor<128x64xf32, #{{.*}}> -> tensor<128x64xf32, #[[$JOIN_USER_PIECE]]>
+    // CHECK-DAG: %[[JOIN_HI_CVT:.*]] = ttg.convert_layout %arg1 : tensor<128x64xf32, #{{.*}}> -> tensor<128x64xf32, #[[$JOIN_USER_PIECE]]>
+    // CHECK: %[[JOIN_LO_REQ:.*]] = ttg.require_layout %[[JOIN_LO_CVT]] : tensor<128x64xf32, #[[$JOIN_USER_PIECE]]> -> tensor<128x64xf32, #[[$JOIN_USER_PIECE]]>
+    %lo = ttg.require_layout %lo_src : tensor<128x64xf32, #join_src_piece> -> tensor<128x64xf32, #join_user_piece>
+    // CHECK: %[[JOIN_HI_REQ:.*]] = ttg.require_layout %[[JOIN_HI_CVT]] : tensor<128x64xf32, #[[$JOIN_USER_PIECE]]> -> tensor<128x64xf32, #[[$JOIN_USER_PIECE]]>
+    %hi = ttg.require_layout %hi_src : tensor<128x64xf32, #join_src_piece> -> tensor<128x64xf32, #join_user_piece>
+    // CHECK: %[[JOINED:.*]] = tt.join %[[JOIN_LO_REQ]], %[[JOIN_HI_REQ]]
+    %joined = tt.join %lo, %hi : tensor<128x64xf32, #join_user_piece> -> tensor<128x64x2xf32, #join_packed>
+    // CHECK: %[[JOIN_TRANS:.*]] = tt.trans %[[JOINED]]
+    %transposed = tt.trans %joined {order = array<i32: 0, 2, 1>} : tensor<128x64x2xf32, #join_packed> -> tensor<128x2x64xf32, #join_trans>
+    // CHECK: %[[JOIN_RESHAPED:.*]] = tt.reshape %[[JOIN_TRANS]]
+    %reshaped = tt.reshape %transposed : tensor<128x2x64xf32, #join_trans> -> tensor<128x128xf32, #join_flat>
+    tt.return %reshaped : tensor<128x128xf32, #join_flat>
+  }
+}
+
+// -----
+
+// Gather has source/result layout preferences and canonicalization patterns that
+// may look through a convert_layout on the gathered source.  A user requirement
+// on that source must remain the operand seen by tt.gather.
+
+#gather_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
+#gather_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$GATHER_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_gather_source_rewrite
+  tt.func @require_layout_blocks_gather_source_rewrite(
+      %src: tensor<64x64xf32, #gather_src>,
+      %idx: tensor<64x64xi32, #gather_user>)
+      -> tensor<64x64xf32, #gather_user> {
+    // CHECK: %[[GATHER_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x64xf32, #{{.*}}> -> tensor<64x64xf32, #[[$GATHER_USER]]>
+    // CHECK: %[[GATHER_REQ:.*]] = ttg.require_layout %[[GATHER_TO_USER]] : tensor<64x64xf32, #[[$GATHER_USER]]> -> tensor<64x64xf32, #[[$GATHER_USER]]>
+    %required = ttg.require_layout %src : tensor<64x64xf32, #gather_src> -> tensor<64x64xf32, #gather_user>
+    // CHECK: %[[GATHERED:.*]] = tt.gather %[[GATHER_REQ]][%{{.*}}]
+    %gathered = tt.gather %required[%idx] {axis = 0 : i32} : (tensor<64x64xf32, #gather_user>, tensor<64x64xi32, #gather_user>) -> tensor<64x64xf32, #gather_user>
+    tt.return %gathered : tensor<64x64xf32, #gather_user>
+  }
+}
+
+// -----
+
+// A direct split of a pinned rank-3 tensor exercises SplitOp's
+// split(convert_layout(x)) canonicalization without the longer FA reshape chain.
+// The split source must remain the user boundary.
+
+#direct_split_src = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 1]], warp = [[32, 0, 0], [64, 0, 0], [16, 0, 0]], block = []}>
+#direct_split_user = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#direct_split_piece = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$DIRECT_SPLIT_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_direct_split_rewrite
+  tt.func @require_layout_blocks_direct_split_rewrite(
+      %src: tensor<128x64x2xf32, #direct_split_src>)
+      -> (tensor<128x64xf32, #direct_split_piece>, tensor<128x64xf32, #direct_split_piece>) {
+    // CHECK: %[[DS_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<128x64x2xf32, #{{.*}}> -> tensor<128x64x2xf32, #[[$DIRECT_SPLIT_USER]]>
+    // CHECK: %[[DS_REQ:.*]] = ttg.require_layout %[[DS_TO_USER]] : tensor<128x64x2xf32, #[[$DIRECT_SPLIT_USER]]> -> tensor<128x64x2xf32, #[[$DIRECT_SPLIT_USER]]>
+    %required = ttg.require_layout %src : tensor<128x64x2xf32, #direct_split_src> -> tensor<128x64x2xf32, #direct_split_user>
+    // CHECK: %[[DS_LO:.*]], %[[DS_HI:.*]] = tt.split %[[DS_REQ]]
+    %lo, %hi = tt.split %required : tensor<128x64x2xf32, #direct_split_user> -> tensor<128x64xf32, #direct_split_piece>
+    tt.return %lo, %hi : tensor<128x64xf32, #direct_split_piece>, tensor<128x64xf32, #direct_split_piece>
+  }
+}
+
+// -----
+
+// allow_reorder reshape is the broadest shape-changing view form used by
+// packing/unpacking helpers.  It may choose a cheaper physical route, but the
+// reshape operand must be the user-required layout.
+
+#reshape_any_src = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#reshape_any_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [0, 1]}>
+#reshape_any_flat = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [8], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$RESHAPE_ANY_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [0, 1]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_allow_reorder_reshape
+  tt.func @require_layout_blocks_allow_reorder_reshape(
+      %src: tensor<64x64xf32, #reshape_any_src>)
+      -> tensor<4096xf32, #reshape_any_flat> {
+    // CHECK: %[[RA_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x64xf32, #{{.*}}> -> tensor<64x64xf32, #[[$RESHAPE_ANY_USER]]>
+    // CHECK: %[[RA_REQ:.*]] = ttg.require_layout %[[RA_TO_USER]] : tensor<64x64xf32, #[[$RESHAPE_ANY_USER]]> -> tensor<64x64xf32, #[[$RESHAPE_ANY_USER]]>
+    %required = ttg.require_layout %src : tensor<64x64xf32, #reshape_any_src> -> tensor<64x64xf32, #reshape_any_user>
+    // CHECK: %[[RA_RESHAPE:.*]] = tt.reshape %[[RA_REQ]] allow_reorder
+    %reshaped = tt.reshape %required allow_reorder : tensor<64x64xf32, #reshape_any_user> -> tensor<4096xf32, #reshape_any_flat>
+    tt.return %reshaped : tensor<4096xf32, #reshape_any_flat>
+  }
+}
+
+// -----
+
+// Dot operands have very specific encodings and RLC aggressively propagates
+// those layouts backward.  A source-level user boundary on an operand must
+// still be represented explicitly before the dot consumes it.
+
+#dot_src = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [4, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [2, 2], instrShape = [32, 32, 8], isTransposed = true}>
+#dot_a = #ttg.dot_op<{opIdx = 0, parent = #dot_mma, kWidth = 4}>
+#dot_b = #ttg.dot_op<{opIdx = 1, parent = #dot_mma, kWidth = 4}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.target = "hip:gfx942"} {
+  // CHECK-DAG: #[[$DOT_MMA:.*]] = #ttg.amd_mfma
+  // CHECK-LABEL: tt.func @require_layout_blocks_dot_operand_rewrite
+  tt.func @require_layout_blocks_dot_operand_rewrite(
+      %a: tensor<64x32xf16, #dot_src>,
+      %b: tensor<32x64xf16, #dot_b>,
+      %acc: tensor<64x64xf32, #dot_mma>)
+      -> tensor<64x64xf32, #dot_mma> {
+    // CHECK: %[[DOT_TO_A:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf16, #{{.*}}> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_MMA]], kWidth = 4}>>
+    // CHECK: %[[DOT_REQ:.*]] = ttg.require_layout %[[DOT_TO_A]] : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_MMA]], kWidth = 4}>> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_MMA]], kWidth = 4}>>
+    %required = ttg.require_layout %a : tensor<64x32xf16, #dot_src> -> tensor<64x32xf16, #dot_a>
+    // CHECK: %[[DOT:.*]] = tt.dot %[[DOT_REQ]], %{{.*}}, %{{.*}} : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #[[$DOT_MMA]], kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #[[$DOT_MMA]], kWidth = 4}>> -> tensor<64x64xf32, #[[$DOT_MMA]]>
+    %dot = tt.dot %required, %b, %acc, inputPrecision = tf32 : tensor<64x32xf16, #dot_a> * tensor<32x64xf16, #dot_b> -> tensor<64x64xf32, #dot_mma>
+    tt.return %dot : tensor<64x64xf32, #dot_mma>
+  }
+}
+
+// -----
+
+// AMD GEMM/addmm epilogues commonly upcast, add a bias, downcast, and
+// materialize in LDS.  The initialized local_alloc is a flexible sink, but the
+// cast chain it sees still has to be derived from the user-required layout.
+
+#alloc_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#alloc_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#alloc_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#alloc_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$ALLOC_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_trunc_alloc_epilogue
+  tt.func @require_layout_blocks_trunc_alloc_epilogue(
+      %src: tensor<64x64xf16, #alloc_src>,
+      %bias: tensor<64x64xf32, #alloc_user>)
+      -> !ttg.memdesc<64x64xf16, #alloc_shared, #alloc_smem, mutable> {
+    // CHECK: %[[ALLOC_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x64xf16, #{{.*}}> -> tensor<64x64xf16, #[[$ALLOC_USER]]>
+    // CHECK: %[[ALLOC_REQ:.*]] = ttg.require_layout %[[ALLOC_TO_USER]] : tensor<64x64xf16, #[[$ALLOC_USER]]> -> tensor<64x64xf16, #[[$ALLOC_USER]]>
+    %required = ttg.require_layout %src : tensor<64x64xf16, #alloc_src> -> tensor<64x64xf16, #alloc_user>
+    // CHECK: %[[ALLOC_EXT:.*]] = arith.extf %[[ALLOC_REQ]] : tensor<64x64xf16, #[[$ALLOC_USER]]> to tensor<64x64xf32, #[[$ALLOC_USER]]>
+    %ext = arith.extf %required : tensor<64x64xf16, #alloc_user> to tensor<64x64xf32, #alloc_user>
+    // CHECK: %[[ALLOC_ADD:.*]] = arith.addf %[[ALLOC_EXT]], %{{.*}} : tensor<64x64xf32, #[[$ALLOC_USER]]>
+    %add = arith.addf %ext, %bias : tensor<64x64xf32, #alloc_user>
+    // CHECK: %[[ALLOC_TRUNC:.*]] = arith.truncf %[[ALLOC_ADD]] : tensor<64x64xf32, #[[$ALLOC_USER]]> to tensor<64x64xf16, #[[$ALLOC_USER]]>
+    %truncated = arith.truncf %add : tensor<64x64xf32, #alloc_user> to tensor<64x64xf16, #alloc_user>
+    // CHECK: %[[ALLOC:.*]] = ttg.local_alloc %[[ALLOC_TRUNC]]
+    %alloc = ttg.local_alloc %truncated : (tensor<64x64xf16, #alloc_user>) -> !ttg.memdesc<64x64xf16, #alloc_shared, #alloc_smem, mutable>
+    tt.return %alloc : !ttg.memdesc<64x64xf16, #alloc_shared, #alloc_smem, mutable>
+  }
+}
+
+// -----
+
+// AMD FA kernels use long elementwise softmax chains after layout-sensitive
+// inputs: where/select masking, maximum, exp2, and output casts.  Remat/hoist
+// may clone cheap elementwise ops, but it must not clone through or bypass the
+// user layout boundary feeding that chain.
+
+#elt_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#elt_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$ELT_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_elementwise_softmax_chain
+  tt.func @require_layout_blocks_elementwise_softmax_chain(
+      %src: tensor<64x32xf32, #elt_src>,
+      %mask: tensor<64x32xi1, #elt_user>,
+      %fallback: tensor<64x32xf32, #elt_user>)
+      -> tensor<64x32xf16, #elt_user> {
+    // CHECK: %[[ELT_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf32, #{{.*}}> -> tensor<64x32xf32, #[[$ELT_USER]]>
+    // CHECK: %[[ELT_REQ:.*]] = ttg.require_layout %[[ELT_TO_USER]] : tensor<64x32xf32, #[[$ELT_USER]]> -> tensor<64x32xf32, #[[$ELT_USER]]>
+    %required = ttg.require_layout %src : tensor<64x32xf32, #elt_src> -> tensor<64x32xf32, #elt_user>
+    // CHECK: %[[MASKED:.*]] = arith.select %{{.*}}, %[[ELT_REQ]], %{{.*}} : tensor<64x32xi1, #[[$ELT_USER]]>, tensor<64x32xf32, #[[$ELT_USER]]>
+    %masked = arith.select %mask, %required, %fallback : tensor<64x32xi1, #elt_user>, tensor<64x32xf32, #elt_user>
+    // CHECK: %[[MAXED:.*]] = arith.maximumf %[[MASKED]], %{{.*}} : tensor<64x32xf32, #[[$ELT_USER]]>
+    %maxed = arith.maximumf %masked, %fallback : tensor<64x32xf32, #elt_user>
+    // CHECK: %[[EXP:.*]] = math.exp2 %[[MAXED]] : tensor<64x32xf32, #[[$ELT_USER]]>
+    %exp = math.exp2 %maxed : tensor<64x32xf32, #elt_user>
+    // CHECK: %[[TRUNC:.*]] = arith.truncf %[[EXP]] : tensor<64x32xf32, #[[$ELT_USER]]> to tensor<64x32xf16, #[[$ELT_USER]]>
+    %trunc = arith.truncf %exp : tensor<64x32xf32, #elt_user> to tensor<64x32xf16, #elt_user>
+    tt.return %trunc : tensor<64x32xf16, #elt_user>
+  }
+}
+
+// -----
+
+// Rank-changing producer chains are another common source of convert sinking.
+// The expand_dims/broadcast chain must start from the user-required slice
+// layout, not from the original one-dimensional source layout.
+
+#bcast_src_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#bcast_src = #ttg.slice<{dim = 1, parent = #bcast_src_parent}>
+#bcast_user_parent = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#bcast_user = #ttg.slice<{dim = 1, parent = #bcast_user_parent}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$BCAST_USER_PARENT:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_expand_broadcast_rewrite
+  tt.func @require_layout_blocks_expand_broadcast_rewrite(
+      %src: tensor<64xf32, #bcast_src>)
+      -> tensor<64x64xf32, #bcast_user_parent> {
+    // CHECK: %[[BCAST_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64xf32, #{{.*}}> -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #[[$BCAST_USER_PARENT]]}>>
+    // CHECK: %[[BCAST_REQ:.*]] = ttg.require_layout %[[BCAST_TO_USER]] : tensor<64xf32, #ttg.slice<{dim = 1, parent = #[[$BCAST_USER_PARENT]]}>> -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #[[$BCAST_USER_PARENT]]}>>
+    %required = ttg.require_layout %src : tensor<64xf32, #bcast_src> -> tensor<64xf32, #bcast_user>
+    // CHECK: %[[EXPANDED:.*]] = tt.expand_dims %[[BCAST_REQ]]
+    %expanded = tt.expand_dims %required {axis = 1 : i32} : tensor<64xf32, #bcast_user> -> tensor<64x1xf32, #bcast_user_parent>
+    // CHECK: %[[BROADCASTED:.*]] = tt.broadcast %[[EXPANDED]]
+    %broadcasted = tt.broadcast %expanded : tensor<64x1xf32, #bcast_user_parent> -> tensor<64x64xf32, #bcast_user_parent>
+    tt.return %broadcasted : tensor<64x64xf32, #bcast_user_parent>
+  }
+}
+
+// -----
+
+// The local-store cleanup pass has a special
+// local_store(reshape(convert_layout(x))) rewrite.  It may prune ordinary
+// physical conversions, but it must not sink the store through a user
+// requirement and reshape the original source directly.
+
+#store_src = #ttg.linear<{register = [[1, 0, 0], [0, 0, 8], [8, 0, 0], [16, 0, 0], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 4]], warp = [[0, 1, 0], [0, 2, 0]], block = []}>
+#store_user = #ttg.linear<{register = [[1, 0, 0], [8, 0, 0], [16, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16]], lane = [[2, 0, 0], [4, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]], warp = [[0, 1, 0], [0, 2, 0]], block = []}>
+#store_flat = #ttg.linear<{register = [[1, 0], [8, 0], [16, 0], [0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[2, 0], [4, 0], [0, 0], [0, 0], [0, 0]], warp = [[0, 32], [0, 64]], block = []}>
+#store_shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#store_smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-LABEL: tt.func @require_layout_blocks_store_reshape_cleanup
+  tt.func @require_layout_blocks_store_reshape_cleanup(
+      %src: tensor<32x4x32xf32, #store_src>,
+      %dst: !ttg.memdesc<32x128xf32, #store_shared, #store_smem, mutable>) {
+    // CHECK: %[[STORE_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<32x4x32xf32, #{{.*}}> -> tensor<32x4x32xf32, #{{.*}}>
+    // CHECK: %[[STORE_REQ:.*]] = ttg.require_layout %[[STORE_TO_USER]] : tensor<32x4x32xf32, #{{.*}}> -> tensor<32x4x32xf32, #{{.*}}>
+    %required = ttg.require_layout %src : tensor<32x4x32xf32, #store_src> -> tensor<32x4x32xf32, #store_user>
+    // CHECK: %[[STORE_RESHAPE:.*]] = tt.reshape %[[STORE_REQ]]
+    %reshaped = tt.reshape %required : tensor<32x4x32xf32, #store_user> -> tensor<32x128xf32, #store_flat>
+    // CHECK: ttg.local_store %[[STORE_RESHAPE]], %{{.*}} : tensor<32x128xf32, #{{.*}}> -> !ttg.memdesc<32x128xf32, #{{.*}}, #{{.*}}, mutable>
+    ttg.local_store %reshaped, %dst : tensor<32x128xf32, #store_flat> -> !ttg.memdesc<32x128xf32, #store_shared, #store_smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A reduction can strongly prefer a different operand/result layout.  The
+// reduce rewrite may materialize a physical conversion before the requirement,
+// but it must not bypass the user boundary and feed the original value directly
+// to tt.reduce.
+
+#red_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#red_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
+#red_row = #ttg.slice<{dim = 1, parent = #red_user}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$RED_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 8], order = [1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_reduce_operand_rewrite
+  tt.func @require_layout_blocks_reduce_operand_rewrite(
+      %arg0: tensor<64x32xf32, #red_src>)
+      -> tensor<64xf32, #red_row> {
+    // CHECK: %[[RED_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf32, #{{.*}}> -> tensor<64x32xf32, #[[$RED_USER]]>
+    // CHECK: %[[RED_REQ:.*]] = ttg.require_layout %[[RED_TO_USER]] : tensor<64x32xf32, #[[$RED_USER]]> -> tensor<64x32xf32, #[[$RED_USER]]>
+    %required = ttg.require_layout %arg0 : tensor<64x32xf32, #red_src> -> tensor<64x32xf32, #red_user>
+    // CHECK: %[[RED_SUM:.*]] = "tt.reduce"(%[[RED_REQ]])
+    // CHECK: }) : (tensor<64x32xf32, #[[$RED_USER]]>) -> tensor<64xf32, #ttg.slice<{dim = 1, parent = #[[$RED_USER]]}>>
+    %sum = "tt.reduce"(%required) <{axis = 1 : i32, reduction_ordering = "unordered"}> ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %next = arith.addf %lhs, %rhs : f32
+      tt.reduce.return %next : f32
+    }) : (tensor<64x32xf32, #red_user>) -> tensor<64xf32, #red_row>
+    tt.return %sum : tensor<64xf32, #red_row>
+  }
+}
+
+// -----
+
+// Reshape/trans/split/join are common in FA subtile helpers.  They rewrite
+// encodings aggressively, but the first reshape must still start from the
+// user-required layout rather than from the original source layout.
+
+#split_src = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#split_user = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 64]], warp = [[32, 0], [64, 0], [16, 0]], block = []}>
+#split_reshape = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 1, 0]], warp = [[32, 0, 0], [64, 0, 0], [16, 0, 0]], block = []}>
+#split_trans = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [0, 0, 1]], warp = [[32, 0, 0], [64, 0, 0], [16, 0, 0]], block = []}>
+#split_blocked3d = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+#split_piece = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$SPLIT_USER:.*]] = #ttg.linear
+  // CHECK-DAG: #[[$SPLIT_BLOCKED3D:.*]] = #ttg.blocked<{sizePerThread = [1, 1, 2], threadsPerWarp = [1, 32, 1], warpsPerCTA = [4, 2, 1], order = [2, 1, 0]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_split_join_rewrite
+  tt.func @require_layout_blocks_split_join_rewrite(
+      %arg0: tensor<128x128xf32, #split_src>)
+      -> tensor<128x64x2xf32, #split_blocked3d> {
+    // CHECK: %[[SPLIT_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<128x128xf32, #{{.*}}> -> tensor<128x128xf32, #[[$SPLIT_USER]]>
+    // CHECK: %[[SPLIT_REQ:.*]] = ttg.require_layout %[[SPLIT_TO_USER]] : tensor<128x128xf32, #[[$SPLIT_USER]]> -> tensor<128x128xf32, #[[$SPLIT_USER]]>
+    %required = ttg.require_layout %arg0 : tensor<128x128xf32, #split_src> -> tensor<128x128xf32, #split_user>
+    // CHECK: %[[RESHAPED:.*]] = tt.reshape %[[SPLIT_REQ]]
+    %reshaped = tt.reshape %required : tensor<128x128xf32, #split_user> -> tensor<128x2x64xf32, #split_reshape>
+    // CHECK: %[[TRANSPOSED:.*]] = tt.trans %[[RESHAPED]]
+    %transposed = tt.trans %reshaped {order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #split_reshape> -> tensor<128x64x2xf32, #split_trans>
+    // CHECK: %[[SPLIT_BLOCKED:.*]] = ttg.convert_layout %[[TRANSPOSED]] : tensor<128x64x2xf32, #{{.*}}> -> tensor<128x64x2xf32, #[[$SPLIT_BLOCKED3D]]>
+    %blocked = ttg.convert_layout %transposed : tensor<128x64x2xf32, #split_trans> -> tensor<128x64x2xf32, #split_blocked3d>
+    // CHECK: %[[LO:.*]], %[[HI:.*]] = tt.split %[[SPLIT_BLOCKED]]
+    %lo, %hi = tt.split %blocked : tensor<128x64x2xf32, #split_blocked3d> -> tensor<128x64xf32, #split_piece>
+    // CHECK: %[[JOINED:.*]] = tt.join %[[LO]], %[[HI]]
+    %joined = tt.join %lo, %hi : tensor<128x64xf32, #split_piece> -> tensor<128x64x2xf32, #split_blocked3d>
+    tt.return %joined : tensor<128x64x2xf32, #split_blocked3d>
+  }
+}
+
+// -----
+
+// tt.cat may rewrite both operands to match the result layout.  Each input
+// boundary must still be visible before concatenation, not bypassed by a
+// backward-propagated result encoding.
+
+#cat_src = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#cat_user = #ttg.linear<{register = [[1], [16]], lane = [[0], [0], [2], [4], [8]], warp = [[0], [0]], block = []}>
+#cat_result = #ttg.linear<{register = [[1], [16]], lane = [[0], [0], [2], [4], [8]], warp = [[0], [0]], block = []}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$CAT_USER:.*]] = #ttg.linear
+  // CHECK-LABEL: tt.func @require_layout_blocks_cat_operand_rewrite
+  tt.func @require_layout_blocks_cat_operand_rewrite(
+      %lhs_src: tensor<16xf32, #cat_src>,
+      %rhs_src: tensor<16xf32, #cat_src>)
+      -> tensor<32xf32, #cat_result> {
+    // CHECK-DAG: %[[CAT_LHS_CVT:.*]] = ttg.convert_layout %arg0 : tensor<16xf32, #{{.*}}> -> tensor<16xf32, #[[$CAT_USER]]>
+    // CHECK-DAG: %[[CAT_RHS_CVT:.*]] = ttg.convert_layout %arg1 : tensor<16xf32, #{{.*}}> -> tensor<16xf32, #[[$CAT_USER]]>
+    // CHECK: %[[CAT_LHS_REQ:.*]] = ttg.require_layout %[[CAT_LHS_CVT]] : tensor<16xf32, #[[$CAT_USER]]> -> tensor<16xf32, #[[$CAT_USER]]>
+    %lhs = ttg.require_layout %lhs_src : tensor<16xf32, #cat_src> -> tensor<16xf32, #cat_user>
+    // CHECK: %[[CAT_RHS_REQ:.*]] = ttg.require_layout %[[CAT_RHS_CVT]] : tensor<16xf32, #[[$CAT_USER]]> -> tensor<16xf32, #[[$CAT_USER]]>
+    %rhs = ttg.require_layout %rhs_src : tensor<16xf32, #cat_src> -> tensor<16xf32, #cat_user>
+    // CHECK: %[[CAT:.*]] = tt.cat %[[CAT_LHS_REQ]], %[[CAT_RHS_REQ]]
+    %cat = tt.cat %lhs, %rhs : tensor<16xf32, #cat_user> -> tensor<32xf32, #cat_result>
+    tt.return %cat : tensor<32xf32, #cat_result>
+  }
+}
+
+// -----
+
+// tt.scan has a region and reduction-like layout preferences.  The scan input
+// must remain anchored at the user-required layout even if the pass can choose
+// a cheaper layout for surrounding arithmetic.
+
+#scan_src = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [2, 2], order = [1, 0]}>
+#scan_user = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  // CHECK-DAG: #[[$SCAN_USER:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+  // CHECK-LABEL: tt.func @require_layout_blocks_scan_operand_rewrite
+  tt.func @require_layout_blocks_scan_operand_rewrite(
+      %src: tensor<64x32xf32, #scan_src>)
+      -> tensor<64x32xf32, #scan_user> {
+    // CHECK: %[[SCAN_TO_USER:.*]] = ttg.convert_layout %{{.*}} : tensor<64x32xf32, #{{.*}}> -> tensor<64x32xf32, #[[$SCAN_USER]]>
+    // CHECK: %[[SCAN_REQ:.*]] = ttg.require_layout %[[SCAN_TO_USER]] : tensor<64x32xf32, #[[$SCAN_USER]]> -> tensor<64x32xf32, #[[$SCAN_USER]]>
+    %required = ttg.require_layout %src : tensor<64x32xf32, #scan_src> -> tensor<64x32xf32, #scan_user>
+    // CHECK: %[[SCAN:.*]] = "tt.scan"(%[[SCAN_REQ]])
+    // CHECK: }) : (tensor<64x32xf32, #[[$SCAN_USER]]>) -> tensor<64x32xf32, #[[$SCAN_USER]]>
+    %scan = "tt.scan"(%required) <{axis = 1 : i32, reverse = false}>({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %next = arith.addf %lhs, %rhs : f32
+      tt.scan.return %next : f32
+    }) : (tensor<64x32xf32, #scan_user>) -> tensor<64x32xf32, #scan_user>
+    tt.return %scan : tensor<64x32xf32, #scan_user>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpSpecializeToLLVM.cpp
@@ -253,9 +253,14 @@ static LogicalResult lowerOneWarpPredicate(WarpPredicateOp op) {
   rewriter.setInsertionPoint(op);
 
   auto asLLVM = [](Value value) -> Value {
-    if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>())
-      if (cast.getNumOperands() == 1 && cast.getNumResults() == 1)
-        return cast.getOperand(0);
+    // Partial conversion can leave several tensor-to-tensor bridges between a
+    // lowered LLVM value and the type expected by warp_predicate. Walk through
+    // the complete single-value chain before comparing the carried ABI.
+    while (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+      if (cast.getNumOperands() != 1 || cast.getNumResults() != 1)
+        break;
+      value = cast.getOperand(0);
+    }
     return value;
   };
 
@@ -288,10 +293,14 @@ static LogicalResult lowerOneWarpPredicate(WarpPredicateOp op) {
     yieldStructs.push_back(value);
     resultTypes.push_back(value.getType());
   }
-  for (auto [init, yielded] : llvm::zip(initStructs, yieldStructs))
+  for (auto [index, values] :
+       llvm::enumerate(llvm::zip(initStructs, yieldStructs))) {
+    auto [init, yielded] = values;
     if (init.getType() != yielded.getType())
-      return op.emitError(
-          "converted init and yield values must have identical types");
+      return op.emitError("converted init and yield values at index ")
+             << index << " must have identical types; init is "
+             << init.getType() << ", yield is " << yielded.getType();
+  }
 
   // Validate every result bridge before changing the CFG. Conversion failure
   // should leave a diagnosable source operation rather than partially inlined

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/PartitionSchedulingMeta.cpp
@@ -2963,10 +2963,9 @@ void PartitionSchedulingMeta::runOnOperation() {
     }
     loops.push_back(loop);
   });
-  for (auto [idx, enumeratedLoop] : llvm::enumerate(loops)) {
-    // Copy out of the structured binding: capturing one in a lambda is a C++20
-    // extension and this file is built as C++17.
-    LoopLikeOpInterface loop = enumeratedLoop;
+  for (auto it : llvm::enumerate(loops)) {
+    auto idx = it.index();
+    LoopLikeOpInterface loop = it.value();
     // Build SchedulingOptions from pass options and per-loop attributes.
     SchedulingOptions schedOpts;
     schedOpts.mergeEpilogue = mergeEpilogue;

--- a/third_party/tlx/dialect/include/Transforms/Passes.td
+++ b/third_party/tlx/dialect/include/Transforms/Passes.td
@@ -43,12 +43,13 @@ def TlxPropagateLayout : Pass<"tlx-propagate-layout", "mlir::ModuleOp"> {
       tensor values when the tensor lattice reaches a concrete encoding
     - applying consensus-based updates for RegionBranchOpInterface carriers and
       `ttg.warp_specialize` partition captures/arguments
-    - lowering residual tensor constraints to `ttg.convert_layout`
+    - lowering residual unpinned tensor constraints to `ttg.convert_layout`
+    - lowering residual pinned tensor constraints to `ttg.require_layout`
     - validating post-conditions such as the absence of unresolved
       DummyTMEMLayoutAttr allocations
 
     Tensor and memdesc constraints are either folded away when propagation
-    successfully retags the producer, or lowered to `ttg.convert_layout`.
+    successfully retags the producer, or lowered to an explicit TTGIR boundary.
   }];
 
   let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
@@ -124,14 +125,15 @@ def TLXFinalizeUserLayouts : Pass<"tlx-finalize-user-layouts", "mlir::ModuleOp">
 
   let description = [{
     Unwraps every remaining `#tlx.user_layout<L>` encoding on a RankedTensorType
-    (a user-pinned *register* layout on a `ttg.local_load`) back to its concrete
-    wrapped layout `L`, and verifies none remain.
+    back to its concrete wrapped layout `L`, defensively lowers any remaining
+    `ttg.require_layout` boundaries to ordinary `ttg.convert_layout`, and
+    verifies none remain.
 
     User-pinned register layouts are kept wrapped through the layout-optimization
-    passes (remove-layout-conversions, accelerate-matmul, optimize-dot-operands):
-    the wrapper carries `PinnedEncodingTrait`, so those passes anchor the load and
-    do not rewrite it. This pass runs after them to retire the marker. (Shared
-    user layouts on `local_alloc` are unwrapped much earlier, in
+    passes (remove-layout-conversions, accelerate-matmul, optimize-dot-operands)
+    as `ttg.require_layout` boundaries whose result wrapper carries
+    `PinnedEncodingTrait`. This pass runs after them to retire the boundary and
+    marker. (Shared user layouts on `local_alloc` are unwrapped much earlier, in
     tlx-propagate-layout, since nothing rewrites a buffer's shared encoding.)
   }];
 

--- a/third_party/tlx/dialect/lib/IR/Ops.cpp
+++ b/third_party/tlx/dialect/lib/IR/Ops.cpp
@@ -19,10 +19,31 @@ namespace mlir {
 namespace triton {
 namespace tlx {
 
+static bool containsUserLayout(Attribute attr) {
+  if (!attr)
+    return false;
+  if (isa<UserLayoutAttr>(attr))
+    return true;
+  bool found = false;
+  attr.walkImmediateSubElements(
+      [&](Attribute a) { found |= containsUserLayout(a); }, [&](Type t) {});
+  return found;
+}
+
+static bool containsUserLayout(Type type) {
+  if (!type)
+    return false;
+  bool found = false;
+  type.walkImmediateSubElements(
+      [&](Attribute a) { found |= containsUserLayout(a); },
+      [&](Type t) { found |= containsUserLayout(t); });
+  return found;
+}
+
 //-- RequireLayoutOp --
 
 OpFoldResult RequireLayoutOp::fold(FoldAdaptor) {
-  if (getType() == getSrc().getType()) {
+  if (getType() == getSrc().getType() && !containsUserLayout(getType())) {
     // no-op
     return getSrc();
   }

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -40,10 +40,17 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     if (!isa<RankedTensorType>(requireLayoutOp.getSrc().getType()))
       return failure();
+    auto resultType = cast<RankedTensorType>(requireLayoutOp.getType());
+    if (containsPinnedEncoding(resultType.getEncoding())) {
+      rewriter.replaceOpWithNewOp<ttg::RequireLayoutOp>(
+          requireLayoutOp, requireLayoutOp.getType(), requireLayoutOp.getSrc());
+      return success();
+    }
     if (requireLayoutOp.getSrc().getType() == requireLayoutOp.getType()) {
       rewriter.replaceOp(requireLayoutOp, requireLayoutOp.getSrc());
       return success();
     }
+
     auto convert = ttg::ConvertLayoutOp::create(
         rewriter, requireLayoutOp.getLoc(), requireLayoutOp.getType(),
         requireLayoutOp.getSrc());
@@ -261,13 +268,11 @@ public:
       changed = true;
     }
 
-    for (auto [enumeratedIndex, enumeratedResult, init, yielded] :
-         llvm::enumerate(predicateOp.getResults(), predicateOp.getInits(),
-                         yieldOp.getValues())) {
-      // Copy out of the structured bindings: capturing one in a lambda is a
-      // C++20 extension and this file is built as C++17.
-      auto index = enumeratedIndex;
-      OpResult result = enumeratedResult;
+    for (unsigned index = 0, e = predicateOp.getNumResults(); index < e;
+         ++index) {
+      OpResult result = cast<OpResult>(predicateOp.getResult(index));
+      Value init = predicateOp.getInits()[index];
+      Value yielded = yieldOp.getValues()[index];
       auto boundaryConvert = yielded.getDefiningOp<ttg::ConvertLayoutOp>();
       if (!boundaryConvert || !boundaryConvert->hasOneUse())
         continue;

--- a/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PropagateLayout.cpp
@@ -42,11 +42,19 @@ public:
       return failure();
     auto resultType = cast<RankedTensorType>(requireLayoutOp.getType());
     if (containsPinnedEncoding(resultType.getEncoding())) {
-      rewriter.replaceOpWithNewOp<ttg::RequireLayoutOp>(
-          requireLayoutOp, requireLayoutOp.getType(), requireLayoutOp.getSrc());
+      auto boundary = ttg::RequireLayoutOp::create(
+          rewriter, requireLayoutOp.getLoc(), requireLayoutOp.getType(),
+          requireLayoutOp.getSrc());
+      if (requireLayoutOp->hasAttr("tlx.rematerialize_coordinates"))
+        boundary->setAttr("tlx.rematerialize_coordinates",
+                          rewriter.getUnitAttr());
+      rewriter.replaceOp(requireLayoutOp, boundary);
       return success();
     }
-    if (requireLayoutOp.getSrc().getType() == requireLayoutOp.getType()) {
+    bool rematerializeCoordinates =
+        requireLayoutOp->hasAttr("tlx.rematerialize_coordinates");
+    if (requireLayoutOp.getSrc().getType() == requireLayoutOp.getType() &&
+        !rematerializeCoordinates) {
       rewriter.replaceOp(requireLayoutOp, requireLayoutOp.getSrc());
       return success();
     }
@@ -54,7 +62,7 @@ public:
     auto convert = ttg::ConvertLayoutOp::create(
         rewriter, requireLayoutOp.getLoc(), requireLayoutOp.getType(),
         requireLayoutOp.getSrc());
-    if (requireLayoutOp->hasAttr("tlx.rematerialize_coordinates"))
+    if (rematerializeCoordinates)
       convert->setAttr("tlx.rematerialize_coordinates", rewriter.getUnitAttr());
     rewriter.replaceOp(requireLayoutOp, convert);
     return success();

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -447,6 +447,25 @@ repairUnwrappedReshapes(ArrayRef<::mlir::triton::ReshapeOp> reshapes) {
   return success();
 }
 
+static void lowerRequireLayouts(ModuleOp moduleOp) {
+  SmallVector<ttg::RequireLayoutOp> requireLayouts;
+  moduleOp.walk([&](ttg::RequireLayoutOp op) { requireLayouts.push_back(op); });
+
+  for (ttg::RequireLayoutOp op : requireLayouts) {
+    if (op.getSrc().getType() == op.getType()) {
+      op.getResult().replaceAllUsesWith(op.getSrc());
+      op.erase();
+      continue;
+    }
+
+    OpBuilder builder(op);
+    auto convert = ttg::ConvertLayoutOp::create(builder, op.getLoc(),
+                                                op.getType(), op.getSrc());
+    op.getResult().replaceAllUsesWith(convert.getResult());
+    op.erase();
+  }
+}
+
 static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
   SmallVector<::mlir::triton::ReshapeOp> wrappedReshapes;
   moduleOp.walk([&](::mlir::triton::ReshapeOp reshape) {
@@ -490,6 +509,8 @@ static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
 
   if (failed(repairUnwrappedReshapes(wrappedReshapes)))
     return failure();
+
+  lowerRequireLayouts(moduleOp);
 
   SmallVector<ttg::ConvertLayoutOp> identityConversions;
   moduleOp.walk([&](ttg::ConvertLayoutOp convert) {

--- a/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp
@@ -452,15 +452,30 @@ static void lowerRequireLayouts(ModuleOp moduleOp) {
   moduleOp.walk([&](ttg::RequireLayoutOp op) { requireLayouts.push_back(op); });
 
   for (ttg::RequireLayoutOp op : requireLayouts) {
+    bool rematerializeCoordinates =
+        op->hasAttr("tlx.rematerialize_coordinates");
     if (op.getSrc().getType() == op.getType()) {
-      op.getResult().replaceAllUsesWith(op.getSrc());
-      op.erase();
-      continue;
+      if (rematerializeCoordinates) {
+        if (auto sourceConvert =
+                op.getSrc().getDefiningOp<ttg::ConvertLayoutOp>()) {
+          sourceConvert->setAttr("tlx.rematerialize_coordinates",
+                                 UnitAttr::get(op.getContext()));
+          op.getResult().replaceAllUsesWith(op.getSrc());
+          op.erase();
+          continue;
+        }
+      } else {
+        op.getResult().replaceAllUsesWith(op.getSrc());
+        op.erase();
+        continue;
+      }
     }
 
     OpBuilder builder(op);
     auto convert = ttg::ConvertLayoutOp::create(builder, op.getLoc(),
                                                 op.getType(), op.getSrc());
+    if (rematerializeCoordinates)
+      convert->setAttr("tlx.rematerialize_coordinates", builder.getUnitAttr());
     op.getResult().replaceAllUsesWith(convert.getResult());
     op.erase();
   }
@@ -514,7 +529,8 @@ static LogicalResult finalizeUserLayouts(ModuleOp moduleOp) {
 
   SmallVector<ttg::ConvertLayoutOp> identityConversions;
   moduleOp.walk([&](ttg::ConvertLayoutOp convert) {
-    if (convert.getSrc().getType() == convert.getType())
+    if (convert.getSrc().getType() == convert.getType() &&
+        !convert->hasAttr("tlx.rematerialize_coordinates"))
       identityConversions.push_back(convert);
   });
   for (ttg::ConvertLayoutOp convert : identityConversions) {


### PR DESCRIPTION
Introduce a TTGIR require_layout boundary for TLX pinned register-layout requests. Pinned tlx.require_layout now lowers to ttg.require_layout, so canonicalization and remove-layout-conversions cannot treat the user request as a transparent convert_layout.

Teach TritonGPURemoveLayoutConversions to preserve that boundary while still materializing physical conversions on either side. TLX finalization lowers the remaining boundary back to ordinary convert_layout after user-layout wrappers have been resolved.

Add Python and lit regressions for release_layout followed by a new pinned layout, including the TMEM-store case where the store-compatible layout must not propagate backward through the user boundary.

Validated with make, focused TLX layout regressions, full test_tlx_layout.py, TLX unit pytest excluding the known storage-alias hang, and the new lit test.
