### PR TITLE
Limit Triton C dispatcher fallback warnings to CUDA

### DIFF
--- a/python/test/unit/runtime/test_fallback_warnings.py
+++ b/python/test/unit/runtime/test_fallback_warnings.py
@@ -8,11 +8,20 @@ are aware of the fallback.
 import warnings
 from unittest.mock import patch
 
+import pytest
 import torch
 import triton
 import triton.language as tl
 from triton import knobs
 from triton.compiler.compiler import ASTSource, compile as triton_compile
+
+
+def _is_cuda_target():
+    try:
+        target = triton.runtime.driver.active.get_current_target()
+    except RuntimeError:
+        return False
+    return target is not None and target.backend == "cuda"
 
 
 @triton.jit
@@ -35,6 +44,7 @@ def _compile_kernel(fn, signature, constexprs=None, attrs=None):
 class TestDispatcherFallbackWarning:
     """Tests for TRITON_USE_C_DISPATCHER fallback warnings."""
 
+    @pytest.mark.skipif(not _is_cuda_target(), reason="C dispatcher fallback warning is CUDA-only")
     def test_dispatcher_fallback_warning_in_compiled_kernel_getitem(self, monkeypatch):
         """CompiledKernel.__getitem__ should warn when dispatcher flag is on but _dispatcher is None."""
         monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
@@ -75,6 +85,7 @@ class TestDispatcherFallbackWarning:
             dispatcher_warnings = [x for x in w if "TRITON_USE_C_DISPATCHER" in str(x.message)]
             assert len(dispatcher_warnings) == 0
 
+    @pytest.mark.skipif(not _is_cuda_target(), reason="C dispatcher fallback warning is CUDA-only")
     def test_dispatcher_fallback_warning_in_jit_run(self, monkeypatch):
         """JITFunction.run() should warn when dispatcher flag is on but kernel has no dispatcher."""
         monkeypatch.setenv("TRITON_USE_C_DISPATCHER", "1")
@@ -181,6 +192,7 @@ class TestCCacheFallbackWarning:
             assert len(cache_warnings) == 0, (f"Expected 0 C cache bypass warnings, got {len(cache_warnings)}. "
                                               f"All warnings: {[str(x.message) for x in w]}")
 
+    @pytest.mark.skipif(not _is_cuda_target(), reason="C dispatcher fallback warning is CUDA-only")
     def test_c_cache_hit_no_dispatcher_warning(self, monkeypatch):
         """When dispatcher flag is on but kernel has no dispatcher, run() should warn."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")
@@ -224,6 +236,7 @@ class TestCCacheFallbackWarning:
 class TestProxyFallbackWarning:
     """Tests for JIT proxy creation fallback warning."""
 
+    @pytest.mark.skipif(not _is_cuda_target(), reason="C JIT proxy is CUDA-only")
     def test_proxy_creation_failure_warning(self, monkeypatch):
         """Should warn when native_create_jit_proxy returns None."""
         monkeypatch.setenv("TRITON_ENABLE_C_CACHE", "1")

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -45,6 +45,10 @@ arg_type_pattern = {
 }
 
 
+def _target_supports_triton_dispatcher(target) -> bool:
+    return getattr(target, "backend", None) == "cuda"
+
+
 def convert_type_repr(x):
     # Currently we only capture the pointer type and assume the pointer is on global memory.
     # TODO: Capture and support shared memory space
@@ -631,7 +635,8 @@ class CompiledKernel:
         self._dispatcher = None
         self._dispatch_arg_indices = None
         self._num_kernel_args = None
-        if knobs.nvidia.use_triton_dispatcher and "launch_metadata" in self.asm:
+        if (knobs.nvidia.use_triton_dispatcher and _target_supports_triton_dispatcher(self.metadata.target)
+                and "launch_metadata" in self.asm):
             try:
                 from triton.backends.nvidia.triton_dispatcher_factory import make_triton_dispatcher
                 schema = json.loads(self.asm["launch_metadata"])
@@ -788,7 +793,8 @@ class CompiledKernel:
             self.run(grid[0], grid[1], grid[2], stream, self.function, self.packed_metadata, launch_metadata,
                      knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *args)
 
-        if knobs.nvidia.use_triton_dispatcher and dispatcher is None:
+        if (knobs.nvidia.use_triton_dispatcher and _target_supports_triton_dispatcher(self.metadata.target)
+                and dispatcher is None):
             warnings.warn(
                 f"[Triton] TRITON_USE_C_DISPATCHER=1 but CompiledKernel '{self.name}' has no C dispatcher, "
                 f"falling back to Python runner",

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -39,6 +39,14 @@ _CACHE_STATS_ON = os.environ.get("TRITON_CACHE_STATS", "0") == "1"
 _CACHE_STATS_PY: dict = {}  # kernel name -> {event: count}
 
 
+def _active_target_supports_triton_dispatcher() -> bool:
+    try:
+        target = driver.active.get_current_target()
+    except Exception:
+        return False
+    return getattr(target, "backend", None) == "cuda"
+
+
 def _cache_stats_record(name: str, event: str) -> None:
     # Callers must guard with `if _CACHE_STATS_ON`.
     k = _CACHE_STATS_PY.get(name)
@@ -509,7 +517,7 @@ class KernelInterface(Generic[T]):
         # hook — so those still fire (mirrors the run() c_cache fast-path guard).
         if native_create_jit_proxy is not None and getattr(self, 'c_cache', False) \
                 and knobs.nvidia.use_triton_dispatcher \
-                and getattr(driver.active, "is_cpu_backend", False) is not True \
+                and _active_target_supports_triton_dispatcher() \
                 and not self.used_global_vals \
                 and not self.pre_run_hooks and not self.launch_metadata \
                 and not knobs.runtime.launch_enter_hook and not knobs.runtime.launch_exit_hook \
@@ -1051,7 +1059,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
                         if not getattr(kernel, '_dispatcher', None):
                             if _CACHE_STATS_ON:
                                 _cache_stats_record(self._fn_name, "run_fast_py_fallback")
-                            if knobs.nvidia.use_triton_dispatcher:
+                            if knobs.nvidia.use_triton_dispatcher and _active_target_supports_triton_dispatcher():
                                 warnings.warn(
                                     f"[Triton] TRITON_USE_C_DISPATCHER=1 but kernel '{self._fn_name}' has no C "
                                     f"dispatcher, falling back to Python launch",
@@ -1209,7 +1217,8 @@ class JITFunction(JITCallable, KernelInterface[T]):
             else:
                 if _CACHE_STATS_ON:
                     _cache_stats_record(self._fn_name, "run_slow_py_fallback")
-                if knobs.nvidia.use_triton_dispatcher and _disp is None and not is_cpu_backend:
+                if (knobs.nvidia.use_triton_dispatcher and _disp is None
+                        and _active_target_supports_triton_dispatcher()):
                     warnings.warn(
                         f"[Triton] TRITON_USE_C_DISPATCHER=1 but kernel '{self._fn_name}' has no C dispatcher, "
                         f"falling back to Python launch",


### PR DESCRIPTION
The Triton C dispatcher is a CUDA-only fast path, but the fallback warning was gated only on non-CPU backends. As a result, HIP launches with TRITON_USE_C_DISPATCHER=1 reported a misleading missing-dispatcher warning even though no CUDA dispatcher should be built there.

Gate dispatcher creation, proxy use, and fallback warnings on CUDA targets. Mark dispatcher fallback warning tests as CUDA-only so HIP runs do not assert NVIDIA-specific behavior.