### PR TITLE
Select CPU backend when no GPU is active

### DIFF
--- a/python/test/unit/tools/test_irsource.py
+++ b/python/test/unit/tools/test_irsource.py
@@ -9,7 +9,7 @@ try:
 except RuntimeError:
     target = None
 
-if target is None:
+if target is None or target.backend == "cpu":
     pytest.skip("No active GPU driver", allow_module_level=True)
 
 backend = make_backend(target)

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -15,16 +15,14 @@ def _create_driver() -> DriverBase:
             raise RuntimeError(f"Backend device '{selected}' is not active.")
         return driver()
     else:
-        if os.getenv("TRITON_CPU_BACKEND", "0") == "1":
-            if "cpu" not in backends:
-                raise RuntimeError("TRITON_CPU_BACKEND is set, but CPU backend is unavailable.")
-            return backends["cpu"].driver()
-        # CPU must be selected explicitly. Otherwise, a missing GPU would
-        # silently fall back to CPU and hide configuration or entitlement
-        # failures in GPU workloads.
+        # Prefer an active GPU driver, falling back to CPU when none are active.
         active_drivers = [
             backend.driver for name, backend in backends.items() if name != "cpu" and backend.driver.is_active()
         ]
+        if not active_drivers:
+            cpu_backend = backends.get("cpu")
+            if cpu_backend is not None and cpu_backend.driver.is_active():
+                active_drivers.append(cpu_backend.driver)
         if len(active_drivers) != 1:
             raise RuntimeError(f"{len(active_drivers)} active drivers ({active_drivers}). There should only be one.")
         return active_drivers[0]()


### PR DESCRIPTION
The upstream now has TRITON_DEFAULT_BACKEND. So, let's not use cpu-only TRITON_CPU_BACKEND.

And, let's also select CPU backend when no GPU exists. This actually changes a behavior such as the `has_triton()` helper. I will follow up as well.