### PR TITLE
 Add predicated Proton device records (#3400)

### DIFF
--- a/test/Proton/amd/protongpu_to_llvm.mlir
+++ b/test/Proton/amd/protongpu_to_llvm.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -convert-proton-amd-gpu-to-llvm="gfx-arch=gfx942" --verify-diagnostics | FileCheck %s --check-prefix=CHECK
+// RUN: triton-opt %s -split-input-file -convert-proton-amd-gpu-to-llvm="gfx-arch=gfx942" --verify-diagnostics | FileCheck %s --check-prefix=BRANCH
 // RUN: triton-opt %s -split-input-file -convert-proton-amd-gpu-to-llvm="gfx-arch=gfx942" --convert-builtin-func-to-llvm --verify-diagnostics | FileCheck -allow-unused-prefixes --check-prefix=CONVERT-BUILTIN %s
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
@@ -54,6 +55,13 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: convert_circular_store_smem
+  // AMD already needs one conditional branch to guard the store with the
+  // existing writer-validity predicate.
+  // BRANCH-LABEL: llvm.func @convert_circular_store_smem()
+  // BRANCH-NOT: llvm.cond_br
+  // BRANCH: llvm.cond_br
+  // BRANCH-NOT: llvm.cond_br
+  // BRANCH: llvm.return
   llvm.func @convert_circular_store_smem() {
     // CHECK-DAG: rocdl.workitem.id.x
     // CHECK-DAG: %[[WARPID:.*]] = llvm.udiv
@@ -66,6 +74,35 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<512xi32, #shared, #smem, mutable> -> !proton_gpu.segment<2048, #smem, warp, [0, 1]>
     %8 = proton_gpu.read_counter : i32
     proton_gpu.circular_store start %3, %8 {scopeId = 1 : i32} : !proton_gpu.segment<2048, #smem, warp, [0, 1]>, i32
+    llvm.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: convert_predicated_circular_store_smem
+  // The user predicate is folded into the existing AMD masked-store
+  // condition, so it does not introduce a second conditional branch.
+  // BRANCH-LABEL: llvm.func @convert_predicated_circular_store_smem
+  // BRANCH-NOT: llvm.cond_br
+  // BRANCH: llvm.cond_br
+  // BRANCH-NOT: llvm.cond_br
+  // BRANCH: llvm.return
+  llvm.func @convert_predicated_circular_store_smem(%pred: i1) {
+    // CHECK-DAG: %[[BASE_PRED:.*]] = llvm.icmp "ne" %{{.*}}, %{{.*}} : i32
+    // CHECK-DAG: %[[WARP_STORE_PRED:.*]] = llvm.and %[[BASE_PRED]], %{{.*}} : i1
+    // CHECK-DAG: %[[STORE_PRED:.*]] = llvm.and %[[WARP_STORE_PRED]], %arg0 : i1
+    // CHECK-DAG: %[[ADVANCE_PRED:.*]] = llvm.and %[[BASE_PRED]], %arg0 : i1
+    // CHECK-DAG: %[[NEXT_IDX:.*]] = llvm.select %[[ADVANCE_PRED]], %{{.*}}, %{{.*}} : i1, i32
+    // CHECK: llvm.store %[[NEXT_IDX]], %{{.*}} : i32, !llvm.ptr
+    // CHECK: llvm.cond_br %[[STORE_PRED]],
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<512xi32, #shared, #smem, mutable>
+    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<512xi32, #shared, #smem, mutable> -> !proton_gpu.segment<2048, #smem, warp, [0, 1]>
+    %8 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %3, %8 if %pred {scopeId = 1 : i32} : !proton_gpu.segment<2048, #smem, warp, [0, 1]>, i32
     llvm.return
   }
 }

--- a/test/Proton/nvidia/protongpu_to_llvm.mlir
+++ b/test/Proton/nvidia/protongpu_to_llvm.mlir
@@ -114,6 +114,28 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: convert_predicated_circular_smem_store
+  llvm.func @convert_predicated_circular_smem_store(%pred: i1) {
+    // CHECK-DAG: %[[BASE_PRED:.*]] = llvm.icmp "ne" %{{.*}}, %{{.*}} : i32
+    // CHECK-DAG: %[[WARP_STORE_PRED:.*]] = llvm.and %[[BASE_PRED]], %{{.*}} : i1
+    // CHECK-DAG: %[[STORE_PRED:.*]] = llvm.and %[[WARP_STORE_PRED]], %arg0 : i1
+    // CHECK-DAG: %[[ADVANCE_PRED:.*]] = llvm.and %[[BASE_PRED]], %arg0 : i1
+    // CHECK-DAG: %[[NEXT_IDX:.*]] = llvm.select %[[ADVANCE_PRED]], %{{.*}}, %{{.*}} : i1, i32
+    // CHECK: llvm.store %[[NEXT_IDX]], %{{.*}} : i32, !llvm.ptr
+    // CHECK: llvm.inline_asm has_side_effects{{.*}}st.shared.v2.b32{{.*}}%[[STORE_PRED]] :
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<512xi32, #shared, #smem, mutable>
+    %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<512xi32, #shared, #smem, mutable> -> !proton_gpu.segment<2048, #smem, warp, [0, 1]>
+    %8 = proton_gpu.read_counter : i32
+    proton_gpu.circular_store start %3, %8 if %pred {scopeId = 1 : i32} : !proton_gpu.segment<2048, #smem, warp, [0, 1]>, i32
+    llvm.return
+  }
+}
+
+// -----
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 8 : i32, ttg.profile_scratch_memory_alignment = 128 : i32, ttg.profile_scratch_memory_size = 384 : i32} {
   // CHECK-LABEL: convert_smem_initialize
   // CHECK-DAG: llvm.cond_br %{{.*}}, ^bb1, ^bb2

--- a/test/Proton/ops.mlir
+++ b/test/Proton/ops.mlir
@@ -3,11 +3,17 @@
 module {
   // CHECK-LABEL: proton_record
   tt.func @proton_record() {
+    // CHECK: %[[PRED:.*]] = arith.constant true
     // CHECK: proton.record start "name0"
     // CHECK: proton.record end "name0"
+    // CHECK: proton.record start "name1" if %[[PRED]]
+    // CHECK: proton.record end "name1" if %[[PRED]]
     // CHECK-NEXT: tt.return
+    %pred = arith.constant true
     proton.record start "name0"
     proton.record end "name0"
+    proton.record start "name1" if %pred
+    proton.record end "name1" if %pred
     tt.return
   }
 } // end module
@@ -26,6 +32,8 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     // CHECK-NEXT: proton_gpu.init_ctx
     // CHECK-NEXT: proton_gpu.read_counter
     // CHECK-NEXT: proton_gpu.circular_store start
+    // CHECK-NEXT: %[[PRED:.*]] = arith.constant true
+    // CHECK-NEXT: proton_gpu.circular_store end {{.*}} if %[[PRED]]
     // CHECK-NEXT: ttg.barrier
     // CHECK-NEXT: proton_gpu.save_ctx
     // CHECK-NEXT: proton_gpu.finalize
@@ -37,6 +45,8 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     proton_gpu.init_ctx %1 : !tt.ptr<i32>
     %3 = proton_gpu.read_counter : i32
     proton_gpu.circular_store start %seg, %3 {scopeId = 0 : i32} : !proton_gpu.segment<256, #shared, warp>, i32
+    %pred = arith.constant true
+    proton_gpu.circular_store end %seg, %3 if %pred {scopeId = 0 : i32} : !proton_gpu.segment<256, #shared, warp>, i32
     ttg.barrier global_read|global_write|local
     proton_gpu.save_ctx %seg, %1: !proton_gpu.segment<256, #shared, warp>, !tt.ptr<i32>
     proton_gpu.finalize %seg, %1 : !proton_gpu.segment<256, #shared, warp>, !tt.ptr<i32>

--- a/test/Proton/proton_to_protongpu.mlir
+++ b/test/Proton/proton_to_protongpu.mlir
@@ -34,6 +34,28 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 // -----
 
 module attributes {"ttg.num-warps" = 8 : i32} {
+  // CHECK-LABEL: predicated_record
+  tt.func @predicated_record(%pred: i1) {
+    // CHECK: %[[SCRATCH:.*]] = ttg.global_scratch_alloc
+    // CHECK: proton_gpu.initialize %[[SCRATCH]] : !tt.ptr<i32>
+    // CHECK: %[[BUF:.*]] = ttg.local_alloc
+    // CHECK: %[[SEGMENT:.*]] = proton_gpu.segment_alloc %[[BUF]]
+    // CHECK: %[[START:.*]] = proton_gpu.read_counter : i32
+    // CHECK: proton_gpu.circular_store start %[[SEGMENT]], %[[START]] if %arg0 {scopeId = 0 : i32}
+    // CHECK: %[[END:.*]] = proton_gpu.read_counter : i32
+    // CHECK: proton_gpu.circular_store end %[[SEGMENT]], %[[END]] if %arg0 {scopeId = 0 : i32}
+    // CHECK: ttg.barrier local|global_read|global_write
+    // CHECK: proton_gpu.finalize %[[SEGMENT]], %[[SCRATCH]]
+    // CHECK: tt.return
+    proton.record start "name0" if %pred
+    proton.record end "name0" if %pred
+    tt.return
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: scf_record
   tt.func @scf_record() {
     %i = arith.constant 0 : index

--- a/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
+++ b/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/Utility.h
@@ -43,6 +43,7 @@ struct CircularStoreDataPack {
 
 CircularStoreDataPack
 lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
+                           Value predicate,
                            ConversionPatternRewriter &rewriter);
 
 SmallVector<FunctionOpInterface> getTritonFunctions(ModuleOp mod);

--- a/third_party/proton/Dialect/include/Dialect/Proton/IR/ProtonOps.td
+++ b/third_party/proton/Dialect/include/Dialect/Proton/IR/ProtonOps.td
@@ -36,10 +36,20 @@ def PT_RecordOp : PT_Op<"record", [
   }];
   let arguments = (
     ins UnitAttr: $isStart,
-    StrAttr: $name
+    StrAttr: $name,
+    Optional<I1>: $predicate
   );
 
-  let assemblyFormat = "(`start` $isStart^):(`end`)? $name attr-dict";
+  let builders = [
+    OpBuilder<(ins "bool":$isStart, "StringAttr":$name), [{
+      build($_builder, $_state, isStart, name,
+            /*predicate=*/static_cast<mlir::Value>(nullptr));
+    }]>
+  ];
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = "(`start` $isStart^):(`end`)? $name (`if` $predicate^)? attr-dict";
 }
 
 #endif // PROTON_OPS

--- a/third_party/proton/Dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/Dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -47,13 +47,22 @@ def PTG_CircularStoreOp : PTG_Op<"circular_store", [
     PTG_SegmentType:$segment,
     AnyTypeOf<[I32, I64]>:$counter,
     UnitAttr:$isStart,
-    I32Attr:$scopeId
+    I32Attr:$scopeId,
+    Optional<I1>:$predicate
   );
+
+  let builders = [
+    OpBuilder<(ins "Value":$segment, "Value":$counter, "bool":$isStart,
+                   "int32_t":$scopeId), [{
+      build($_builder, $_state, segment, counter, isStart, scopeId,
+            /*predicate=*/static_cast<mlir::Value>(nullptr));
+    }]>
+  ];
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`start` $isStart^):(`end`)? $segment `,` $counter attr-dict `:`
+    (`start` $isStart^):(`end`)? $segment `,` $counter (`if` $predicate^)? attr-dict `:`
     qualified(type($segment)) `,` type($counter)
   }];
 }

