### PR TITLE
[triton][beta] Filter per-hardware CI to avoid backend-mismatched triggers

### DIFF
--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -3,7 +3,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   pull_request:
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -3,7 +3,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   pull_request:
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -3,7 +3,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/nvidia/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'python/test/unit/cuda/**'
+      - 'python/test/unit/language/test_tlx_tma.py'
+      - 'third_party/proton/test/**'
   pull_request:
+    paths-ignore:
+      - 'third_party/nvidia/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'python/test/unit/cuda/**'
+      - 'python/test/unit/language/test_tlx_tma.py'
+      - 'third_party/proton/test/**'
   schedule:
     # Every 6 hours at the top of the hour (00:00, 06:00, 12:00, 18:00 UTC).
     - cron: '0 */6 * * *'


### PR DESCRIPTION
Summary:
OSS CI (`b200.yml`/`h100.yml`/`mi350.yml`) and internal `ci_hint` (`defs.bzl:triton_pytest`) previously had no per-hardware path filtering. Every file under `third-party/triton/beta/triton/**` fanned out to all hardware (e.g. Blackwell `blackwell-*`/`tcgen05` change triggered H100/AMD, `test_tlx_amd.py` triggered B200/H100, `python/test/unit/cuda/**` triggered MI350). Runtime `skipif(not is_blackwell()/is_hopper()/is_hip())` (`_internal_testing.py`) only skips at runtime — job still scheduled, wastes `nvidia-dgx-b200`/`linux-gcp-h100`/`linux-fb-triton-mi350-1` and `TRITON_OVERRIDE_ARCH` can turn a skip into illegal-instruction `tcgen05`/`wgmma`/`amdgcn` vs `nvptx` failure.

OSS CI: add `paths-ignore` on `push`/`pull_request` (schedule nightly still runs all):
- `b200.yml`: ignore AMD-only `third_party/amd/**`, `third_party/tlx/tutorials/gfx9_gemm/**`, `third_party/amd/python/test/**`, `python/test/unit/language/test_tlx_amd.py`
- `h100.yml`: same AMD ignores + Blackwell-only `third_party/tlx/tutorials/blackwell-*/**`, `blackwell-*`, `testing/test_correctness_autows.py`
- `mi350.yml`: ignore NVIDIA-only `third_party/nvidia/**`, `blackwell*`, `python/test/unit/cuda/**`, `python/test/unit/language/test_tlx_tma.py` (`TLX_CUDA_TEST_FILES`), `third_party/proton/test/**`

Differential Revision: D117886825


