### PR TITLE
[AMD][GFX950] Unify the backend behavior of global/buffer_load_to_local

### DIFF
--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -5353,12 +5353,18 @@ def _async_load_1d_kernel(
     BLOCK_SIZE: tl.constexpr,
     OTHER_VAL: tl.constexpr,
     HAS_WRITE_MASK: tl.constexpr,
+    INITIALIZE_LOCAL: tl.constexpr,
 ):
     """Load via async_load (pointer-tensor path) and write result to output."""
     pid = tl.program_id(0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offs < n_elements
     buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
+
+    if INITIALIZE_LOCAL:
+        val = tl.zeros((BLOCK_SIZE, ), tl.float32)
+        tlx.local_store(tlx.local_view(buf, 0), val)
+
     tok = tlx.async_load(src_ptr + offs, tlx.local_view(buf, 0), mask=mask, other=OTHER_VAL)
     tlx.async_load_commit_group([tok])
     tlx.async_load_wait_group(0)
@@ -5375,12 +5381,18 @@ def _buffer_load_to_local_1d_kernel(
     BLOCK_SIZE: tl.constexpr,
     OTHER_VAL: tl.constexpr,
     HAS_WRITE_MASK: tl.constexpr,
+    INITIALIZE_LOCAL: tl.constexpr,
 ):
     """Load via buffer_load_to_local (scalar-ptr + offsets path) and write result to output."""
     pid = tl.program_id(0)
     offs = (pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)).to(tl.int32)
     mask = offs < n_elements
     buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
+
+    if INITIALIZE_LOCAL:
+        val = tl.zeros((BLOCK_SIZE, ), tl.float32)
+        tlx.local_store(tlx.local_view(buf, 0), val)
+
     tlx.buffer_load_to_local(tlx.local_view(buf, 0), src_ptr, offs, mask=mask, other=OTHER_VAL)
     tlx.async_load_commit_group()
     tlx.async_load_wait_group(0)