--- a/third_party/proton/Dialect/lib/Dialect/Proton/IR/Ops.cpp
+++ b/third_party/proton/Dialect/lib/Dialect/Proton/IR/Ops.cpp
@@ -10,3 +10,20 @@
 #include "Dialect/Proton/IR/Ops.cpp.inc"
 
 #include "Dialect/Proton/IR/OpsEnums.cpp.inc"
+
+namespace mlir {
+namespace triton {
+namespace proton {
+
+LogicalResult RecordOp::verify() {
+  if (Value predicate = getPredicate()) {
+    auto predTy = dyn_cast<IntegerType>(predicate.getType());
+    if (!predTy || predTy.getWidth() != 1)
+      return emitOpError("predicate must be a scalar i1");
+  }
+  return success();
+}
+
+} // namespace proton
+} // namespace triton
+} // namespace mlir

--- a/third_party/proton/Dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
+++ b/third_party/proton/Dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
@@ -35,6 +35,12 @@ LogicalResult CircularStoreOp::verify() {
   if (scopeId < 0 || scopeId > 255)
     return emitOpError("scope id must be in [0, 255]");
 
+  if (Value predicate = getPredicate()) {
+    auto predTy = dyn_cast<IntegerType>(predicate.getType());
+    if (!predTy || predTy.getWidth() != 1)
+      return emitOpError("predicate must be a scalar i1");
+  }
+
   return success();
 }
 

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
@@ -31,8 +31,12 @@ struct CircularStoreOpConversion
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
-    auto dataPack =
-        lowerCircularStoreOpHelper(op, adaptor.getSegment(), rewriter);
+    // AMD lowers the existing writer predicate through a masked store, so a
+    // dynamic user predicate only strengthens that condition but still uses a
+    // branch. If this becomes costly, consider rejecting dynamic predicates on
+    // AMD while preserving unpredicated records and constant-false elision.
+    auto dataPack = lowerCircularStoreOpHelper(
+        op, adaptor.getSegment(), adaptor.getPredicate(), rewriter);
 
     uint32_t addrSpace = dataPack.addrSpace;
     if (addrSpace == 1) {

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/NvidiaPatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/NvidiaPatternProtonGPUOpToLLVM.cpp
@@ -40,8 +40,8 @@ struct CircularStoreOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
 
-    auto dataPack =
-        lowerCircularStoreOpHelper(op, adaptor.getSegment(), rewriter);
+    auto dataPack = lowerCircularStoreOpHelper(
+        op, adaptor.getSegment(), adaptor.getPredicate(), rewriter);
 
     uint32_t addrSpace = dataPack.addrSpace;
     if (addrSpace == 1) {

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/Utility.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/Utility.cpp
@@ -67,6 +67,7 @@ namespace proton::gpu {
 
 CircularStoreDataPack
 lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
+                           Value predicate,
                            ConversionPatternRewriter &rewriter) {
   auto loc = op.getLoc();
   auto mod = op.getOperation()->getParentOfType<ModuleOp>();
@@ -135,12 +136,13 @@ lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
   Value isWarpMaster =
       b.icmp_eq(b.urem(curThreadId, b.i32_val(warpSize)), b.i32_val(0));
   Value isWriter;
+  Value shouldAdvance;
 
-  Value idxToStore = newIdx;
   auto granularity = segmentType.getGranularity();
   if (selectedIds.empty()) {
     if (granularity == proton::gpu::Granularity::WARP) {
       isWriter = isWarpMaster;
+      shouldAdvance = b.true_val();
     } else {
       llvm::report_fatal_error(
           "segment address specialization not implemented yet");
@@ -148,9 +150,15 @@ lowerCircularStoreOpHelper(CircularStoreOp op, Value segmentStruct,
   } else {
     Value isCurWarpEnabled = b.icmp_ne(segmentBase, b.i32_val(-1));
     isWriter = b.and_(isCurWarpEnabled, isWarpMaster);
-    idxToStore = b.select(isCurWarpEnabled, newIdx, curIdx);
+    shouldAdvance = isCurWarpEnabled;
   }
 
+  if (Value userPredicate = predicate) {
+    isWriter = b.and_(isWriter, userPredicate);
+    shouldAdvance = b.and_(shouldAdvance, userPredicate);
+  }
+
+  Value idxToStore = b.select(shouldAdvance, newIdx, curIdx);
   b.store(idxToStore, indexPtr);
 
   uint32_t addrSpace =

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -105,7 +105,8 @@ LogicalResult replaceProtonRecordOp(OpBuilder &builder, FuncOp func,
                                                      clkType, metricType);
           int scopeId = scopeInfo.getOpScopeId(record);
           gpu::CircularStoreOp::create(builder, record.getLoc(), newSegment,
-                                       counter, record.getIsStart(), scopeId);
+                                       counter, record.getIsStart(), scopeId,
+                                       record.getPredicate());
           record.erase();
         });
 
@@ -132,7 +133,8 @@ LogicalResult replaceProtonRecordOp(OpBuilder &builder, FuncOp func,
                                                clkType, metricType);
     int scopeId = scopeInfo.getOpScopeId(record);
     gpu::CircularStoreOp::create(builder, record.getLoc(), segment, counter,
-                                 record.getIsStart(), scopeId);
+                                 record.getIsStart(), scopeId,
+                                 record.getPredicate());
     record.erase();
   });
 

