### PR TITLE
[triton][CI] Increase MI350 TLX correctness timeout

### DIFF
--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -127,13 +127,13 @@ jobs:
           pytest python/test/unit/language/test_tlx_*.py -v --junitxml=/tmp/tlx-unit.xml
       - name: Run TLX tutorial correctness tests
         id: run_correctness_tests
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: |
           set -eux
           . "${SETUP_SCRIPT}"
-          # AMD (gfx950/CDNA4) + ikbo cases run; Hopper/Blackwell and gfx1250
-          # cases auto-skip via @pytest.mark.skipif arch gates.
-          pytest third_party/tlx/tutorials/testing/test_correctness.py -v --junitxml=/tmp/tlx-correctness.xml
+          # Report the slowest cases so future changes can reduce the runtime
+          # without relying on brittle test-name filters.
+          pytest third_party/tlx/tutorials/testing/test_correctness.py -v --durations=25 --junitxml=/tmp/tlx-correctness.xml
       - name: Collect nightly failures (TLX)
         id: parse
         if: always() && github.event_name == 'schedule'


### PR DESCRIPTION
Summary:
The complete MI350 TLX correctness suite now takes longer than its fixed 10-minute step timeout. In CI it completed tests through 63% with no failures before GitHub terminated pytest, preventing JUnit XML finalization and producing the misleading pytest-junit-missing identity.

Increase the correctness-step timeout to 30 minutes and report the 25 slowest tests. Keeping the complete test file avoids brittle name-based filtering and preserves all architecture-gated coverage while providing evidence for targeted runtime reductions later.

This change was authored with Codex.

Differential Revision: D117819763


