### PR TITLE
[triton][beta] Add file-level hardware skip for whole-file tests

### DIFF
--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -3,7 +3,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   pull_request:
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -3,7 +3,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   pull_request:
+    paths-ignore:
+      - 'third_party/amd/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'third_party/tlx/tutorials/gfx9_gemm/**'
+      - 'third_party/amd/python/test/**'
+      - 'python/test/unit/language/test_tlx_amd.py'
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -3,7 +3,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'third_party/nvidia/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'python/test/unit/cuda/**'
+      - 'python/test/unit/language/test_tlx_tma.py'
+      - 'third_party/proton/test/**'
   pull_request:
+    paths-ignore:
+      - 'third_party/nvidia/**'
+      - 'third_party/tlx/tutorials/blackwell-*/**'
+      - 'third_party/tlx/tutorials/blackwell-*'
+      - 'third_party/tlx/tutorials/testing/test_correctness_autows.py'
+      - 'python/test/unit/cuda/**'
+      - 'python/test/unit/language/test_tlx_tma.py'
+      - 'third_party/proton/test/**'
   schedule:
     # Every 6 hours at the top of the hour (00:00, 06:00, 12:00, 18:00 UTC).
     - cron: '0 */6 * * *'

--- a/python/test/gsan/test_symmetric_memory.py
+++ b/python/test/gsan/test_symmetric_memory.py
@@ -17,6 +17,8 @@ from triton.experimental.gsan._testing_utils import (SHADOW_GRANULARITY_BYTES, s
                                                      shadow_tensor_for)
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
+
 
 def _get_free_tcp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -194,9 +196,6 @@ def _distributed_worker(rank: int, world_size: int, master_port: int, run_subgro
         dist.barrier()
     finally:
         dist.destroy_process_group()
-
-
-@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_gsan_symmetric_memory_rendezvous():
     if torch.cuda.device_count() < 2:
         pytest.skip("requires 2 CUDA devices")
@@ -209,9 +208,6 @@ def test_gsan_symmetric_memory_rendezvous():
         nprocs=world_size,
         join=True,
     )
-
-
-@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_gsan_symmetric_memory_rendezvous_subgroup_without_global_zero():
     if torch.cuda.device_count() < 3:
         pytest.skip("requires 3 CUDA devices")
@@ -402,9 +398,6 @@ def _distributed_worker_triton_kernels_convert_dp_to_ep(rank: int, world_size: i
         dist.barrier()
     finally:
         dist.destroy_process_group()
-
-
-@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_gsan_symmetric_memory_rendezvous_multi_node_simulated():
     if torch.cuda.device_count() < 2:
         pytest.skip("requires 2 CUDA devices")
@@ -417,9 +410,6 @@ def test_gsan_symmetric_memory_rendezvous_multi_node_simulated():
         nprocs=world_size,
         join=True,
     )
-
-
-@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
 def test_gsan_symmetric_memory_with_triton_kernels_convert_dp_to_ep():
     pytest.importorskip("triton_kernels.distributed")
     if torch.cuda.device_count() < 2:

--- a/python/test/gsan/test_utils.py
+++ b/python/test/gsan/test_utils.py
@@ -4,8 +4,7 @@ import torch
 from triton._internal_testing import is_cuda
 from triton.experimental.gsan._utils import uint8_cuda_tensor_from_ptr
 
-
-@pytest.mark.skipif(not is_cuda(), reason="requires CUDA backend")
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
 def test_uint8_cuda_tensor_from_ptr_delete_tensor():
     device = torch.device("cuda:1" if torch.cuda.device_count() > 1 else "cuda:0")
     backing = torch.arange(10, dtype=torch.uint8, device=device)

--- a/python/test/unit/cuda/test_libdevice_cuda.py
+++ b/python/test/unit/cuda/test_libdevice_cuda.py
@@ -9,6 +9,8 @@ import triton.language as tl
 from triton._internal_testing import is_cuda
 from triton.language.extra import libdevice
 
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
+
 
 # -----------------------
 # test extern functions

--- a/python/test/unit/language/test_autows_auto_tma.py
+++ b/python/test/unit/language/test_autows_auto_tma.py
@@ -45,6 +45,9 @@ def _is_sm90plus() -> bool:
     return major >= 9  # Hopper (sm_90) and Blackwell (sm_100)
 
 
+pytestmark = pytest.mark.skipif(not _is_sm90plus(), reason="Requires Hopper or newer (sm90+)")
+
+
 # ---------------------------------------------------------------------------
 # 1. Non-WS 2D strided promotion + numerics
 # ---------------------------------------------------------------------------
