### PR TITLE
[TLX] Fix Blackwell GEMM split-K wrong results when the tile grid ove…

### DIFF
--- a/python/test/unit/tlx_ops/test_mm.py
+++ b/python/test/unit/tlx_ops/test_mm.py
@@ -1,19 +1,7 @@
 """L1 correctness for ``tlx.ops.mm``.
 
-TODO(split-K remainder tile): ``[1000, 1000, 1024]`` and ``[64, 4096, 4096]``
-are commented out of SHAPES below because they FAIL. Re-enable them with the
-fix -- they are the regression test for it.
-
-Split-K gives wrong results when M is not a multiple of BLOCK_SIZE_M: partials
-go into a (SPLIT_K * M, N) workspace that the reduction reads at fixed M
-strides, and the masked edge tile breaks that correspondence.
-
-Measured at M=1000, N=1000, K=1024, BLOCK_SIZE_M=256 (relative L2 vs torch):
-SPLIT_K=1 -> 0.0 exact, =2 -> 1.04e-1, =4 -> 1.30e-1.
-
-Pre-existing, not a promotion artifact: reproduces as
-`blackwell_gemm_ws.matmul(a, b, config=get_heuristic_config(...))`. Reachable in
-production -- the heuristic picks SPLIT_K=4 for both shapes. Not yet filed.
+Black-box: everything here goes through the public ``tlx.ops.mm``. The split-K
+workspace layout is covered white-box in ``test_mm_splitk.py``.
 """
 
 import time
@@ -49,14 +37,12 @@ SHAPES = [
     # M not a multiple of any plausible block size -- masked edge tile.
     [136, 256, 128, True, True],
     # Non-power-of-two in M and N together.
-    # TODO(split-K remainder tile): fails, see module docstring.
-    # [1000, 1000, 1024, True, True],
+    [1000, 1000, 1024, True, True],
     # K-heavy: few output tiles, long reduction. Split-K territory, the one
     # path that runs a second kernel.
     [256, 256, 16384, True, True],
     # Tall-skinny: most of the grid idle.
-    # TODO(split-K remainder tile): fails, see module docstring.
-    # [64, 4096, 4096, True, True],
+    [64, 4096, 4096, True, True],
 ]
 
 REL_PRECISION = {torch.float16: 1e-3, torch.bfloat16: 8e-3}

