### PR TITLE
[Triton][NVIDIA] Infer async-proxy fences across logical buffer lifetimes

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -1,9 +1,13 @@
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Tools/Sys/GetEnv.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 
 //===----------------------------------------------------------------------===//
@@ -120,6 +124,10 @@ public:
   }
 
 private:
+  static bool isLogicalLifetimeBoundary(Operation *op) {
+    return op->hasAttr("tlx.logical_lifetime_boundary");
+  }
+
   // Erase `fence` if a matching FenceAsyncSharedOp already exists earlier
   // in the same block, with only pure (memory-effect-free) ops in between.
   void eraseIfDuplicateFence(FenceAsyncSharedOp fence) {
@@ -149,9 +157,47 @@ private:
       for (auto *user : v.getUsers()) {
         if (isa<ttg::LocalStoreOp>(user)) {
           result.insert(user);
-        } else if (user->hasTrait<OpTrait::MemDescViewTrait>()) {
-          for (auto res : user->getResults())
-            worklist.push_back(res);
+        } else if (auto yield = dyn_cast<scf::YieldOp>(user)) {
+          Operation *parent = yield->getParentOp();
+          for (auto [index, yielded] : llvm::enumerate(yield.getOperands())) {
+            if (yielded != v)
+              continue;
+            if (auto ifOp = dyn_cast<scf::IfOp>(parent))
+              worklist.push_back(ifOp.getResult(index));
+            else if (auto forOp = dyn_cast<scf::ForOp>(parent))
+              worklist.push_back(forOp.getResult(index));
+            else
+              result.insert(user);
+          }
+        } else if (auto forOp = dyn_cast<scf::ForOp>(user)) {
+          for (auto [index, initArg] : llvm::enumerate(forOp.getInitArgs())) {
+            if (initArg == v)
+              worklist.push_back(forOp.getBody()->getArgument(index + 1));
+          }
+        } else if (auto partOp =
+                       dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
+          auto captures = partOp.getExplicitCaptures();
+          auto wsOp = cast<ttg::WarpSpecializeOp>(partOp->getParentOp());
+          for (unsigned i = 0; i < captures.size(); ++i) {
+            if (captures[i] != v)
+              continue;
+            for (Region *region : wsOp.getPartitionRegions())
+              worklist.push_back(region->getArgument(i));
+          }
+        } else if (isa<triton::ReturnOp, CallOpInterface,
+                       RegionBranchOpInterface,
+                       RegionBranchTerminatorOpInterface>(user)) {
+          result.insert(user);
+        } else if (user->hasTrait<OpTrait::MemDescViewTrait>() ||
+                   isMemoryEffectFree(user)) {
+          // A local_alias starts a new logical use of reused physical storage.
+          // Stores in that lifetime do not populate the preceding lifetime.
+          if (isLogicalLifetimeBoundary(user))
+            continue;
+          for (Value res : user->getResults()) {
+            if (isa<ttg::MemDescType>(res.getType()))
+              worklist.push_back(res);
+          }
         }
       }
     }
