### PR TITLE
[triton][beta] Score linear layouts by contiguity, not sizePerThread

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -670,15 +670,20 @@ static unsigned estimateConvertScratchCost(Value value, Attribute encoding) {
 }
 
 // Compute a score for a layout to guide conflict resolution.
-// Based on sizePerThread (vectorization) for both blocked and linear encodings.
-// Higher score is preferred — layouts with more elements per thread allow
-// better vectorized memory access (ld.shared, st.shared).
+// Based on per-thread contiguity (vectorization) for both blocked and linear
+// encodings. Higher score is preferred — layouts with more contiguous elements
+// per thread allow better vectorized memory access (ld.shared, st.shared).
 static int64_t getLayoutScore(Attribute encoding) {
   SmallVector<unsigned> sizePerThread;
   if (auto blocked = dyn_cast<BlockedEncodingAttr>(encoding)) {
     sizePerThread = SmallVector<unsigned>(blocked.getSizePerThread());
   } else if (auto linear = dyn_cast<LinearEncodingAttr>(encoding)) {
-    sizePerThread = linear.getSizePerThread();
+    // Not getSizePerThread(): it canonicalizes away any trailing register
+    // bases that tile a whole tensor dimension, treating them as reps. A
+    // tmem_load layout holding a full 128-wide row per thread therefore
+    // reports [1, 1] and loses to a narrow blocked layout, which is the
+    // opposite of what this heuristic wants.
+    sizePerThread = linear.getContigPerThread();
   }
   if (sizePerThread.empty())
     return 0;


### PR DESCRIPTION
Summary:
`getLayoutScore` in `RemoveLayoutConversions` ranks candidate layouts by the
product of `getSizePerThread()`. For a `LinearEncodingAttr` that is the wrong
metric: `LinearEncodingTrait::getSizePerThread()` canonicalizes away any
trailing register bases that tile a whole tensor dimension, treating them as
reps. A layout holding a full 128-wide row per thread therefore reports
`[1, 1]`.

On `sdyt_gdpa` forward (B200, `long_event_pffn`, `BLOCK_M=128, BLOCK_N=32,
num_warps=4, num_stages=3`) the `tmem_load` result layout is exactly that: a
linear encoding bit-identical to the blocked layout 3.5 used, but scoring 1
against the store layout's 8. The heuristic then picks the narrow store layout
and the epilogue relayouts the f32 accumulator (128 registers per thread)
instead of the bf16 result, costing 70 spill loads and stores and 32% more PTX.
That is the inverse of what the comment on this function says it wants.

Use `getContigPerThread()` for linear encodings. It walks the register bases
directly and survives that canonicalization. For blocked encodings it agrees
with `getSizePerThread()`, so mixed blocked/linear comparisons stay sound.
Note `getAtomicContiguousWidth` in this same file already uses
`getContigPerThread` for the atomic path, with a comment warning against
treating `sizePerThread` as a scalar; this applies the same correction to the
generic path.

beta carries the identical defect; this is the beta counterpart of the same
change on 3.8.

Reviewed By: manman-ren

Differential Revision: D117547043