@@ -5389,7 +5401,7 @@ def _buffer_load_to_local_1d_kernel(
     tl.store(out_ptr + offs, val, mask=write_mask)
 
 
-def _run_load_to_local_1d(device, kernel_fn, size, n_valid, other_val, block_size=256, has_write_mask=True):
+def _run_load_to_local_1d(device, kernel_fn, size, n_valid, other_val, block_size=256, has_write_mask=True, init_local=False):
     """Helper: run a 1D load-to-local kernel and return the output tensor.
 
     Uses float32 with block_size=256 and num_warps=4 so each thread handles
@@ -5406,6 +5418,7 @@ def _run_load_to_local_1d(device, kernel_fn, size, n_valid, other_val, block_siz
         BLOCK_SIZE=block_size,
         OTHER_VAL=other_val,
         HAS_WRITE_MASK=has_write_mask,
+        INITIALIZE_LOCAL=init_local,
         num_warps=4,
         num_stages=1,
         
@@ -5413,8 +5426,13 @@ def _run_load_to_local_1d(device, kernel_fn, size, n_valid, other_val, block_siz
     return x, out
 
 
+
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_buffer_load_to_local_no_mask(device):
+def test_buffer_load_to_local_no_mask(device, monkeypatch):
+    # set env var AMDGCN_USE_BUFFER_OPS=0 to ensure async_load to be lowered to global_load
+    # so can compare behaviors of global_load and buffer_load
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", 0)
+
     """buffer_load_to_local without mask matches async_load without mask."""
     size = 256
     torch.manual_seed(42)
@@ -5426,26 +5444,34 @@ def test_buffer_load_to_local_no_mask(device):
     
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_buffer_load_to_local_masked_other_none(device):
+def test_buffer_load_to_local_masked_other_none(device, monkeypatch):
+    # set env var AMDGCN_USE_BUFFER_OPS=0 to ensure async_load to be lowered to global_load
+    # so can compare behaviors of global_load and buffer_load
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", 0)
+
     """buffer_load_to_local with mask and other=None zero-fills masked elements, matching async_load."""
     size = 256
     n_valid = 128
     torch.manual_seed(42)
-    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, None, has_write_mask=False)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, None, has_write_mask=False, init_local=True)
     torch.manual_seed(42)
-    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, None, has_write_mask=False)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, None, has_write_mask=False, init_local=True)
     # Valid region must match the source data.
     torch.testing.assert_close(out_a[:n_valid], x_a[:n_valid])
     torch.testing.assert_close(out_b[:n_valid], x_b[:n_valid])
     # Masked region must be nan in both paths.
-    assert torch.all(torch.isnan(out_a[n_valid:]))
-    assert torch.all(torch.isnan(out_b[n_valid:]))
+    assert torch.all(out_a[n_valid:] == 0)
+    assert torch.all(out_b[n_valid:] == 0)
     # Overall outputs must be identical.
     torch.testing.assert_close(out_a, out_b, equal_nan=True)
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_buffer_load_to_local_masked_other_zero(device):
+def test_buffer_load_to_local_masked_other_zero(device, monkeypatch):
+    # set env var AMDGCN_USE_BUFFER_OPS=0 to ensure async_load to be lowered to global_load
+    # so can compare behaviors of global_load and buffer_load
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", 0)
+
     """buffer_load_to_local with mask and other=0.0 zero-fills masked elements, matching async_load."""
     size = 256
     n_valid = 128
@@ -5462,7 +5488,11 @@ def test_buffer_load_to_local_masked_other_zero(device):
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 @pytest.mark.parametrize("n_valid", [128, 200], ids=["half", "near_full"])
-def test_buffer_load_to_local_masked_other_none_boundary(device, n_valid):
+def test_buffer_load_to_local_masked_other_none_boundary(device, n_valid, monkeypatch):
+    # set env var AMDGCN_USE_BUFFER_OPS=0 to ensure async_load to be lowered to global_load
+    # so can compare behaviors of global_load and buffer_load
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", 0)
+
     """buffer_load_to_local with other=None at various mask boundaries."""
     size = 256
     torch.manual_seed(42)
@@ -5475,7 +5505,11 @@ def test_buffer_load_to_local_masked_other_none_boundary(device, n_valid):
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_buffer_load_to_local_multi_cta_masked_other_none(device):
+def test_buffer_load_to_local_multi_cta_masked_other_none(device, monkeypatch):
+    # set env var AMDGCN_USE_BUFFER_OPS=0 to ensure async_load to be lowered to global_load
+    # so can compare behaviors of global_load and buffer_load
+    monkeypatch.setenv("AMDGCN_USE_BUFFER_OPS", 0)
+
     """buffer_load_to_local with mask, other=None, and multiple CTAs (partial last tile)."""
     # Two CTAs: first full (256 elements), second partial (128 valid out of 256).
     size = 512

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -5333,3 +5333,159 @@ def test_amd_sched_barrier_compiles_gfx950():
         constexprs={"BLOCK": 64},
     )
     assert "llvm.amdgcn.sched.barrier" in compiled.asm["llir"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: buffer_load_to_local vs async_load equivalence.
+#
+# The commit 02a6a3ed4a fixed how buffer_load_to_local handles other=None when
+# a mask is present: masked-out elements leave unchanged, matching the
+# behavior global_load_to_local.  These tests exercise that fix by comparing 
+# the two load paths across several mask/other combinations.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _async_load_1d_kernel(
+    src_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    OTHER_VAL: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+):
+    """Load via async_load (pointer-tensor path) and write result to output."""
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
+    tok = tlx.async_load(src_ptr + offs, tlx.local_view(buf, 0), mask=mask, other=OTHER_VAL)
+    tlx.async_load_commit_group([tok])
+    tlx.async_load_wait_group(0)
+    val = tlx.local_load(tlx.local_view(buf, 0))
+    write_mask = offs < n_elements if HAS_WRITE_MASK else None
+    tl.store(out_ptr + offs, val, mask=write_mask)
+
+
+@triton.jit
+def _buffer_load_to_local_1d_kernel(
+    src_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    OTHER_VAL: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+):
+    """Load via buffer_load_to_local (scalar-ptr + offsets path) and write result to output."""
+    pid = tl.program_id(0)
+    offs = (pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)).to(tl.int32)
+    mask = offs < n_elements
+    buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
+    tlx.buffer_load_to_local(tlx.local_view(buf, 0), src_ptr, offs, mask=mask, other=OTHER_VAL)
+    tlx.async_load_commit_group()
+    tlx.async_load_wait_group(0)
+    val = tlx.local_load(tlx.local_view(buf, 0))
+    write_mask = offs < n_elements if HAS_WRITE_MASK else None
+    tl.store(out_ptr + offs, val, mask=write_mask)
+
+
+def _run_load_to_local_1d(device, kernel_fn, size, n_valid, other_val, block_size=256, has_write_mask=True):
+    """Helper: run a 1D load-to-local kernel and return the output tensor.
+
+    Uses float32 with block_size=256 and num_warps=4 so each thread handles
+    exactly one 32-bit element.  This gives per-element mask granularity that
+    is compatible with the 32-bit minimum direct-to-LDS width on CDNA4.
+    """
+    x = torch.randn(size, dtype=torch.float32, device=device)
+    out = torch.full((size, ), float("nan"), dtype=torch.float32, device=device)
+    grid = (triton.cdiv(size, block_size), )
+    kernel_fn[grid](
+        x,
+        out,
+        n_valid,
+        BLOCK_SIZE=block_size,
+        OTHER_VAL=other_val,
+        HAS_WRITE_MASK=has_write_mask,
+        num_warps=4,
+        num_stages=1,
+        
+    )
+    return x, out
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_buffer_load_to_local_no_mask(device):
+    """buffer_load_to_local without mask matches async_load without mask."""
+    size = 256
+    torch.manual_seed(42)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, size, None)
+    torch.manual_seed(42)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, size, None)
+    torch.testing.assert_close(out_a, out_b)
+    torch.testing.assert_close(out_a, x_a)
+    
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_buffer_load_to_local_masked_other_none(device):
+    """buffer_load_to_local with mask and other=None zero-fills masked elements, matching async_load."""
+    size = 256
+    n_valid = 128
+    torch.manual_seed(42)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, None, has_write_mask=False)
+    torch.manual_seed(42)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, None, has_write_mask=False)
+    # Valid region must match the source data.
+    torch.testing.assert_close(out_a[:n_valid], x_a[:n_valid])
+    torch.testing.assert_close(out_b[:n_valid], x_b[:n_valid])
+    # Masked region must be nan in both paths.
+    assert torch.all(torch.isnan(out_a[n_valid:]))
+    assert torch.all(torch.isnan(out_b[n_valid:]))
+    # Overall outputs must be identical.
+    torch.testing.assert_close(out_a, out_b, equal_nan=True)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_buffer_load_to_local_masked_other_zero(device):
+    """buffer_load_to_local with mask and other=0.0 zero-fills masked elements, matching async_load."""
+    size = 256
+    n_valid = 128
+    torch.manual_seed(42)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, 0.0, has_write_mask=False)
+    torch.manual_seed(42)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, 0.0, has_write_mask=False)
+    torch.testing.assert_close(out_a[:n_valid], x_a[:n_valid])
+    torch.testing.assert_close(out_b[:n_valid], x_b[:n_valid])
+    torch.testing.assert_close(out_b[n_valid:], torch.zeros(size - n_valid, dtype=torch.float32, device=device))
+    torch.testing.assert_close(out_a[n_valid:], torch.zeros(size - n_valid, dtype=torch.float32, device=device))
+    torch.testing.assert_close(out_a, out_b)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize("n_valid", [128, 200], ids=["half", "near_full"])
+def test_buffer_load_to_local_masked_other_none_boundary(device, n_valid):
+    """buffer_load_to_local with other=None at various mask boundaries."""
+    size = 256
+    torch.manual_seed(42)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, None)
+    torch.manual_seed(42)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, None)
+    torch.testing.assert_close(out_a[:n_valid], x_a[:n_valid])
+    torch.testing.assert_close(out_b[:n_valid], x_b[:n_valid])
+    torch.testing.assert_close(out_a, out_b, equal_nan=True)
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_buffer_load_to_local_multi_cta_masked_other_none(device):
+    """buffer_load_to_local with mask, other=None, and multiple CTAs (partial last tile)."""
+    # Two CTAs: first full (256 elements), second partial (128 valid out of 256).
+    size = 512
+    n_valid = 384  # First CTA fully valid, second CTA half masked.
+    block_size = 256
+    torch.manual_seed(42)
+    x_a, out_a = _run_load_to_local_1d(device, _async_load_1d_kernel, size, n_valid, None, block_size=block_size)
+    torch.manual_seed(42)
+    x_b, out_b = _run_load_to_local_1d(device, _buffer_load_to_local_1d_kernel, size, n_valid, None,
+                                       block_size=block_size)
+    torch.testing.assert_close(out_a[:n_valid], x_a[:n_valid])
+    torch.testing.assert_close(out_b[:n_valid], x_b[:n_valid])
+    torch.testing.assert_close(out_a, out_b, equal_nan=True)

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -5360,11 +5360,9 @@ def _async_load_1d_kernel(
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offs < n_elements
     buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
-
     if INITIALIZE_LOCAL:
         val = tl.zeros((BLOCK_SIZE, ), tl.float32)
         tlx.local_store(tlx.local_view(buf, 0), val)
-
     tok = tlx.async_load(src_ptr + offs, tlx.local_view(buf, 0), mask=mask, other=OTHER_VAL)
     tlx.async_load_commit_group([tok])
     tlx.async_load_wait_group(0)
@@ -5388,11 +5386,9 @@ def _buffer_load_to_local_1d_kernel(
     offs = (pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)).to(tl.int32)
     mask = offs < n_elements
     buf = tlx.local_alloc((BLOCK_SIZE, ), tl.float32, 1)
-
     if INITIALIZE_LOCAL:
         val = tl.zeros((BLOCK_SIZE, ), tl.float32)
         tlx.local_store(tlx.local_view(buf, 0), val)
-
     tlx.buffer_load_to_local(tlx.local_view(buf, 0), src_ptr, offs, mask=mask, other=OTHER_VAL)
     tlx.async_load_commit_group()
     tlx.async_load_wait_group(0)

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -139,14 +139,62 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
-  // COMMON-LABEL: buffer_load_to_local_mask_other
-  tt.func public @buffer_load_to_local_mask_other(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+  // COMMON-LABEL: buffer_load_to_local_mask_other_0
+  tt.func public @buffer_load_to_local_mask_other_0(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
                                 %arg1: !tt.ptr<f32>,
                                 %arg2: tensor<32x32xi32, #blocked>,
                                 %arg3: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
                                 %arg4: i32) {
     // We need the splat to allow the AxisAnalysis to work during lowering
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c31_i32 = arith.constant 31 : i32
+    %1 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x32x!tt.ptr<f32>, #blocked>
+    %29 = arith.addi %arg4, %c31_i32 : i32
+    %30 = arith.divsi %29, %c32_i32 : i32
+    %31 = arith.cmpi sgt, %30, %c0_i32 : i32
+
+    %51 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>>
+    %52 = tt.expand_dims %51 {axis = 1 : i32} : tensor<32xi32, #ttg.slice<{dim = 1, parent = #blocked}>> -> tensor<32x1xi32, #blocked>
+    %65 = tt.splat %arg4 : i32 -> tensor<32x1xi32, #blocked>
+    %66 = arith.cmpi slt, %52, %65 : tensor<32x1xi32, #blocked>
+    %67 = tt.broadcast %66 : tensor<32x1xi1, #blocked> -> tensor<32x32xi1, #blocked>
+
+    %70 = tt.splat %31 : i1 -> tensor<32x32xi1, #blocked>
+    %71 = arith.andi %70, %67 : tensor<32x32xi1, #blocked>
+
+    // Each thread needs to load 4 elements and we load 1 (sizePerThread) per buffer load instruction
+    // no conditionals are generated with other = 0.0
+
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: rocdl.raw.ptr.buffer.load.async.lds
+    // COMMON-NOT: _predicated_store
+    // COMMON-NOT: llvm.cond_br
+    // COMMON-NOT: llvm.store
+
+    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: buffer_load_to_local_mask_other_not_zero
+  tt.func public @buffer_load_to_local_mask_other_not_zero(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+                                %arg1: !tt.ptr<f32>,
+                                %arg2: tensor<32x32xi32, #blocked>,
+                                %arg3: !ttg.memdesc<32x32xf32, #shared, #smem, mutable>,
+                                %arg4: i32) {
+    // We need the splat to allow the AxisAnalysis to work during lowering
+    %cst_1 = arith.constant dense<1.000000e+00> : tensor<32x32xf32, #blocked>
     %c0_i32 = arith.constant 0 : i32
     %c32_i32 = arith.constant 32 : i32
     %c31_i32 = arith.constant 31 : i32
@@ -192,7 +240,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON-NOT: llvm.cond_br
     // COMMON-NOT: llvm.store
 
-    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
+    amdg.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_1 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
     tt.return
   }
 }
@@ -286,26 +334,18 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON: llvm.cond_br
-    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON: llvm.cond_br
-    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON: llvm.cond_br
-    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.async.lds
-    // COMMON: llvm.cond_br
-    // COMMON: llvm.store
 
     // COMMON-NOT: rocdl.ds_bpermute
     // COMMON-NOT: rocdl.ballot
@@ -406,7 +446,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
 // -----
 
-// Verify that when mask+other are present, the `other` store is emitted in the
+// Verify that when mask+other are present, the `other` (not 0.0) store is emitted in the
 // after-load block (not inside the load block). This ensures masked-out lanes
 // write the `other` value to LDS even when the load branch is not taken.
 // Regression test: before the fix, `emitOtherStore` was placed inside the
@@ -418,7 +458,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
   // COMMON-LABEL: @buffer_load_to_local_other_in_after_block
   tt.func @buffer_load_to_local_other_in_after_block(%ptr: !tt.ptr<f32>, %lds: !ttg.memdesc<64xf32, #shared, #smem, mutable>, %mask: tensor<64xi1, #blocked>) {
     %off = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
-    %other = arith.constant dense<0.000000e+00> : tensor<64xf32, #blocked>
+    %other = arith.constant dense<1.000000e+00> : tensor<64xf32, #blocked>
     // The conditional branch enters the load block only when pred is true.
     // COMMON: llvm.cond_br %{{.*}}, ^[[LOAD_BB:bb[0-9]+]], ^[[AFTER_BB:bb[0-9]+]]
     // COMMON-NEXT: ^[[LOAD_BB]]:
@@ -428,6 +468,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
     // regardless of whether the load branch was taken (i.e., for masked-out lanes).
     // COMMON-NEXT: ^[[AFTER_BB]]:
     // COMMON: llvm.store
+    amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : <f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Verify that when mask+other are present, if `other` is 0.0, no store is emitted
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  // COMMON-LABEL: @buffer_load_to_local_no_other_in_after_block
+  tt.func @buffer_load_to_local_no_other_in_after_block(%ptr: !tt.ptr<f32>, %lds: !ttg.memdesc<64xf32, #shared, #smem, mutable>, %mask: tensor<64xi1, #blocked>) {
+    %off = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #blocked>
+    %other = arith.constant dense<1.000000e+00> : tensor<64xf32, #blocked>
+    // COMMON: rocdl.raw.ptr.buffer.load.async.lds
     amdg.buffer_load_to_local %ptr[%off] mask=%mask other=%other into %lds : <f32>[tensor<64xi32, #blocked>] tensor<64xf32, #blocked> -> <64xf32, #shared, #smem, mutable>
     tt.return
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -13,6 +13,7 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
@@ -771,9 +772,12 @@ struct BufferLoadToLocalOpConversion
     SmallVector<Value> offsetElems =
         unpackTensorElements(loc, llOffset, rewriter, offset.getType());
     SmallVector<Value> otherElems;
-    if (llOther)
+    bool isOtherZeroConst = false;
+    if (llOther) {
       otherElems =
           unpackTensorElements(loc, llOther, rewriter, op.getOther().getType());
+      isOtherZeroConst = isZeroConst(op.getOther());
+    }
 
     auto dstTy = op.getDest().getType();
     auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());
@@ -847,12 +851,12 @@ struct BufferLoadToLocalOpConversion
       // Buffer-load-to-local supports zero-fill for per-lane masks by adjusting
       // the src offset to be OOB. Redundant-thread predication still needs a
       // branch when there are other values, otherwise inactive threads
-      // zero-fill values loaded by active lanes from another warp.
+      // will lave the lds untorched.
       // Optimization: for warp-uniform thread predicates and no other values we
       // can avoid the branch by selecting an out-of-range *shared* address. The
       // HW will drop the load before fetching the data from global memory so we
       // will not overwrite values.
-      if (isThreadPredWarpUniform && !hasOther) {
+      if (isThreadPredWarpUniform && isOtherZeroConst) {
         Value predicatedAddress =
             selectLdsAddressForPredicate(b, threadPred, shmemAddr);
         auto bufferLoadToLds = bufferEmitter.emitLoadToLds(
@@ -861,8 +865,7 @@ struct BufferLoadToLocalOpConversion
         if (targetInfo.requiresAliasInfoForAsyncOps())
           AMD::addAsyncCopyAliasScope(bufferLoadToLds);
       } else {
-        Value pred =
-            hasOther ? b.and_(threadPred, maybeSwizzledMaskElem) : threadPred;
+        Value pred = b.and_(threadPred, maybeSwizzledMaskElem);
         auto [loadBlock, afterLoadBlock] = emitBranch(rewriter, loc, pred);
 
         auto bufferLoadToLds = bufferEmitter.emitLoadToLds(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -778,6 +778,7 @@ struct BufferLoadToLocalOpConversion
           unpackTensorElements(loc, llOther, rewriter, op.getOther().getType());
       isOtherZeroConst = isZeroConst(op.getOther());
     }
+    bool hasMask = llMask != nullptr;
 
     auto dstTy = op.getDest().getType();
     auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());
@@ -856,7 +857,7 @@ struct BufferLoadToLocalOpConversion
       // can avoid the branch by selecting an out-of-range *shared* address. The
       // HW will drop the load before fetching the data from global memory so we
       // will not overwrite values.
-      if (isThreadPredWarpUniform && isOtherZeroConst) {
+      if (isThreadPredWarpUniform && ((!hasMask) || isOtherZeroConst)) {
         Value predicatedAddress =
             selectLdsAddressForPredicate(b, threadPred, shmemAddr);
         auto bufferLoadToLds = bufferEmitter.emitLoadToLds(

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -522,7 +522,7 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
       auto splatOp = tensorPtr.getDefiningOp<triton::SplatOp>();
       Value basePtr = splatOp.getSrc();
       Value maybeOther{};
-      if (op.getOther() && !isZeroConst(op.getOther()))
+      if (op.getOther())
         maybeOther = op.getOther();
       Value maybeMask{};
       if (op.getMask() && !isSplatOneConstTensor(op.getMask()))


### PR DESCRIPTION
## Summary

`buffer_load_to_local` was not handling `other=None` correctly when a mask was present. Previously,
`ConvertToBufferOps` silently dropped the `other` operand when it was a zero constant, and
`LoadStoreOpToLLVM` used a fast path (OOB address trick) only when there was **no** `other` at all.
This meant masked-out lanes were silently zero-filled, diverging from the behavior of
`global_load_to_local`/`async_load` that masked-out lanes leave local memory untorched.

This PR fixes the lowering in two places:

- **`ConvertToBufferOps.cpp`**: Always propagate the `other` operand through to the buffer load op,
  even when it is a zero splat. The previous early-drop made downstream code unable to distinguish
  "no other" from "zero other".
- **`LoadStoreOpToLLVM.cpp`**: Use the warp-uniform OOB-address fast path when `other` is a zero
  constant (not just when `other` is absent), and always AND the per-lane mask with the thread
  predicate in the branch path. This ensures masked-out elements get untorched in LDS, matching
  `global_load_to_local` semantics.

## Test plan

- [ ] New tests in `test_tlx_amd.py` comparing `buffer_load_to_local` vs `async_load` output:
  - No mask
  - Mask with `other=None` (the bug case)
  - Mask with `other=0.0`
  - Boundary variations (`n_valid=128, 200` out of 256)
  - Multi-CTA with partial last tile
- [ ] All tests gated on gfx950 hardware (`is_hip_cdna4()`)
- [ ] Existing correctness tests pass