--- a/python/test/unit/tlx_ops/test_mm_splitk.py
+++ b/python/test/unit/tlx_ops/test_mm_splitk.py
@@ -1,0 +1,204 @@
+"""Split-K workspace layout for ``tlx.ops.mm`` (sm100).
+
+White-box: the public API cannot pin ``SPLIT_K``/``NUM_CTAS``, and the invariant
+is host arithmetic whose only symptom is silently wrong rows.
+
+The bug: workspace was ``(SPLIT_K * M, N)``, giving split ``s`` the rows
+``[s*M, (s+1)*M)``, but the epilogue stores whole ``BLOCK_SIZE_M`` tiles on a
+``padded_num_pid_m`` grid. The overhang is interior to the descriptor, so TMA
+does not drop it and it overwrites split ``s+1``'s partials.
+
+Two triggers: ``M % BLOCK_SIZE_M != 0``, or ``NUM_CTAS=2`` with an odd tile
+count, which pads by a whole tile row even when ``M % BLOCK_SIZE_M == 0``.
+
+The layout tests need no GPU and no compile.
+"""
+
+import contextlib
+import time
+
+import pytest
+import torch
+import triton
+
+from triton._internal_testing import is_blackwell
+from triton.tlx.ops.kernels.mm import sm100
+
+torch.manual_seed(0)
+
+ARCH = "sm100"
+MAX_SECONDS_PER_CASE = 60
+REL_PRECISION = {torch.float16: 1e-3, torch.bfloat16: 8e-3}
+
+# ``(M, BLOCK_SIZE_M, NUM_CTAS, expected_overhang_rows)``. The overhang is what
+# the last tile writes past M; it is what used to land on the next split.
+GEOMETRIES = [
+    # No overhang: M is a whole number of tiles and the count already divides
+    # NUM_CTAS. These must stay at zero -- they are the canary for the fix
+    # over-padding and wasting memory on the common case.
+    (1024, 256, 1, 0),
+    (1024, 256, 2, 0),
+    (256, 256, 1, 0),
+    # M % BLOCK_SIZE_M != 0.
+    (1000, 256, 1, 24),
+    (136, 128, 1, 120),
+    (64, 128, 1, 64),
+    # M % BLOCK_SIZE_M == 0, but an odd tile count padded up to NUM_CTAS=2.
+    (384, 128, 2, 128),
+    (768, 256, 2, 256),
+]
+
+SPLIT_KS = [1, 2, 3, 4, 8]
+
+
+def _geometry(M, BLOCK_SIZE_M, NUM_CTAS):
+    num_pid_m = sm100._padded_num_pid_m(M, BLOCK_SIZE_M, NUM_CTAS)
+    rows = sm100._workspace_rows_per_split(M, BLOCK_SIZE_M, NUM_CTAS)
+    # Exclusive upper bound on rows the epilogue stores within one split.
+    written = num_pid_m * BLOCK_SIZE_M
+    return num_pid_m, rows, written
+
+
+@pytest.mark.parametrize("M, BLOCK_SIZE_M, NUM_CTAS, overhang", GEOMETRIES)
+def test_geometry_is_what_the_case_claims(M, BLOCK_SIZE_M, NUM_CTAS, overhang):
+    """Pin the overhang, so a config change cannot quietly defang these cases."""
+    _, _, written = _geometry(M, BLOCK_SIZE_M, NUM_CTAS)
+    assert written - M == overhang
+
+
+@pytest.mark.parametrize("M, BLOCK_SIZE_M, NUM_CTAS, overhang", GEOMETRIES)
+def test_rows_per_split_covers_the_tile_grid(M, BLOCK_SIZE_M, NUM_CTAS, overhang):
+    """A split's region must hold every row the epilogue can store into it."""
+    _, rows, written = _geometry(M, BLOCK_SIZE_M, NUM_CTAS)
+    assert rows >= written, (f"split region is {rows} rows but the epilogue writes up to {written}; "
+                             f"the last tile overhangs by {written - rows} rows into the next split")
+    # And the reduction reads M rows back out of that region.
+    assert rows >= M
+
+
+@pytest.mark.parametrize("SPLIT_K", SPLIT_KS)
+@pytest.mark.parametrize("M, BLOCK_SIZE_M, NUM_CTAS, overhang", GEOMETRIES)
+def test_splits_do_not_alias(M, BLOCK_SIZE_M, NUM_CTAS, overhang, SPLIT_K):
+    """No split may write into the next split's region."""
+    _, rows, written = _geometry(M, BLOCK_SIZE_M, NUM_CTAS)
+    for s in range(SPLIT_K - 1):
+        end_of_writes = s * rows + written
+        start_of_next = (s + 1) * rows
+        assert end_of_writes <= start_of_next, (f"split {s} writes through row {end_of_writes}, "
+                                                f"but split {s + 1} starts at row {start_of_next}")
+
+
+@pytest.mark.parametrize("SPLIT_K", SPLIT_KS)
+@pytest.mark.parametrize("M, BLOCK_SIZE_M, NUM_CTAS, overhang", GEOMETRIES)
+def test_allocation_covers_every_written_row(M, BLOCK_SIZE_M, NUM_CTAS, overhang, SPLIT_K):
+    """The workspace must be at least as tall as the highest row written."""
+    _, rows, written = _geometry(M, BLOCK_SIZE_M, NUM_CTAS)
+    allocated = SPLIT_K * rows
+    highest = (SPLIT_K - 1) * rows + written
+    assert allocated >= highest
+
+
+@pytest.mark.parametrize("M, N, K", [
+    (1000, 1000, 1024),
+    (64, 4096, 4096),
+    (256, 256, 16384),
+    (136, 256, 128),
+])
+def test_heuristic_configs_have_a_sound_workspace(M, N, K):
+    """Tie the invariant to configs the heuristic actually emits in production."""
+    for num_sms in (148, 132):  # B200 and H100-class SM counts
+        cfg = sm100.get_heuristic_config(M, N, K, num_sms)
+        if cfg is None or cfg.get("SPLIT_K", 1) == 1:
+            continue
+        _, rows, written = _geometry(M, cfg["BLOCK_SIZE_M"], cfg.get("NUM_CTAS", 1))
+        assert rows >= written, f"heuristic config for {M}x{N}x{K} on {num_sms} SMs has an aliasing workspace: {cfg}"
+
+
+# --------------------------------------------------------------------------
+# GPU: the layout tests above check the host arithmetic. This checks that the
+# device actually agrees with it, which no amount of host-side reasoning can.
+# --------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _pinned_config(overrides):
+    """Force ``space="heuristic"`` to compile exactly one config.
+
+    Overrides are applied on top of the shape's own heuristic config, so every
+    required key is present and only the axes under test move.
+    """
+    original = sm100.heuristic_config
+
+    def one_config(M, N, K):
+        cfg = sm100.get_heuristic_config(M, N, K, sm100._get_num_sms())
+        assert cfg is not None, f"no heuristic config for {M}x{N}x{K}"
+        cfg = dict(cfg)
+        cfg.pop("ctas_per_cga", None)
+        pre_hook = cfg.pop("pre_hook", None) or sm100.matmul_tma_set_block_size_hook
+        cfg.update(overrides)
+        num_ctas = cfg.get("NUM_CTAS", 1)
+        return [
+            triton.Config(cfg, num_warps=4, num_stages=1, pre_hook=pre_hook,
+                          ctas_per_cga=(num_ctas, 1, 1) if num_ctas > 1 else None)
+        ]
+
+    sm100.heuristic_config = one_config
+    sm100._tuned.cache_clear()
+    try:
+        yield
+    finally:
+        sm100.heuristic_config = original
+        sm100._tuned.cache_clear()
+
+
+# ``(M, N, K, NUM_CTAS)``. Each runs across SPLIT_KS_GPU and must agree.
+#
+# TODO(NUM_CTAS=2 on narrow tiles): (384, 512, 8192, 2) would exercise NUM_CTAS
+# padding end-to-end, but is wrong for an unrelated reason. B200, heuristic
+# config (BM=128, BN=64, MMA_GROUPS=2), assert_close atol=0.412 rtol=1e-3:
+# NUM_CTAS=1 passes at SPLIT_K=1 and 4; NUM_CTAS=2 gives 32670/196608 mismatched
+# (16.6%), max abs diff 583.0, at SPLIT_K=1 and 4 alike. Failing at SPLIT_K=1
+# rules out the workspace bug, and it reproduces with the fix reverted.
+# Reachable: (NUM_CTAS=2, NUM_MMA_GROUPS=2) has 88 survivors of
+# preprocess_configs here. Not 2-CTA in general -- 2cta_2group (BN=256) passes.
+# Not filed. NUM_CTAS padding is still covered by the layout tests above.
+GPU_SHAPES = [
+    # M % BLOCK_SIZE_M != 0 -- the reported bug (BLOCK_SIZE_M=256 -> 24 rows over).
+    (1000, 1000, 1024, 1),
+    # Whole region overhangs: one tile of 128 rows holds only 64 real rows.
+    (64, 4096, 4096, 1),
+]
+SPLIT_KS_GPU = [1, 4]
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="tlx.ops.mm is sm100-only today")
+@pytest.mark.parametrize("SPLIT_K", SPLIT_KS_GPU)
+@pytest.mark.parametrize("M, N, K, NUM_CTAS", GPU_SHAPES)
+def test_output_is_independent_of_split_k(M, N, K, NUM_CTAS, SPLIT_K):
+    """Splitting the reduction must not change the result."""
+    from triton.tlx.ops import mm as tlx_mm
+
+    dtype = torch.float16
+    a = torch.randn((M, K), device="cuda", dtype=dtype)
+    b = torch.randn((K, N), device="cuda", dtype=dtype)
+
+    with _pinned_config({"SPLIT_K": SPLIT_K, "NUM_CTAS": NUM_CTAS}):
+        torch.cuda.synchronize()
+        started = time.perf_counter()
+        out = tlx_mm(a, b, arch=ARCH, space="heuristic")
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - started
+
+        # The autotuner widens back to the full space when pruning empties a
+        # reduced one, which would silently run a different config than the one
+        # under test. Confirm the pin survived.
+        chosen = sm100._tuned("heuristic", (M, N, K)).best_config.kwargs
+        assert chosen["SPLIT_K"] == SPLIT_K and chosen["NUM_CTAS"] == NUM_CTAS, \
+            f"pin was defeated by config pruning; ran {chosen}"
+
+    assert elapsed < MAX_SECONDS_PER_CASE, (f"mm({M}x{N}x{K}, SPLIT_K={SPLIT_K}) took {elapsed:.1f}s, "
+                                            f"over the {MAX_SECONDS_PER_CASE}s budget")
+
+    ref = torch.matmul(a, b)
+    precision = REL_PRECISION[dtype]
+    torch.testing.assert_close(out, ref, atol=precision * ref.abs().max().item(), rtol=precision)