@@ -58,9 +61,6 @@ def _scale_2d_strided(x_ptr, out_ptr, M, N, stride_xm, stride_om, BLOCK_M: tl.co
     # Row-major x: innermost (offs_n) is contiguous -> auto-TMA eligible.
     x = tl.load(x_ptr + offs_m[:, None] * stride_xm + offs_n[None, :], mask=mask, other=0.0)
     tl.store(out_ptr + offs_m[:, None] * stride_om + offs_n[None, :], x * 2.0, mask=mask)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
 def test_auto_tma_2d_strided_numerics():
     M, N = 512, 384
     BLOCK_M, BLOCK_N = 64, 64
@@ -100,9 +100,6 @@ def _gemm_nows(a_ptr, b_ptr, c_ptr, M, N, K, stride_am, stride_bn, stride_cm, BL
         acc = tl.dot(a, b.T, acc)
     tl.store(c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :], acc.to(tl.float16),
              mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
 def test_auto_tma_gemm_nows():
     """Isolates the auto-TMA DOT-operand path WITHOUT warp specialization."""
     M, N, K = 256, 256, 256
@@ -126,9 +123,6 @@ def test_auto_tma_gemm_nows():
     assert "tt.descriptor_load" in kernel.asm["ttir"], "expected auto-TMA promotion"
     ref = (A.to(torch.float32) @ B.T.to(torch.float32)).to(dtype)
     torch.testing.assert_close(ref, C, atol=0.05, rtol=0.05)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
 def test_auto_tma_gemm_nows_device(monkeypatch):
     """Phase A: addptr loads promoted to a DEVICE-built tt.make_tensor_descriptor
     (TRITON_AUTO_TMA_DEVICE=1), not the host-recipe path. Verifies the pass
@@ -193,9 +187,6 @@ def _batched_scale(x_ptr, out_ptr, B, M, N, stride_b, stride_m, BLOCK_M: tl.cons
     ob = out_ptr + pid_b * stride_b
     x = tl.load(xb + offs_m[:, None] * stride_m + offs_n[None, :], mask=mask, other=0.0)
     tl.store(ob + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
 def test_auto_tma_batched_device(monkeypatch):
     """per-program base (pid_b*stride_b) must fold into the DEVICE descriptor base
     (make_tensor_descriptor(addptr(x, off), ...)), giving a per-batch view."""
@@ -280,9 +271,6 @@ def _ws_auto_tma_matmul(
         c = acc.to(tl.float16)
         tl.store(c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :], c,
                  mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 def test_ws_auto_tma_data_partition_numerics():
     M, N, K = 512, 512, 512
     BLOCK_M, BLOCK_N, BLOCK_K = 256, 128, 64  # dp=2 needs BLOCK_M=256 (256/2=128) so Blackwell tcgen05.mma M=128 is satisfied per partition
@@ -388,7 +376,6 @@ def _ws_autotma_perf_matmul(
     reason="perf benchmark (large GEMMs via do_bench); set TRITON_RUN_PERF=1 to run",
 )
 @pytest.mark.parametrize("M, N, K", [(2048, 2048, 2048), (4096, 4096, 4096), (8192, 8192, 8192)])
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 def test_ws_auto_tma_perf(M, N, K):
     """Perf: autoWS + dp=2 GEMM (self-contained _ws_autotma_perf_matmul),
     auto-TMA off vs on (same kernel; only the loads change from cp.async to
@@ -494,7 +481,6 @@ def _bench_autotma_variant(grid, A, B, C, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GR
     reason="perf benchmark (autotuner over large GEMMs); set TRITON_RUN_PERF=1 to run",
 )
 @pytest.mark.parametrize("M, N, K", [(256, 256, 256), (4096, 4096, 4096), (8192, 8192, 8192)])
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 def test_ws_auto_tma_autotuner_picks_faster(M, N, K):
     """Perf study: the autotuner selects auto_tma=True only when it is actually
     faster. Two Configs (identical except auto_tma) are autotuned over a WS+dp
@@ -590,7 +576,6 @@ def _bench_scale_variant(grid, x, out, M, N, BLOCK_M, BLOCK_N, auto_tma):
     reason="perf benchmark (autotuner over elementwise); set TRITON_RUN_PERF=1 to run",
 )
 @pytest.mark.parametrize("M, N", [(512, 512), (4096, 4096)])
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA requires sm_90+")
 def test_scale_auto_tma_autotuner_picks_faster(M, N):
     """Perf study (False direction): on a memory-bound elementwise scale there is
     no compute to overlap the copy with, so auto-TMA is at best neutral and often
@@ -678,9 +663,6 @@ def _plain_fa_fwd(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: tl.c
         m_i = m_ij
     acc = acc / l_i[:, None]
     tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="auto-TMA promotion requires sm_90+")
 def test_plain_fa_fwd_device(monkeypatch):
     """A plain-pointer FA fwd (no descriptors, no warp_specialize): the Q/K/V
     loads are auto-TMA promoted to DEVICE make_tensor_descriptor + descriptor_load
@@ -757,9 +739,6 @@ def _plain_fa_fwd_ws(Q, K, V, O, sm_scale, N_CTX, stride_h, stride_m, BLOCK_M: t
         m_i = m_ij
     acc = acc / l_i[:, None]
     tl.store(o_base + offs_m[:, None] * stride_m + offs_d[None, :], acc.to(tl.float16), mask=offs_m[:, None] < N_CTX)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 def test_plain_fa_fwd_ws_device(monkeypatch):
     """plain-pointer FA + warp_specialize: loads auto-TMA'd to device descriptors,
     loop warp-specialized, numerics vs torch SDPA."""
@@ -815,9 +794,6 @@ def _run_plain_fa_ws(q, k, v, o, sm_scale, N_CTX, BLOCK_M, BLOCK_N, HEAD_DIM):
         triton.knobs.nvidia.disable_wsbarrier_reorder = True
         return _plain_fa_fwd_ws[grid](q, k, v, o, sm_scale, N_CTX, q.stride(1), q.stride(2), BLOCK_M=BLOCK_M,
                                       BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM, num_warps=4, num_stages=2, maxRegAutoWS=192)
-
-
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 @pytest.mark.parametrize("N_CTX", [512, 1024, 2048])
 @pytest.mark.parametrize("HEAD_DIM", [64, 128])
 def test_plain_fa_fwd_ws_shapes(monkeypatch, N_CTX, HEAD_DIM):
@@ -842,7 +818,6 @@ def test_plain_fa_fwd_ws_shapes(monkeypatch, N_CTX, HEAD_DIM):
     os.environ.get("TRITON_RUN_PERF", "0") != "1",
     reason="perf benchmark (large FA via do_bench); set TRITON_RUN_PERF=1 to run",
 )
-@pytest.mark.skipif(not _is_sm90plus(), reason="WS + auto-TMA requires sm_90+")
 def test_perf_plain_fa_fwd_ws(monkeypatch):
     """Perf of the plain-pointer FA + WS + auto-TMA at a representative shape,
     with accuracy vs torch SDPA. Prints TFLOP/s (pin a free GPU)."""

--- a/python/test/unit/language/test_dot_2cta.py
+++ b/python/test/unit/language/test_dot_2cta.py
@@ -7,6 +7,8 @@ import triton.language as tl
 from triton._internal_testing import is_blackwell
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
+
 
 @triton.jit
 def _tl_dot_2cta_data_partition_kernel(
@@ -104,7 +106,6 @@ def _tl_dot_2cta_sliced_dependent_chain_ws_kernel(q_ptr, k_ptr, v_ptr, o_ptr):
 
 
 @pytest.mark.parametrize("DATA_PARTITION_FACTOR", [2])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tl_dot_2cta_data_partition(DATA_PARTITION_FACTOR, device):
     torch.manual_seed(0)
     dtype = torch.bfloat16
@@ -211,7 +212,6 @@ def _tl_dot_2cta_persistent_meta_ws_kernel(
 
 @pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
 @pytest.mark.parametrize("m", [512, 384])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tl_dot_2cta_persistent_meta_ws(DATA_PARTITION_FACTOR, m, device):
     """2-CTA under a persistent meta-WS loop, the convention production kernels use.
 
@@ -277,9 +277,6 @@ def test_tl_dot_2cta_persistent_meta_ws(DATA_PARTITION_FACTOR, m, device):
     ttgir = kernel.asm["ttgir"]
     assert "ttg.warp_specialize" in ttgir
     assert "two_ctas" in ttgir
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tl_dot_2cta_sliced_dependent_chain(device):
     torch.manual_seed(0)
     q = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
@@ -308,9 +305,6 @@ def test_tl_dot_2cta_sliced_dependent_chain(device):
     ttgir = compiled.asm["ttgir"]
     assert ttgir.count('ttng.two_cta_dependency = "collective_contraction"') == 2
     assert 'ttng.two_cta_dependency = "requires_peer_gather"' not in ttgir
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 def test_tl_dot_2cta_sliced_dependent_chain_ws(device):
     torch.manual_seed(0)
     q = torch.randn((256, 128), device=device, dtype=torch.bfloat16)

--- a/python/test/unit/runtime/test_core_tma_encoding.py
+++ b/python/test/unit/runtime/test_core_tma_encoding.py
@@ -19,6 +19,9 @@ def _has_hopper():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
 
+pytestmark = pytest.mark.skipif(not _has_hopper(), reason="Requires Hopper or newer (sm90+)")
+
+
 # (shape, block_shape, elem_size_bytes, host_tma_dtype)
 # host_tma_dtype: CUtensorMapDataType — 6=FLOAT16, 7=FLOAT32, 4=INT32, 5=INT64
 _CASES = [
@@ -27,9 +30,6 @@ _CASES = [
     ((128, 256), (32, 64), 4, 7),
     ((64, 128, 256), (16, 32, 64), 2, 6),
 ]
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="cuTensorMapEncodeTiled requires Hopper+")
 @pytest.mark.parametrize("shape,block,elem_size,host_dtype", _CASES)
 def test_core_recipe_matches_fill_tma_tiled(shape, block, elem_size, host_dtype):
     mod = triton.runtime.driver.active.utils

--- a/python/test/unit/runtime/test_dispatcher_core.py
+++ b/python/test/unit/runtime/test_dispatcher_core.py
@@ -19,6 +19,8 @@ import triton.language as tl
 from triton import knobs
 from triton._internal_testing import is_cuda
 
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
+
 
 @contextlib.contextmanager
 def force_dispatcher():
@@ -57,9 +59,6 @@ def _disp_scalar_mix(x_ptr, out_ptr, fscale, iadd, N, BLOCK: tl.constexpr):
 @triton.jit
 def _disp_nop():
     pass
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_add_numerics():
     N = 4096
     x = torch.randn(N, device="cuda")
@@ -69,9 +68,6 @@ def test_dispatcher_core_add_numerics():
     with force_dispatcher():
         _disp_add[grid](x, y, out, N, BLOCK=256)
     torch.testing.assert_close(out, x + y)
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_uses_default_profile_allocator(fresh_knobs):
     from triton.runtime import _allocation
 
@@ -96,9 +92,6 @@ def test_dispatcher_core_uses_default_profile_allocator(fresh_knobs):
         _allocation.set_profile_allocator(previous_profile_allocator)
 
     torch.testing.assert_close(out, x + y)
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_mixed_scalar_args():
     N = 2048
     x = torch.randn(N, device="cuda")
@@ -107,16 +100,10 @@ def test_dispatcher_core_mixed_scalar_args():
     with force_dispatcher():
         _disp_scalar_mix[grid](x, out, 2.5, 3, N, BLOCK=128)
     torch.testing.assert_close(out, x * 2.5 + 3)
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_nop():
     with force_dispatcher():
         _disp_nop[(1, )]()
     torch.cuda.synchronize()
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_empty_grid():
     N = 1024
     x = torch.randn(N, device="cuda")
@@ -126,9 +113,6 @@ def test_dispatcher_core_empty_grid():
         _disp_add[(0, )](x, y, out, N, BLOCK=256)
     torch.cuda.synchronize()
     torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_built_and_converged_path():
     """Directly verify a dispatcher is created (proves the dispatcher path is
     active, not a launchKernel fallback) and that calling it launches correctly
@@ -163,9 +147,6 @@ def _disp_pid_write(out_ptr, GX: tl.constexpr, GY: tl.constexpr):
     pid_z = tl.program_id(2)
     offset = pid_x + GX * (pid_y + GY * pid_z)
     tl.store(out_ptr + offset, offset)
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_dispatcher_core_multidim_cluster():
     """An explicit multi-dimensional cluster (ctas_per_cga, which forces
     cluster_dims=(x,y,z) and num_ctas==1) must launch correctly through the

--- a/python/test/unit/runtime/test_launch_kernel_core.py
+++ b/python/test/unit/runtime/test_launch_kernel_core.py
@@ -19,6 +19,8 @@ import triton.language as tl
 from triton import knobs
 from triton._internal_testing import is_cuda
 
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
+
 
 @contextlib.contextmanager
 def force_launch_kernel_path():
@@ -56,9 +58,6 @@ def _scalar_mix_kernel(x_ptr, out_ptr, fscale, iadd, N, BLOCK: tl.constexpr):
     mask = offs < N
     x = tl.load(x_ptr + offs, mask=mask)
     tl.store(out_ptr + offs, x * fscale + iadd, mask=mask)
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_launchkernel_path_add_numerics():
     N = 4096
     x = torch.randn(N, device="cuda")
@@ -69,17 +68,11 @@ def test_launchkernel_path_add_numerics():
         _add_kernel[grid](x, y, out, N, BLOCK=256)
     torch.testing.assert_close(out, x + y)
     assert counter["calls"] > 0, "launchKernel path was not exercised"
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_launchkernel_path_nop_zero_args():
     with force_launch_kernel_path() as counter:
         _nop_kernel[(1, )]()
     torch.cuda.synchronize()
     assert counter["calls"] > 0, "launchKernel path was not exercised"
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_launchkernel_path_mixed_scalar_args():
     N = 2048
     x = torch.randn(N, device="cuda")
@@ -89,9 +82,6 @@ def test_launchkernel_path_mixed_scalar_args():
         _scalar_mix_kernel[grid](x, out, 2.5, 3, N, BLOCK=128)
     torch.testing.assert_close(out, x * 2.5 + 3)
     assert counter["calls"] > 0, "launchKernel path was not exercised"
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_launchkernel_path_empty_grid():
     """An empty (0) grid must be a no-op, not a CUDA error — the shared core
     skips a zero-sized grid (parity with the legacy JIT _launch)."""
@@ -105,9 +95,6 @@ def test_launchkernel_path_empty_grid():
     # out must be untouched (kernel never ran)
     torch.testing.assert_close(out, torch.zeros(N, device="cuda"))
     assert counter["calls"] > 0, "launchKernel path was not exercised"
-
-
-@pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 def test_launchkernel_path_host_tma_passthrough():
     """Host-side TMA: Python builds the CUtensorMap; launchKernel passes it
     through args_buf as an ordinary (is_tma=0) param to the shared core."""

--- a/python/test/unit/runtime/test_promote_load_to_tma.py
+++ b/python/test/unit/runtime/test_promote_load_to_tma.py
@@ -17,6 +17,9 @@ def _has_hopper():
     return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
 
 
+pytestmark = pytest.mark.skipif(not _has_hopper(), reason="Requires Hopper or newer (sm90+)")
+
+
 @pytest.fixture(autouse=True)
 def _auto_tma_env():
     # TMA descriptors are built into global scratch, which needs an allocator.
@@ -34,9 +37,6 @@ def _add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
     x = tl.load(x_ptr + offs, mask=mask)
     y = tl.load(y_ptr + offs, mask=mask)
     tl.store(out_ptr + offs, x + y, mask=mask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_vector_add():
     N = 8192
     x = torch.randn(N, device="cuda", dtype=torch.float16)
@@ -45,9 +45,6 @@ def test_auto_tma_vector_add():
     grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
     _add_kernel[grid](x, y, out, N, BLOCK=256)
     torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_vector_add_non_multiple():
     # N not a multiple of BLOCK exercises the masked / OOB-zero-fill tail.
     N = 8000
@@ -69,9 +66,6 @@ def _scale_2d_kernel(x_ptr, out_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLOC
     ptrs = x_ptr + offs_m[:, None] * stride_m + offs_n[None, :]
     x = tl.load(ptrs, mask=mask, other=0.0)
     tl.store(out_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_2d_scale():
     M, N = 200, 300  # non-multiples of BLOCK to exercise the mask
     BLOCK_M, BLOCK_N = 64, 64
@@ -80,9 +74,6 @@ def test_auto_tma_2d_scale():
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
     _scale_2d_kernel[grid](x, out, M, N, x.stride(0), BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N)
     torch.testing.assert_close(out, x * 2.0, atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_no_allocator_needed():
     # Host-built TMA (launch.h recipe core) must NOT require a runtime allocator:
     # the CUtensorMap is built on the host, not in device global scratch. With
@@ -109,9 +100,6 @@ def _knob_add_kernel(x_ptr, y_ptr, out_ptr, N, BLOCK: tl.constexpr):
     x = tl.load(x_ptr + offs, mask=mask)
     y = tl.load(y_ptr + offs, mask=mask)
     tl.store(out_ptr + offs, x + y, mask=mask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_per_call_option():
     # With the global TRITON_AUTO_TMA knob OFF, the per-call `auto_tma` compile
     # option must independently control promotion: auto_tma=True promotes the
@@ -135,9 +123,6 @@ def test_auto_tma_per_call_option():
     k_off = _knob_add_kernel[grid](x, y, out_off, N, BLOCK=BLOCK, auto_tma=False)
     torch.testing.assert_close(out_off, x + y, atol=1e-2, rtol=1e-2)
     assert "tt.descriptor_load" not in k_off.asm["ttir"], "auto_tma=False should stay a plain load"
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_autotune_config():
     # auto_tma is an autotunable per-Config option (like num_warps): the
     # autotuner compiles both the non-TMA and TMA variants and picks one; both
@@ -169,9 +154,6 @@ def test_auto_tma_autotune_config():
     grid = lambda meta: (triton.cdiv(N, meta["BLOCK"]), )
     _autotuned_add[grid](x, y, out, N)
     torch.testing.assert_close(out, x + y, atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_block_over_256_promoted():
     # A BLOCK > 256 load IS auto-TMA promoted: the host recipe encodes a
     # getTMABlockShape-clamped box (<=256) while the descriptor_load keeps the
@@ -199,9 +181,6 @@ def _mixed_block_kernel(a_ptr, b_ptr, oa_ptr, ob_ptr, Na, Nb, BLOCK_A: tl.conste
     mask_b = offs_b < Nb
     b = tl.load(b_ptr + offs_b, mask=mask_b)
     tl.store(ob_ptr + offs_b, b + 2.0, mask=mask_b)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_mixed_promoted_loads():
     # A single kernel with a BLOCK_A=256 load and a BLOCK_B=512 load. With box>256
     # support BOTH promote: the 512 load encodes a getTMABlockShape-clamped (<=256)
@@ -239,9 +218,6 @@ def _ws_scale_store(x_ptr, o_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLOCK_N
         mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
         x = tl.load(x_ptr + offs_m[:, None] * stride_m + offs_n[None, :], mask=mask, other=0.0)
         tl.store(o_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_store_block_over_256_promoted():
     # STORE path with contiguous box dim BLOCK_N=512 > 256 IS promoted: the store
     # recipe encodes a getTMABlockShape-clamped box and the device
@@ -285,9 +261,6 @@ def _ws_extra_pred_store(x_ptr, o_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BL
         # extra predicate beyond the rectangular boundary: skip column 0.
         mask = rect & (offs_n[None, :] > 0)
         tl.store(o_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=mask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_store_nonrectangular_mask_not_promoted():
     # A store whose mask is not a pure rectangular boundary (here: an extra
     # skip-column-0 predicate) must NOT be promoted to a descriptor_store: the TMA
@@ -308,9 +281,6 @@ def test_auto_tma_store_nonrectangular_mask_not_promoted():
     cols = torch.arange(N, device="cuda")[None, :]
     ref = torch.where(cols > 0, x * 2.0, torch.zeros_like(x))
     torch.testing.assert_close(o, ref, atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_outer_dim_over_256():
     # OUTER (strided) box dim BLOCK_M=512 > 256, inner BLOCK_N=64. getTMABlockShape
     # caps the outer box at 256 and the device lowering multi-copies 512/256=2
@@ -346,9 +316,6 @@ def _ws_load_only_scale(x_ptr, o_ptr, M, N, stride_m, BLOCK_M: tl.constexpr, BLO
         # extra predicate -> STORE is NOT promoted, isolating the load path
         smask = rect & (offs_n[None, :] > 0)
         tl.store(o_ptr + offs_m[:, None] * stride_m + offs_n[None, :], x * 2.0, mask=smask)
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_autows_load_over_256():
     # Exercise a host-recipe TMA load inside AutoWS with BLOCK_N > 256.
     M, N = 128, 512
@@ -363,9 +330,6 @@ def test_auto_tma_autows_load_over_256():
     ref[:, 0] = 0.0
     torch.testing.assert_close(o, ref, atol=1e-2, rtol=1e-2)
     assert "tt.descriptor_load" in k.asm["ttir"], "expected the BLOCK_N=512 load to promote"
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_metaws_store_over_256():
     # Exercise a promoted store through meta-WS with BLOCK_N > 256.
     M, N = 128, 512
@@ -383,9 +347,6 @@ def test_auto_tma_metaws_store_over_256():
         "meta-WS BLOCK_N=512 load must be auto-TMA promoted (clamped box + multi-copy)")
     assert "tt.descriptor_store" in k.asm["ttir"], (
         "meta-WS BLOCK_N=512 store must be auto-TMA store-promoted (clamped box + multi-copy)")
-
-
-@pytest.mark.skipif(not _has_hopper(), reason="auto-TMA requires Hopper+ (sm_90)")
 def test_auto_tma_device_block_over_256(monkeypatch):
     # DEVICE-descriptor mode (TRITON_AUTO_TMA_DEVICE=1, added in this diff): the load
     # is promoted to an in-kernel tt.make_tensor_descriptor. Contiguous BLOCK_N=512 >

--- a/python/test/unit/test_stages_inspection.py
+++ b/python/test/unit/test_stages_inspection.py
@@ -6,8 +6,7 @@ import hashlib
 import pytest
 from triton._internal_testing import is_cuda
 
-
-@pytest.mark.skipif(not is_cuda(), reason="only currently tested on CUDA")
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
 def test_inspection(monkeypatch, fresh_knobs, tmp_path: pathlib.Path):
     stage_name = 'make_ttgir'
     curr_repro_path = tmp_path / ("repro_prefix." + stage_name + ".repro.mlir")

--- a/third_party/amd/python/test/test_address_sanitizer.py
+++ b/third_party/amd/python/test/test_address_sanitizer.py
@@ -5,14 +5,17 @@ from pathlib import Path
 
 import triton
 
+import pytest
+
 
 def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 
 
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP backend")
+
+
 def test_address_sanitizer():
-    if not is_hip():
-        return  #not supported on NV backend
 
     # It is recommended to disable various memory caching strategies both within the ROCm stack and PyTorch
     # This will give the address sanitizer the best chance at finding the memory fault where it originates,

--- a/third_party/amd/python/test/test_convert_op_permlane_swap.py
+++ b/third_party/amd/python/test/test_convert_op_permlane_swap.py
@@ -4,8 +4,10 @@ import pathlib
 
 import triton
 
-from triton._internal_testing import is_hip_cdna4, is_hip_gfx1250, to_triton, numpy_random
+from triton._internal_testing import is_hip, is_hip_cdna4, is_hip_gfx1250, to_triton, numpy_random
 
+
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP backend")
 num_ctas_list = [1]
 
 GPU_DIALECT = "ttg"

--- a/third_party/amd/python/test/test_f16_gemm_tdm.py
+++ b/third_party/amd/python/test/test_f16_gemm_tdm.py
@@ -7,6 +7,8 @@ from triton._internal_testing import is_hip_gfx1250
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 
+
+pytestmark = pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def supports_tensor_descriptor():
     # AMD GPUs with tensor ops support
     return is_hip_gfx1250() and hasattr(tl, "make_tensor_descriptor")
@@ -84,7 +86,6 @@ def _run_kernel(x, y, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, use_tdm='device'):
 @pytest.mark.parametrize("M,N,K", [(256, 256, 512)])
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 64), (128, 128, 128)])
 @pytest.mark.parametrize("use_tdm", ['device', 'host'])
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="TDM is only tested on gfx1250.")
 def test_gemm_fp16(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, use_tdm):
     x = torch.randn(M, K, dtype=torch.float16).cuda()
     y = torch.randn(K, N, dtype=torch.float16).cuda()

--- a/third_party/amd/python/test/test_gluon_gfx1250_consan.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250_consan.py
@@ -11,6 +11,8 @@ import os
 from triton._internal_testing import is_hip_gfx1250
 
 
+
+pytestmark = pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def _run_consan_subprocess(test_name, *args, timeout=120):
     """Run a ConSan test kernel in a subprocess and return captured stderr.
 
@@ -29,9 +31,6 @@ def _run_consan_subprocess(test_name, *args, timeout=120):
         proc.kill()
         _, stderr = proc.communicate()
     return stderr.decode(errors="replace")
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_store_wait_load(FAILURE):
     """
@@ -47,9 +46,6 @@ def test_ws_store_wait_load(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_load_wait_store(FAILURE):
     """
@@ -65,9 +61,6 @@ def test_ws_load_wait_store(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_deadlock_two_partitions():
     """
     Verifies that ConSan detects a deadlock when two warp-specialize partitions
@@ -76,9 +69,6 @@ def test_deadlock_two_partitions():
     stderr_str = _run_consan_subprocess("deadlock_two_partitions")
 
     assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_deadlock_overarrival():
     """
     Verifies that ConSan detects a deadlock caused by over-arrival on an mbarrier.
@@ -87,9 +77,6 @@ def test_deadlock_overarrival():
     stderr_str = _run_consan_subprocess("deadlock_overarrival")
 
     assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_deadlock_underarrival():
     """
     Verifies that ConSan detects a deadlock caused by under-arrival on mbarriers.
@@ -99,9 +86,6 @@ def test_deadlock_underarrival():
     stderr_str = _run_consan_subprocess("deadlock_underarrival")
 
     assert "Deadlock detected" in stderr_str, f"Expected 'Deadlock detected' in stderr, got:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_deadlock_different_phases():
     """
     Positive test: verifies ConSan does NOT report a false deadlock when two
@@ -111,9 +95,6 @@ def test_deadlock_different_phases():
 
     assert "device assertion failed" not in stderr_str, \
         f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 def test_barrier_underflow():
     """
     Verifies that ConSan detects a barrier arrive underflow when each thread
@@ -124,9 +105,6 @@ def test_barrier_underflow():
 
     assert "Barrier arrive underflow" in stderr_str, \
         f"Expected 'Barrier arrive underflow' in stderr, got:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("MISSING_BAR", [True, False])
 @pytest.mark.parametrize("OVERLAP", [True, False])
 def test_aliasing_shared_visibility(MISSING_BAR, OVERLAP):
@@ -147,9 +125,6 @@ def test_aliasing_shared_visibility(MISSING_BAR, OVERLAP):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
 def test_ws_two_loads_two_bars(MISSING_BAR):
     """
@@ -169,9 +144,6 @@ def test_ws_two_loads_two_bars(MISSING_BAR):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_two_loads_one_bar(FAILURE):
     """
@@ -190,9 +162,6 @@ def test_ws_two_loads_one_bar(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "0", "1"])
 def test_ws_two_loads_two_bars_loop(MISSING_BAR):
     """
@@ -211,9 +180,6 @@ def test_ws_two_loads_two_bars_loop(MISSING_BAR):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_ws_load_ordering(FAILURE):
     """
@@ -231,9 +197,6 @@ def test_ws_load_ordering(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("MISSING_BAR", ["none", "1", "2"])
 def test_ws_different_warp_sizes(MISSING_BAR):
     """
@@ -250,9 +213,6 @@ def test_ws_different_warp_sizes(MISSING_BAR):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_tdm_kernel(FAILURE):
     """
@@ -270,9 +230,6 @@ def test_async_tdm_kernel(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_tdm_kernel_2bufs_1bar(FAILURE):
     """
@@ -287,9 +244,6 @@ def test_async_tdm_kernel_2bufs_1bar(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_tdm_interleave_kernel(FAILURE):
     """
@@ -304,9 +258,6 @@ def test_tdm_interleave_kernel(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_async_copy(FAILURE):
     """
@@ -321,9 +272,6 @@ def test_consan_async_copy(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_store(FAILURE):
     """
@@ -339,9 +287,6 @@ def test_consan_tdm_store(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_load_no_barrier(FAILURE):
     """
@@ -357,9 +302,6 @@ def test_consan_tdm_load_no_barrier(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_two_bufs_one_wait(FAILURE):
     """
@@ -375,9 +317,6 @@ def test_consan_tdm_two_bufs_one_wait(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_load_store_combined(FAILURE):
     """
@@ -393,9 +332,6 @@ def test_consan_tdm_load_store_combined(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_cross_partition(FAILURE):
     """
@@ -412,9 +348,6 @@ def test_consan_tdm_cross_partition(FAILURE):
     else:
         assert "device assertion failed" not in stderr_str, \
             f"Unexpected ConSan violation in stderr:\n{stderr_str}"
-
-
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_consan_tdm_cross_partition_load_store(FAILURE):
     """

--- a/third_party/amd/python/test/test_launcher.py
+++ b/third_party/amd/python/test/test_launcher.py
@@ -6,6 +6,8 @@ import triton.language as tl
 from triton._internal_testing import is_hip
 
 
+
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP backend")
 @triton.jit
 def _add_kernel(x, y, output, n_elements):
     BLOCK_SIZE: tl.constexpr = 256
@@ -21,9 +23,6 @@ def _add_kernel(x, y, output, n_elements):
 @triton.jit
 def _tuple_scale_kernel(inputs, output, SCALE: tl.constexpr):
     tl.store(output, (tl.load(inputs[0]) + tl.load(inputs[1])) * SCALE)
-
-
-@pytest.mark.skipif(not is_hip(), reason="Requires HIP")
 def test_flat_signature_launcher():
     n_elements = 1025
     x = torch.randn(n_elements, device="cuda")
@@ -37,9 +36,6 @@ def test_flat_signature_launcher():
     _add_kernel[grid](x, y, output, n_elements)
 
     torch.testing.assert_close(output, x + y)
-
-
-@pytest.mark.skipif(not is_hip(), reason="Requires HIP")
 def test_structured_signature_launcher_fallback():
     x = torch.tensor([11.0], device="cuda")
     y = torch.tensor([31.0], device="cuda")

--- a/third_party/amd/python/test/test_link_hsaco_error_message.py
+++ b/third_party/amd/python/test/test_link_hsaco_error_message.py
@@ -9,7 +9,7 @@ def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 
 
-@pytest.mark.skipif(not is_hip(), reason="link_hsaco only available on HIP backend")
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP backend")
 def test_nonexistent_input_reports_lld_error_details():
     """Verify that lld linker errors are captured and surfaced in exceptions.
 

--- a/third_party/amd/python/test/test_mxfp_gemm_tdm.py
+++ b/third_party/amd/python/test/test_mxfp_gemm_tdm.py
@@ -21,6 +21,8 @@ import pytest
 from triton.tools.mxfp import MXScaleTensor, MXFP4Tensor
 from triton._internal_testing import is_hip_gfx1250
 
+
+pytestmark = pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires GFX1250")
 # ============================================================================
 # Constants
 # ============================================================================
@@ -350,7 +352,6 @@ def run_mxfp_gemm(
 @pytest.mark.parametrize("BM, BN, BK", [(128, 128, 128)])
 @pytest.mark.parametrize("dtype_a", ['float8_e5m2', 'float8_e4m3', 'float4'])
 @pytest.mark.parametrize("dtype_b", ['float8_e5m2', 'float8_e4m3', 'float4'])
-@pytest.mark.skipif(not is_hip_gfx1250(), reason="Scaled dot with TDM is only tested on gfx1250.")
 def test_mxgemm(M, N, K, BM, BN, BK, dtype_a, dtype_b):
     """Test MXFP GEMM with descriptor loads and pre-shuffled scales."""
 

--- a/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
+++ b/third_party/tlx/tutorials/blackwell-grouped-gemm_test.py
@@ -36,6 +36,8 @@ import triton.language.extra.tlx as tlx
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton._internal_testing import is_blackwell
 
+
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 

--- a/third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py
+++ b/third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py
@@ -23,6 +23,8 @@ import triton.language.extra.tlx as tlx
 from torch._inductor.runtime.triton_compat import libdevice
 from triton._internal_testing import is_blackwell
 
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
+
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 

--- a/third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py
+++ b/third_party/tlx/tutorials/blackwell-triton-addmm-2cta_test.py
@@ -38,6 +38,9 @@ import triton.language as tl
 from triton.language.extra.tlx.tutorials.blackwell_gemm_2cta import (
     tcgen5_dot_kernel2cta_tma as _tlx_2cta_kernel, )
 from triton.tools.tensor_descriptor import TensorDescriptor
+from triton._internal_testing import is_blackwell
+
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
 
 
 def alloc_fn(size: int, align: int, stream: int | None):

--- a/third_party/tlx/tutorials/blackwell_multi_cta_layernorm_ws_test.py
+++ b/third_party/tlx/tutorials/blackwell_multi_cta_layernorm_ws_test.py
@@ -67,6 +67,8 @@ import triton.language.extra.tlx as tlx
 from torch._inductor.runtime.triton_compat import libdevice
 from triton._internal_testing import is_blackwell
 
+
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 NUM_SMS = (torch.cuda.get_device_properties(0).multi_processor_count if torch.cuda.is_available() else 0)
 
@@ -359,9 +361,6 @@ def _torch_layernorm_impl(x, weight, bias, eps=1e-5):
 
 
 torch_layernorm = torch.compile(_torch_layernorm_impl)
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU for multi-CTA support")
 @pytest.mark.parametrize("M,N", [(4, 16384), (1152, 16384), (1024, 16384), (1024, 32768)])
 @pytest.mark.parametrize("dtype", [torch.float16])
 def test_op(M, N, dtype):

--- a/third_party/tlx/tutorials/fused_attention_ws_auto_tma_dp.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_auto_tma_dp.py
@@ -19,12 +19,15 @@ Extra Credits:
 import os
 
 import pytest
+from triton._internal_testing import is_blackwell, is_hopper
 import torch
 
 import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+
+pytestmark = pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 FORCE_ON_DEVICE = os.getenv("FORCE_ON_DEVICE") == "1"
@@ -987,7 +990,6 @@ def attention(q, k, v, causal, sm_scale, baseVariant="ws_persistent", config=Non
 @pytest.mark.parametrize("baseVariant",
                          ["ws"])  # ws_persistent: pre-existing GROUP_SIZE_N issue in this untested tutorial
 @pytest.mark.parametrize("HEAD_DIM", [64, 128])
-@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell GPU")
 def test_op(HEAD_DIM, baseVariant):
     Z, H, N_CTX = 2, 8, 1024
     sm_scale = 0.5
@@ -1002,9 +1004,6 @@ def test_op(HEAD_DIM, baseVariant):
     }
     tri = attention(q, k, v, False, sm_scale, baseVariant, config=dict(cfg)).half()
     torch.testing.assert_close(tri, ref, atol=1e-2, rtol=0)
-
-
-@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell GPU")
 def test_bench():
     Z, H, N, D = 4, 32, 4096, 128
     q = torch.randn((Z, H, N, D), dtype=torch.float16, device="cuda")

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-cooperative.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import pytest
+from triton._internal_testing import is_cuda
 import torch
 
 import triton
@@ -8,6 +9,8 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 M, N, K = (2176, 2176, 2176)

--- a/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py
+++ b/third_party/tlx/tutorials/hopper-persistent-gemm-ws-pingpong.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import pytest
+from triton._internal_testing import is_cuda
 import torch
 
 import triton
@@ -8,6 +9,8 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+
+pytestmark = pytest.mark.skipif(not is_cuda(), reason="Requires CUDA backend")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 M, N, K = (8192, 8192, 8192)  # (2176, 2176, 2176)

--- a/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
+++ b/third_party/tlx/tutorials/test_cross_attention_bwd_autows.py
@@ -33,6 +33,8 @@ import bench_bwd as bb  # noqa: E402
 import triton_bw_cross_attention as xa  # noqa: E402
 
 
+
+pytestmark = pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell")
 def _reset_captured_globals(module):
     """Clear every Triton jit function's captured ``used_global_vals`` in ``module``.
 
@@ -73,7 +75,7 @@ _SHAPES = [(256, 64, 2), (256, 128, 2), (256, 192, 2), (256, 256, 2)]
 
 @pytest.mark.parametrize("ns", [1, 2])
 @pytest.mark.parametrize("Lq,Lkv,Z", _SHAPES)
-@pytest.mark.skipif(not is_blackwell(), reason="Hand-written TLX backward requires a Blackwell GPU")
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) — hand-written TLX backward")
 def test_cross_attention_bwd_autows(Lq, Lkv, Z, ns):
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -115,7 +117,7 @@ _SHARED_SHAPES = [(256, 256, 2), (256, 384, 2), (256, 512, 2)]
 
 @pytest.mark.parametrize("ns", [1, 2])
 @pytest.mark.parametrize("Lq,Lkv,Z", _SHARED_SHAPES)
-@pytest.mark.skipif(not is_blackwell(), reason="Hand-written TLX backward requires a Blackwell GPU")
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100) — hand-written TLX backward")
 def test_cross_attention_bwd_tlx_2kv(Lq, Lkv, Z, ns):
     """TLX 2-KV-block data-partitioned reduce_dq (BwdVariant.TLX_2KV), shared-KV.
     Must match the torch-float reference and be run-to-run deterministic."""
@@ -156,7 +158,6 @@ _AUTOWS_2KV_SHAPES = [(256, 256, 2), (256, 320, 2), (256, 384, 2), (256, 512, 2)
     "variant",
     [xa.BwdVariant.TRITON_AUTOWS_2KV, xa.BwdVariant.TRITON_AUTOWS_2KV_HOST_TMA],
 )
-@pytest.mark.skipif(not (is_hopper() or is_blackwell()), reason="Requires Hopper or Blackwell GPU")
 def test_cross_attention_bwd_autows_2kv(Lq, Lkv, Z, ns, variant, monkeypatch):
     """MANUAL 2-KV-block data-partition reduce_dq (BwdVariant.TRITON_AUTOWS_2KV),
     shared-KV + compute fold, warp specialization ON (milestone 2). Two KV blocks

--- a/third_party/tlx/tutorials/test_self_attention_bwd.py
+++ b/third_party/tlx/tutorials/test_self_attention_bwd.py
@@ -31,8 +31,9 @@ from triton._internal_testing import is_blackwell  # noqa: E402
 import bench_self as bs  # noqa: E402
 
 
+
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
 @pytest.mark.parametrize("L,Z", [(256, 4), (512, 2)])
-@pytest.mark.skipif(not is_blackwell(), reason="TLX self-attention backward requires Blackwell GPU")
 def test_self_attention_bwd_triton_vs_tlx(L, Z):
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")

--- a/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
+++ b/third_party/tlx/tutorials/testing/test_amd_pa_decode_perf.py
@@ -14,6 +14,8 @@ from triton.language.extra.tlx.tutorials.amd_pa_decode import (
 
 from triton._internal_testing import is_hip, is_hip_cdna4
 
+
+pytestmark = pytest.mark.skipif(not is_hip(), reason="Requires HIP backend")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 # Fixed decode problem geometry (GQA, bf16 KV), matching the paged-decode

--- a/third_party/tlx/tutorials/testing/test_correctness_autows.py
+++ b/third_party/tlx/tutorials/testing/test_correctness_autows.py
@@ -24,6 +24,8 @@ from triton.language.extra.tlx.tutorials.fused_attention_ws_device_tma_dp import
 
 from triton._internal_testing import is_blackwell
 
+
+pytestmark = pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell (sm100)")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 # =============================================================================
@@ -75,7 +77,6 @@ class FlashAttention:
 @pytest.mark.parametrize("GROUP_SIZE_N", [1])
 @pytest.mark.parametrize("maxRegAutoWS", [152, 192])
 @pytest.mark.parametrize("pingpongAutoWS", [True, False])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_dp_non_causal(SUBTILING, SUBTILING_P, VECT_MUL, FADD2_REDUCE, BLOCK_N, GROUP_SIZE_N, maxRegAutoWS,
                                  pingpongAutoWS):
     config = FlashAttention.CONFIGS["autows_fa_dp"].copy()
@@ -109,7 +110,6 @@ def test_autows_fa_dp_non_causal(SUBTILING, SUBTILING_P, VECT_MUL, FADD2_REDUCE,
 @pytest.mark.parametrize("GROUP_SIZE_N", [4])
 @pytest.mark.parametrize("maxRegAutoWS", [152, 192])
 @pytest.mark.parametrize("pingpongAutoWS", [False])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_dp_causal(SUBTILING, SUBTILING_P, VECT_MUL, FADD2_REDUCE, BLOCK_N, GROUP_SIZE_N, maxRegAutoWS,
                              pingpongAutoWS):
     config = FlashAttention.CONFIGS["autows_fa_dp"].copy()
@@ -138,7 +138,6 @@ def test_autows_fa_dp_causal(SUBTILING, SUBTILING_P, VECT_MUL, FADD2_REDUCE, BLO
 @pytest.mark.parametrize("VECT_MUL", [0, 1])
 @pytest.mark.parametrize("FADD2_REDUCE", [False])
 @pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_non_causal(SUBTILING, VECT_MUL, FADD2_REDUCE, baseVariant):
     sm_scale = 0.5
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
@@ -149,7 +148,6 @@ def test_autows_fa_non_causal(SUBTILING, VECT_MUL, FADD2_REDUCE, baseVariant):
 
 
 @pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_2cta_non_causal(baseVariant):
     config = next(
         (config for config in _autows_fwd_configs if config.kwargs.get("NUM_CTAS") == 2),
@@ -171,9 +169,6 @@ def test_autows_fa_2cta_non_causal(baseVariant):
     finally:
         kernel.configs = old_configs
         kernel.cache = old_cache
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_2cta_persistent_multi_iteration():
     """Cover persistent tile reuse and V staging-slot rotation."""
     config = next(
@@ -198,7 +193,6 @@ def test_autows_fa_2cta_persistent_multi_iteration():
 
 
 @pytest.mark.parametrize("N_CTX", [1024, 4096])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_rescale_opt_long_sequence(N_CTX):
     """Cover the optimized accumulator update at both target sequence lengths."""
     num_ctas = int(os.environ.get("AUTOWS_FWD_NUM_CTAS", "1"))
@@ -224,9 +218,6 @@ def test_autows_fa_rescale_opt_long_sequence(N_CTX):
     finally:
         _attn_fwd_persist.configs = old_configs
         _attn_fwd_persist.cache = old_cache
-
-
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 @pytest.mark.skipif(
     os.environ.get("AUTOWS_FWD_CLC") != "1" or os.environ.get("AUTOWS_FWD_NUM_CTAS") != "2",
     reason="Run with AUTOWS_FWD_CLC=1 and AUTOWS_FWD_NUM_CTAS=2",
@@ -268,7 +259,6 @@ def test_autows_fa_rescale_opt_clc_repeated_high_grid():
 @pytest.mark.parametrize("VECT_MUL", [0, 1])
 @pytest.mark.parametrize("FADD2_REDUCE", [False])
 @pytest.mark.parametrize("baseVariant", ["ws_persistent", "ws"])
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_autows_fa_causal(SUBTILING, VECT_MUL, FADD2_REDUCE, baseVariant):
     sm_scale = 0.5
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:

--- a/third_party/tlx/tutorials/vector-add2.py
+++ b/third_party/tlx/tutorials/vector-add2.py
@@ -19,6 +19,8 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton._internal_testing import is_hopper_or_newer
 
+
+pytestmark = pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper or newer (sm90+)")
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 


### PR DESCRIPTION
Summary:
Followup to D117886825 (per-hardware CI path filtering). Scan every
hardware-specific file under `third-party/triton/beta/triton` and ensure
it skips at collection time on incompatible hardware. For whole files
(majority or all `def test_*` gated to same backend) apply `pytestmark`
at file level — per `tools/target_determinator` guidance, a SKIPPED file
still schedules the job, but a file-level skip avoids per-test SKIPPING
issues that never auto-heal and prevents collecting incompatible files
on the wrong backend (e.g. AMD file collected on B200).

Files patched (29):
- CUDA-only whole files: `python/test/gsan/test_symmetric_memory.py`,
  `test_utils.py`, `python/test/unit/cuda/test_libdevice_cuda.py`,
  `test_stages_inspection.py`, `unit/runtime/test_launch_kernel_core.py`,
  `test_dispatcher_core.py`
- Hopper+ (sm90+) whole files: `unit/runtime/test_core_tma_encoding.py`
  (`_has_hopper` → `is_hopper_or_newer`), `test_promote_load_to_tma.py`,
  `language/test_autows_auto_tma.py` (`_is_sm90plus` → `is_hopper_or_newer`)
- Blackwell (sm100) whole files: `language/test_dot_2cta.py`,
  `third_party/tlx/tutorials/blackwell-grouped-gemm_test.py`,
  `blackwell-multi-cta-layernorm_test.py`, `blackwell_multi_cta_layernorm_ws_test.py`,
  `blackwell-triton-addmm-2cta_test.py`, `fused_attention_ws_auto_tma_dp.py`,
  `test_cross_attention_bwd_autows.py`, `test_self_attention_bwd.py`,
  `testing/test_correctness_autows.py`
- Hopper / CUDA tutorials: `vector-add2.py` (`is_hopper`),
  `hopper-persistent-gemm-ws-*` (`is_cuda`)
- AMD whole files: `third_party/amd/python/test/test_address_sanitizer.py`,
  `test_convert_op_permlane_swap.py`, `test_launcher.py`,
  `test_link_hsaco_error_message.py` (`is_hip`);
  `test_f16_gemm_tdm.py`, `test_gluon_gfx1250_consan.py`,
  `test_mxfp_gemm_tdm.py` (`is_hip_gfx1250`); `testing/test_amd_pa_decode_perf.py`
  (`is_hip`)

Mixed-predicate or partially-gated files (e.g. `test_amd_warp_pipeline.py`,
`test_tlx_tma.py`, `test_autows_addmm.py` with Hopper vs Blackwell splits)
intentionally left per-test.

Predicate source: `python/triton/_internal_testing.py:44 is_cuda, :53 is_blackwell,
:65 is_hopper_or_newer, :77 is_hip, :108 is_hip_gfx1250`.

Differential Revision: D117891492