--- a/third_party/proton/Dialect/triton_proton.cc
+++ b/third_party/proton/Dialect/triton_proton.cc
@@ -11,9 +11,11 @@
 #include "mlir/Pass/PassManager.h"
 #include "passes.h"
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
+#include <optional>
 
 namespace py = nanobind;
 using namespace mlir::triton;
@@ -72,13 +74,17 @@ void init_triton_proton(py::module_ &m) {
   });
 
   // Proton operations
-  m.def("create_proton_record",
-        [](TritonOpBuilder &opBuilder, bool isStart,
-           const std::string &name) -> void {
-          auto nameAttr = mlir::StringAttr::get(opBuilder.getContext(),
-                                                llvm::StringRef(name));
-          opBuilder.create<proton::RecordOp>(isStart, nameAttr);
-        });
+  m.def(
+      "create_proton_record",
+      [](TritonOpBuilder &opBuilder, bool isStart, const std::string &name,
+         std::optional<mlir::Value> predicate) -> void {
+        auto nameAttr = mlir::StringAttr::get(opBuilder.getContext(),
+                                              llvm::StringRef(name));
+        opBuilder.create<proton::RecordOp>(isStart, nameAttr,
+                                           predicate.value_or(mlir::Value{}));
+      },
+      py::arg("opBuilder"), py::arg("isStart"), py::arg("name"),
+      py::arg("predicate").none() = py::none());
 
   m.def("add_convert_proton_to_protongpu",
         [](mlir::PassManager &pm, proton::MetricType &metricType,

--- a/third_party/proton/proton/language.py
+++ b/third_party/proton/proton/language.py
@@ -31,33 +31,40 @@ def disable_semantic(semantic_name: str):
     _SEMANTICS.remove(_ALL_SEMANTICS[semantic_name])
 
 
-def record(is_start: tl.constexpr, scope_name: tl.constexpr, semantic):
+@builtin
+def record(is_start: tl.constexpr, scope_name: tl.constexpr, predicate=True, _semantic=None):
     if not flags.instrumentation_on:
         return
-    _check_supported_semantic(semantic)
+    _check_supported_semantic(_semantic)
     is_start = tl._unwrap_if_constexpr(is_start)
     scope_name = tl._unwrap_if_constexpr(scope_name)
-    return tl.tensor(triton_proton.create_proton_record(semantic.builder, is_start, scope_name), tl.void)
+    predicate = tl._unwrap_if_constexpr(predicate)
+    if predicate is False:
+        return
+    predicate_handle = None if predicate is True else predicate.handle
+    handle = triton_proton.create_proton_record(_semantic.builder, is_start, scope_name, predicate_handle)
+    return tl.tensor(handle, tl.void)
 
 
 @builtin
-def enter_scope(name: tl.constexpr, _semantic=None):
-    record(is_start=True, scope_name=name, semantic=_semantic)
+def enter_scope(name: tl.constexpr, predicate=True, _semantic=None):
+    record(is_start=True, scope_name=name, predicate=predicate, _semantic=_semantic)
 
 
 @builtin
-def exit_scope(name: tl.constexpr, _semantic=None):
-    record(is_start=False, scope_name=name, semantic=_semantic)
+def exit_scope(name: tl.constexpr, predicate=True, _semantic=None):
+    record(is_start=False, scope_name=name, predicate=predicate, _semantic=_semantic)
 
 
 class scope:
 
-    def __init__(self, name: str, _semantic=None):
+    def __init__(self, name: str, predicate=True, _semantic=None):
         self.name = name
+        self.predicate = predicate
         self.semantic = _semantic
 
     def __enter__(self):
-        enter_scope(self.name, _semantic=self.semantic)
+        enter_scope(self.name, predicate=self.predicate, _semantic=self.semantic)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        exit_scope(self.name, _semantic=self.semantic)
+        exit_scope(self.name, predicate=self.predicate, _semantic=self.semantic)

--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -225,6 +225,42 @@ def test_record(method, fresh_knobs, tmp_path: pathlib.Path):
     assert "line: " in loc_line and "line: 0" not in loc_line
 
 
+def test_record_predicate_ir(fresh_knobs, tmp_path: pathlib.Path):
+    fresh_knobs.compilation.disable_line_info = False
+
+    @triton.jit
+    def add_kernel(x_ptr, y_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(axis=0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        pred = tl.program_id(axis=0) == 0
+        pl.record(True, "record_dynamic", predicate=pred)
+        pl.record(False, "record_dynamic", predicate=pred)
+        pl.enter_scope("emit_dynamic", predicate=pred)
+        pl.exit_scope("emit_dynamic", predicate=pred)
+        pl.enter_scope("compile_time_false", predicate=False)
+        pl.exit_scope("compile_time_false", predicate=False)
+        output = tl.load(x_ptr + offsets, mask=mask) + tl.load(y_ptr + offsets, mask=mask)
+        tl.store(output_ptr + offsets, output, mask=mask)
+
+    size = 256
+    x = torch.rand(size, device="cuda")
+    y = torch.rand(size, device="cuda")
+    output = torch.empty_like(x)
+    temp_file = tmp_path / "test_record_predicate_ir.hatchet"
+
+    proton.start(str(temp_file.with_suffix("")), backend="instrumentation")
+    pgm = add_kernel[(1, )](x, y, output, size, BLOCK_SIZE=1024, num_warps=4)
+    proton.finalize()
+
+    ttir = pgm.asm["ttir"]
+    assert "proton.record start \"record_dynamic\" if %" in ttir
+    assert "proton.record end \"record_dynamic\" if %" in ttir
+    assert "proton.record start \"emit_dynamic\" if %" in ttir
+    assert "proton.record end \"emit_dynamic\" if %" in ttir
+    assert "compile_time_false" not in ttir
+    assert "scf.if" not in ttir
+
+
 def test_select_ids(tmp_path: pathlib.Path):
     from contextlib import contextmanager
 


### PR DESCRIPTION
Summary:
Persistent warp-specialized kernels can produce different numbers of profiling events on each task warp. Once per-warp circular buffers wrap, their retained tails no longer describe the same logical tile, so comparing producer and consumer timelines becomes misleading.

Wrapping record pairs in a dynamic `scf.if` would change the control-flow structure of warp-specialized regions. A native record predicate keeps profiling instrumentation from perturbing that high-level CFG and allows each backend to use its normal predicated or masked-store lowering.

- Extend record, enter_scope, exit_scope, and scope with a predicate argument that defaults to true. Preserve existing IR when the predicate is omitted or constant true, and elide records guarded by constant false.
- Add an optional scalar i1 predicate to proton.record and proton_gpu.circular_store, including builders, verification, parsing, and dialect conversion support.
- Propagate dynamic predicates through the Proton-to-ProtonGPU pipeline and both NVIDIA and AMD LLVM lowerings.
- Gate both record emission and circular-buffer index advancement. A false predicate writes no record and consumes no buffer slot, keeping selected events aligned across task warps.
- Keep initialization, synchronization, save/restore, and finalization unconditional. Lower dynamic predicates without introducing high-level control flow by combining them with existing writer-validity checks and selecting the next buffer index.
- Add IR coverage for predicated records and target lowering, plus an instrumentation regression test for dynamic predicates and compile-time false elimination.

This is a Proton recording primitive rather than target-specific profiling logic. Consumers such as kernel profilers can use it to capture matching logical work across independently executing warps.


Test Plan:
CUDA_VISIBLE_DEVICES=4 python -m pytest \
    third_party/proton/test/test_instrumentation.py::test_record_predicate_ir -q

Reviewed By: CRobeck

Differential Revision: D118180126

Pulled By: htyu