--- a/third_party/tlx/ops/kernels/mm/sm100.py
+++ b/third_party/tlx/ops/kernels/mm/sm100.py
@@ -403,6 +403,14 @@ def get_cuda_autotune_config():
     ]
 
 
+def _padded_num_pid_m(M, BLOCK_SIZE_M, NUM_CTAS):
+    return -((-M) // BLOCK_SIZE_M // NUM_CTAS) * NUM_CTAS
+
+
+def _workspace_rows_per_split(M, BLOCK_SIZE_M, NUM_CTAS):
+    return _padded_num_pid_m(M, BLOCK_SIZE_M, NUM_CTAS) * BLOCK_SIZE_M
+
+
 def matmul_tma_set_block_size_hook(nargs):
     BLOCK_M = nargs["BLOCK_SIZE_M"]
     BLOCK_N = nargs["BLOCK_SIZE_N"]
@@ -429,7 +437,8 @@ def matmul_tma_set_block_size_hook(nargs):
     if SPLIT_K > 1:
         M = nargs["M"]
         N = nargs["N"]
-        workspace = torch.empty((SPLIT_K * M, N), device=nargs["c_desc"].base.device, dtype=nargs["c_desc"].base.dtype)
+        rows = SPLIT_K * _workspace_rows_per_split(M, BLOCK_M, NUM_CTAS)
+        workspace = torch.empty((rows, N), device=nargs["c_desc"].base.device, dtype=nargs["c_desc"].base.dtype)
         nargs["workspace_desc"].base = workspace
         nargs["workspace_desc"].shape = list(workspace.shape)
     else:
@@ -687,7 +696,6 @@ def _process_tile_epilogue_inner(
     num_pid_m,
     num_mn_tiles,
     GROUP_SIZE_M,
-    M,
     BLOCK_SIZE_M,
     BLOCK_SIZE_N,
     EPILOGUE_SUBTILE,
@@ -715,7 +723,8 @@ def _process_tile_epilogue_inner(
     if SPLIT_K > 1:
         split_id = tile_id // num_mn_tiles
         out_desc = workspace_desc
-        row_base = split_id * M
+        # Tile-grid stride, not M; mirrors _workspace_rows_per_split.
+        row_base = split_id * num_pid_m * BLOCK_SIZE_M
     else:
         out_desc = c_desc
         row_base = 0
@@ -1105,11 +1114,14 @@ def _reduce_k_kernel(
     c_ptr,
     M,
     N,
+    ROWS_PER_SPLIT,
     SPLIT_K: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     OUTPUT_DTYPE: tl.constexpr,
 ):
+    # Row stride between splits: padded tile-grid height, not M. Callers derive
+    # it from the allocation.
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -1119,7 +1131,7 @@ def _reduce_k_kernel(
 
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for s in range(SPLIT_K):
-        ws_offs = base_offs + s * M * N
+        ws_offs = base_offs + s * ROWS_PER_SPLIT * N
         partial = tl.load(workspace_ptr + ws_offs, mask=mask, other=0.0)
         acc += partial.to(tl.float32)
 
@@ -1155,6 +1167,7 @@ def reduce_post_hook(nargs, exception=None):
             c,
             M,
             N,
+            workspace.shape[0] // split_k,
             SPLIT_K=split_k,
             BLOCK_SIZE_M=32,
             BLOCK_SIZE_N=32,
@@ -1308,7 +1321,6 @@ def matmul_kernel_tma_ws_blackwell(
                         num_pid_m=num_pid_m,
                         num_mn_tiles=num_mn_tiles,
                         GROUP_SIZE_M=GROUP_SIZE_M,
-                        M=M,
                         BLOCK_SIZE_M=BLOCK_SIZE_M,
                         BLOCK_SIZE_N=BLOCK_SIZE_N,
                         EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
@@ -1599,10 +1611,8 @@ def mm(a, b, *, space="full"):
     workspace_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
 
     def grid(META):
-        num_ctas = META["NUM_CTAS"]
-        num_pid_m = triton.cdiv(M, META["BLOCK_SIZE_M"])
+        num_pid_m = _padded_num_pid_m(M, META["BLOCK_SIZE_M"], META["NUM_CTAS"])
         num_pid_n = triton.cdiv(N, META["BLOCK_SIZE_N"])
-        num_pid_m = (num_pid_m + num_ctas - 1) // num_ctas * num_ctas
         return (num_pid_m * num_pid_n * META["SPLIT_K"], )
 
     kernel = _tuned(space, (M, N, K) if space == "heuristic" else None)
@@ -1628,6 +1638,7 @@ def mm(a, b, *, space="full"):
             c,
             M,
             N,
+            workspace_desc.base.shape[0] // split_k,
             SPLIT_K=split_k,
             BLOCK_SIZE_M=32,
             BLOCK_SIZE_N=32,

--- a/third_party/tlx/tutorials/blackwell_gemm_ws.py
+++ b/third_party/tlx/tutorials/blackwell_gemm_ws.py
@@ -425,7 +425,8 @@ def matmul_tma_set_block_size_hook(nargs):
     if SPLIT_K > 1:
         M = nargs["M"]
         N = nargs["N"]
-        workspace = torch.empty((SPLIT_K * M, N), device=nargs["c_desc"].base.device, dtype=nargs["c_desc"].base.dtype)
+        rows = SPLIT_K * (-((-M) // BLOCK_M // NUM_CTAS) * NUM_CTAS * BLOCK_M)
+        workspace = torch.empty((rows, N), device=nargs["c_desc"].base.device, dtype=nargs["c_desc"].base.dtype)
         nargs["workspace_desc"].base = workspace
         nargs["workspace_desc"].shape = list(workspace.shape)
     else:
@@ -683,7 +684,6 @@ def _process_tile_epilogue_inner(
     num_pid_m,
     num_mn_tiles,
     GROUP_SIZE_M,
-    M,
     BLOCK_SIZE_M,
     BLOCK_SIZE_N,
     EPILOGUE_SUBTILE,
@@ -711,7 +711,8 @@ def _process_tile_epilogue_inner(
     if SPLIT_K > 1:
         split_id = tile_id // num_mn_tiles
         out_desc = workspace_desc
-        row_base = split_id * M
+        # Tile-grid stride, not M; mirrors the workspace row count.
+        row_base = split_id * num_pid_m * BLOCK_SIZE_M
     else:
         out_desc = c_desc
         row_base = 0
@@ -1101,11 +1102,14 @@ def _reduce_k_kernel(
     c_ptr,
     M,
     N,
+    ROWS_PER_SPLIT,
     SPLIT_K: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     OUTPUT_DTYPE: tl.constexpr,
 ):
+    # Row stride between splits: padded tile-grid height, not M. Callers derive
+    # it from the allocation.
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -1115,7 +1119,7 @@ def _reduce_k_kernel(
 
     acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for s in range(SPLIT_K):
-        ws_offs = base_offs + s * M * N
+        ws_offs = base_offs + s * ROWS_PER_SPLIT * N
         partial = tl.load(workspace_ptr + ws_offs, mask=mask, other=0.0)
         acc += partial.to(tl.float32)
 
@@ -1151,6 +1155,7 @@ def reduce_post_hook(nargs, exception=None):
             c,
             M,
             N,
+            workspace.shape[0] // split_k,
             SPLIT_K=split_k,
             BLOCK_SIZE_M=32,
             BLOCK_SIZE_N=32,
@@ -1310,7 +1315,6 @@ def matmul_kernel_tma_ws_blackwell(
                         num_pid_m=num_pid_m,
                         num_mn_tiles=num_mn_tiles,
                         GROUP_SIZE_M=GROUP_SIZE_M,
-                        M=M,
                         BLOCK_SIZE_M=BLOCK_SIZE_M,
                         BLOCK_SIZE_N=BLOCK_SIZE_N,
                         EPILOGUE_SUBTILE=EPILOGUE_SUBTILE,
@@ -1542,7 +1546,9 @@ def matmul(a, b, config=None):
         pre_hook = config.pop("pre_hook", None)
         split_k = config.get("SPLIT_K", 1)
         if split_k > 1:
-            workspace = torch.empty((split_k * M, N), device=a.device, dtype=a.dtype)
+            bm, nc = config["BLOCK_SIZE_M"], config.get("NUM_CTAS", 1)
+            rows = split_k * (-((-M) // bm // nc) * nc * bm)
+            workspace = torch.empty((rows, N), device=a.device, dtype=a.dtype)
             workspace_desc = TensorDescriptor(workspace, workspace.shape, workspace.stride(), dummy_block)
         else:
             workspace_desc = TensorDescriptor(c, c.shape, c.stride(), dummy_block)
@@ -1592,6 +1598,7 @@ def matmul(a, b, config=None):
                 c,
                 M,
                 N,
+                workspace_desc.base.shape[0] // split_k,
                 SPLIT_K=split_k,
                 BLOCK_SIZE_M=32,
                 BLOCK_SIZE_N=32,
@@ -1638,6 +1645,7 @@ def matmul(a, b, config=None):
                 c,
                 M,
                 N,
+                workspace.shape[0] // split_k,
                 SPLIT_K=split_k,
                 BLOCK_SIZE_M=32,
                 BLOCK_SIZE_N=32,


### PR DESCRIPTION
Fix split-K accuracy error by sizing each split's workspace region to padded tile grid instead of M.

`pytest python/test/unit/tlx_ops/ `