### PR TITLE
[TLX][AMD] Fix v9 inter-wave LDS ordering

### DIFF
--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16/v9_beyond_hotloop/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16/v9_beyond_hotloop/matmul_kernel.py
@@ -161,20 +161,20 @@ def v9_beyond_hotloop(
     # ── Main loop: step 2, four regions per body (identical to v8) ──
     for k in tl.range(0, iterMax - 2, 2, num_stages=1):
         # ──── Region 0 ────
+        tlx.async_load_wait_group(2)
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc_left = tl.dot(a, b_left, acc_left)
         with tlx.warp_pipeline_stage("mem", priority=1):
-            tlx.async_load_wait_group(2)
             b_right = tlx.local_load(smem_b_right[0], relaxed=True)
             tlx.buffer_load_to_local(smem_a[0], a_ptr, a_off + a_k)
             tlx.buffer_load_to_local(smem_b_left[0], b_ptr, bl_off + b_k)
             tlx.async_load_commit_group()
 
         # ──── Region 1 ────
+        tlx.async_load_wait_group(2)
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc_right = tl.dot(a, b_right, acc_right)
         with tlx.warp_pipeline_stage("mem", priority=1):
-            tlx.async_load_wait_group(2)
             a = tlx.local_load(smem_a[1], relaxed=True)
             b_left = tlx.local_load(smem_b_left[1], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[0], b_ptr, br_off + b_k)
@@ -183,20 +183,20 @@ def v9_beyond_hotloop(
             b_k += BLOCK_K * stride_bk
 
         # ──── Region 2 ────
+        tlx.async_load_wait_group(2)
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc_left = tl.dot(a, b_left, acc_left)
         with tlx.warp_pipeline_stage("mem", priority=1):
-            tlx.async_load_wait_group(2)
             b_right = tlx.local_load(smem_b_right[1], relaxed=True)
             tlx.buffer_load_to_local(smem_a[1], a_ptr, a_off + a_k)
             tlx.buffer_load_to_local(smem_b_left[1], b_ptr, bl_off + b_k)
             tlx.async_load_commit_group()
 
         # ──── Region 3 ────
+        tlx.async_load_wait_group(2)
         with tlx.warp_pipeline_stage("mfma", priority=0):
             acc_right = tl.dot(a, b_right, acc_right)
         with tlx.warp_pipeline_stage("mem", priority=1):
-            tlx.async_load_wait_group(2)
             a = tlx.local_load(smem_a[0], relaxed=True)
             b_left = tlx.local_load(smem_b_left[0], relaxed=True)
             tlx.buffer_load_to_local(smem_b_right[1], b_ptr, br_off + b_k)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -93,6 +93,8 @@ from triton.language.extra.tlx.tutorials.amd_bmm_gfx942 import (
 )
 from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16.matmul_kernel_split_m import (
     matmul as _amd_gemm_pingpong, )
+from triton.language.extra.tlx.tutorials.gfx9_gemm.a16w16.v9_beyond_hotloop.matmul_kernel import (
+    matmul as _amd_gemm_v9_beyond_hotloop, )
 from triton.language.extra.tlx.tutorials.amd_bmm import (
     bmm as _amd_bmm,
     make_bmm_inputs as _amd_bmm_inputs,
@@ -1036,11 +1038,7 @@ def test_blackwell_fa_ws_pipelined_persistent_2cta_pruning():
         N_CTX=1024,
     )
     assert any(config.kwargs.get("NUM_CTAS", 1) == 2 for config in selected)
-    assert all(
-        config.kwargs["NUM_BUFFERS_KV"] == 3
-        for config in selected
-        if config.kwargs.get("NUM_CTAS", 1) == 2
-    )
+    assert all(config.kwargs["NUM_BUFFERS_KV"] == 3 for config in selected if config.kwargs.get("NUM_CTAS", 1) == 2)
 
 
 @pytest.mark.parametrize("Z,H", [(4, 8), (4, 48), (24, 8)])
@@ -2414,6 +2412,19 @@ def test_amd_gemm_pingpong(dtype):
         a = (torch.randn((M, K), device=DEVICE, dtype=dtype) + 1) / K
         b = (torch.randn((K, N), device=DEVICE, dtype=dtype) + 1) / K
         torch.testing.assert_close(_amd_gemm_pingpong(a, b), torch.matmul(a, b))
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_amd_gemm_v9_beyond_hotloop_is_deterministic():
+    M, N, K = 131072, 512, 256
+    torch.manual_seed(0)
+    a = torch.randn((M, K), device=DEVICE, dtype=torch.float16)
+    b = torch.randn((N, K), device=DEVICE, dtype=torch.float16).T
+    reference = torch.matmul(a, b)
+
+    for _ in range(5):
+        actual = _amd_gemm_v9_beyond_hotloop(a, b)
+        torch.testing.assert_close(actual, reference, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])


### PR DESCRIPTION
Hoist async waits before each MFMA stage so flat warp-pipeline lowering cannot overlap a trailing wave group's LDS reads with the leading group's buffer refill. Cover the failure with a repeated K=256 bit-exact regression in the CI-run TLX correctness suite.

Test Plan:
- `CUDA_VISIBLE_DEVICES=0 python third_party/tlx/tutorials/gfx9_gemm/a16w16/repro_v9_numerics.py`
- `pre-commit run --files third_party/tlx/tutorials/gfx9_gemm/a16w16/v9_beyond_hotloop/matmul_kernel.py third_party/tlx/tutorials/testing/test_correctness.py`