@@ -216,6 +262,39 @@ private:
 
     auto op = operand.getDefiningOp();
     if (op) {
+      // Do not trace a local_alias back into the physical backing allocation:
+      // the alias is a distinct logical lifetime. Scan forward from the alias
+      // so generic writes within this lifetime are still fenced.
+      if (isLogicalLifetimeBoundary(op)) {
+        findLocalStoresThroughViews(operand, result);
+        return;
+      }
+
+      if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        unsigned resultNum = cast<OpResult>(operand).getResultNumber();
+        for (Region *region : {&ifOp.getThenRegion(), &ifOp.getElseRegion()}) {
+          if (region->empty()) {
+            result.insert(op);
+            continue;
+          }
+          auto yield = dyn_cast<scf::YieldOp>(region->front().getTerminator());
+          if (!yield || resultNum >= yield.getNumOperands()) {
+            result.insert(op);
+            continue;
+          }
+          findCopyRegToSharedOps(yield.getOperand(resultNum), visited, result);
+        }
+        return;
+      }
+
+      if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+        unsigned resultNum = cast<OpResult>(operand).getResultNumber();
+        findCopyRegToSharedOps(forOp.getInitArgs()[resultNum], visited, result);
+        auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+        findCopyRegToSharedOps(yieldOp.getOperand(resultNum), visited, result);
+        return;
+      }
+
       // reach an alloc copying from register, we need a fence.
       if (auto localAlloc = dyn_cast<ttg::LocalAllocOp>(op)) {
         if (localAlloc.getSrc()) {
@@ -227,42 +306,10 @@ private:
         findLocalStoresThroughViews(localAlloc.getResult(), result);
         if (!result.empty())
           return;
-        // When the alloc is captured by a warp_specialize op, check all
-        // partition regions for local_store ops to the corresponding block
-        // arg. This handles the case where early TMA store lowering creates
-        // a local_alloc + async_tma_copy in the epilogue partition, and
-        // code partitioning splits the alloc: the local_store ends up in
-        // the computation partition while the TMA copy stays in the
-        // epilogue partition.
-        // Walk through memdesc view ops (e.g. memdesc_index) since the
-        // warp_specialize may capture a view of the alloc rather than the
-        // alloc directly.
-        SmallVector<Value> wsWorklist = {localAlloc.getResult()};
-        DenseSet<Value> wsSeen;
-        while (!wsWorklist.empty()) {
-          Value v = wsWorklist.pop_back_val();
-          if (!wsSeen.insert(v).second)
-            continue;
-          for (auto *user : v.getUsers()) {
-            if (auto partOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
-              auto captures = partOp.getExplicitCaptures();
-              auto wsOp = cast<ttg::WarpSpecializeOp>(partOp->getParentOp());
-              for (unsigned i = 0; i < captures.size(); i++) {
-                if (captures[i] != v)
-                  continue;
-                for (Region *region : wsOp.getPartitionRegions()) {
-                  Value blockArg = region->getArgument(i);
-                  findLocalStoresThroughViews(blockArg, result);
-                  if (!result.empty())
-                    return;
-                }
-              }
-            } else if (user->hasTrait<OpTrait::MemDescViewTrait>()) {
-              for (auto res : user->getResults())
-                wsWorklist.push_back(res);
-            }
-          }
-        }
+      }
+      if (isa<CallOpInterface, RegionBranchOpInterface>(op)) {
+        result.insert(op);
+        return;
       }
       // if it is not an alloc, iterate over the operands.
       for (auto v : op->getOperands()) {

--- a/test/Hopper/WarpSpecialization/ws_code_partition_bwd_staging_slot_rotation.mlir
+++ b/test/Hopper/WarpSpecialization/ws_code_partition_bwd_staging_slot_rotation.mlir
@@ -27,8 +27,8 @@
 // The original subtiled staging allocs must be erased: leaving zero-use
 // explicit allocs here still charges their SMEM in AllocateSharedMemoryNv.
 // CHECK-NOT: ttg.local_alloc {{.*}}buffer.tmaStaging = 1
-// CHECK-DAG: ttg.memdesc_reinterpret {{.*}} -> !ttg.memdesc<2x128x64xf16
-// CHECK-DAG: ttg.memdesc_reinterpret {{.*}} -> !ttg.memdesc<2x128x64xf16
+// CHECK-DAG: ttg.memdesc_reinterpret {{.*}}tlx.logical_lifetime_boundary{{.*}} -> !ttg.memdesc<2x128x64xf16
+// CHECK-DAG: ttg.memdesc_reinterpret {{.*}}tlx.logical_lifetime_boundary{{.*}} -> !ttg.memdesc<2x128x64xf16
 // Staging slot = (constant subtile index) % K, in the staging task (3): the
 // arith.subi reducing the index takes a CONSTANT (%c...) operand, not the
 // loop accumCnt iter_arg.

--- a/test/TLX/rewrite-local-alias.mlir
+++ b/test/TLX/rewrite-local-alias.mlir
@@ -24,7 +24,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
     %barriers = ttg.local_alloc : () -> !ttg.memdesc<3xi64, #bar_shared, #smem, mutable>
 
     // CHECK-NOT: tlx.local_alias
-    // CHECK: ttg.memdesc_reinterpret %[[$LOCAL_ALLOC]] : !ttg.memdesc<1x64x16xf16, #[[$SHARED]], #smem, mutable> -> !ttg.memdesc<1x32x32xf16, #[[$SHARED1]], #smem, mutable>
+    // CHECK: ttg.memdesc_reinterpret %[[$LOCAL_ALLOC]] {tlx.logical_lifetime_boundary} : !ttg.memdesc<1x64x16xf16, #[[$SHARED]], #smem, mutable> -> !ttg.memdesc<1x32x32xf16, #[[$SHARED1]], #smem, mutable>
     %2 = tlx.local_alias %0 : !ttg.memdesc<1x64x16xf16, #shared, #smem, mutable> -> !ttg.memdesc<1x32x32xf16, #shared1, #smem, mutable>
 
     // CHECK: %[[$TMEM_ALLOC:.*]] = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable>
@@ -32,6 +32,7 @@ module attributes {tlx.has_explicit_local_mem_access = true, tlx.has_tlx_ops = t
 
     // CHECK-NOT: tlx.local_alias
     // CHECK: ttg.memdesc_reinterpret %[[$TMEM_ALLOC]] : !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf16, #[[$TMEM]], #ttng.tensor_memory, mutable>
+    // CHECK: ttg.memdesc_reinterpret %[[$TMEM_ALLOC]] {tlx.logical_lifetime_boundary} : !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf32, #[[$TMEM]], #ttng.tensor_memory, mutable>
     %result_0 = tlx.local_alias %result : !ttg.memdesc<1x64x32xf16, #tmem1, #ttng.tensor_memory, mutable> -> !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>
     %result_1 = ttng.tmem_alloc : () -> !ttg.memdesc<1x64x32xf32, #tmem, #ttng.tensor_memory, mutable>
     ttg.warp_specialize(%0, %result_0, %1, %2, %result_1, %result)
@@ -83,6 +84,7 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.th
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x256x128xbf16, #v_shared, #smem, mutable>
     // CHECK-NOT: tlx.local_alias
     // CHECK: ttg.memdesc_reinterpret
+    // CHECK-SAME: {tlx.logical_lifetime_boundary, tlx.storage_alias_view}
     // CHECK-SAME: !ttg.memdesc<1x256x128xbf16
     // CHECK-SAME: -> !ttg.memdesc<2x256x16xbf16
     %1 = tlx.local_alias %0 : !ttg.memdesc<1x256x128xbf16, #v_shared, #smem, mutable> -> !ttg.memdesc<2x256x16xbf16, #ds_shared, #smem, mutable>
@@ -107,6 +109,10 @@ module attributes {"ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.th
     %0 = ttg.local_alloc : () -> !ttg.memdesc<1x256x16xbf16, #plain_shared, #smem, mutable>
     // CHECK-NOT: tlx.local_alias
     // CHECK: ttg.memdesc_reinterpret %[[BACKING]]
+    // CHECK-SAME: {tlx.storage_alias_view}
+    // CHECK-SAME: -> !ttg.memdesc<1x256x16xbf16
+    // CHECK: ttg.memdesc_reinterpret %[[BACKING]]
+    // CHECK-SAME: {tlx.logical_lifetime_boundary, tlx.storage_alias_view}
     // CHECK-SAME: -> !ttg.memdesc<1x256x16xbf16
     %1 = tlx.local_alias %0 : !ttg.memdesc<1x256x16xbf16, #plain_shared, #smem, mutable> -> !ttg.memdesc<1x256x16xbf16, #padded_shared, #smem, mutable>
     tt.return

--- a/test/TritonGPU/fence-proxy-source-inference.mlir
+++ b/test/TritonGPU/fence-proxy-source-inference.mlir
@@ -1,0 +1,185 @@
+// RUN: triton-opt %s --triton-nvidia-gpu-fence-insertion | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked_ws = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma_a = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#mma_b = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
+
+module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: tt.func @backing_ignores_alias_lifetime
+  tt.func @backing_ignores_alias_lifetime(
+      %src: tensor<64x32xf16, #blocked>,
+      %acc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %alias = ttg.memdesc_reinterpret %a {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    ttg.local_store %src, %alias : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %bt = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %b = ttg.memdesc_trans %bt {order = array<i32: 1, 0>} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>
+    %false = arith.constant false
+    %true = arith.constant true
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func @alias_lifetime_sees_cross_partition_store
+  tt.func @alias_lifetime_sees_cross_partition_store(
+      %src: tensor<64x64xf16, #blocked_ws>) {
+    %backing = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %a = ttg.memdesc_reinterpret %backing {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %a_view = ttg.memdesc_reinterpret %a : !ttg.memdesc<64x64xf16, #shared, #smem, mutable> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttg.warp_specialize(%a_view, %b, %acc, %src)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%buf: !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, %rhs: !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, %dst: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, %value: tensor<64x64xf16, #blocked_ws>) num_warps(4) {
+      %true = arith.constant true
+      %selected = scf.if %true -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable> {
+        scf.yield %buf : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+      } else {
+        scf.yield %buf : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+      }
+      ttg.local_store %value, %selected : tensor<64x64xf16, #blocked_ws> -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+      ttg.warp_return
+    }
+    partition1(%lhs: !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, %rhs: !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, %dst: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, %value: tensor<64x64xf16, #blocked_ws>) num_warps(4) {
+      %true = arith.constant true
+      // CHECK: ttng.fence_async_shared
+      // CHECK-NEXT: ttng.tc_gen5_mma
+      ttng.tc_gen5_mma %lhs, %rhs, %dst, %true, %true : !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      ttg.warp_return
+    } : (!ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf16, #shared, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>, tensor<64x64xf16, #blocked_ws>) -> ()
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func @alias_lifetime_ignores_backing_and_sibling_stores
+  tt.func @alias_lifetime_ignores_backing_and_sibling_stores(
+      %src: tensor<64x32xf16, #blocked>,
+      %acc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %backing = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    ttg.local_store %src, %backing : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %a = ttg.memdesc_reinterpret %backing {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %sibling = ttg.memdesc_reinterpret %backing {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    ttg.local_store %src, %sibling : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %bt = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %b = ttg.memdesc_trans %bt {order = array<i32: 1, 0>} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>
+    %false = arith.constant false
+    %true = arith.constant true
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func public @unknown_function_argument
+  tt.func public @unknown_function_argument(
+      %a: !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>,
+      %b: !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>,
+      %acc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %false = arith.constant false
+    %true = arith.constant true
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  tt.func private @identity_buffer(
+      %a: !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>) -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> {
+    tt.return %a : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+  }
+
+  // CHECK-LABEL: tt.func @unknown_call_and_if_results
+  tt.func @unknown_call_and_if_results(
+      %src: tensor<64x32xf16, #blocked>,
+      %acc0: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc1: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %from_call = tt.call @identity_buffer(%a) : (!ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>) -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %bt = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %b = ttg.memdesc_trans %bt {order = array<i32: 1, 0>} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>
+    %false = arith.constant false
+    %true = arith.constant true
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %from_call, %b, %acc0, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    %safe_backing = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    ttg.local_store %src, %safe_backing : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %safe_alias = ttg.memdesc_reinterpret %safe_backing {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %safe = scf.if %true -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> {
+      scf.yield %safe_alias : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    } else {
+      scf.yield %safe_alias : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    }
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %safe, %b, %acc1, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    %unsafe_backing = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %unsafe_alias = ttg.memdesc_reinterpret %unsafe_backing {tlx.logical_lifetime_boundary} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %unsafe = scf.if %true -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> {
+      ttg.local_store %src, %unsafe_alias : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+      scf.yield %unsafe_alias : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    } else {
+      scf.yield %unsafe_alias : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    }
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %unsafe, %b, %acc1, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func @safe_loop_carried_mma
+  tt.func @safe_loop_carried_mma(
+      %acc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %false = arith.constant false
+    %true = arith.constant true
+    %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %bt = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %b = ttg.memdesc_trans %bt {order = array<i32: 1, 0>} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>
+    %result = scf.for %i = %c0 to %c1 step %c1 iter_args(%iter = %a) -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> {
+      // CHECK-NOT: ttng.fence_async_shared
+      // CHECK: ttng.tc_gen5_mma
+      ttng.tc_gen5_mma %iter, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %iter : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    }
+    // CHECK-NOT: ttng.fence_async_shared
+    // CHECK: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %result, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // CHECK-LABEL: tt.func @unsafe_loop_carried_mma
+  tt.func @unsafe_loop_carried_mma(
+      %src: tensor<64x32xf16, #blocked>,
+      %acc: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %false = arith.constant false
+    %true = arith.constant true
+    %a = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %bt = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    %b = ttg.memdesc_trans %bt {order = array<i32: 1, 0>} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> -> !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>
+    %result = scf.for %i = %c0 to %c1 step %c1 iter_args(%iter = %a) -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable> {
+      ttg.local_store %src, %iter : tensor<64x32xf16, #blocked> -> !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+      // CHECK: ttng.fence_async_shared
+      // CHECK-NEXT: ttng.tc_gen5_mma
+      ttng.tc_gen5_mma %iter, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %iter : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>
+    }
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %result, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    // CHECK: ttng.fence_async_shared
+    // CHECK-NEXT: ttng.tc_gen5_mma
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true {is_async} : !ttg.memdesc<64x32xf16, #mma_a, #smem, mutable>, !ttg.memdesc<32x64xf16, #mma_b, #smem, mutable>, !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -5360,6 +5360,8 @@ void mergeStagingReuseIntoHost(triton::FuncOp funcOp,
       builder.setInsertionPointAfter(insertAnchor);
       auto stagingView = ttg::MemDescReinterpretOp::create(
           builder, stagingAlloc.getLoc(), stagingTy, backingAlloc.getResult());
+      stagingView->setAttr("tlx.logical_lifetime_boundary",
+                           builder.getUnitAttr());
       for (StringRef name : {"buffer.id", "buffer.copy", "buffer.idx_in_group",
                              "allocation.shareGroup", "async_task_id"}) {
         if (auto a = stagingAlloc->getAttr(name))

--- a/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/RewriteLocalAlias.cpp
@@ -50,14 +50,16 @@ int64_t getMemDescStorageBits(ttg::MemDescType ty) {
 // that allocation. This preserves the existing shared- and tensor-memory
 // aliasing semantics, including non-integral logical element-size ratios.
 FailureOr<Value> emitAliasView(OpBuilder &builder, Operation *errorOp,
-                               Location loc, Value base,
-                               ttg::MemDescType dstTy) {
+                               Location loc, Value base, ttg::MemDescType dstTy,
+                               bool isLogicalLifetimeBoundary = false) {
   auto srcTy = cast<ttg::MemDescType>(base.getType());
   int64_t srcBits = getMemDescStorageBits(srcTy);
   int64_t dstBits = getMemDescStorageBits(dstTy);
 
   if (dstBits <= srcBits) {
     auto view = ttg::MemDescReinterpretOp::create(builder, loc, dstTy, base);
+    if (isLogicalLifetimeBoundary)
+      view->setAttr("tlx.logical_lifetime_boundary", builder.getUnitAttr());
     // Explicit storage aliases may intentionally expose the same allocation
     // through a different padded address mapping.
     if (isa<ttg::PaddedSharedEncodingAttr>(srcTy.getEncoding()) ||
@@ -246,7 +248,8 @@ LogicalResult rewriteLocalAlias(ModuleOp m) {
       auto aliasType = cast<ttg::MemDescType>(aliasOp.getResult().getType());
       FailureOr<Value> baseAllocToAlias =
           emitAliasView(builder, aliasOp, baseAllocOp->getLoc(),
-                        baseAllocOp->getResult(0), aliasType);
+                        baseAllocOp->getResult(0), aliasType,
+                        /*isLogicalLifetimeBoundary=*/true);
       if (failed(baseAllocToAlias))
         return failure();
       aliasOp.getResult().replaceAllUsesWith(*baseAllocToAlias);


### PR DESCRIPTION
Summary:
When looking into ptx/ttgir dump of flash attention, spotted this weird thing (see test plan).

We have separate logical barriers path, but they might point to exactly the same smem allocation. In this case, we really don't need having both, but we still emit that. (in this particular case it was TMA preceeding tcgen05.mma). 

With the existing logic, both of tlx.local_alias are lowered and the information where they come from is lost. This diff exposes same lifetime with isLogicalLifetimeBoundary helper. Then whenever we try to emit the barrier, we double check whether we already did it for the same lifetime.

Differential Revision: D117942752


