### PR TITLE
[TLX][Agent] Add autonomous kernel optimization workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,5 +78,3 @@ changes. Instead, if the PR is large, explain the order to review changes
 entirely.
 
 Don't overwrite existing commits.
-
-Disclose that the PR was authored with Claude.

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/SKILL.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/SKILL.md
@@ -103,7 +103,7 @@ Harnesses that implement `profile` should accept a structured request with:
 ```json
 {
   "level": "summary",
-  "tools": ["proton", "ncu"],
+  "tools": ["proton_launch", "native_profiler"],
   "experiment_id": "stable candidate or baseline id",
   "artifacts_dir": "/absolute/path/to/profile-artifacts",
   "reason": "why this profile was requested",
@@ -120,9 +120,9 @@ Profiling has three distinct layers:
 
 - Proton wrapper/launch attribution: read `references/proton-profiling.md` and
   collect for every correctness-passing candidate.
-- Target summary/deep profiling: for CUDA/NVIDIA, read
-  `targets/nvidia/ncu-profiling.md`; other backends use their own target guide
-  or the generic profile contract.
+- Target summary/deep profiling: request `native_profiler`; each target harness
+  maps it to its platform tool. For CUDA/NVIDIA, this is NCU and the harness
+  should follow `targets/nvidia/ncu-profiling.md`.
 - Diagnostic-only Proton intra-kernel instrumentation: use only for attribution
   questions that cannot be answered from wrapper timelines or target counters.
 

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/SKILL.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: trx-kernel-optimization-agent
+description: >
+  Execute the TLX Kernel Optimization Agent CLI on a Triton or TLX kernel.
+  Use this skill whenever the user says "use the TLX agent", "use the kernel
+  optimization agent", "用 TLX agent 优化", or asks Carl/Claude to optimize a
+  kernel with the repository agent. The required outcome is an actual agent CLI
+  invocation and its measured result, not a walkthrough or reimplementation.
+---
+
+# Run The TLX Kernel Optimization Agent
+
+The executable is `third_party/tlx/tools/agents/kernel_optimization/cli.py`.
+Use the user-facing name "TLX kernel optimization agent"; the on-disk skill
+name is compatibility-only. Follow the layers below in order. Target-specific
+profiling rules supplement, but never replace, the generic workflow.
+
+## Layer 0: Invocation And Safety
+
+1. Invoke the public CLI. Do not manually optimize the kernel or substitute a
+   generic subagent before the first CLI attempt.
+2. Resolve the repository root, absolute kernel path, and target bundle. Record
+   initial source-control status and treat existing bytes as the user baseline.
+   Never clean or revert a dirty worktree.
+3. Keep candidate generation isolated from the live checkout. Candidate source
+   may exist only in the provider's temporary workspace and output artifacts
+   until final promotion.
+4. Run stdout and stderr separately. Tee stderr to a stable absolute live log;
+   write stdout JSON to a separate artifact. When starting a run, respond only
+   with the absolute log path unless the user asks for more.
+5. The CLI commits a revalidated winner by default. Use
+   `--no-commit-winner` only for an explicitly requested artifact-only run.
+   Submission remains a separate explicit action.
+6. If the live kernel changes concurrently, do not overwrite it. Preserve the
+   winner artifact and report the conflict.
+
+Reading agent implementation is allowed only after the CLI reports an internal
+failure that requires diagnosis. The first attempt must use the public contract.
+
+## Layer 1: Inputs And Standard Loop
+
+The CLI needs:
+
+```text
+kernel.py                  complete source file
+bundle/harness.py          build, verify, benchmark, optional profile
+bundle/cases.json          workloads, weights, protected cases
+bundle/target.json         backend, architecture, device, environment
+output/                    fresh artifact directory
+```
+
+Optional inputs are `reference_kernel.py` and `budget.json`. The higher-level
+coding agent owns target-bundle preparation; the TLX Agent consumes the bundle
+as a frozen trust boundary and must never generate or modify it during the
+optimization loop.
+
+Before invoking the CLI, the higher-level agent must:
+
+1. Search for an existing bundle that exactly matches the kernel entry point,
+   workload, mode, backend, and architecture. Do not silently reuse a nearby
+   shape or provider.
+2. If no exact bundle exists, create a run-specific bundle from the nearest
+   authoritative correctness test and production benchmark. Keep it outside
+   the candidate workspace and do not modify the user's kernel permanently.
+3. Encode all requested workloads in `cases.json`, hardware and environment in
+   `target.json`, and kernel-specific invariants, known failed experiments, and
+   evidence-to-knob guidance in `target.json` as `optimization_guidance`.
+4. Run the bundle against the untouched kernel before launching the Agent.
+   Confirm build succeeds, every protected case passes, repeated benchmark
+   samples are stable, and summary profiling selects the intended kernel.
+5. Negative-test the trust boundary with an intentionally invalid or incorrect
+   temporary candidate and confirm build or verification rejects it.
+6. Freeze the validated bundle for the duration of the run. Record its absolute
+   paths and content hashes in the run log, and pass all paths explicitly to the
+   public CLI.
+
+Read `references/input-contract.md` for the complete construction and
+validation checklist. Do not start the optimization loop until the bundle is
+validated.
+
+For every candidate, the standard loop is:
+
+```text
+build -> verify -> benchmark -> profile -> decide -> repeat
+```
+
+The live log must include:
+
+- hypothesis and evidence;
+- one coherent source/configuration change;
+- expected effect and risk;
+- correctness, median, p95, CV, and speedup;
+- Proton attribution plus target summary profile deltas and a concise decision.
+
+Do not print kernel source or private chain-of-thought. Continue through the
+configured round budget after an unpromoted round. Reject incorrect, duplicate,
+unstable, and materially regressing candidates.
+
+## Layer 2: Profiling Request And Artifacts
+
+Harnesses that implement `profile` should accept a structured request with:
+
+```json
+{
+  "level": "summary",
+  "tools": ["proton", "ncu"],
+  "experiment_id": "stable candidate or baseline id",
+  "artifacts_dir": "/absolute/path/to/profile-artifacts",
+  "reason": "why this profile was requested",
+  "diagnostic_only": false
+}
+```
+
+The legacy two-argument `profile(build_artifact, case)` contract remains
+supported and means summary profiling for the default tools. Return compact,
+normalized JSON inline. Store raw `.hatchet`, `.chrome_trace`, `.ncu-rep`, CSV,
+mapping, and command files as artifacts, and reference them with absolute paths.
+
+Profiling has three distinct layers:
+
+- Proton wrapper/launch attribution: read `references/proton-profiling.md` and
+  collect for every correctness-passing candidate.
+- Target summary/deep profiling: for CUDA/NVIDIA, read
+  `targets/nvidia/ncu-profiling.md`; other backends use their own target guide
+  or the generic profile contract.
+- Diagnostic-only Proton intra-kernel instrumentation: use only for attribution
+  questions that cannot be answered from wrapper timelines or target counters.
+
+## Layer 3: Proton Attribution
+
+Use Proton to attribute wrapper, benchmark phase, launch, and profiler overhead.
+An ordinary Proton timeline with `hook='triton'` that shows one kernel launch
+does not prove `tlx.async_task` overlap; it only shows launch/wrapper
+attribution around the compiled kernel. Do not infer per-task overlap from that
+timeline.
+
+Diagnostic intra-kernel attribution must use Proton instrumentation mode with
+`backend='instrumentation'`, `data='trace'`, `granularity='warp'`, and explicit
+Triton semantic enabled. Group warp lanes by known async-task warp ranges from
+the source, generated metadata, or a saved mapping artifact. Do not request
+`warp_group` granularity because the runtime rejects it today.
+
+Instrumentation changes are diagnostic-only. Compiler transforms may move or
+merge scopes, so instrumented source and timing must never be benchmarked,
+promoted, committed, or used as speedup evidence.
+
+## Layer 4: Target Profiling
+
+Select target profiling guidance from `target.json`:
+
+- CUDA/NVIDIA: read `targets/nvidia/ncu-profiling.md`.
+- Other backends: use a sibling target guide when present; otherwise use the
+  vendor-neutral `profile()` contract without inventing NVIDIA requirements.
+
+Every correctness-passing candidate receives Proton attribution and the target
+guide's summary profile. Escalate to the target guide's deep profile for:
+
+- the baseline before candidate generation;
+- a candidate within one percentage point of the promotion threshold;
+- disagreement between endpoint benchmark, Proton attribution, and target
+  summary profile;
+- repeated rounds with no promoted candidate;
+- schedule or WS hypotheses that need stall, occupancy, spill, or
+  memory-hierarchy evidence;
+- the final promoted candidate before commit.
+
+Do not spend deep-profile time on incorrect or clearly slow candidates.
+Unsupported counters must be reported as unavailable with JSON `null` and a
+diagnostic, never as zero.
+
+## Layer 5: Evidence-To-Action Policy
+
+Each candidate hypothesis must cite measured evidence and change one subsystem
+or tightly coupled invariant-preserving pair. Feed failed hypotheses and their
+metric regressions into subsequent prompts as exclusions.
+
+Generic interpretation rules:
+
+- Higher kernel duration with lower compute and memory utilization indicates
+  scheduling, serialization, synchronization, or insufficient parallelism.
+- A benchmark-only change inside the noise floor with unchanged kernel metrics
+  is not optimization evidence.
+- Lower utilization without lower work, traffic, and duration is not a win.
+- Register-budget or buffering changes require spill/occupancy evidence and a
+  producer-consumer/barrier proof.
+- Main-kernel profile time and public-wrapper benchmark time cover different
+  scopes; do not subtract them to manufacture a bottleneck.
+
+Use the target guide for vendor-specific counter interpretation.
+
+## Layer 6: Promotion, Revalidation, And Commit
+
+Promote only when:
+
+- every protected case passes;
+- weighted speedup meets the configured threshold;
+- measurement variance is within budget;
+- target profiling shows no material main-kernel regression.
+
+Revalidate the finalist with benchmark, Proton attribution, summary target
+profile, and required deep target profile. Only then may the default commit
+occur. Auto-commit must detect Git or Mercurial from the kernel path, preserve
+unrelated dirty/staged work, include `TLX agent authored` in the commit body,
+and log VCS, revision, repository, target, subject, and failure diagnostics. If
+commit fails, keep all artifacts and return the distinct commit-failure status.
+
+## Layer 7: Command And Completion
+
+From the repository root:
+
+```bash
+PYTHONPATH=<repo-root> python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel <absolute-kernel.py> \
+  --harness <absolute-harness.py> \
+  --cases <absolute-cases.json> \
+  --target <absolute-target.json> \
+  --output-dir <absolute-output-dir> \
+  --provider codex \
+  --max-rounds 5 \
+  --candidates-per-round 2 \
+  --max-candidate-seconds 600 \
+  --max-total-seconds 3600 \
+  --min-speedup 1.01 \
+  --max-cv 0.10 \
+  --benchmark-repetitions 10 \
+  --profile
+```
+
+Add `--reference-kernel`, `--budget`, `--arch`, `--model`, `--vcs`, or
+`--commit-message` only when required. Do not invent a model name. Never run
+`optimizer.py` directly.
+
+The task is complete only after the actual CLI run reaches final revalidation
+or a diagnosed blocking failure. Report the exact workload, GPU, baseline and
+final latency, speedup, CV, correctness, stopping reason, commit result, and
+absolute output directory. `best_kernel.py` by itself is not completion.

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
@@ -148,8 +148,9 @@ Field meanings:
 
 - `level`: `summary` or `deep`; use `diagnostic_only: true` for
   instrumentation-only requests.
-- `tools`: profiler names requested by the agent, such as `proton` plus any
-  target-specific tool from `targets/<vendor>/`.
+- `tools`: profiler intents requested by the agent. `proton_launch` collects
+  launch attribution, while `native_profiler` is mapped by the target harness
+  to its platform profiler, such as NCU on NVIDIA.
 - `experiment_id`: stable baseline, round, or candidate identifier used in
   artifact names and profile metadata.
 - `artifacts_dir`: absolute directory where raw profiler outputs and commands

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
@@ -146,7 +146,8 @@ A structured profile request contains these fields:
 
 Field meanings:
 
-- `level`: `summary`, `deep`, or `diagnostic`.
+- `level`: `summary` or `deep`; use `diagnostic_only: true` for
+  instrumentation-only requests.
 - `tools`: profiler names requested by the agent, such as `proton` plus any
   target-specific tool from `targets/<vendor>/`.
 - `experiment_id`: stable baseline, round, or candidate identifier used in

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/input-contract.md
@@ -1,0 +1,320 @@
+# TLX Kernel Optimization Input Contract
+
+## Directory layout
+
+Keep one target bundle together so another agent can reproduce the run:
+
+```text
+<target-bundle>/
+  harness.py
+  cases.json
+  target.json
+  budget.json          # optional
+  reference_kernel.py  # optional
+```
+
+The kernel under optimization may live elsewhere in the repository. Pass every
+path to the CLI as an absolute path.
+
+## Kernel source
+
+`--kernel` points to one complete Python source file. The optimizer sends its
+entire contents to the candidate provider and expects each proposal to be a
+complete replacement file, not a patch.
+
+The file must preserve every public entry point used by `harness.py`. Keep host
+wrappers and imports needed to compile the kernel in the same candidate source,
+or make the harness inject the candidate into a stable wrapper without changing
+the candidate contract.
+
+Use `--reference-kernel` only for a trusted correctness oracle. The reference is
+persisted in the output directory and exposed to harness workers as
+`TLX_REFERENCE_KERNEL_PATH`.
+
+## Harness ownership and preparation
+
+The higher-level coding agent prepares and validates the harness before it
+starts the TLX Agent CLI. The optimization loop treats the harness, cases, and
+target metadata as immutable inputs. Candidate generation must never edit them.
+
+Build a new bundle only after searching for an exact existing match. Derive it
+from the repository's authoritative correctness test and production benchmark,
+not from an ad hoc timing loop. The harness must exercise the same public entry
+point, input preparation, precision, mode, and cache behavior that the user
+asked to optimize.
+
+Before handing the bundle to the TLX Agent:
+
+1. Run `build`, `verify`, and `benchmark` on the untouched kernel.
+2. Confirm every protected case passes and each benchmark returns positive
+   microsecond samples with acceptable repeatability.
+3. When profiling is enabled, confirm the profile selects the intended kernel
+   and labels wrapper, launch, and kernel scopes accurately.
+4. Run an intentionally invalid source and confirm `build` rejects it.
+5. Run an intentionally incorrect but compilable source and confirm `verify`
+   rejects it.
+6. Place the validated files in a run-specific directory, compute content
+   hashes, and do not modify them until the optimization run finishes.
+
+Kernel-specific optimization knowledge belongs in the bundle's
+`target.json` `optimization_guidance` string. Include algorithm and layout
+invariants, synchronization and aliasing contracts, exact measurement scopes,
+known failed configurations, and evidence-to-action rules. Do not put such
+knowledge into the generic candidate provider.
+
+The harness is a Python module with this API:
+
+```python
+def build(kernel_source: str, target: dict):
+    """Compile or materialize the candidate and return its build artifact."""
+
+
+def verify(build_artifact, case: dict):
+    """Return bool or {passed, diagnostics, metrics}."""
+
+
+def benchmark(build_artifact, case: dict, repetitions: int):
+    """Return positive microsecond samples or timing metadata."""
+
+
+def profile(build_artifact, case: dict, request: dict | None = None):
+    """Optional. Return a compact JSON-serializable profile mapping."""
+```
+
+The legacy `profile(build_artifact, case)` form remains supported. It is treated
+as a summary profile request for the default tools selected by `target.json`.
+New harnesses should accept the structured request form so the agent can request
+summary, deep, or diagnostic-only profiling without changing the harness API.
+
+A successful `build` may return the artifact directly, or:
+
+```python
+{
+    "success": True,
+    "artifact": artifact,
+    "diagnostics": "",
+}
+```
+
+A failed build returns:
+
+```python
+{
+    "success": False,
+    "artifact": None,
+    "diagnostics": "compiler output",
+}
+```
+
+A verification result should include useful numerical metrics:
+
+```python
+{
+    "passed": True,
+    "diagnostics": "",
+    "metrics": {
+        "max_abs_error": 0.003,
+        "max_rel_error": 0.021,
+    },
+}
+```
+
+A benchmark result uses microseconds, not milliseconds:
+
+```python
+{
+    "samples_us": [81.2, 80.9, 81.0, 81.1, 80.8],
+    "warmup_count": 25,
+    "cache_policy": "warm",
+}
+```
+
+## Profile requests
+
+A structured profile request contains these fields:
+
+```json
+{
+  "level": "summary",
+  "tools": ["proton"],
+  "experiment_id": "baseline-or-candidate-id",
+  "artifacts_dir": "/absolute/path/to/output/profiles/baseline",
+  "reason": "baseline before candidate generation",
+  "diagnostic_only": false
+}
+```
+
+Field meanings:
+
+- `level`: `summary`, `deep`, or `diagnostic`.
+- `tools`: profiler names requested by the agent, such as `proton` plus any
+  target-specific tool from `targets/<vendor>/`.
+- `experiment_id`: stable baseline, round, or candidate identifier used in
+  artifact names and profile metadata.
+- `artifacts_dir`: absolute directory where raw profiler outputs and commands
+  must be written.
+- `reason`: concise explanation for why profiling was requested.
+- `diagnostic_only`: `true` only for instrumentation that perturbs source,
+  compilation, or timing and must never be benchmarked, promoted, or committed.
+
+`profile` returns a vendor-neutral, JSON-serializable mapping with a declared
+profiling level, exact wrapper/launch/kernel scope, normalized semantic groups,
+optional raw metrics, and diagnostics for unavailable data. Summary profiling
+should be inexpensive enough for every correct candidate; deep profiling may use
+slower target-specific tools. Diagnostic profiling is for attribution questions
+that cannot be answered by normal benchmark, wrapper, launch, and target summary
+data.
+
+Return compact normalized JSON inline. Store raw profiler output under
+`artifacts_dir`, and reference those files by absolute path. Raw artifacts may
+include `.hatchet`, `.chrome_trace`, target profiler reports, CSV exports,
+async-task or warp mapping files, and the exact commands that generated them.
+Large payloads are spilled into the agent artifact directory automatically.
+
+Generic Proton guidance lives in `references/proton-profiling.md`. Target-specific
+tools and metric mappings live under `targets/<vendor>/`. CUDA/NVIDIA bundles
+must follow `targets/nvidia/ncu-profiling.md`. Other targets must not fabricate
+NVIDIA fields. Unsupported counters are omitted or represented as `null` with
+diagnostics, never silently converted to zero.
+
+A compact profile response should look like:
+
+```json
+{
+  "level": "summary",
+  "tools": ["proton"],
+  "scope": {
+    "case_id": "production-shape",
+    "experiment_id": "baseline",
+    "kernel": "exact_kernel_name_or_null"
+  },
+  "summary": {
+    "median_us": 81.0,
+    "p95_us": 81.2
+  },
+  "artifacts": {
+    "trace": "/absolute/path/to/profile.chrome_trace",
+    "commands": "/absolute/path/to/profile.commands.txt"
+  },
+  "diagnostics": []
+}
+```
+
+### Buck and TritonBench harnesses
+
+For a Buck-managed kernel, `build` must make the candidate visible to the exact
+Buck target without permanently modifying the user's source. Prefer an isolated
+worktree or a target-specific candidate import hook. If temporary replacement is
+unavoidable:
+
+- Verify the destination path exactly.
+- Save the original bytes and mode.
+- Replace only the designated kernel file.
+- Restore it in `finally`, including timeout and exception paths.
+- Serialize evaluations so candidates cannot race on the same source file.
+
+`verify` must run the target's real correctness check. `benchmark` must run the
+existing TritonBench+Buck command with the exact `--op`, `--only`, `--mode`, and
+shape/config selectors, then parse only the requested row. Do not substitute a
+unit-test duration or a different provider.
+
+## Cases metadata
+
+`cases.json` is a list. Each case has a stable ID, arbitrary harness parameters,
+a positive weight, and a correctness protection flag:
+
+```json
+[
+  {
+    "case_id": "production-shape",
+    "parameters": {
+      "m": 4096,
+      "n": 4096,
+      "k": 4096,
+      "dtype": "float16"
+    },
+    "weight": 10.0,
+    "protected": true
+  },
+  {
+    "case_id": "tail-shape",
+    "parameters": {
+      "m": 257,
+      "n": 509,
+      "k": 129,
+      "dtype": "float16"
+    },
+    "weight": 1.0,
+    "protected": true
+  }
+]
+```
+
+Every protected case must pass. Unprotected failures remain diagnostic and do
+not contribute to aggregate speedup. Weight the production workload more
+heavily, but keep representative correctness/tail cases protected.
+
+## Target metadata
+
+`target.json` describes execution, not the workload shape:
+
+```json
+{
+  "backend": "cuda",
+  "architecture": "B200",
+  "device": "cuda:0",
+  "environment": {
+    "CUDA_VISIBLE_DEVICES": "0"
+  },
+  "optimization_guidance": "Preserve the documented layout and synchronization contracts. Change one measured bottleneck per candidate."
+}
+```
+
+Valid architecture aliases include `blackwell`, `B200`, `sm_100`, `hopper`,
+`H100`, and `sm_90`. The CLI validates the visible CUDA device against the
+selected architecture.
+
+Put required runtime knobs in `environment`, for example compiler feature flags,
+cache directories, or Triton dump controls. Do not put shape parameters here;
+they belong in `cases.json`.
+
+## Budget metadata
+
+An optional `budget.json` overrides CLI budget flags:
+
+```json
+{
+  "max_rounds": 5,
+  "candidates_per_round": 2,
+  "max_candidate_seconds": 600,
+  "max_total_seconds": 3600,
+  "min_speedup": 1.01,
+  "max_cv": 0.10,
+  "benchmark_repetitions": 10
+}
+```
+
+`min_speedup` must be at least `1.0`. Lower `max_cv` for stable microbenchmarks;
+raise it only when the harness documents unavoidable variance.
+
+## Full invocation example
+
+```bash
+cd /home/hoy/triton-fb
+PYTHONPATH=/home/hoy/triton-fb \
+python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel /absolute/path/to/kernel.py \
+  --reference-kernel /absolute/path/to/reference_kernel.py \
+  --harness /absolute/path/to/target-bundle/harness.py \
+  --cases /absolute/path/to/target-bundle/cases.json \
+  --target /absolute/path/to/target-bundle/target.json \
+  --budget /absolute/path/to/target-bundle/budget.json \
+  --output-dir /absolute/path/to/output \
+  --arch blackwell \
+  --provider codex \
+  --model sonnet \
+  --profile
+```
+
+Before launching, run the same harness once against the original source and
+confirm that correctness, benchmark parsing, and profile collection all work.

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/proton-profiling.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/references/proton-profiling.md
@@ -1,0 +1,111 @@
+# Proton Profiling Guidance
+
+Use Proton for vendor-neutral attribution around the benchmark wrapper, launch
+path, and optional diagnostic source instrumentation. Keep target-specific
+counters in `targets/<vendor>/`; this file only describes Proton usage and
+artifact expectations.
+
+## Wrapper And Launch Attribution
+
+Collect Proton attribution for every correctness-passing candidate and for the
+baseline. This layer answers whether endpoint time is spent in the benchmark
+wrapper, setup/teardown, launch path, synchronization, or the profiled kernel
+window.
+
+An ordinary Proton timeline using `hook='triton'` can show the wrapper and one
+compiled Triton kernel launch. That timeline does not show TLX async-task
+overlap inside the kernel. Do not treat a single kernel region as evidence that
+producer, consumer, TMA, MMA, or store tasks overlapped.
+
+Return compact normalized JSON inline and keep raw files in the requested
+`artifacts_dir`:
+
+```json
+{
+  "proton": {
+    "level": "summary",
+    "scope": {
+      "experiment_id": "candidate-r2-c1",
+      "case_id": "case-id",
+      "hook": "triton"
+    },
+    "wrapper": {
+      "median_us": 81.0,
+      "kernel_launches": 1,
+      "kernel_window_us": 78.4
+    },
+    "artifacts": {
+      "hatchet": "/absolute/path/to/proton.hatchet",
+      "chrome_trace": "/absolute/path/to/proton.chrome_trace",
+      "commands": "/absolute/path/to/proton.commands.txt"
+    },
+    "diagnostics": []
+  }
+}
+```
+
+Use absolute artifact paths for `.hatchet`, `.chrome_trace`, CSV exports, and
+commands. Keep inline JSON compact; do not paste raw traces into the live log.
+
+## Diagnostic Intra-Kernel Instrumentation
+
+Use this layer only when wrapper attribution and target counters disagree or
+when a specific async-task overlap hypothesis needs lane-level evidence.
+Instrumentation perturbs source, compiler decisions, and timing, so it is
+strictly diagnostic-only.
+
+When requested, use Proton instrumentation mode with:
+
+```python
+backend = "instrumentation"
+data = "trace"
+granularity = "warp"
+```
+
+Enable Triton semantic explicitly for source-level scopes. Group warp lanes by
+known async-task warp ranges from the kernel source, generated metadata, or a
+saved mapping artifact. Persist the mapping and the instrumentation command as
+absolute artifact paths so another agent can reproduce the grouping.
+
+Do not request `warp_group` granularity because the runtime rejects it today.
+Do not infer async-task overlap from CTA-level or kernel-level scopes.
+
+## Diagnostic Safety
+
+Compiler transforms may move, clone, merge, or delete semantic scopes. Treat
+instrumented source locations as best-effort labels, not an ownership proof.
+Always cross-check surprising ranges against the generated IR or a mapping file
+before changing scheduling, barrier, or buffering code.
+
+Instrumented source and timing must never be:
+
+- used as benchmark or speedup evidence;
+- promoted as a candidate;
+- committed to the user's source tree;
+- compared numerically against non-instrumented benchmark samples.
+
+A diagnostic response should set `diagnostic_only` to `true` and include that in
+the returned JSON:
+
+```json
+{
+  "proton": {
+    "level": "diagnostic",
+    "diagnostic_only": true,
+    "instrumentation": {
+      "backend": "instrumentation",
+      "data": "trace",
+      "granularity": "warp",
+      "triton_semantic": true,
+      "warp_mapping": "/absolute/path/to/async_task_warp_mapping.json"
+    },
+    "artifacts": {
+      "chrome_trace": "/absolute/path/to/proton.instrumented.chrome_trace",
+      "commands": "/absolute/path/to/proton.instrumented.commands.txt"
+    },
+    "diagnostics": [
+      "instrumented timing is diagnostic-only and must not be benchmarked"
+    ]
+  }
+}
+```

--- a/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/targets/nvidia/ncu-profiling.md
+++ b/third_party/tlx/.claude/skills/trx-kernel-optimization-agent/targets/nvidia/ncu-profiling.md
@@ -1,0 +1,210 @@
+# NVIDIA Target Profiling With NCU
+
+Use this guide only when `target.json.backend` is CUDA/NVIDIA. It supplements
+the generic TLX optimization workflow with NVIDIA NCU requirements. Proton
+wrapper/launch attribution and diagnostic instrumentation live in
+`references/proton-profiling.md`.
+
+## Metric Discovery
+
+Do not assume one hard-coded metric list works across Hopper, Blackwell, NCU
+versions, and kernel launch modes. Before the run, query the active profiler and
+GPU for supported metrics using `ncu --query-metrics` or the equivalent command
+supported by that installation. Resolve the semantic groups below to available
+metric names and persist the resolved mapping in the run artifacts.
+
+If a metric is unsupported, encode the normalized field as JSON `null` and add a
+diagnostic explaining that the metric was unavailable on this profiler/GPU. Never
+encode a missing metric as zero.
+
+Resolve metrics for these groups when supported:
+
+- barrier and async-wait stalls;
+- scoreboard and dependency stalls;
+- registers, occupancy, and occupancy limiters;
+- spill and local-memory traffic;
+- L1/shared-memory behavior;
+- L2 bytes, sectors, and hit behavior;
+- DRAM bytes, sectors, and throughput;
+- tensor-core or MMA activity.
+
+Persist the raw NCU report, CSV exports, metric mapping, and exact commands as
+absolute artifact paths.
+
+## Summary Profile
+
+Collect this inexpensive group for the baseline and every correct candidate:
+
+- profiled kernel duration;
+- SM throughput percentage;
+- DRAM throughput percentage;
+- exact profiled kernel name and launch scope.
+
+Use summary data for fast rejection and for deciding whether deep profiling is
+needed. It cannot by itself prove that a kernel is compute-bound or memory-bound.
+Pair it with Proton attribution so endpoint benchmark time, wrapper time, and
+main-kernel time are not conflated.
+
+## Deep Profile
+
+Collect deep profiling for:
+
+- the baseline before candidate generation;
+- a candidate within one percentage point of the promotion threshold;
+- disagreement between benchmark timing, Proton attribution, and NCU summary;
+- repeated rounds with no promoted candidate;
+- schedule or warp-specialization hypotheses that depend on stall, occupancy,
+  spill, or memory-hierarchy evidence;
+- the finalist before promotion or commit.
+
+Do not spend deep-profile time on incorrect or clearly slow candidates.
+
+### Barrier And Async Waits
+
+Resolve counters for:
+
+- barrier stall cycles or warp issue stall due to barriers;
+- memory-barrier or async-wait stalls when exposed by the architecture;
+- active/eligible warps needed to distinguish waits from insufficient occupancy.
+
+A barrier increase with higher duration directs investigation to wait placement,
+phase arithmetic, producer-consumer imbalance, and overly shallow/deep buffering.
+Do not change barriers without proving ownership and phase transitions.
+
+### Scoreboards And Dependencies
+
+Resolve counters for:
+
+- long-scoreboard stalls;
+- short-scoreboard stalls;
+- MIO/throttle or instruction-dependency stalls when available.
+
+Higher long-scoreboard stalls usually justify investigating global/TMA latency,
+load-to-use distance, and overlap. Higher short-scoreboard or MIO stalls point
+toward shared-memory, special-function, or instruction-pipeline pressure. Use
+the architecture documentation before mapping a stall name to a source change.
+
+### Registers, Occupancy, And Spills
+
+Collect or derive:
+
+- registers per thread or task where the tool exposes them;
+- achieved occupancy and occupancy limiters;
+- theoretical occupancy when available;
+- local-memory load/store sectors or bytes;
+- compiler-reported spill loads/stores when available.
+
+A register-budget reduction is invalidated when local-memory/spill traffic rises
+or duration regresses. Lower register allocation is not itself an optimization;
+it must improve occupancy/scheduling without introducing spills.
+
+### L1, Shared Memory, L2, And DRAM
+
+Resolve counters for:
+
+- L1/TEX traffic and hit behavior when relevant;
+- shared-memory traffic or bank-conflict signals when available;
+- L2 read/write bytes or sectors and hit rate;
+- DRAM read/write bytes or sectors, not only throughput percentage.
+
+Lower DRAM throughput with unchanged bytes and worse duration means the pipeline
+feeds memory less effectively. Lower L2/DRAM bytes with unchanged useful work can
+support a locality or traffic-reduction hypothesis.
+
+### Tensor And Issue Activity
+
+Resolve counters for:
+
+- tensor/MMA activity;
+- issue-slot utilization;
+- eligible/active warps;
+- instruction mix when needed to explain a close candidate.
+
+Use these metrics to distinguish tensor-core starvation from arithmetic or
+instruction-issue pressure. Do not optimize a utilization percentage in
+isolation; kernel duration and useful work remain primary.
+
+## Normalized Profile Schema
+
+Return target profiling under `profile()["ncu"]`. Keep normalized JSON compact
+and spill raw reports to artifacts:
+
+```json
+{
+  "ncu": {
+    "level": "summary or deep",
+    "scope": {
+      "kernel": "exact kernel name",
+      "launches": 1
+    },
+    "summary": {
+      "duration_ns": 0,
+      "sm_throughput_pct": 0.0,
+      "dram_throughput_pct": 0.0
+    },
+    "stalls": {
+      "barrier_pct": null,
+      "async_wait_pct": null,
+      "long_scoreboard_pct": null,
+      "short_scoreboard_pct": null,
+      "mio_throttle_pct": null,
+      "dependency_pct": null
+    },
+    "registers": {
+      "registers_per_thread": null,
+      "achieved_occupancy_pct": null,
+      "theoretical_occupancy_pct": null,
+      "occupancy_limiters": null,
+      "local_load_bytes": null,
+      "local_store_bytes": null,
+      "spill_loads": null,
+      "spill_stores": null
+    },
+    "memory": {
+      "l1_bytes": null,
+      "l1_hit_rate_pct": null,
+      "shared_bank_conflicts": null,
+      "l2_read_bytes": null,
+      "l2_write_bytes": null,
+      "l2_hit_rate_pct": null,
+      "dram_read_bytes": null,
+      "dram_write_bytes": null
+    },
+    "compute": {
+      "tensor_activity_pct": null,
+      "issue_active_pct": null,
+      "eligible_warps_per_cycle": null,
+      "active_warps_per_cycle": null
+    },
+    "artifacts": {
+      "ncu_report": "/absolute/path/to/profile.ncu-rep",
+      "csv": "/absolute/path/to/profile.csv",
+      "metric_mapping": "/absolute/path/to/ncu_metric_mapping.json",
+      "commands": "/absolute/path/to/ncu.commands.txt"
+    },
+    "raw_metrics": {},
+    "diagnostics": []
+  }
+}
+```
+
+Omit unsupported normalized fields only when the consumer accepts sparse output;
+otherwise use JSON `null` with a diagnostic. Include units in `raw_metrics` when
+values are strings; normalized numeric fields must use the units implied by their
+names.
+
+## Candidate Decisions
+
+- Veto material kernel-duration regressions even when endpoint timing improves
+  inside the measurement noise floor.
+- Veto lower register budgets that increase spill/local-memory traffic.
+- Treat higher duration plus lower SM/DRAM utilization as scheduling or
+  synchronization loss.
+- Require a barrier or scoreboard hypothesis to cite the corresponding deep
+  counter and compare it with baseline.
+- Require memory-traffic claims to cite bytes and cache behavior, not throughput
+  percentage alone.
+- Require tensor-core or issue-pressure claims to cite tensor activity,
+  eligible/active warps, or instruction mix as appropriate.
+- Feed rejected metric signatures into later candidate prompts so the agent does
+  not repeat the same configuration under different wording.

--- a/third_party/tlx/tools/agents/kernel_optimization/README.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/README.md
@@ -123,26 +123,26 @@ isolation in the CLI path; `StandaloneHarness` is available via the Python API.
 
 `harnesses/blackwell/targets/gemm/harness.py` runs any complete candidate source that exports
 `matmul(a, b)`. It compares against `torch.matmul`, benchmarks with
-`triton.testing.do_bench`, and reports latency and TFLOP/s. Its optional three-argument
-`profile(build_artifact, case, request)` honors structured profile requests: `proton_launch`
-collects one Triton launch-attribution-only Proton tree under the per-case artifacts
-directory, and `native_profiler` selects the target platform profiler. NVIDIA harnesses map
-it to NCU, which writes a one-launch replay runner plus command/query/stdout/stderr/report
-artifacts before returning normalized supported metrics. Missing tools, unsupported metrics,
-and profiler failures are returned as profile diagnostics so correctness and benchmark results
-remain usable. `proton_intra_kernel` is intentionally unsupported by the reference harness and
-requires a target-supplied instrumented replay; the harness never rewrites candidate source.
+`triton.testing.do_bench`, and reports latency and TFLOP/s. Its legacy two-argument
+`profile(build_artifact, case)` returns latency and throughput, and can optionally collect a
+basic Proton trace when `TRITON_PROTON` is set. It does not implement structured profile
+requests or NCU collection.
 
-### Profiling recipes
+### Target-supplied profiling
 
-- **Triton Proton launch attribution:** request `tools=["proton_launch"]` with an absolute
-  `artifacts_dir`. The reference GEMM harness warms up, synchronizes, starts Proton with
-  `hook="triton"` and tree data, runs one matmul, flushes/deactivates, saves raw tree JSON and
-  any `.hatchet` artifact, then parses `launch_attribution_only` totals.
-- **Native profiler:** request `tools=["native_profiler"]`. Each target harness maps this
-  portable name to its platform profiler. NVIDIA harnesses map it to NCU, select supported
-  summary or deep metrics, save command/query/CSV/stderr artifacts, and return unsupported
-  metrics as `null` plus diagnostics. Explicit `ncu` remains a compatible NVIDIA-only request.
+A target harness may implement `profile(build_artifact, case, request)` to honor structured
+profile requests. Missing tools, unsupported metrics, and profiler failures should be returned
+as diagnostics so correctness and benchmark results remain usable.
+
+- **Triton Proton launch attribution:** handle `tools=["proton_launch"]` with an absolute
+  `artifacts_dir`. A supporting harness should warm up, synchronize, collect one
+  launch-attribution-only Proton tree, save raw artifacts, and return normalized totals.
+- **Native profiler:** handle `tools=["native_profiler"]` by mapping this portable name to the
+  target platform profiler. NVIDIA requests are resolved to NCU, and a supporting harness may
+  collect summary or deep metrics and save command/query/CSV/stderr artifacts. Explicit `ncu`
+  remains a compatible NVIDIA-only request.
+- **Diagnostic instrumentation:** `proton_intra_kernel` requires a target-supplied instrumented
+  replay. Instrumented source and timing must never be benchmarked, promoted, or committed.
 
 Target-specific `harness.py`/`cases.json`/`target.json` live colocated under `harnesses/<arch>/targets/<kernel>/` (B200,
 `sm_100` for blackwell and H100, `sm_90` for hopper); pick `--arch` to match the

--- a/third_party/tlx/tools/agents/kernel_optimization/README.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/README.md
@@ -57,6 +57,12 @@ python -m third_party.tlx.tools.agents.kernel_optimization.cli \
   --output-dir /tmp/tlx-kernel-agent-run \
   --max-rounds 5 \
   --provider codex --arch blackwell
+
+# A revalidated winner is committed by default:
+python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel my_kernel.py --output-dir /tmp/tlx-kernel-agent-run \
+  --vcs auto \
+  --commit-message "Optimize my kernel with TLX agent"
 ```
 
 `--arch` selects `harnesses/<arch>/targets/<kernel>`; `harness`/`cases`/`target` can also be passed explicitly.
@@ -66,6 +72,24 @@ python -m third_party.tlx.tools.agents.kernel_optimization.cli \
 `--provider` is `codex` (default, shells `codex exec`) or `mock` (deterministic stub for
 CI that replays canned candidates or echoes the current source). When `codex` is not
 installed the provider fails fast with a clear error suggesting `--provider mock`.
+
+Winner commits are enabled by default and run only after successful final revalidation.
+Use `--no-commit-winner` for artifact-only runs. The CLI
+finds the repository from the absolute kernel path and supports `--vcs auto|git|hg` without
+using `sl`. Every generated commit includes the body line `TLX agent authored`. Existing
+unrelated staged and dirty work is preserved. If the target was already dirty, only the
+baseline-to-winner delta is committed and the original target edits remain unstaged/dirty;
+overlapping edits fail safely. Exit code `3` means optimization succeeded but commit failed,
+and `best_kernel.py` remains available. Commit metadata is written to `auto_commit.json`.
+
+The optimizer reports baseline, every candidate, and final revalidation performance
+to stderr as soon as each evaluation completes. Each line includes status, aggregate
+speedup, and per-case correctness, median, p95, CV, and speedup. Each try also logs a
+bounded hypothesis/change/expected-effect/risk summary before evaluation and a concise
+decision afterward. A requested commit emits one `commit status=committed|failed` event
+with VCS, revision, repository, target file, subject, and attribution. Kernel source is
+never printed to the live log. The final JSON remains on stdout so callers can parse it
+independently of live progress.
 
 `--budget` accepts an optional JSON file that overrides the `--max-*` / `--min-speedup` /
 `--max-cv` flags (`{max_rounds, candidates_per_round, max_candidate_seconds,
@@ -84,6 +108,7 @@ result.json                 # KernelOptimizationResult (success, baseline, final
 experiments.json            # alias of result.experiments (Google Doc compatibility)
 baseline_profile.json       # aggregated per-case profile for the baseline
 best_profile.json           # aggregated per-case profile for the promoted winner
+auto_commit.json             # present when --commit-winner reaches finalization
 artifacts/profile_traces/   # spilled large profile payloads
 experiments/
   baseline/{kernel.py, result.json, profile.json}
@@ -98,18 +123,25 @@ isolation in the CLI path; `StandaloneHarness` is available via the Python API.
 
 `harnesses/blackwell/targets/gemm/harness.py` runs any complete candidate source that exports
 `matmul(a, b)`. It compares against `torch.matmul`, benchmarks with
-`triton.testing.do_bench`, and reports latency and TFLOP/s. Set `TRITON_PROTON=1`
-to also collect a Triton Proton trace (returned inside `profile()`).
+`triton.testing.do_bench`, and reports latency and TFLOP/s. Its optional three-argument
+`profile(build_artifact, case, request)` honors structured profile requests: `proton_launch`
+collects one Triton launch-attribution-only Proton tree under the per-case artifacts
+directory, and `ncu` writes a one-launch replay runner plus command/query/stdout/stderr/report
+artifacts before returning normalized supported metrics. Missing tools, unsupported metrics,
+and profiler failures are returned as profile diagnostics so correctness and benchmark results
+remain usable. `proton_intra_kernel` is intentionally unsupported by the reference harness and
+requires a target-supplied instrumented replay; the harness never rewrites candidate source.
 
 ### Profiling recipes
 
-- **Triton Proton / Triton-MPP:** inside `profile()` wrap the kernel with
-  `import triton.profiler as proton; proton.start("matmul"); module.matmul(a,b); proton.deactivate()`
-  and return `{"proton_trace": ...}`. The agent persists it as-is.
-- **NCU:** shell `ncu --csv --metrics sm__throughput.avg.pct_of_peak_sustained_elapsed ...`
-  on a single rep, parse stdout, and return a small dict like
-  `{"ncu": {"sm_throughput": ...}}`. Large CSV traces can be written to a file and
-  returned as `{"artifact": "path/to/trace.csv"}` — the agent will spill >1MB payloads.
+- **Triton Proton launch attribution:** request `tools=["proton_launch"]` with an absolute
+  `artifacts_dir`. The reference GEMM harness warms up, synchronizes, starts Proton with
+  `hook="triton"` and tree data, runs one matmul, flushes/deactivates, saves raw tree JSON and
+  any `.hatchet` artifact, then parses `launch_attribution_only` totals.
+- **NCU:** request `tools=["ncu"]`. The reference GEMM harness queries metrics from the active
+  `ncu`/GPU, selects supported summary or deep aliases, runs a replay script importing the exact
+  candidate source path, saves command/query/CSV/stderr artifacts, and returns unsupported metrics
+  as `null` plus diagnostics.
 
 Target-specific `harness.py`/`cases.json`/`target.json` live colocated under `harnesses/<arch>/targets/<kernel>/` (B200,
 `sm_100` for blackwell and H100, `sm_90` for hopper); pick `--arch` to match the

--- a/third_party/tlx/tools/agents/kernel_optimization/README.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/README.md
@@ -126,7 +126,8 @@ isolation in the CLI path; `StandaloneHarness` is available via the Python API.
 `triton.testing.do_bench`, and reports latency and TFLOP/s. Its optional three-argument
 `profile(build_artifact, case, request)` honors structured profile requests: `proton_launch`
 collects one Triton launch-attribution-only Proton tree under the per-case artifacts
-directory, and `ncu` writes a one-launch replay runner plus command/query/stdout/stderr/report
+directory, and `native_profiler` selects the target platform profiler. NVIDIA harnesses map
+it to NCU, which writes a one-launch replay runner plus command/query/stdout/stderr/report
 artifacts before returning normalized supported metrics. Missing tools, unsupported metrics,
 and profiler failures are returned as profile diagnostics so correctness and benchmark results
 remain usable. `proton_intra_kernel` is intentionally unsupported by the reference harness and
@@ -138,10 +139,10 @@ requires a target-supplied instrumented replay; the harness never rewrites candi
   `artifacts_dir`. The reference GEMM harness warms up, synchronizes, starts Proton with
   `hook="triton"` and tree data, runs one matmul, flushes/deactivates, saves raw tree JSON and
   any `.hatchet` artifact, then parses `launch_attribution_only` totals.
-- **NCU:** request `tools=["ncu"]`. The reference GEMM harness queries metrics from the active
-  `ncu`/GPU, selects supported summary or deep aliases, runs a replay script importing the exact
-  candidate source path, saves command/query/CSV/stderr artifacts, and returns unsupported metrics
-  as `null` plus diagnostics.
+- **Native profiler:** request `tools=["native_profiler"]`. Each target harness maps this
+  portable name to its platform profiler. NVIDIA harnesses map it to NCU, select supported
+  summary or deep metrics, save command/query/CSV/stderr artifacts, and return unsupported
+  metrics as `null` plus diagnostics. Explicit `ncu` remains a compatible NVIDIA-only request.
 
 Target-specific `harness.py`/`cases.json`/`target.json` live colocated under `harnesses/<arch>/targets/<kernel>/` (B200,
 `sm_100` for blackwell and H100, `sm_90` for hopper); pick `--arch` to match the

--- a/third_party/tlx/tools/agents/kernel_optimization/cli.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/cli.py
@@ -8,11 +8,13 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
+from .harness import HarnessExecutionError, SubprocessHarness
 from .models import (
     InputCase,
     KernelOptimizationRequest,
     KernelTarget,
     OptimizationBudget,
+    passes_protected_cases,
     to_json_value,
 )
 from .optimizer import KernelOptimizer
@@ -311,9 +313,29 @@ def main() -> int:
     exit_code = 0 if result.success else 2
     if args.commit_winner and result.success:
         assert commit_snapshot is not None
+
+        def validate_committed_source(committed_source: str) -> None:
+            harness = SubprocessHarness(harness_path, budget.max_candidate_seconds)
+            validation = harness.evaluate(
+                committed_source,
+                cases,
+                target,
+                budget.benchmark_repetitions,
+            )
+            args.output_dir.joinpath("commit_revalidation.json").write_text(
+                json.dumps(to_json_value(validation), indent=2, sort_keys=True) + "\n"
+            )
+            if not passes_protected_cases(validation, cases):
+                raise HarnessExecutionError(
+                    "merged commit source failed one or more protected correctness cases"
+                )
+
         try:
             commit_result = commit_winner(
-                commit_snapshot, result.best_kernel, commit_subject
+                commit_snapshot,
+                result.best_kernel,
+                commit_subject,
+                validate_committed_source=validate_committed_source,
             )
         except Exception as error:  # noqa: BLE001
             commit_result = failed_auto_commit(commit_snapshot, commit_subject, error)

--- a/third_party/tlx/tools/agents/kernel_optimization/cli.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
@@ -15,6 +17,7 @@ from .models import (
 )
 from .optimizer import KernelOptimizer
 from .providers import CodexCandidateProvider, MockLLMProvider
+from .vcs import commit_winner, failed_auto_commit, prepare_auto_commit
 
 
 def _load_json(path: Path) -> Any:
@@ -22,7 +25,7 @@ def _load_json(path: Path) -> Any:
         return json.load(stream)
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(arguments: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Optimize a Triton or TLX kernel with a deterministic harness."
     )
@@ -44,7 +47,27 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--min-speedup", type=float, default=1.01)
     parser.add_argument("--max-cv", type=float, default=0.10)
     parser.add_argument("--benchmark-repetitions", type=int, default=10)
-    parser.add_argument("--model", default="sonnet")
+    parser.add_argument("--model", default=None)
+    parser.add_argument(
+        "--commit-winner",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Commit a successfully revalidated winner to the kernel's repository "
+            "(default: enabled; use --no-commit-winner to disable)."
+        ),
+    )
+    parser.add_argument(
+        "--commit-message",
+        default=None,
+        help="Commit subject; the TLX agent attribution is always added to the body.",
+    )
+    parser.add_argument(
+        "--vcs",
+        choices=["auto", "git", "hg"],
+        default="auto",
+        help="Version control for --commit-winner; auto detects from --kernel.",
+    )
     parser.add_argument(
         "--provider",
         choices=["codex", "mock"],
@@ -63,12 +86,21 @@ def _parse_args() -> argparse.Namespace:
         help="Collect harness profile() for baseline and candidates (default: profile is always collected).",
     )
     parser.add_argument(
+        "--diagnostic-proton-intra-kernel",
+        action="store_true",
+        default=False,
+        help=(
+            "Collect diagnostic-only per-warp proton_intra_kernel traces for the "
+            "baseline and final winner only."
+        ),
+    )
+    parser.add_argument(
         "--budget",
         type=Path,
         default=None,
         help="Optional JSON file that overrides --max-* / --min-speedup / --max-cv flags.",
     )
-    return parser.parse_args()
+    return parser.parse_args(arguments)
 
 
 def _budget_from_args(args: argparse.Namespace) -> OptimizationBudget:
@@ -190,6 +222,27 @@ def _validate_host_matches_target(
         )
 
 
+def _report_commit(commit_result: object) -> None:
+    result = commit_result
+    parts = [
+        "[tlx-agent] commit",
+        f"status={'committed' if result.success else 'failed'}",
+        f"vcs={result.vcs or 'unknown'}",
+    ]
+    if result.commit_revision:
+        parts.append(f"id={result.commit_revision}")
+    if result.repo_root:
+        parts.append(f"repo={result.repo_root}")
+    if result.target_relpath:
+        parts.append(f"file={result.target_relpath}")
+    if result.subject:
+        parts.append(f"subject={json.dumps(result.subject)}")
+    parts.append(f"attribution={json.dumps(result.attribution)}")
+    if result.diagnostics:
+        parts.append(f"diagnostics={json.dumps(result.diagnostics)}")
+    print(" ".join(parts), file=sys.stderr, flush=True)
+
+
 def main() -> int:
     args = _parse_args()
     harness_path, cases_path, target_path = _resolve_harness_paths(args.kernel, args.harness, args.cases, args.target, args.arch)
@@ -209,6 +262,7 @@ def main() -> int:
         architecture=str(target_payload["architecture"]),
         device=target_payload.get("device"),
         environment=target_payload.get("environment", {}),
+        optimization_guidance=str(target_payload.get("optimization_guidance", "")),
     )
     _validate_host_matches_target(target, args.arch)
     budget = _budget_from_args(args)
@@ -230,19 +284,50 @@ def main() -> int:
             model=args.model, timeout_seconds=budget.max_candidate_seconds
         )
     )
+    kernel_path = args.kernel.resolve()
+    kernel_source = kernel_path.read_text()
+    commit_subject = args.commit_message or f"Optimize {kernel_path.name} with TLX agent"
+    commit_snapshot = None
+    if args.commit_winner:
+        try:
+            commit_snapshot = prepare_auto_commit(kernel_path, kernel_source, args.vcs)
+        except Exception as error:  # noqa: BLE001
+            commit_result = failed_auto_commit(None, commit_subject, error)
+            _report_commit(commit_result)
+            print(json.dumps(to_json_value(commit_result), indent=2, sort_keys=True))
+            return 3
     reference_source = args.reference_kernel.read_text() if args.reference_kernel else None
     request = KernelOptimizationRequest(
-        kernel_source=args.kernel.read_text(),
+        kernel_source=kernel_source,
         reference_kernel_source=reference_source,
         harness_path=harness_path,
         cases=cases,
         target=target,
         budget=budget,
         output_dir=args.output_dir,
+        diagnostic_proton_intra_kernel=args.diagnostic_proton_intra_kernel,
     )
     result = KernelOptimizer(provider).optimize(request)
+    exit_code = 0 if result.success else 2
+    if args.commit_winner and result.success:
+        assert commit_snapshot is not None
+        try:
+            commit_result = commit_winner(
+                commit_snapshot, result.best_kernel, commit_subject
+            )
+        except Exception as error:  # noqa: BLE001
+            commit_result = failed_auto_commit(commit_snapshot, commit_subject, error)
+            exit_code = 3
+        result = replace(result, auto_commit=commit_result)
+        _report_commit(commit_result)
+        args.output_dir.joinpath("auto_commit.json").write_text(
+            json.dumps(to_json_value(commit_result), indent=2, sort_keys=True) + "\n"
+        )
+        args.output_dir.joinpath("result.json").write_text(
+            json.dumps(to_json_value(result), indent=2, sort_keys=True) + "\n"
+        )
     print(json.dumps(to_json_value(result), indent=2, sort_keys=True))
-    return 0 if result.success else 2
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tools/agents/kernel_optimization/harness.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harness.py
@@ -10,7 +10,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Mapping, Protocol, runtime_checkable
+from typing import Any, Mapping, Protocol, runtime_checkable
 
 from .models import (
     CaseEvaluation,
@@ -21,6 +21,13 @@ from .models import (
     TimingSamples,
     VerificationResult,
     to_json_value,
+)
+from .profiling import (
+    ProfileRequest,
+    compact_profile_output,
+    invoke_profile,
+    per_case_profile_request,
+    profile_request_to_json,
 )
 
 
@@ -55,7 +62,10 @@ class KernelHarness(Protocol):
     ) -> list[float] | Mapping[str, JsonValue]: ...
 
     def profile(
-        self, build_artifact: object, case: Mapping[str, JsonValue]
+        self,
+        build_artifact: object,
+        case: Mapping[str, JsonValue],
+        request: Mapping[str, JsonValue] | None = None,
     ) -> Mapping[str, JsonValue]: ...
 
 
@@ -75,14 +85,14 @@ class SubprocessHarness:
         cases: tuple[InputCase, ...],
         target: KernelTarget,
         benchmark_repetitions: int,
-        profile: bool = False,
+        profile: bool | ProfileRequest | Mapping[str, Any] = False,
     ) -> PerformanceSummary:
         request = {
             "kernel_source": kernel_source,
             "cases": to_json_value(cases),
             "target": to_json_value(target),
             "benchmark_repetitions": benchmark_repetitions,
-            "profile": profile,
+            "profile": profile_request_to_json(profile),
         }
         worker_path = Path(__file__).with_name("worker.py")
         environment = os.environ.copy()
@@ -169,7 +179,7 @@ class StandaloneHarness:
         cases: tuple[InputCase, ...],
         target: KernelTarget,
         benchmark_repetitions: int,
-        profile: bool = False,
+        profile: bool | ProfileRequest | Mapping[str, Any] = False,
     ) -> PerformanceSummary:
         harness = _load_harness(self.harness_path)
         if not hasattr(harness, "build") or not hasattr(harness, "verify") or not hasattr(harness, "benchmark"):
@@ -180,6 +190,7 @@ class StandaloneHarness:
         # Reuse worker normalization helpers for consistency.
         from .worker import _normalize_build, _normalize_timing, _normalize_verification
 
+        profile_payload_root = profile_request_to_json(profile)
         build_result = harness.build(kernel_source, dict(target_dict))  # type: ignore[arg-type]
         success, artifact, diagnostics = _normalize_build(build_result)
         if not success:
@@ -205,21 +216,15 @@ class StandaloneHarness:
                     warmup_count=int(timing_norm.get("warmup_count", 0)),
                     cache_policy=str(timing_norm.get("cache_policy", "unspecified")),
                 )
-                if profile and hasattr(harness, "profile"):
+                if profile_payload_root and hasattr(harness, "profile"):
                     try:
-                        raw_profile = harness.profile(artifact, dict(case_dict))  # type: ignore[arg-type]
-                        if not isinstance(raw_profile, Mapping):
-                            raise TypeError("profile() must return a mapping")
-                        # Cap inline size to keep PerformanceSummary bounded.
-                        serialized = json.dumps(dict(raw_profile))
-                        if len(serialized) > 1_000_000:
-                            profile_payload = {
-                                "error": "profile payload exceeded inline limit (1MB)",
-                                "size_bytes": len(serialized),
-                                "truncated_keys": list(raw_profile.keys()),
-                            }
-                        else:
-                            profile_payload = dict(raw_profile)
+                        profile_request = per_case_profile_request(
+                            profile_payload_root, case.case_id
+                        )
+                        raw_profile = invoke_profile(
+                            harness.profile, artifact, dict(case_dict), profile_request
+                        )
+                        profile_payload = compact_profile_output(raw_profile, profile_request)
                     except Exception as error:  # noqa: BLE001
                         profile_payload = {"error": f"{type(error).__name__}: {error}"}
             evaluations.append(

--- a/third_party/tlx/tools/agents/kernel_optimization/harness.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harness.py
@@ -28,6 +28,7 @@ from .profiling import (
     invoke_profile,
     per_case_profile_request,
     profile_request_to_json,
+    resolve_profile_request_for_target,
 )
 
 
@@ -92,7 +93,10 @@ class SubprocessHarness:
             "cases": to_json_value(cases),
             "target": to_json_value(target),
             "benchmark_repetitions": benchmark_repetitions,
-            "profile": profile_request_to_json(profile),
+            "profile": resolve_profile_request_for_target(
+                profile_request_to_json(profile),
+                to_json_value(target),  # type: ignore[arg-type]
+            ),
         }
         worker_path = Path(__file__).with_name("worker.py")
         environment = os.environ.copy()
@@ -190,7 +194,10 @@ class StandaloneHarness:
         # Reuse worker normalization helpers for consistency.
         from .worker import _normalize_build, _normalize_timing, _normalize_verification
 
-        profile_payload_root = profile_request_to_json(profile)
+        profile_payload_root = resolve_profile_request_for_target(
+            profile_request_to_json(profile),
+            target_dict,
+        )
         build_result = harness.build(kernel_source, dict(target_dict))  # type: ignore[arg-type]
         success, artifact, diagnostics = _normalize_build(build_result)
         if not success:

--- a/third_party/tlx/tools/agents/kernel_optimization/models.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/models.py
@@ -31,6 +31,7 @@ class KernelTarget:
     architecture: str
     device: str | None = None
     environment: Mapping[str, str] = field(default_factory=dict)
+    optimization_guidance: str = ""
 
 
 @dataclass(frozen=True)
@@ -66,6 +67,7 @@ class KernelOptimizationRequest:
     strategy: str = "best_first"
     reference_kernel_source: str | None = None
     output_dir: Path | None = None
+    diagnostic_proton_intra_kernel: bool = False
 
     def __post_init__(self) -> None:
         if not self.kernel_source.strip():
@@ -170,7 +172,27 @@ class ExperimentSummary:
     performance: PerformanceSummary | None = None
     diagnostics: str = ""
     mutation_summary: str = ""
+    hypothesis: str = ""
+    evidence: str = ""
+    expected_effect: str = ""
+    risk: str = ""
     profile_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class AutoCommitResult:
+    requested: bool
+    success: bool
+    vcs: str | None = None
+    repo_root: Path | None = None
+    target_path: Path | None = None
+    target_relpath: str | None = None
+    base_revision: str | None = None
+    commit_revision: str | None = None
+    subject: str | None = None
+    attribution: str = "TLX agent authored"
+    dirty_target_at_start: bool = False
+    diagnostics: str = ""
 
 
 @dataclass(frozen=True)
@@ -182,6 +204,7 @@ class KernelOptimizationResult:
     experiments: tuple[ExperimentSummary, ...]
     artifacts_dir: Path
     stopping_reason: str
+    auto_commit: AutoCommitResult | None = None
 
 
 def weighted_geometric_speedup(

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -260,6 +260,42 @@ def _profile_log_parts(profile: Mapping[str, Any]) -> list[str]:
     return parts
 
 
+def _rejection_feedback(
+    experiment_id: str,
+    proposal: object,
+    performance: PerformanceSummary,
+    baseline: PerformanceSummary,
+    cases: tuple[InputCase, ...],
+    decision: str,
+) -> str:
+    parts = [
+        f"{experiment_id}: rejected",
+        f"hypothesis={getattr(proposal, 'hypothesis', '')!r}",
+        f"change={getattr(proposal, 'summary', '')!r}",
+        f"decision={decision}",
+        f"aggregate_speedup={performance.aggregate_speedup:.4f}x",
+    ]
+    speedups = per_case_speedups(baseline, performance, cases)
+    for evaluation in performance.cases:
+        case_parts = [
+            evaluation.case_id,
+            "correct" if evaluation.verification.passed else "incorrect",
+        ]
+        if evaluation.timing is not None:
+            case_parts.extend(
+                (
+                    f"median={evaluation.timing.median_us:.3f}us",
+                    f"cv={evaluation.timing.coefficient_of_variation:.4f}",
+                )
+            )
+        speedup = speedups.get(evaluation.case_id)
+        if speedup is not None:
+            case_parts.append(f"speedup={speedup:.4f}x")
+        case_parts.extend(_profile_log_parts(evaluation.profile))
+        parts.append("case=" + ",".join(case_parts))
+    return " ".join(parts)[:4000]
+
+
 def _find_mapping_with_keys(
     value: Any,
     keys: frozenset[str],
@@ -514,14 +550,6 @@ class KernelOptimizer:
                         if not evaluation.verification.passed
                         and evaluation.verification.diagnostics
                     )
-                    if status == "rejected" and rejection_diagnostics:
-                        diagnostics.append(
-                            f"{experiment_id}: rejected: {rejection_diagnostics}"
-                        )
-                    if status == "rejected" and ncu_diagnostics:
-                        diagnostics.append(
-                            f"{experiment_id}: rejected: {ncu_diagnostics}"
-                        )
                     decision = (
                         "correct and exceeded speedup threshold"
                         if status == "promoted"
@@ -529,6 +557,17 @@ class KernelOptimizer:
                         or rejection_diagnostics
                         or f"speedup below {request.budget.min_speedup:.4f}x threshold"
                     )
+                    if status == "rejected":
+                        diagnostics.append(
+                            _rejection_feedback(
+                                experiment_id,
+                                proposal,
+                                performance,
+                                baseline,
+                                request.cases,
+                                decision,
+                            )
+                        )
                     _report_performance(
                         experiment_id,
                         status,

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -1,22 +1,336 @@
 from __future__ import annotations
 
+import sys
 import tempfile
 import time
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 from .artifacts import ArtifactStore
 from .harness import HarnessExecutionError, SubprocessHarness
 from .models import (
     ExperimentSummary,
+    InputCase,
     KernelOptimizationRequest,
     KernelOptimizationResult,
+    PerformanceSummary,
     is_promotable,
     passes_protected_cases,
+    per_case_speedups,
     weighted_geometric_speedup,
+)
+from .profiling import (
+    ProfileRequest,
+    compact_profile_summary,
+    extract_ncu_duration_us,
+    ncu_regression_diagnostic,
 )
 from .providers import CandidateContext, CandidateProvider, CodexCandidateProvider
 from .source import source_digest
+
+_PROFILE_TOOLS = ("proton_launch", "ncu")
+_DIAGNOSTIC_PROFILE_TOOLS = ("proton_intra_kernel",)
+_DIAGNOSTIC_PROFILE_KEY = "diagnostic_proton_intra_kernel"
+_NEAR_THRESHOLD_WINDOW = 0.01
+
+
+def _profile_request(
+    artifacts_dir: Path,
+    experiment_id: str,
+    *,
+    level: str,
+    reason: str,
+) -> ProfileRequest:
+    return ProfileRequest(
+        level=level,
+        tools=_PROFILE_TOOLS,
+        experiment_id=experiment_id,
+        artifacts_dir=artifacts_dir / "experiments" / experiment_id / "profile_artifacts",
+        reason=reason,
+    )
+
+
+def _diagnostic_profile_request(
+    artifacts_dir: Path,
+    experiment_id: str,
+    *,
+    reason: str,
+) -> ProfileRequest:
+    return ProfileRequest(
+        level="deep",
+        tools=_DIAGNOSTIC_PROFILE_TOOLS,
+        experiment_id=experiment_id,
+        artifacts_dir=artifacts_dir
+        / "experiments"
+        / experiment_id
+        / "diagnostic_profile_artifacts",
+        reason=reason,
+        diagnostic_only=True,
+        granularity="warp",
+    )
+
+
+def _profiles_by_case(performance: PerformanceSummary) -> dict[str, dict[str, Any]]:
+    return {evaluation.case_id: dict(evaluation.profile) for evaluation in performance.cases}
+
+
+def _diagnostic_error_profiles(
+    cases: tuple[InputCase, ...], error: Exception
+) -> dict[str, dict[str, Any]]:
+    return {
+        case.case_id: {"error": f"{type(error).__name__}: {error}"}
+        for case in cases
+    }
+
+
+def _collect_diagnostic_profiles(
+    harness: SubprocessHarness,
+    source: str,
+    request: KernelOptimizationRequest,
+    artifacts_dir: Path,
+    experiment_id: str,
+    *,
+    reason: str,
+) -> dict[str, dict[str, Any]]:
+    try:
+        performance = harness.evaluate(
+            source,
+            request.cases,
+            request.target,
+            request.budget.benchmark_repetitions,
+            profile=_diagnostic_profile_request(
+                artifacts_dir,
+                experiment_id,
+                reason=reason,
+            ),
+        )
+    except Exception as error:  # noqa: BLE001
+        return _diagnostic_error_profiles(request.cases, error)
+    return _profiles_by_case(performance)
+
+
+def _merge_diagnostic_profiles(
+    performance: PerformanceSummary,
+    diagnostic_profiles: Mapping[str, Mapping[str, Any]],
+) -> PerformanceSummary:
+    if not diagnostic_profiles:
+        return performance
+    merged_cases = []
+    for evaluation in performance.cases:
+        diagnostic_profile = diagnostic_profiles.get(evaluation.case_id)
+        if not diagnostic_profile:
+            merged_cases.append(evaluation)
+            continue
+        profile = dict(evaluation.profile)
+        profile[_DIAGNOSTIC_PROFILE_KEY] = compact_profile_summary(diagnostic_profile)
+        merged_cases.append(replace(evaluation, profile=profile))
+    return replace(performance, cases=tuple(merged_cases))
+
+
+def _report_candidate_summary(experiment_id: str, proposal: object) -> None:
+    fields = (
+        ("hypothesis", getattr(proposal, "hypothesis", "")),
+        ("evidence", getattr(proposal, "evidence", "")),
+        ("change", getattr(proposal, "summary", "")),
+        ("expected", getattr(proposal, "expected_effect", "")),
+        ("risk", getattr(proposal, "risk", "")),
+    )
+    details = " ".join(
+        f"{name}={value!r}" for name, value in fields if value
+    ) or "change='candidate source edited'"
+    print(f"[tlx-agent] {experiment_id} {details}", file=sys.stderr, flush=True)
+
+
+def _report_performance(
+    experiment_id: str,
+    status: str,
+    performance: PerformanceSummary | None,
+    *,
+    baseline: PerformanceSummary | None = None,
+    cases: tuple[InputCase, ...] = (),
+    diagnostics: str = "",
+) -> None:
+    parts = [f"[tlx-agent] {experiment_id} status={status}"]
+    if performance is not None:
+        parts.append(f"aggregate_speedup={performance.aggregate_speedup:.4f}x")
+        speedups = (
+            per_case_speedups(baseline, performance, cases)
+            if baseline is not None
+            else {}
+        )
+        for evaluation in performance.cases:
+            case_parts = [
+                evaluation.case_id,
+                "correct" if evaluation.verification.passed else "incorrect",
+            ]
+            if evaluation.timing is not None:
+                timing = evaluation.timing
+                case_parts.extend(
+                    (
+                        f"median={timing.median_us:.3f}us",
+                        f"p95={timing.p95_us:.3f}us",
+                        f"cv={timing.coefficient_of_variation:.4f}",
+                    )
+                )
+            speedup = speedups.get(evaluation.case_id)
+            if speedup is not None:
+                case_parts.append(f"speedup={speedup:.4f}x")
+            case_parts.extend(_profile_log_parts(evaluation.profile))
+            parts.append("case=" + ",".join(case_parts))
+    if diagnostics:
+        parts.append(f"diagnostics={diagnostics}")
+    print(" ".join(parts), file=sys.stderr, flush=True)
+
+
+def _profile_log_parts(profile: Mapping[str, Any]) -> list[str]:
+    if not profile:
+        return ["ncu=unavailable"]
+    compact = compact_profile_summary(profile)
+    parts: list[str] = []
+    proton_totals = _find_mapping_with_keys(
+        compact,
+        frozenset({"wrapper_us", "main_kernel_us", "non_main_kernel_us"}),
+    ) or _find_mapping_with_keys(
+        profile,
+        frozenset({"wrapper_us", "main_kernel_us", "non_main_kernel_us"}),
+    )
+    if proton_totals is not None:
+        for label, key in (
+            ("proton.wrapper_us", "wrapper_us"),
+            ("proton.main_kernel_us", "main_kernel_us"),
+            ("proton.non_main_kernel_us", "non_main_kernel_us"),
+        ):
+            value = _coerce_float(proton_totals.get(key))
+            if value is not None:
+                parts.append(f"{label}={value:.3f}")
+    ncu_duration = extract_ncu_duration_us(compact)
+    if ncu_duration is None:
+        ncu_duration = extract_ncu_duration_us(profile)
+    if ncu_duration is not None:
+        parts.append(f"ncu.duration_us={ncu_duration:.3f}")
+    else:
+        parts.append("ncu=unavailable")
+    diagnostic = compact.get(_DIAGNOSTIC_PROFILE_KEY)
+    if not isinstance(diagnostic, Mapping):
+        diagnostic = profile.get(_DIAGNOSTIC_PROFILE_KEY)
+    if isinstance(diagnostic, Mapping):
+        intra = diagnostic.get(_DIAGNOSTIC_PROFILE_KEY)
+        if not isinstance(intra, Mapping):
+            intra = diagnostic
+        valid = intra.get("valid")
+        if isinstance(valid, bool):
+            parts.append(f"proton.intra.valid={str(valid).lower()}")
+        selected_cta = intra.get("selected_cta")
+        if selected_cta is not None:
+            parts.append(f"proton.intra.cta={selected_cta}")
+        coordinates = intra.get("logical_coordinates")
+        if isinstance(coordinates, Mapping):
+            coordinate_text = "/".join(
+                f"{key}:{coordinates[key]}"
+                for key in (
+                    "start_n",
+                    "logical_block",
+                    "curr_m",
+                    "mma_producer_j",
+                    "load_input_j",
+                )
+                if key in coordinates
+            )
+            if coordinate_text:
+                parts.append(f"proton.intra.tile={coordinate_text}")
+        waits = intra.get("dominant_waits")
+        if isinstance(waits, list) and waits and isinstance(waits[0], Mapping):
+            wait_name = waits[0].get("name")
+            wait_duration = _coerce_float(waits[0].get("duration"))
+            if wait_name and wait_duration is not None:
+                parts.append(
+                    f"proton.intra.dominant_wait={wait_name}:{wait_duration:.3f}us"
+                )
+        trace_path = intra.get("trace_path")
+        if trace_path:
+            parts.append(f"proton.intra.trace={trace_path}")
+    error = compact.get("error")
+    if error:
+        parts.append(f"profile.error={error}")
+    artifact = compact.get("artifact")
+    if artifact:
+        parts.append(f"profile.artifact={artifact}")
+    return parts
+
+
+def _find_mapping_with_keys(
+    value: Any,
+    keys: frozenset[str],
+) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        if keys.issubset({str(key) for key in value.keys()}):
+            return value
+        for item in value.values():
+            match = _find_mapping_with_keys(item, keys)
+            if match is not None:
+                return match
+    if isinstance(value, list | tuple):
+        for item in value:
+            match = _find_mapping_with_keys(item, keys)
+            if match is not None:
+                return match
+    return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    try:
+        return float(str(value).strip().replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _is_correct_and_stable(
+    performance: PerformanceSummary,
+    budget: object,
+    cases: tuple[InputCase, ...],
+) -> bool:
+    case_by_id = {case.case_id: case for case in cases}
+    for evaluation in performance.cases:
+        case = case_by_id.get(evaluation.case_id)
+        protected = case.protected if case is not None else True
+        if not evaluation.verification.passed:
+            if protected:
+                return False
+            continue
+        if evaluation.timing is None:
+            return False
+        if evaluation.timing.coefficient_of_variation > budget.max_cv:
+            return False
+    return True
+
+
+def _is_near_threshold(speedup: float, threshold: float) -> bool:
+    return threshold - _NEAR_THRESHOLD_WINDOW <= speedup <= threshold + _NEAR_THRESHOLD_WINDOW
+
+
+def _ncu_regression_diagnostics(
+    baseline: PerformanceSummary,
+    candidate: PerformanceSummary,
+) -> str:
+    baseline_by_case = {evaluation.case_id: evaluation for evaluation in baseline.cases}
+    diagnostics: list[str] = []
+    for evaluation in candidate.cases:
+        baseline_evaluation = baseline_by_case.get(evaluation.case_id)
+        if baseline_evaluation is None:
+            continue
+        diagnostic = ncu_regression_diagnostic(
+            baseline_evaluation.profile,
+            evaluation.profile,
+        )
+        if diagnostic:
+            diagnostics.append(f"{evaluation.case_id}: {diagnostic}")
+    return "; ".join(diagnostics)
 
 
 class KernelOptimizer:
@@ -45,17 +359,30 @@ class KernelOptimizer:
             request.cases,
             request.target,
             request.budget.benchmark_repetitions,
-            profile=True,
+            profile=_profile_request(
+                artifacts_dir,
+                "baseline",
+                level="deep",
+                reason="baseline",
+            ),
         )
         if not passes_protected_cases(baseline, request.cases):
             raise HarnessExecutionError(
                 "baseline failed one or more protected correctness cases"
             )
         baseline = replace(baseline, aggregate_speedup=1.0)
-        baseline_profiles = {
-            evaluation.case_id: dict(evaluation.profile) for evaluation in baseline.cases
-        }
-        store.write_profile("baseline", baseline_profiles)
+        if request.diagnostic_proton_intra_kernel:
+            baseline_diagnostics = _collect_diagnostic_profiles(
+                harness,
+                request.kernel_source,
+                request,
+                artifacts_dir,
+                "baseline",
+                reason="baseline_diagnostic",
+            )
+            baseline = _merge_diagnostic_profiles(baseline, baseline_diagnostics)
+        baseline_profiles = _profiles_by_case(baseline)
+        baseline_profile_path = store.write_profile("baseline", baseline_profiles)
         store.write_aggregated_profile("baseline_profile", baseline_profiles)
         experiments = [
             ExperimentSummary(
@@ -65,9 +392,11 @@ class KernelOptimizer:
                 status="baseline",
                 source_path=baseline_source_path,
                 performance=baseline,
+                profile_path=baseline_profile_path,
             )
         ]
         store.write_json("experiments/baseline/result.json", baseline)
+        _report_performance("baseline", "baseline", baseline)
 
         best_source = request.kernel_source
         best_performance = baseline
@@ -91,6 +420,7 @@ class KernelOptimizer:
                 experiment_id = f"r{round_index:03d}-c{candidate_index:03d}"
                 proposal = None
                 try:
+                    _report_performance(experiment_id, "generating", None)
                     proposal = self._provider.propose(
                         request,
                         CandidateContext(
@@ -101,33 +431,66 @@ class KernelOptimizer:
                             previous_diagnostics=tuple(diagnostics),
                         ),
                     )
+                    _report_candidate_summary(experiment_id, proposal)
                     digest = source_digest(proposal.source)
                     if digest in seen_sources:
                         raise ValueError("candidate source duplicates an earlier experiment")
                     seen_sources.add(digest)
                     source_path = store.write_source(experiment_id, proposal.source)
+                    _report_performance(experiment_id, "evaluating", None)
                     performance = harness.evaluate(
                         proposal.source,
                         request.cases,
                         request.target,
                         request.budget.benchmark_repetitions,
-                        profile=True,
+                        profile=_profile_request(
+                            artifacts_dir,
+                            experiment_id,
+                            level="summary",
+                            reason="candidate",
+                        ),
                     )
-                    # Persist per-case profiles for this candidate regardless of promotion.
-                    perf_profiles = {
-                        evaluation.case_id: dict(evaluation.profile)
-                        for evaluation in performance.cases
-                    }
-                    store.write_profile(experiment_id, perf_profiles)
                     speedup = weighted_geometric_speedup(
                         baseline, performance, request.cases
                     )
-                    performance = replace(
-                        performance, aggregate_speedup=speedup
-                    )
+                    performance = replace(performance, aggregate_speedup=speedup)
+                    if _is_correct_and_stable(
+                        performance,
+                        request.budget,
+                        request.cases,
+                    ) and _is_near_threshold(speedup, request.budget.min_speedup):
+                        _report_performance(
+                            experiment_id,
+                            "near-threshold-profiling",
+                            performance,
+                            baseline=baseline,
+                            cases=request.cases,
+                            diagnostics="reason=near_threshold",
+                        )
+                        performance = harness.evaluate(
+                            proposal.source,
+                            request.cases,
+                            request.target,
+                            request.budget.benchmark_repetitions,
+                            profile=_profile_request(
+                                artifacts_dir,
+                                experiment_id,
+                                level="deep",
+                                reason="near_threshold",
+                            ),
+                        )
+                        speedup = weighted_geometric_speedup(
+                            baseline, performance, request.cases
+                        )
+                        performance = replace(performance, aggregate_speedup=speedup)
+                    # Persist per-case profiles for this candidate regardless of promotion.
+                    perf_profiles = _profiles_by_case(performance)
+                    profile_path = store.write_profile(experiment_id, perf_profiles)
+                    ncu_diagnostics = _ncu_regression_diagnostics(baseline, performance)
                     status = (
                         "promoted"
-                        if is_promotable(performance, request.budget, request.cases)
+                        if not ncu_diagnostics
+                        and is_promotable(performance, request.budget, request.cases)
                         and speedup > best_performance.aggregate_speedup
                         else "rejected"
                     )
@@ -139,6 +502,40 @@ class KernelOptimizer:
                         source_path=source_path,
                         performance=performance,
                         mutation_summary=proposal.summary,
+                        hypothesis=proposal.hypothesis,
+                        evidence=proposal.evidence,
+                        expected_effect=proposal.expected_effect,
+                        risk=proposal.risk,
+                        profile_path=profile_path,
+                    )
+                    rejection_diagnostics = "; ".join(
+                        f"{evaluation.case_id}: {evaluation.verification.diagnostics}"
+                        for evaluation in performance.cases
+                        if not evaluation.verification.passed
+                        and evaluation.verification.diagnostics
+                    )
+                    if status == "rejected" and rejection_diagnostics:
+                        diagnostics.append(
+                            f"{experiment_id}: rejected: {rejection_diagnostics}"
+                        )
+                    if status == "rejected" and ncu_diagnostics:
+                        diagnostics.append(
+                            f"{experiment_id}: rejected: {ncu_diagnostics}"
+                        )
+                    decision = (
+                        "correct and exceeded speedup threshold"
+                        if status == "promoted"
+                        else ncu_diagnostics
+                        or rejection_diagnostics
+                        or f"speedup below {request.budget.min_speedup:.4f}x threshold"
+                    )
+                    _report_performance(
+                        experiment_id,
+                        status,
+                        performance,
+                        baseline=baseline,
+                        cases=request.cases,
+                        diagnostics=f"decision={decision}",
                     )
                     if status == "promoted":
                         best_source = proposal.source
@@ -160,6 +557,12 @@ class KernelOptimizer:
                         source_path=source_path,
                         diagnostics=message,
                     )
+                    _report_performance(
+                        experiment_id,
+                        "failed",
+                        None,
+                        diagnostics=message,
+                    )
                 experiments.append(experiment)
                 store.write_json(
                     f"experiments/{experiment_id}/result.json", experiment
@@ -167,15 +570,19 @@ class KernelOptimizer:
             if exhausted:
                 break
             if not promoted_this_round:
-                stopping_reason = "no_promotable_candidate"
-                break
+                stopping_reason = "round_budget_exhausted"
 
         final_profile = harness.evaluate(
             best_source,
             request.cases,
             request.target,
             request.budget.benchmark_repetitions,
-            profile=True,
+            profile=_profile_request(
+                artifacts_dir,
+                "final",
+                level="deep",
+                reason="final",
+            ),
         )
         final_profile = replace(
             final_profile,
@@ -183,19 +590,45 @@ class KernelOptimizer:
                 baseline, final_profile, request.cases
             ),
         )
-        final_profiles = {
-            evaluation.case_id: dict(evaluation.profile) for evaluation in final_profile.cases
-        }
-        if best_experiment_id != "baseline" and not is_promotable(
-            final_profile, request.budget, request.cases
+        final_ncu_diagnostics = _ncu_regression_diagnostics(baseline, final_profile)
+        if best_experiment_id != "baseline" and (
+            final_ncu_diagnostics
+            or not is_promotable(final_profile, request.budget, request.cases)
         ):
+            if final_ncu_diagnostics:
+                diagnostics.append(f"final: rejected: {final_ncu_diagnostics}")
             best_source = request.kernel_source
             final_profile = baseline
             final_profiles = baseline_profiles
             best_experiment_id = "baseline"
             stopping_reason = "finalist_revalidation_failed"
-        else:
+        elif best_experiment_id != "baseline":
+            if request.diagnostic_proton_intra_kernel:
+                final_diagnostics = _collect_diagnostic_profiles(
+                    harness,
+                    best_source,
+                    request,
+                    artifacts_dir,
+                    "final",
+                    reason="final_winner_diagnostic",
+                )
+                final_profile = _merge_diagnostic_profiles(
+                    final_profile, final_diagnostics
+                )
+            final_profiles = _profiles_by_case(final_profile)
             best_profiles = final_profiles
+        else:
+            final_profile = baseline
+            final_profiles = baseline_profiles
+        store.write_profile("final", final_profiles)
+        _report_performance(
+            "final",
+            "revalidated" if best_experiment_id != "baseline" else "baseline",
+            final_profile,
+            baseline=baseline,
+            cases=request.cases,
+            diagnostics=final_ncu_diagnostics,
+        )
         store.write_aggregated_profile("best_profile", best_profiles)
         # Doc-compatible alias: experiments.json mirrors the experiments list.
         store.write_json("experiments.json", tuple(experiments))

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -600,6 +600,7 @@ class KernelOptimizer:
             best_source = request.kernel_source
             final_profile = baseline
             final_profiles = baseline_profiles
+            best_profiles = baseline_profiles
             best_experiment_id = "baseline"
             stopping_reason = "finalist_revalidation_failed"
         elif best_experiment_id != "baseline":

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -30,7 +30,7 @@ from .profiling import (
 from .providers import CandidateContext, CandidateProvider, CodexCandidateProvider
 from .source import source_digest
 
-_PROFILE_TOOLS = ("proton_launch", "ncu")
+_PROFILE_TOOLS = ("proton_launch", "native_profiler")
 _DIAGNOSTIC_PROFILE_TOOLS = ("proton_intra_kernel",)
 _DIAGNOSTIC_PROFILE_KEY = "diagnostic_proton_intra_kernel"
 _NEAR_THRESHOLD_WINDOW = 0.01

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -212,6 +212,23 @@ def per_case_profile_request(
     return replace(request, artifacts_dir=case_dir).to_json()
 
 
+def resolve_profile_tools(
+    tools: Iterable[object],
+    *,
+    native_profiler: str | None = None,
+    default: Iterable[object] = (),
+) -> tuple[str, ...]:
+    """Resolve target-neutral profiler names while preserving request order."""
+    requested = tuple(str(tool) for tool in tools) or tuple(str(tool) for tool in default)
+    resolved: list[str] = []
+    for tool in requested:
+        if tool == "native_profiler" and native_profiler is not None:
+            tool = native_profiler
+        if tool not in resolved:
+            resolved.append(tool)
+    return tuple(resolved)
+
+
 def profile_accepts_request(profile_fn: Callable[..., Any]) -> bool:
     try:
         signature = inspect.signature(profile_fn)
@@ -433,6 +450,7 @@ def compact_profile_summary(profile: Mapping[str, Any]) -> dict[str, Any]:
         "summary",
         "proton",
         "ncu",
+        "native_profiler",
         "diagnostics",
         "diagnostic_proton_intra_kernel",
         "artifacts",

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -1,0 +1,601 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import inspect
+import io
+import json
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+_INLINE_PROFILE_LIMIT_BYTES = 1_000_000
+_PROFILE_LEVELS = frozenset({"summary", "deep"})
+_RAW_PROFILE_KEYS = frozenset(
+    {
+        "blob",
+        "content",
+        "contents",
+        "data",
+        "events",
+        "raw",
+        "raw_metrics",
+        "raw_profile",
+        "rows",
+        "trace_events",
+    }
+)
+
+SUMMARY_NCU_METRIC_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "duration_us": (
+        "duration_us",
+        "gpu__time_duration.sum",
+        "gpu__time_duration.avg",
+        "Duration",
+    ),
+    "sm_throughput_pct": (
+        "sm_throughput_pct",
+        "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+    ),
+    "dram_throughput_pct": (
+        "dram_throughput_pct",
+        "dram__throughput.avg.pct_of_peak_sustained_elapsed",
+    ),
+}
+
+DEEP_NCU_METRIC_ALIASES: Mapping[str, tuple[str, ...]] = {
+    **SUMMARY_NCU_METRIC_ALIASES,
+    "barrier_pct": ("smsp__warp_issue_stalled_barrier_per_warp_active.pct",),
+    "async_wait_pct": ("smsp__warp_issue_stalled_wait_per_warp_active.pct",),
+    "long_scoreboard_pct": (
+        "smsp__warp_issue_stalled_long_scoreboard_per_warp_active.pct",
+    ),
+    "short_scoreboard_pct": (
+        "smsp__warp_issue_stalled_short_scoreboard_per_warp_active.pct",
+    ),
+    "mio_throttle_pct": (
+        "smsp__warp_issue_stalled_mio_throttle_per_warp_active.pct",
+    ),
+    "dependency_pct": ("smsp__warp_issue_stalled_math_pipe_throttle_per_warp_active.pct",),
+    "registers_per_thread": ("launch__registers_per_thread",),
+    "achieved_occupancy_pct": ("sm__warps_active.avg.pct_of_peak_sustained_active",),
+    "theoretical_occupancy_pct": ("launch__occupancy_limit_registers",),
+    "local_load_bytes": ("memory_l1_wavefronts_shared",),
+    "local_store_bytes": ("l1tex__t_bytes_pipe_lsu_mem_local_op_st.sum",),
+    "spill_loads": ("launch__sass_reg_spill_loads",),
+    "spill_stores": ("launch__sass_reg_spill_stores",),
+    "l1_bytes": ("l1tex__t_bytes.sum",),
+    "l1_hit_rate_pct": ("l1tex__t_sector_hit_rate.pct",),
+    "shared_bank_conflicts": ("l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum",),
+    "l2_read_bytes": ("lts__t_bytes_op_read.sum",),
+    "l2_write_bytes": ("lts__t_bytes_op_write.sum",),
+    "l2_hit_rate_pct": ("lts__t_sector_hit_rate.pct",),
+    "dram_read_bytes": ("dram__bytes_read.sum",),
+    "dram_write_bytes": ("dram__bytes_write.sum",),
+    "tensor_activity_pct": ("sm__pipe_tensor_active.avg.pct_of_peak_sustained_active",),
+    "issue_active_pct": ("smsp__issue_active.avg.pct_of_peak_sustained_active",),
+    "eligible_warps_per_cycle": ("smsp__warps_eligible.avg.per_cycle_active",),
+    "active_warps_per_cycle": ("smsp__warps_active.avg.per_cycle_active",),
+}
+
+_NCU_FIELD_GROUPS: Mapping[str, str] = {
+    "duration_us": "summary",
+    "sm_throughput_pct": "summary",
+    "dram_throughput_pct": "summary",
+    "barrier_pct": "stalls",
+    "async_wait_pct": "stalls",
+    "long_scoreboard_pct": "stalls",
+    "short_scoreboard_pct": "stalls",
+    "mio_throttle_pct": "stalls",
+    "dependency_pct": "stalls",
+    "registers_per_thread": "registers",
+    "achieved_occupancy_pct": "registers",
+    "theoretical_occupancy_pct": "registers",
+    "occupancy_limiters": "registers",
+    "local_load_bytes": "registers",
+    "local_store_bytes": "registers",
+    "spill_loads": "registers",
+    "spill_stores": "registers",
+    "l1_bytes": "memory",
+    "l1_hit_rate_pct": "memory",
+    "shared_bank_conflicts": "memory",
+    "l2_read_bytes": "memory",
+    "l2_write_bytes": "memory",
+    "l2_hit_rate_pct": "memory",
+    "dram_read_bytes": "memory",
+    "dram_write_bytes": "memory",
+    "tensor_activity_pct": "compute",
+    "issue_active_pct": "compute",
+    "eligible_warps_per_cycle": "compute",
+    "active_warps_per_cycle": "compute",
+}
+
+
+@dataclass(frozen=True)
+class ProfileRequest:
+    level: str = "summary"
+    tools: tuple[str, ...] = ()
+    experiment_id: str = ""
+    artifacts_dir: Path | None = None
+    reason: str = ""
+    diagnostic_only: bool = False
+    granularity: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.level not in _PROFILE_LEVELS:
+            raise ValueError("profile level must be 'summary' or 'deep'")
+        object.__setattr__(self, "tools", tuple(str(tool) for tool in self.tools))
+        if self.artifacts_dir is not None:
+            artifacts_dir = Path(self.artifacts_dir)
+            if not artifacts_dir.is_absolute():
+                raise ValueError("profile artifacts_dir must be absolute")
+            object.__setattr__(self, "artifacts_dir", artifacts_dir)
+        if "proton_intra_kernel" in self.tools:
+            if not self.diagnostic_only:
+                raise ValueError("proton_intra_kernel requires diagnostic_only=True")
+            if self.granularity is not None and self.granularity != "warp":
+                raise ValueError("proton_intra_kernel only supports warp granularity")
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "level": self.level,
+            "tools": list(self.tools),
+            "experiment_id": self.experiment_id,
+            "artifacts_dir": str(self.artifacts_dir) if self.artifacts_dir else None,
+            "reason": self.reason,
+            "diagnostic_only": self.diagnostic_only,
+            "granularity": self.granularity,
+        }
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> ProfileRequest:
+        tools = payload.get("tools", ())
+        if isinstance(tools, str):
+            tools = (tools,)
+        if not isinstance(tools, Iterable):
+            raise TypeError("profile tools must be a string or iterable")
+        artifacts_dir_raw = payload.get("artifacts_dir")
+        artifacts_dir = Path(str(artifacts_dir_raw)) if artifacts_dir_raw else None
+        return cls(
+            level=str(payload.get("level", "summary")),
+            tools=tuple(str(tool) for tool in tools),
+            experiment_id=str(payload.get("experiment_id", "")),
+            artifacts_dir=artifacts_dir,
+            reason=str(payload.get("reason", "")),
+            diagnostic_only=bool(payload.get("diagnostic_only", False)),
+            granularity=(
+                str(payload["granularity"]) if payload.get("granularity") is not None else None
+            ),
+        )
+
+
+def normalize_profile_request(profile: bool | ProfileRequest | Mapping[str, Any]) -> ProfileRequest | None:
+    if profile is False or profile is None:
+        return None
+    if profile is True:
+        return ProfileRequest()
+    if isinstance(profile, ProfileRequest):
+        return profile
+    if isinstance(profile, Mapping):
+        return ProfileRequest.from_mapping(profile)
+    raise TypeError("profile must be bool, ProfileRequest, or mapping")
+
+
+def profile_request_to_json(profile: bool | ProfileRequest | Mapping[str, Any]) -> dict[str, Any] | bool:
+    request = normalize_profile_request(profile)
+    return request.to_json() if request is not None else False
+
+
+def safe_case_id(case_id: object) -> str:
+    raw = str(case_id)
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("._-") or "case"
+    if safe == raw and len(safe) <= 96:
+        return safe
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8]
+    return f"{safe[:80].rstrip('._-') or 'case'}-{digest}"
+
+
+def per_case_profile_request(
+    request_payload: Mapping[str, Any] | bool | None, case_id: object
+) -> dict[str, Any] | None:
+    if not request_payload:
+        return None
+    request = normalize_profile_request(request_payload)
+    if request is None:
+        return None
+    if request.artifacts_dir is None:
+        return request.to_json()
+    case_dir = request.artifacts_dir / safe_case_id(case_id)
+    case_dir.mkdir(parents=True, exist_ok=True)
+    return replace(request, artifacts_dir=case_dir).to_json()
+
+
+def profile_accepts_request(profile_fn: Callable[..., Any]) -> bool:
+    try:
+        signature = inspect.signature(profile_fn)
+    except (TypeError, ValueError):
+        return False
+    try:
+        signature.bind(object(), {}, {})
+    except TypeError:
+        return False
+    return True
+
+
+def invoke_profile(
+    profile_fn: Callable[..., Any],
+    artifact: object,
+    case: Mapping[str, Any],
+    request_payload: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    if profile_accepts_request(profile_fn):
+        raw_profile = profile_fn(artifact, case, request_payload)
+    else:
+        raw_profile = profile_fn(artifact, case)
+    if not isinstance(raw_profile, Mapping):
+        raise TypeError("profile() must return a mapping")
+    return raw_profile
+
+
+def compact_profile_output(
+    raw_profile: Mapping[str, Any], request_payload: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    serialized = json.dumps(dict(raw_profile))
+    if len(serialized.encode("utf-8")) <= _INLINE_PROFILE_LIMIT_BYTES:
+        return dict(raw_profile)
+    artifacts_dir_raw = request_payload.get("artifacts_dir") if request_payload else None
+    if artifacts_dir_raw:
+        artifacts_dir = Path(str(artifacts_dir_raw))
+        if artifacts_dir.is_absolute():
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            artifact_path = artifacts_dir / "raw_profile.json"
+            artifact_path.write_text(serialized + "\n")
+            return {
+                "artifact": str(artifact_path),
+                "size_bytes": len(serialized.encode("utf-8")),
+                "truncated": True,
+            }
+    return {
+        "error": "profile payload exceeded inline limit (1MB)",
+        "size_bytes": len(serialized.encode("utf-8")),
+        "truncated_keys": list(raw_profile.keys()),
+    }
+
+
+def parse_proton_launch_attribution(payload: Any) -> dict[str, Any]:
+    leaves: list[dict[str, Any]] = []
+    for node in _iter_nodes(payload):
+        children = _node_children(node)
+        if children:
+            continue
+        time_us = _node_time_us(node)
+        if time_us is None:
+            continue
+        name = _node_name(node)
+        count = _node_count(node)
+        leaves.append({"name": name, "time_us": time_us, "count": count})
+
+    totals = {
+        "wrapper_us": 0.0,
+        "main_kernel_us": 0.0,
+        "non_main_kernel_us": 0.0,
+        "leaf_time_us": 0.0,
+        "count": 0,
+    }
+    for leaf in leaves:
+        time_us = float(leaf["time_us"] or 0.0)
+        totals["leaf_time_us"] += time_us
+        totals["count"] += int(leaf["count"] or 0)
+        kind = _leaf_kind(leaf["name"])
+        if kind == "main_kernel":
+            totals["main_kernel_us"] += time_us
+        elif kind == "non_main_kernel":
+            totals["non_main_kernel_us"] += time_us
+        else:
+            totals["wrapper_us"] += time_us
+    return {
+        "schema": "launch_attribution_only",
+        "leaves": leaves,
+        "totals": totals,
+    }
+
+
+def parse_ncu_csv(csv_text: str) -> dict[str, dict[str, Any]]:
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if reader.fieldnames is None:
+        return {}
+    headers = {_normalize_header(header): header for header in reader.fieldnames}
+    name_key = _first_header(headers, ("metric_name", "name", "metric"))
+    value_key = _first_header(headers, ("metric_value", "value"))
+    unit_key = _first_header(headers, ("metric_unit", "unit"))
+    if name_key is None or value_key is None:
+        return {}
+    metrics: dict[str, dict[str, Any]] = {}
+    for row in reader:
+        name = str(row.get(name_key, "")).strip()
+        if not name:
+            continue
+        value_raw = str(row.get(value_key, "")).strip()
+        unit = str(row.get(unit_key, "")).strip() if unit_key else ""
+        metrics[name] = {"value": _parse_metric_value(value_raw), "unit": unit}
+    return metrics
+
+
+def parse_ncu_query_metrics(query_text: str) -> set[str]:
+    reader = csv.DictReader(io.StringIO(query_text))
+    if reader.fieldnames is not None:
+        headers = {_normalize_header(header): header for header in reader.fieldnames}
+        name_key = _first_header(
+            headers,
+            ("metric_name", "name", "metric", "identifier", "metric_identifier"),
+        )
+        if name_key is not None:
+            metrics = {
+                str(row.get(name_key, "")).strip()
+                for row in reader
+                if str(row.get(name_key, "")).strip()
+            }
+            if metrics:
+                return metrics
+    metrics: set[str] = set()
+    for line in query_text.splitlines():
+        token = line.strip().split(",", 1)[0].strip().strip('"')
+        if token and "__" in token:
+            metrics.add(token)
+    return metrics
+
+
+def select_ncu_metric_names(
+    supported_names: Iterable[str], level: str = "summary"
+) -> dict[str, Any]:
+    aliases = _ncu_aliases_for_level(level)
+    supported = {str(name) for name in supported_names}
+    selected: dict[str, str | None] = {}
+    diagnostics: list[str] = []
+    for semantic_name, candidates in aliases.items():
+        match = next((candidate for candidate in candidates if candidate in supported), None)
+        selected[semantic_name] = match
+        if match is None:
+            diagnostics.append(f"missing NCU metric for {semantic_name}")
+    return {"metrics": selected, "diagnostics": diagnostics}
+
+
+def normalize_ncu_metrics(raw_metrics: Mapping[str, Any], level: str = "summary") -> dict[str, Any]:
+    selected = select_ncu_metric_names(raw_metrics.keys(), level)
+    result: dict[str, Any] = {
+        "level": level,
+        "summary": {},
+        "stalls": {},
+        "registers": {},
+        "memory": {},
+        "compute": {},
+        "raw_metrics": {},
+        "diagnostics": list(selected["diagnostics"]),
+    }
+    for semantic_name, metric_name in selected["metrics"].items():
+        group = _NCU_FIELD_GROUPS.get(semantic_name, "summary")
+        if metric_name is None:
+            result[group][semantic_name] = None
+            continue
+        record = raw_metrics[metric_name]
+        value = _metric_record_value(record)
+        if semantic_name == "duration_us":
+            value = _duration_to_us(value, _metric_record_unit(record))
+        result[group][semantic_name] = value
+        result["raw_metrics"][metric_name] = record
+    return result
+
+
+def extract_ncu_duration_us(profile: Mapping[str, Any]) -> float | None:
+    ncu = profile.get("ncu", profile)
+    if not isinstance(ncu, Mapping):
+        return None
+    summary = ncu.get("summary")
+    if isinstance(summary, Mapping):
+        duration = _coerce_float(summary.get("duration_us"))
+        if duration is not None:
+            return duration
+    for key in SUMMARY_NCU_METRIC_ALIASES["duration_us"]:
+        if key in ncu:
+            value = ncu[key]
+            return _duration_to_us(_metric_record_value(value), _metric_record_unit(value))
+    raw_metrics = ncu.get("raw_metrics")
+    if isinstance(raw_metrics, Mapping):
+        for key in SUMMARY_NCU_METRIC_ALIASES["duration_us"]:
+            if key in raw_metrics:
+                value = raw_metrics[key]
+                return _duration_to_us(_metric_record_value(value), _metric_record_unit(value))
+    return None
+
+
+def ncu_regression_diagnostic(
+    baseline_profile: Mapping[str, Any], candidate_profile: Mapping[str, Any]
+) -> str:
+    baseline_us = extract_ncu_duration_us(baseline_profile)
+    candidate_us = extract_ncu_duration_us(candidate_profile)
+    if baseline_us is None or candidate_us is None:
+        return ""
+    if candidate_us > baseline_us * 1.01:
+        return (
+            "NCU duration regressed: "
+            f"candidate {candidate_us:.3f}us > baseline {baseline_us:.3f}us by >1%"
+        )
+    return ""
+
+
+def compact_profile_summary(profile: Mapping[str, Any]) -> dict[str, Any]:
+    preferred = (
+        "level",
+        "tools",
+        "scope",
+        "summary",
+        "proton",
+        "ncu",
+        "diagnostics",
+        "diagnostic_proton_intra_kernel",
+        "artifacts",
+        "artifact",
+        "size_bytes",
+        "truncated",
+        "error",
+    )
+    compact = {key: _compact_value(profile[key]) for key in preferred if key in profile}
+    if compact:
+        return compact
+    return _compact_value(profile)
+
+
+def _ncu_aliases_for_level(level: str) -> Mapping[str, tuple[str, ...]]:
+    if level == "summary":
+        return SUMMARY_NCU_METRIC_ALIASES
+    if level == "deep":
+        return DEEP_NCU_METRIC_ALIASES
+    raise ValueError("profile level must be 'summary' or 'deep'")
+
+
+def _iter_nodes(payload: Any) -> Iterable[Mapping[str, Any]]:
+    if isinstance(payload, Mapping):
+        yield payload
+        for child in _node_children(payload):
+            yield from _iter_nodes(child)
+        for key in ("result", "tree", "list"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    yield from _iter_nodes(item)
+    elif isinstance(payload, list):
+        for item in payload:
+            yield from _iter_nodes(item)
+
+
+def _node_children(node: Mapping[str, Any]) -> list[Any]:
+    for key in ("children", "child", "nodes"):
+        value = node.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _node_name(node: Mapping[str, Any]) -> str:
+    for key in ("name", "label", "scope", "function", "kernel_name"):
+        value = node.get(key)
+        if value:
+            return str(value)
+    return "unknown"
+
+
+def _node_time_us(node: Mapping[str, Any]) -> float | None:
+    for key, multiplier in (
+        ("time_us", 1.0),
+        ("duration_us", 1.0),
+        ("total_time_us", 1.0),
+        ("time_ns", 0.001),
+        ("duration_ns", 0.001),
+        ("time_ms", 1000.0),
+        ("duration_ms", 1000.0),
+        ("time", 1.0),
+        ("duration", 1.0),
+    ):
+        value = _coerce_float(node.get(key))
+        if value is not None:
+            return value * multiplier
+    metrics = node.get("metrics")
+    if isinstance(metrics, Mapping):
+        return _node_time_us(metrics)
+    return None
+
+
+def _node_count(node: Mapping[str, Any]) -> int:
+    for key in ("count", "calls", "num_calls", "instances"):
+        value = _coerce_float(node.get(key))
+        if value is not None:
+            return int(value)
+    return 1
+
+
+def _leaf_kind(name: object) -> str:
+    lowered = str(name).lower()
+    if "main" in lowered and "kernel" in lowered:
+        return "main_kernel"
+    if "kernel" in lowered or "launch" in lowered:
+        return "non_main_kernel"
+    return "wrapper"
+
+
+def _normalize_header(header: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", header.strip().lower()).strip("_")
+
+
+def _first_header(headers: Mapping[str, str], candidates: tuple[str, ...]) -> str | None:
+    for candidate in candidates:
+        if candidate in headers:
+            return headers[candidate]
+    return None
+
+
+def _parse_metric_value(value: str) -> float | str | None:
+    parsed = _coerce_float(value)
+    return parsed if parsed is not None else value or None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip().replace(",", "")
+    if text.endswith("%"):
+        text = text[:-1].strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _metric_record_value(record: Any) -> float | str | None:
+    if isinstance(record, Mapping):
+        return _parse_metric_value(str(record.get("value", "")))
+    return _parse_metric_value(str(record))
+
+
+def _metric_record_unit(record: Any) -> str:
+    if isinstance(record, Mapping):
+        return str(record.get("unit", ""))
+    return ""
+
+
+def _duration_to_us(value: float | str | None, unit: str) -> float | None:
+    duration = _coerce_float(value)
+    if duration is None:
+        return None
+    normalized = unit.strip().lower()
+    if normalized in {"ns", "nsecond", "nseconds", "nanosecond", "nanoseconds"}:
+        return duration / 1000.0
+    if normalized in {"ms", "msecond", "mseconds", "millisecond", "milliseconds"}:
+        return duration * 1000.0
+    if normalized in {"s", "sec", "second", "seconds"}:
+        return duration * 1_000_000.0
+    return duration
+
+
+def _compact_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        compact: dict[str, Any] = {}
+        for key, item in value.items():
+            if str(key) in _RAW_PROFILE_KEYS:
+                continue
+            compact[str(key)] = _compact_value(item)
+        return compact
+    if isinstance(value, list):
+        return [_compact_value(item) for item in value[:50]]
+    if isinstance(value, tuple):
+        return [_compact_value(item) for item in value[:50]]
+    if isinstance(value, (str, bytes)) and len(value) > 4096:
+        return f"<omitted {len(value)} bytes>"
+    return value

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -62,7 +62,7 @@ DEEP_NCU_METRIC_ALIASES: Mapping[str, tuple[str, ...]] = {
     "registers_per_thread": ("launch__registers_per_thread",),
     "achieved_occupancy_pct": ("sm__warps_active.avg.pct_of_peak_sustained_active",),
     "theoretical_occupancy_pct": ("launch__occupancy_limit_registers",),
-    "local_load_bytes": ("memory_l1_wavefronts_shared",),
+    "local_load_bytes": ("l1tex__t_bytes_pipe_lsu_mem_local_op_ld.sum",),
     "local_store_bytes": ("l1tex__t_bytes_pipe_lsu_mem_local_op_st.sum",),
     "spill_loads": ("launch__sass_reg_spill_loads",),
     "spill_stores": ("launch__sass_reg_spill_stores",),

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -229,6 +229,24 @@ def resolve_profile_tools(
     return tuple(resolved)
 
 
+def resolve_profile_request_for_target(
+    request_payload: Mapping[str, Any] | bool | None,
+    target: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    request = normalize_profile_request(request_payload)
+    if request is None:
+        return None
+    backend = str(target.get("backend", "")).strip().lower()
+    native_profiler = "ncu" if backend in {"cuda", "nvidia"} else None
+    return replace(
+        request,
+        tools=resolve_profile_tools(
+            request.tools,
+            native_profiler=native_profiler,
+        ),
+    ).to_json()
+
+
 def profile_accepts_request(profile_fn: Callable[..., Any]) -> bool:
     try:
         signature = inspect.signature(profile_fn)

--- a/third_party/tlx/tools/agents/kernel_optimization/providers.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/providers.py
@@ -1,51 +1,48 @@
 from __future__ import annotations
 
+import json
 import subprocess
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 from .models import KernelOptimizationRequest, PerformanceSummary
-from .source import extract_python_source
+from .profiling import compact_profile_summary
+from .source import validate_replacement_source
 
-TLX_PROMPT_PREAMBLE = """You are optimizing a Triton/TLX GPU kernel.
+TLX_PROMPT_PREAMBLE = """You are optimizing one Triton or TLX kernel against an external deterministic harness.
+The candidate is a complete replacement source file. Preserve every public entry point,
+algorithmic contract, supported workload, and synchronization invariant required by the
+harness and target guidance.
 
-Grouped MXFP8 target: C_g = A_g @ B_g.T for g in [0, G), A_g is E4M3 [M_g, K]
-and B_g is E4M3 [N, K], one E8M0 scale per 32 K values. Scales are swizzled
-to 5-D [1, rows//128, K//128, 2, 256] for tlx.async_dot_scaled.
+Evidence-driven optimization workflow:
+1. Keep measurement scopes separate. The public benchmark, individual kernel profiles,
+   Proton launch attribution, and diagnostic intra-kernel traces may cover different work.
+   Do not subtract unrelated measurements or infer task overlap from a launch timeline.
+2. Treat lower end-to-end benchmark latency with passing correctness as the promotion goal.
+   Use target profiler duration, utilization, traffic, occupancy, registers, and stalls as
+   explanatory evidence rather than standalone optimization targets.
+3. Choose exactly one testable hypothesis and one coherent change. Map measured evidence to
+   the narrowest relevant subsystem, and use failed hypotheses as exclusions in later rounds.
+4. For warp-specialized or asynchronous kernels, change barriers, buffer counts, aliases,
+   task scheduling, or visibility only with an explicit producer/consumer and lifetime proof.
+5. Treat changes inside the noise floor as inconclusive. Do not repeat a configuration when
+   benchmark and profile evidence show that it did not affect the targeted bottleneck.
 
-References you should follow (prefer grouped_gemm.py:752 for scheduling,
-blackwell_gemm_ws_mxfp8.py / fburl.com/code/wdyi24fn for MX):
-- Grouped scheduling (genai/msl/ops/kernels/tlx/gemm/grouped_gemm.py:752
-  _tlx_grouped_gemm_blackwell): 3 async_tasks (producer TMA / MMA async_dot
-  / epilogue TMEM), split_sizes per-group M (_get_group_sizes), flat vs
-  persistent dispatch via counter_ptr atomicAdd + tile_id_smem DSMEM +
-  remote_shmem_store + fence.proxy.async.shared::cluster, GROUP_SIZE_M
-  swizzle via _compute_pid, 1CTA/2CTA (cluster_cta_rank, cta_bars,
-  remote_cta_rank), NUM_SMEM_BUFFERS / NUM_TMEM_BUFFERS / EPILOGUE_SUBTILE
-  pipeline, _get_tile_grid / _producer_fetch_tile_idx_2cta, tmem_empty/full
-  mbarriers.
-- MX block-scaled MMA (third_party/tlx/tutorials/blackwell_gemm_ws_mxfp8.py  # fburl.com/code/wdyi24fn):
-  BLOCK_SIZE_M==128 required for scaled MMA, tlx.async_dot_scaled on E4M3+E8M0
-  with tlx.dtype_of(desc), swizzled scales [1, REP_M, REP_K, 2, 256] via
-  TensorDescriptor + async_descriptor_load + barrier_expect_bytes, REP_K=
-  BLOCK_K//32//4, tlx.local_trans on B, tmem empty/full + smem empty/full
-  phases via get_bufidx_phase, tlx.tcgen05_commit.
+TLX API guidance:
+- Treat `.claude/skills/tlx-api-reference/SKILL.md` in the target repository as the primary
+  TLX API reference when present.
+- Reuse APIs, synchronization patterns, and architecture-specific examples already used by
+  the supplied source and nearby code. Do not invent APIs or transplant incompatible target
+  patterns.
 
-Optimization axes to tune (pick 1-2 per candidate, keep harness verifiable):
-- GROUP_SIZE_M in {1, 4, 8, 64} — swizzle order of M vs N tiles.
-- NUM_SMEM_BUFFERS in {3, 4, 6} and NUM_TMEM_BUFFERS in {1, 2} — pipeline depth.
-- NUM_CTAS in {1, 2} — only use 2 with a persistent counter + DSMEM tile_idx
-  path and ctas_per_cga=(2,1,1); remember 2-CTA needs full B-scale reload.
-- BLOCK_SIZE_K 128 vs 256 — must stay %128; larger reduces K tiles but grows SMEM.
-Promote from the flat-grid tl.dot baseline to TMA + TMEM + tlx.async_dot_scaled
-when cases have K>=256 (form is block-scaled MXFP8, scale tiling assumes K%128==0).
-
-TLX essentials:
-- `import triton.language as tl` and `import triton.language.extra.tlx as tlx`
-- Warp spec: `with tlx.async_tasks(exclusive=True, no_ending_cluster_sync=True, mbarrier_try_wait_suspend_ns=50000): with tlx.async_task("default"): ... with tlx.async_task(num_warps=1, num_regs=24): ...`
-- Memory: `tlx.local_alloc(shape, dtype, num_buffers, tlx.storage_kind.tmem)` + `tlx.alloc_barriers`, `tlx.async_descriptor_load`, `tlx.barrier_wait/arrive/expect_bytes`, `tlx.local_slice/load/store`, `tlx.barrier_arrive` + `tcgen05_commit`
-- Persistent grouped GEMMs: `tlx.local_alloc((1,), tl.int32, NUM_TILE_BUFFERS)` for tile_id_smem, `tlx.remote_shmem_store` / `local_load` for 2-CTA, `tl.atomic_add(counter_ptr, 1 or 2)` for dispatch.
-- Follow https://www.internalfb.com/wiki/Triton_Core/Agentic_Reference/ and third_party/tlx/doc/tlx_barriers.md.
+The complete current source is available as `candidate.py` in your writable working
+directory. Edit that file directly and leave it as the complete replacement source. Also
+write `candidate_metadata.json` containing exactly these short string fields: `hypothesis`,
+`evidence`, `change`, `expected_effect`, and `risk`. Each field must be one line and under
+240 characters. Do not modify any other file. Keep the final response to one short plain-text
+summary; do not print source code or a patch.
 """
 
 
@@ -53,6 +50,10 @@ TLX essentials:
 class CandidateProposal:
     source: str
     summary: str = ""
+    hypothesis: str = ""
+    evidence: str = ""
+    expected_effect: str = ""
+    risk: str = ""
 
 
 @dataclass(frozen=True)
@@ -110,10 +111,30 @@ class MockLLMProvider:
         return CandidateProposal(source=context.current_source, summary="mock-echo")
 
 
+def _read_candidate_metadata(path: Path) -> dict[str, str]:
+    fields = ("hypothesis", "evidence", "change", "expected_effect", "risk")
+    fallback = {field: "" for field in fields}
+    if not path.exists():
+        return fallback
+    try:
+        payload = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return fallback
+    if not isinstance(payload, dict):
+        return fallback
+    return {
+        field: " ".join(str(payload.get(field, "")).split())[:240]
+        for field in fields
+    }
+
+
 @dataclass(frozen=True)
 class CodexCandidateProvider:
-    model: str = "sonnet"
+    model: str | None = None
     timeout_seconds: float = 300.0
+
+    # Candidate generation is source-in/source-out. The model must never mutate
+    # the live checkout; harness workers materialize and evaluate returned source.
 
     def propose(
         self,
@@ -122,35 +143,57 @@ class CodexCandidateProvider:
     ) -> CandidateProposal:
         prompt = _build_prompt(request, context)
         try:
-            completed = subprocess.run(
-                [
+            with tempfile.TemporaryDirectory(prefix="tlx-agent-candidate-") as directory:
+                workspace = Path(directory)
+                candidate_path = workspace / "candidate.py"
+                output_path = workspace / "last-message.txt"
+                metadata_path = workspace / "candidate_metadata.json"
+                candidate_path.write_text(context.current_source)
+                command = [
                     "codex",
                     "exec",
                     "--skip-git-repo-check",
-                    "-m",
-                    self.model,
                     "--sandbox",
                     "workspace-write",
-                    prompt,
-                ],
-                text=True,
-                capture_output=True,
-                timeout=self.timeout_seconds,
-                check=False,
-            )
+                    "--cd",
+                    str(workspace),
+                    "--output-last-message",
+                    str(output_path),
+                ]
+                if self.model:
+                    command.extend(("--model", self.model))
+                command.append("-")
+                completed = subprocess.run(
+                    command,
+                    input=prompt,
+                    text=True,
+                    capture_output=True,
+                    timeout=self.timeout_seconds,
+                    check=False,
+                )
+                if completed.returncode != 0:
+                    diagnostics = completed.stderr.strip().splitlines()
+                    raise RuntimeError(
+                        f"candidate generator exited with code {completed.returncode}: "
+                        + " | ".join(diagnostics[-8:])
+                    )
+                source = candidate_path.read_text()
+                metadata = _read_candidate_metadata(metadata_path)
         except FileNotFoundError as error:
             raise RuntimeError(
                 "codex binary not found; install it or use --provider mock"
             ) from error
-        if completed.returncode != 0:
-            raise RuntimeError(
-                f"candidate generator exited with code {completed.returncode}: "
-                f"{completed.stderr.strip()}"
-            )
-        source = extract_python_source(completed.stdout)
         if not source.strip():
             raise RuntimeError("candidate generator returned empty source")
-        return CandidateProposal(source=source, summary="Codex-generated candidate")
+        validate_replacement_source(source, context.current_source)
+        return CandidateProposal(
+            source=source,
+            summary=metadata["change"] or "Codex-edited candidate",
+            hypothesis=metadata["hypothesis"],
+            evidence=metadata["evidence"],
+            expected_effect=metadata["expected_effect"],
+            risk=metadata["risk"],
+        )
 
 
 def _build_prompt(
@@ -166,17 +209,23 @@ def _build_prompt(
         f"{case.timing.median_us if case.timing else 'unavailable'}, "
         f"p95_us={case.timing.p95_us if case.timing else 'unavailable'}, "
         f"cv={case.timing.coefficient_of_variation if case.timing else 'unavailable'}, "
-        f"profile={dict(case.profile)}"
+        f"profile={compact_profile_summary(case.profile)}"
         for case in context.current_performance.cases
     )
     diagnostics = "\n".join(context.previous_diagnostics[-5:]) or "None"
     reference_block = ""
     if getattr(request, "reference_kernel_source", None):
         reference_block = f"\nReference kernel (oracle, do not copy verbatim — use for correctness/performance comparison):\n```python\n{request.reference_kernel_source[:4000]}\n```\n"
-    return f"""{TLX_PROMPT_PREAMBLE}{reference_block}
+    guidance = request.target.optimization_guidance.strip()
+    guidance_block = (
+        f"\nFrozen target-specific optimization guidance:\n{guidance}\n"
+        if guidance
+        else ""
+    )
+    return f"""{TLX_PROMPT_PREAMBLE}{guidance_block}{reference_block}
 You are proposing one candidate for the closed loop `build -> verify -> benchmark -> profile -> propose -> repeat`.
-Return exactly one complete replacement source file. Do not return a diff and do not
-claim correctness or performance; an external deterministic harness decides both.
+Edit `candidate.py` directly. Do not return source or a diff, and do not claim correctness
+or performance; an external deterministic harness reads the file and decides both.
 Preserve the public entry points expected by the harness. Make one coherent optimization
 that can be diagnosed if it fails.
 
@@ -191,8 +240,5 @@ Current measurements:
 Recent failed-candidate diagnostics:
 {diagnostics}
 
-Current source:
-```python
-{context.current_source}
-```
+Current source: read and edit `candidate.py` in the working directory.
 """

--- a/third_party/tlx/tools/agents/kernel_optimization/source.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/source.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import ast
 import hashlib
 import re
+import subprocess
+import tempfile
+from pathlib import Path
 
 _CODE_BLOCK_RE = re.compile(r"```(?P<language>[A-Za-z0-9_+-]*)\s*\n(?P<code>.*?)```", re.DOTALL)
+_DIFF_HEADER_RE = re.compile(r"(?m)^--- candidate\.py\n\+\+\+ candidate\.py\n")
 
 
 def extract_python_source(output: str) -> str:
@@ -18,8 +22,54 @@ def extract_python_source(output: str) -> str:
         match.group("code") for match in blocks if not match.group("language")
     ]
     candidates = python_blocks or generic_blocks or [output]
-    source = canonicalize_source(candidates[-1])
-    validate_kernel_source(source)
+    valid_sources: list[str] = []
+    last_error: ValueError | None = None
+    for candidate in candidates:
+        source = canonicalize_source(candidate)
+        try:
+            validate_kernel_source(source)
+        except ValueError as error:
+            last_error = error
+            continue
+        valid_sources.append(source)
+    if valid_sources:
+        return max(valid_sources, key=len)
+    assert last_error is not None
+    raise last_error
+
+
+def apply_candidate_diff(output: str, current_source: str) -> str:
+    """Apply a model-produced unified diff to an isolated source copy."""
+    blocks = list(_CODE_BLOCK_RE.finditer(output))
+    diff_blocks = [
+        match.group("code")
+        for match in blocks
+        if match.group("language").lower() in {"diff", "patch"}
+    ]
+    candidates = diff_blocks or [output]
+    patches = [candidate.strip() + "\n" for candidate in candidates if _DIFF_HEADER_RE.search(candidate)]
+    if not patches:
+        raise ValueError("candidate response does not contain a candidate.py unified diff")
+    patch = max(patches, key=len)
+    with tempfile.TemporaryDirectory(prefix="tlx-agent-patch-") as directory:
+        root = Path(directory)
+        candidate_path = root / "candidate.py"
+        patch_path = root / "candidate.patch"
+        candidate_path.write_text(current_source)
+        patch_path.write_text(patch)
+        completed = subprocess.run(
+            ["patch", "--batch", "--forward", "--silent", "-p0", "-i", str(patch_path)],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        if completed.returncode != 0:
+            diagnostics = (completed.stderr or completed.stdout).strip()
+            raise ValueError(f"candidate diff did not apply cleanly: {diagnostics}")
+        source = canonicalize_source(candidate_path.read_text())
+    validate_replacement_source(source, current_source)
     return source
 
 
@@ -31,6 +81,31 @@ def validate_kernel_source(source: str) -> None:
         ast.parse(source)
     except SyntaxError as error:
         raise ValueError(f"candidate is not valid Python: {error}") from error
+
+
+def validate_replacement_source(candidate: str, current: str) -> None:
+    """Reject responses that are valid Python but not a complete replacement."""
+    validate_kernel_source(candidate)
+    current_tree = ast.parse(current)
+    candidate_tree = ast.parse(candidate)
+    node_types = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+    required_names = {node.name for node in current_tree.body if isinstance(node, node_types)}
+    candidate_names = {
+        node.name for node in candidate_tree.body if isinstance(node, node_types)
+    }
+    missing_names = sorted(required_names - candidate_names)
+    if missing_names:
+        preview = ", ".join(missing_names[:8])
+        suffix = "..." if len(missing_names) > 8 else ""
+        raise ValueError(
+            f"candidate is not a complete replacement; missing top-level symbols: "
+            f"{preview}{suffix}"
+        )
+    if len(candidate) < len(current) * 0.8:
+        raise ValueError(
+            "candidate is not a complete replacement; source is unexpectedly short "
+            f"({len(candidate)} bytes versus {len(current)} bytes)"
+        )
 
 
 def canonicalize_source(source: str) -> str:

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import io
+import json
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 
-from .cli import _resolve_harness_paths, _validate_host_matches_target
-from .harness import StandaloneHarness
+from .cli import _parse_args, _resolve_harness_paths, _validate_host_matches_target
+from .harness import StandaloneHarness, SubprocessHarness
 from .models import (
     CaseEvaluation,
     InputCase,
@@ -19,9 +22,22 @@ from .models import (
     per_case_speedups,
     weighted_geometric_speedup,
 )
-from .optimizer import KernelOptimizer
-from .providers import CandidateProposal, FixedCandidateProvider, MockLLMProvider
-from .source import extract_python_source, source_digest, validate_kernel_source
+from .optimizer import KernelOptimizer, _profile_log_parts
+from .profiling import ProfileRequest
+from .providers import (
+    CandidateContext,
+    CandidateProposal,
+    FixedCandidateProvider,
+    MockLLMProvider,
+    _build_prompt,
+)
+from .source import (
+    apply_candidate_diff,
+    extract_python_source,
+    source_digest,
+    validate_kernel_source,
+    validate_replacement_source,
+)
 
 
 class ScoringTest(unittest.TestCase):
@@ -75,12 +91,134 @@ class ScoringTest(unittest.TestCase):
             extract_python_source("Explanation\n```python\nVALUE = 1\n```"),
             "VALUE = 1\n",
         )
+        self.assertEqual(
+            extract_python_source(
+                "```python\nVALUE = 1\nOTHER = 2\n```\n"
+                "```python\nVALUE = 3\n```\n```python\nif:\n```"
+            ),
+            "VALUE = 1\nOTHER = 2\n",
+        )
         with self.assertRaisesRegex(ValueError, "not valid Python"):
             extract_python_source("```python\nif:\n```")
+
+    def test_codex_prompt_has_generic_and_target_guidance(self) -> None:
+        target_guidance = (
+            "Preserve the producer/consumer barrier phases. "
+            "Do not retry BLOCK_SIZE=256 because baseline profiling rejected it."
+        )
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("target", {"mode": "bwd"}),),
+            target=KernelTarget(
+                "cuda", "blackwell", optimization_guidance=target_guidance
+            ),
+            budget=OptimizationBudget(),
+            output_dir=Path("/tmp/tlx-agent-test"),
+        )
+        prompt = _build_prompt(
+            request,
+            CandidateContext(
+                round_index=1,
+                candidate_index=0,
+                current_source=request.kernel_source,
+                current_performance=_performance(("target", 100.0)),
+                previous_diagnostics=(),
+            ),
+        )
+        self.assertIn("Evidence-driven optimization workflow", prompt)
+        self.assertIn("Keep measurement scopes separate", prompt)
+        self.assertIn("exactly one testable hypothesis", prompt)
+        self.assertIn(".claude/skills/tlx-api-reference/SKILL.md", prompt)
+        self.assertIn("Frozen target-specific optimization guidance", prompt)
+        self.assertIn(target_guidance, prompt)
+        self.assertNotIn("MXFP8", prompt)
+        self.assertNotIn("DQ_REDUCE_NCOL", prompt)
+        self.assertIn("edit `candidate.py`", prompt)
+        self.assertIn("Do not modify any other file", prompt)
+        self.assertIn("do not print source code or a patch", prompt)
+        self.assertIn("candidate_metadata.json", prompt)
+        self.assertIn("expected_effect", prompt)
+
+    def test_codex_prompt_compacts_profile_and_preserves_scope_boundaries(self) -> None:
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("target", {"mode": "bwd"}),),
+            target=KernelTarget("cuda", "blackwell"),
+            budget=OptimizationBudget(),
+            output_dir=Path("/tmp/tlx-agent-test"),
+        )
+        performance = PerformanceSummary(
+            cases=(
+                CaseEvaluation(
+                    case_id="target",
+                    verification=VerificationResult(True),
+                    timing=TimingSamples((100.0, 100.0, 100.0)),
+                    profile={
+                        "level": "deep",
+                        "raw": "x" * 5000,
+                        "proton": {
+                            "totals": {
+                                "wrapper_us": 1.0,
+                                "main_kernel_us": 2.0,
+                                "non_main_kernel_us": 3.0,
+                            }
+                        },
+                    },
+                ),
+            )
+        )
+        prompt = _build_prompt(
+            request,
+            CandidateContext(1, 0, request.kernel_source, performance, ()),
+        )
+        self.assertIn("infer task overlap from a launch timeline", prompt)
+        self.assertIn("diagnostic intra-kernel traces", prompt)
+        self.assertIn("wrapper_us", prompt)
+        self.assertNotIn("xxxxx", prompt)
+
+    def test_applies_candidate_unified_diff(self) -> None:
+        current = "VALUE = 1\n\ndef kernel():\n    return VALUE\n"
+        output = """```diff
+--- candidate.py
++++ candidate.py
+@@ -1 +1 @@
+-VALUE = 1
++VALUE = 2
+```
+"""
+        self.assertEqual(
+            apply_candidate_diff(output, current),
+            "VALUE = 2\n\ndef kernel():\n    return VALUE\n",
+        )
+
+    def test_rejects_response_without_candidate_diff(self) -> None:
+        with self.assertRaisesRegex(ValueError, "candidate.py unified diff"):
+            apply_candidate_diff("```python\nVALUE = 2\n```", "VALUE = 1\n")
+
+    def test_replacement_source_requires_all_top_level_symbols(self) -> None:
+        current = "def kernel():\n    return 1\n\ndef wrapper():\n    return kernel()\n"
+        with self.assertRaisesRegex(ValueError, "missing top-level symbols: wrapper"):
+            validate_replacement_source("def kernel():\n    return 2\n", current)
+
+    def test_replacement_source_rejects_unexpectedly_short_source(self) -> None:
+        current = "def kernel():\n    return 1\n" + ("VALUE = 1\n" * 100)
+        with self.assertRaisesRegex(ValueError, "unexpectedly short"):
+            validate_replacement_source("def kernel():\n    return 2\n", current)
 
     def test_validate_kernel_source_rejects_empty(self) -> None:
         with self.assertRaisesRegex(ValueError, "empty"):
             validate_kernel_source("   \n")
+
+    def test_kernel_optimization_request_disables_diagnostic_proton_by_default(self) -> None:
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("a", {}),),
+            target=KernelTarget("fake", "fake"),
+        )
+        self.assertFalse(request.diagnostic_proton_intra_kernel)
 
     def test_failed_protected_case_is_not_promotable(self) -> None:
         summary = PerformanceSummary(
@@ -134,6 +272,40 @@ class ScoringTest(unittest.TestCase):
 
     def test_source_digest_stable(self) -> None:
         self.assertEqual(source_digest("VALUE = 1\n"), source_digest("VALUE = 1\n  \n"))
+
+
+class CliTest(unittest.TestCase):
+    def test_commit_winner_is_enabled_by_default(self) -> None:
+        args = _parse_args(["--kernel", "kernel.py", "--output-dir", "/tmp/out"])
+        self.assertTrue(args.commit_winner)
+
+    def test_commit_winner_can_be_disabled(self) -> None:
+        args = _parse_args(
+            [
+                "--kernel",
+                "kernel.py",
+                "--output-dir",
+                "/tmp/out",
+                "--no-commit-winner",
+            ]
+        )
+        self.assertFalse(args.commit_winner)
+
+    def test_diagnostic_proton_intra_kernel_is_disabled_by_default(self) -> None:
+        args = _parse_args(["--kernel", "kernel.py", "--output-dir", "/tmp/out"])
+        self.assertFalse(args.diagnostic_proton_intra_kernel)
+
+    def test_diagnostic_proton_intra_kernel_can_be_enabled(self) -> None:
+        args = _parse_args(
+            [
+                "--kernel",
+                "kernel.py",
+                "--output-dir",
+                "/tmp/out",
+                "--diagnostic-proton-intra-kernel",
+            ]
+        )
+        self.assertTrue(args.diagnostic_proton_intra_kernel)
 
 
 class HarnessTest(unittest.TestCase):
@@ -211,6 +383,129 @@ class HarnessTest(unittest.TestCase):
         self.assertTrue(all(case.verification.passed for case in performance.cases))
         self.assertEqual(performance.cases[0].profile.get("bottleneck"), "synthetic")
 
+    def test_subprocess_harness_evaluates_legacy_profile_signature(self) -> None:
+        harness = SubprocessHarness(
+            Path(__file__).with_name("testdata") / "fake_harness.py",
+            timeout_seconds=30.0,
+        )
+        performance = harness.evaluate(
+            "LATENCY_US = 50\nCORRECT = True\n",
+            (InputCase("a", {"scale": 1.0}),),
+            KernelTarget("fake", "fake"),
+            benchmark_repetitions=2,
+            profile=True,
+        )
+        self.assertEqual(performance.cases[0].profile.get("bottleneck"), "synthetic")
+
+    def test_profile_request_passed_after_benchmark_with_case_artifact_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            harness_path = Path(tmp) / "three_arg_harness.py"
+            harness_path.write_text(
+                "from pathlib import Path\n"
+                "def build(kernel_source, target):\n"
+                "    return {'success': True, 'artifact': {'events': []}}\n"
+                "def verify(artifact, case):\n"
+                "    artifact['events'].append('verify')\n"
+                "    return {'passed': True}\n"
+                "def benchmark(artifact, case, repetitions):\n"
+                "    artifact['events'].append('benchmark')\n"
+                "    return {'samples_us': [10.0] * repetitions}\n"
+                "def profile(artifact, case, request):\n"
+                "    artifact['events'].append('profile')\n"
+                "    assert artifact['events'] == ['verify', 'benchmark', 'profile']\n"
+                "    path = Path(request['artifacts_dir'])\n"
+                "    assert path.is_absolute()\n"
+                "    assert path.exists()\n"
+                "    return {'request': request, 'events': artifact['events']}\n"
+            )
+            artifacts_dir = Path(tmp) / "profiles"
+            performance = StandaloneHarness(harness_path).evaluate(
+                "source",
+                (InputCase("shape/128?case", {}),),
+                KernelTarget("fake", "fake"),
+                benchmark_repetitions=2,
+                profile=ProfileRequest(
+                    level="deep",
+                    tools=("ncu",),
+                    experiment_id="r001-c000",
+                    artifacts_dir=artifacts_dir,
+                    reason="unit test",
+                ),
+            )
+            profile = performance.cases[0].profile
+            request = profile["request"]
+            self.assertEqual(request["level"], "deep")
+            self.assertEqual(request["tools"], ["ncu"])
+            per_case_dir = Path(str(request["artifacts_dir"]))
+            self.assertEqual(per_case_dir.parent, artifacts_dir)
+            self.assertTrue(per_case_dir.exists())
+            self.assertNotIn("/", per_case_dir.name)
+            self.assertEqual(profile["events"], ["verify", "benchmark", "profile"])
+
+    def test_subprocess_harness_passes_three_arg_profile_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            harness_path = Path(tmp) / "three_arg_subprocess_harness.py"
+            harness_path.write_text(
+                "from pathlib import Path\n"
+                "def build(kernel_source, target):\n"
+                "    return {'success': True, 'artifact': {}}\n"
+                "def verify(artifact, case):\n"
+                "    return {'passed': True}\n"
+                "def benchmark(artifact, case, repetitions):\n"
+                "    return {'samples_us': [11.0] * repetitions}\n"
+                "def profile(artifact, case, request):\n"
+                "    return {'case_id': case['case_id'], 'request': request, 'exists': Path(request['artifacts_dir']).exists()}\n"
+            )
+            artifacts_dir = Path(tmp) / "profiles"
+            performance = SubprocessHarness(harness_path, timeout_seconds=30.0).evaluate(
+                "source",
+                (InputCase("case a", {}),),
+                KernelTarget("fake", "fake"),
+                benchmark_repetitions=2,
+                profile={
+                    "level": "summary",
+                    "tools": ["proton"],
+                    "experiment_id": "baseline",
+                    "artifacts_dir": str(artifacts_dir),
+                    "reason": "unit test",
+                },
+            )
+            profile = performance.cases[0].profile
+            self.assertEqual(profile["case_id"], "case a")
+            self.assertTrue(profile["exists"])
+            request = profile["request"]
+            self.assertEqual(request["tools"], ["proton"])
+            self.assertEqual(Path(str(request["artifacts_dir"])).parent, artifacts_dir)
+
+    def test_large_profile_spills_to_raw_profile_when_artifacts_dir_available(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            harness_path = Path(tmp) / "big_profile_harness.py"
+            harness_path.write_text(
+                "def build(kernel_source, target):\n"
+                "    return {'success': True, 'artifact': {}}\n"
+                "def verify(artifact, case):\n"
+                "    return {'passed': True}\n"
+                "def benchmark(artifact, case, repetitions):\n"
+                "    return {'samples_us': [12.0] * repetitions}\n"
+                "def profile(artifact, case, request):\n"
+                "    return {'big': 'x' * 2000000}\n"
+            )
+            artifacts_dir = Path(tmp) / "profiles"
+            performance = StandaloneHarness(harness_path).evaluate(
+                "source",
+                (InputCase("a", {}),),
+                KernelTarget("fake", "fake"),
+                benchmark_repetitions=2,
+                profile=ProfileRequest(artifacts_dir=artifacts_dir),
+            )
+            profile = performance.cases[0].profile
+            self.assertEqual(profile["truncated"], True)
+            artifact = Path(str(profile["artifact"]))
+            self.assertTrue(artifact.is_absolute())
+            self.assertTrue(artifact.exists())
+            self.assertEqual(artifact.name, "raw_profile.json")
+            self.assertGreater(profile["size_bytes"], 1_000_000)
+
     def test_standalone_harness_reports_build_error(self) -> None:
         harness = StandaloneHarness(
             Path(__file__).with_name("testdata") / "fake_harness.py"
@@ -259,6 +554,75 @@ class HarnessTest(unittest.TestCase):
 
 
 class KernelOptimizerTest(unittest.TestCase):
+    def test_reports_performance_after_each_evaluation(self) -> None:
+        provider = FixedCandidateProvider(
+            [
+                CandidateProposal("LATENCY_US = 120\nCORRECT = True\n", "slower"),
+                CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = KernelOptimizer(provider).optimize(
+                    KernelOptimizationRequest(
+                        kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                        harness_path=Path(__file__).with_name("testdata")
+                        / "fake_harness.py",
+                        cases=(InputCase("a", {"scale": 1.0}),),
+                        target=KernelTarget("fake", "fake"),
+                        budget=OptimizationBudget(
+                            max_rounds=1,
+                            candidates_per_round=2,
+                            min_speedup=1.01,
+                            benchmark_repetitions=3,
+                        ),
+                        output_dir=Path(directory),
+                    )
+                )
+
+            output = stderr.getvalue()
+            self.assertIn("[tlx-agent] baseline status=baseline", output)
+            self.assertIn("median=100.000us", output)
+            self.assertIn("[tlx-agent] r001-c000 status=rejected", output)
+            self.assertIn("speedup=0.8333x", output)
+            self.assertIn("[tlx-agent] r001-c001 change='faster'", output)
+            self.assertIn("[tlx-agent] r001-c001 status=promoted", output)
+            self.assertIn("speedup=1.2500x", output)
+            self.assertIn("decision=correct and exceeded speedup threshold", output)
+            self.assertIn("ncu=unavailable", output)
+            self.assertIn("[tlx-agent] final status=revalidated", output)
+            self.assertTrue(result.success)
+
+    def test_continues_after_round_without_promotion(self) -> None:
+        provider = FixedCandidateProvider(
+            [
+                CandidateProposal("LATENCY_US = 120\nCORRECT = True\n", "slower"),
+                CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                    harness_path=Path(__file__).with_name("testdata")
+                    / "fake_harness.py",
+                    cases=(InputCase("a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=2,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=3,
+                    ),
+                    output_dir=Path(directory),
+                )
+            )
+            self.assertTrue(result.success)
+            self.assertEqual(result.best_kernel, "LATENCY_US = 80\nCORRECT = True\n")
+            self.assertEqual(result.experiments[1].status, "rejected")
+            self.assertEqual(result.experiments[2].status, "promoted")
+
     def test_rejects_incorrect_candidate_and_promotes_faster_candidate(self) -> None:
         provider = FixedCandidateProvider(
             [
@@ -299,6 +663,297 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertTrue((Path(directory) / "baseline_profile.json").exists())
             self.assertTrue((Path(directory) / "best_profile.json").exists())
 
+    def test_optimizer_uses_profile_policy_and_records_profile_paths(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            harness_path = _write_policy_harness(Path(tmp))
+            output_dir = Path(tmp) / "out"
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\nNCU_US = 100\n",
+                    harness_path=harness_path,
+                    cases=(InputCase("case/a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=output_dir,
+                )
+            )
+
+        baseline_request = result.baseline.cases[0].profile["request"]
+        candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
+        final_request = result.final.cases[0].profile["request"]
+        self.assertEqual(baseline_request["level"], "deep")
+        self.assertEqual(baseline_request["tools"], ["proton_launch", "ncu"])
+        self.assertEqual(baseline_request["reason"], "baseline")
+        self.assertEqual(
+            Path(str(baseline_request["artifacts_dir"])).parent,
+            output_dir / "experiments" / "baseline" / "profile_artifacts",
+        )
+        self.assertEqual(candidate_request["level"], "summary")
+        self.assertEqual(candidate_request["reason"], "candidate")
+        self.assertEqual(
+            Path(str(candidate_request["artifacts_dir"])).parent,
+            output_dir / "experiments" / "r001-c000" / "profile_artifacts",
+        )
+        self.assertEqual(final_request["level"], "deep")
+        self.assertEqual(final_request["reason"], "final")
+        self.assertEqual(
+            Path(str(final_request["artifacts_dir"])).parent,
+            output_dir / "experiments" / "final" / "profile_artifacts",
+        )
+        self.assertEqual(
+            result.experiments[0].profile_path,
+            output_dir / "experiments" / "baseline" / "profile.json",
+        )
+        self.assertEqual(
+            result.experiments[1].profile_path,
+            output_dir / "experiments" / "r001-c000" / "profile.json",
+        )
+        self.assertTrue(result.success)
+
+    def test_near_threshold_candidate_gets_deep_profile_rerun(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 100\nCORRECT = True\nTAG = 1\n", "same")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                    harness_path=_write_policy_harness(Path(tmp)),
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(tmp) / "out",
+                )
+            )
+        candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
+        self.assertEqual(candidate_request["level"], "deep")
+        self.assertEqual(candidate_request["reason"], "near_threshold")
+        self.assertFalse(result.success)
+
+    def test_ncu_regression_diagnostic_vetoes_candidate(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 102\n", "fast-wrapper")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = KernelOptimizer(provider).optimize(
+                    KernelOptimizationRequest(
+                        kernel_source="LATENCY_US = 100\nCORRECT = True\nNCU_US = 100\n",
+                        harness_path=_write_policy_harness(Path(tmp)),
+                        cases=(InputCase("a", {}),),
+                        target=KernelTarget("fake", "fake"),
+                        budget=OptimizationBudget(
+                            max_rounds=1,
+                            candidates_per_round=1,
+                            min_speedup=1.01,
+                            benchmark_repetitions=2,
+                        ),
+                        output_dir=Path(tmp) / "out",
+                    )
+                )
+        self.assertFalse(result.success)
+        self.assertEqual(result.experiments[1].status, "rejected")
+        self.assertIn("NCU duration regressed", stderr.getvalue())
+
+    def test_missing_ncu_does_not_veto_candidate(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                    harness_path=_write_policy_harness(Path(tmp)),
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(tmp) / "out",
+                )
+            )
+        self.assertTrue(result.success)
+        self.assertEqual(result.experiments[1].status, "promoted")
+
+    def test_diagnostic_proton_log_includes_capture_summary(self) -> None:
+        trace_path = "/tmp/selected_cta.chrome_trace"
+        parts = _profile_log_parts(
+            {
+                "diagnostic_proton_intra_kernel": {
+                    "diagnostic_proton_intra_kernel": {
+                        "valid": True,
+                        "selected_cta": 6,
+                        "logical_coordinates": {
+                            "start_n": 3840,
+                            "logical_block": 31,
+                            "curr_m": 3968,
+                            "mma_producer_j": 32,
+                            "load_input_j": 31,
+                        },
+                        "dominant_waits": [
+                            {"name": "reduction_wait_dq", "duration": 2.852}
+                        ],
+                        "trace_path": trace_path,
+                    }
+                }
+            }
+        )
+        self.assertIn("proton.intra.valid=true", parts)
+        self.assertIn("proton.intra.cta=6", parts)
+        self.assertIn(
+            "proton.intra.tile=start_n:3840/logical_block:31/curr_m:3968/mma_producer_j:32/load_input_j:31",
+            parts,
+        )
+        self.assertIn(
+            "proton.intra.dominant_wait=reduction_wait_dq:2.852us", parts
+        )
+        self.assertIn(f"proton.intra.trace={trace_path}", parts)
+
+    def test_diagnostic_proton_profiles_baseline_and_successful_final_only(self) -> None:
+        provider = FixedCandidateProvider(
+            [
+                CandidateProposal("LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower"),
+                CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output_dir = root / "out"
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\nNCU_US = 100\n",
+                    harness_path=_write_policy_harness(root),
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=2,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=output_dir,
+                    diagnostic_proton_intra_kernel=True,
+                )
+            )
+            requests = _read_profile_requests(root)
+            baseline_profile = _read_json(output_dir / "baseline_profile.json")
+            best_profile = _read_json(output_dir / "best_profile.json")
+
+        diagnostic_requests = [
+            request
+            for request in requests
+            if request["tools"] == ["proton_intra_kernel"]
+        ]
+        self.assertEqual(
+            [(request["experiment_id"], request["reason"]) for request in diagnostic_requests],
+            [("baseline", "baseline_diagnostic"), ("final", "final_winner_diagnostic")],
+        )
+        candidate_diagnostics = [
+            request
+            for request in diagnostic_requests
+            if request["experiment_id"].startswith("r")
+        ]
+        self.assertEqual(candidate_diagnostics, [])
+        self.assertTrue(result.success)
+        self.assertEqual(result.experiments[1].status, "rejected")
+        self.assertEqual(result.experiments[2].status, "promoted")
+        self.assertEqual(result.final.aggregate_speedup, 1.25)
+        self.assertIn("diagnostic_proton_intra_kernel", result.baseline.cases[0].profile)
+        self.assertIn("diagnostic_proton_intra_kernel", result.final.cases[0].profile)
+        self.assertNotIn(
+            "diagnostic_proton_intra_kernel",
+            result.experiments[1].performance.cases[0].profile,  # type: ignore[union-attr]
+        )
+        baseline_diag = baseline_profile["a"]["diagnostic_proton_intra_kernel"]
+        self.assertEqual(baseline_diag["tools"], ["proton_intra_kernel"])
+        self.assertEqual(baseline_diag["artifacts"]["trace"], "/tmp/proton.trace")
+        self.assertNotIn("trace_events", baseline_diag)
+        self.assertEqual(best_profile["a"]["diagnostic_proton_intra_kernel"]["summary"]["granularity"], "warp")
+
+    def test_diagnostic_proton_does_not_duplicate_final_when_baseline_wins(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\nNCU_US = 100\n",
+                    harness_path=_write_policy_harness(root),
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=root / "out",
+                    diagnostic_proton_intra_kernel=True,
+                )
+            )
+            requests = _read_profile_requests(root)
+
+        diagnostic_requests = [
+            request
+            for request in requests
+            if request["tools"] == ["proton_intra_kernel"]
+        ]
+        self.assertFalse(result.success)
+        self.assertEqual(
+            [(request["experiment_id"], request["reason"]) for request in diagnostic_requests],
+            [("baseline", "baseline_diagnostic")],
+        )
+        self.assertIn("diagnostic_proton_intra_kernel", result.final.cases[0].profile)
+
+    def test_diagnostic_proton_is_promotion_neutral(self) -> None:
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster")]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\nNCU_US = 100\n",
+                    harness_path=_write_policy_harness(root),
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=root / "out",
+                    diagnostic_proton_intra_kernel=True,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.experiments[1].status, "promoted")
+        self.assertEqual(result.final.aggregate_speedup, 1.25)
+        self.assertEqual(
+            result.final.cases[0].profile["diagnostic_proton_intra_kernel"]["ncu"]["summary"]["duration_us"],
+            999999.0,
+        )
+
     def test_profile_payload_caps_large_values(self) -> None:
         # Use a harness that returns a >1MB profile to exercise spill logic.
         provider = FixedCandidateProvider(
@@ -333,6 +988,69 @@ class KernelOptimizerTest(unittest.TestCase):
                 )
                 # Optimizer should complete without error even with oversized profile.
                 self.assertIsNotNone(result)
+
+
+def _write_policy_harness(directory: Path) -> Path:
+    harness_path = directory / "policy_harness.py"
+    log_path = directory / "profile_requests.jsonl"
+    harness_path.write_text(
+        "from __future__ import annotations\n"
+        "import json\n"
+        "import re\n"
+        f"LOG_PATH = {str(log_path)!r}\n"
+        "def build(kernel_source, target):\n"
+        "    del target\n"
+        "    latency = re.search(r'LATENCY_US\\s*=\\s*([0-9.]+)', kernel_source)\n"
+        "    correct = re.search(r'CORRECT\\s*=\\s*(True|False)', kernel_source)\n"
+        "    ncu = re.search(r'NCU_US\\s*=\\s*([0-9.]+)', kernel_source)\n"
+        "    if latency is None or correct is None:\n"
+        "        return {'success': False, 'diagnostics': 'missing fake kernel controls'}\n"
+        "    artifact = {\n"
+        "        'latency_us': float(latency.group(1)),\n"
+        "        'correct': correct.group(1) == 'True',\n"
+        "        'ncu_us': float(ncu.group(1)) if ncu else None,\n"
+        "    }\n"
+        "    return {'success': True, 'artifact': artifact}\n"
+        "def verify(artifact, case):\n"
+        "    del case\n"
+        "    return {'passed': artifact['correct'], 'diagnostics': '' if artifact['correct'] else 'wrong'}\n"
+        "def benchmark(artifact, case, repetitions):\n"
+        "    scale = float(case.get('parameters', {}).get('scale', 1.0))\n"
+        "    return {'samples_us': [artifact['latency_us'] * scale] * repetitions}\n"
+        "def profile(artifact, case, request):\n"
+        "    del case\n"
+        "    with open(LOG_PATH, 'a') as stream:\n"
+        "        stream.write(json.dumps(request, sort_keys=True) + '\\n')\n"
+        "    tools = request.get('tools', []) if request else []\n"
+        "    if tools == ['proton_intra_kernel']:\n"
+        "        return {\n"
+        "            'level': request['level'],\n"
+        "            'tools': tools,\n"
+        "            'request': request,\n"
+        "            'summary': {'active_warps': 8, 'granularity': request.get('granularity')},\n"
+        "            'ncu': {'summary': {'duration_us': 999999.0}},\n"
+        "            'artifacts': {'trace': '/tmp/proton.trace'},\n"
+        "            'trace_events': [{'raw': 'event'}],\n"
+        "            'raw_profile': 'raw trace blob',\n"
+        "        }\n"
+        "    proton = {'totals': {'wrapper_us': 1.0, 'main_kernel_us': 2.0, 'non_main_kernel_us': 3.0}}\n"
+        "    payload = {'request': request, 'proton': proton}\n"
+        "    if artifact['ncu_us'] is not None:\n"
+        "        payload['ncu'] = {'summary': {'duration_us': artifact['ncu_us']}}\n"
+        "    return payload\n"
+    )
+    return harness_path
+
+
+def _read_profile_requests(directory: Path) -> list[dict[str, object]]:
+    path = directory / "profile_requests.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text())
+    assert isinstance(payload, dict)
+    return payload
 
 
 def _performance(*values: tuple[str, float]) -> PerformanceSummary:

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -596,6 +596,61 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertIn("[tlx-agent] final status=revalidated", output)
             self.assertTrue(result.success)
 
+    def test_rejected_candidate_evidence_reaches_next_proposal(self) -> None:
+        contexts: list[CandidateContext] = []
+        proposals = [
+            CandidateProposal(
+                "LATENCY_US = 120\nCORRECT = True\n",
+                summary="increase tile size",
+                hypothesis="larger tiles improve reuse",
+            ),
+            CandidateProposal(
+                "LATENCY_US = 80\nCORRECT = True\n",
+                summary="reduce tile size",
+            ),
+        ]
+
+        class RecordingProvider:
+            def propose(
+                self,
+                request: KernelOptimizationRequest,
+                context: CandidateContext,
+            ) -> CandidateProposal:
+                del request
+                contexts.append(context)
+                return proposals.pop(0)
+
+        with tempfile.TemporaryDirectory() as directory:
+            result = KernelOptimizer(RecordingProvider()).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                    harness_path=Path(__file__).with_name("testdata")
+                    / "fake_harness.py",
+                    cases=(InputCase("a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=2,
+                        min_speedup=1.01,
+                        benchmark_repetitions=3,
+                    ),
+                    output_dir=Path(directory),
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(contexts), 2)
+        feedback = contexts[1].previous_diagnostics[-1]
+        self.assertIn("r001-c000: rejected", feedback)
+        self.assertIn("hypothesis='larger tiles improve reuse'", feedback)
+        self.assertIn("change='increase tile size'", feedback)
+        self.assertIn("decision=speedup below 1.0100x threshold", feedback)
+        self.assertIn("aggregate_speedup=0.8333x", feedback)
+        self.assertIn("median=120.000us", feedback)
+        self.assertIn("cv=0.0000", feedback)
+        self.assertIn("speedup=0.8333x", feedback)
+        self.assertIn("ncu=unavailable", feedback)
+
     def test_continues_after_round_without_promotion(self) -> None:
         provider = FixedCandidateProvider(
             [

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -690,19 +690,22 @@ class KernelOptimizerTest(unittest.TestCase):
         candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
         final_request = result.final.cases[0].profile["request"]
         self.assertEqual(baseline_request["level"], "deep")
-        self.assertEqual(baseline_request["tools"], ["proton_launch", "ncu"])
+        expected_tools = ["proton_launch", "native_profiler"]
+        self.assertEqual(baseline_request["tools"], expected_tools)
         self.assertEqual(baseline_request["reason"], "baseline")
         self.assertEqual(
             Path(str(baseline_request["artifacts_dir"])).parent,
             output_dir / "experiments" / "baseline" / "profile_artifacts",
         )
         self.assertEqual(candidate_request["level"], "summary")
+        self.assertEqual(candidate_request["tools"], expected_tools)
         self.assertEqual(candidate_request["reason"], "candidate")
         self.assertEqual(
             Path(str(candidate_request["artifacts_dir"])).parent,
             output_dir / "experiments" / "r001-c000" / "profile_artifacts",
         )
         self.assertEqual(final_request["level"], "deep")
+        self.assertEqual(final_request["tools"], expected_tools)
         self.assertEqual(final_request["reason"], "final")
         self.assertEqual(
             Path(str(final_request["artifacts_dir"])).parent,
@@ -740,6 +743,10 @@ class KernelOptimizerTest(unittest.TestCase):
             )
         candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
         self.assertEqual(candidate_request["level"], "deep")
+        self.assertEqual(
+            candidate_request["tools"],
+            ["proton_launch", "native_profiler"],
+        )
         self.assertEqual(candidate_request["reason"], "near_threshold")
         self.assertFalse(result.success)
 

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -422,11 +422,11 @@ class HarnessTest(unittest.TestCase):
             performance = StandaloneHarness(harness_path).evaluate(
                 "source",
                 (InputCase("shape/128?case", {}),),
-                KernelTarget("fake", "fake"),
+                KernelTarget("cuda", "blackwell"),
                 benchmark_repetitions=2,
                 profile=ProfileRequest(
                     level="deep",
-                    tools=("ncu",),
+                    tools=("native_profiler",),
                     experiment_id="r001-c000",
                     artifacts_dir=artifacts_dir,
                     reason="unit test",
@@ -460,11 +460,11 @@ class HarnessTest(unittest.TestCase):
             performance = SubprocessHarness(harness_path, timeout_seconds=30.0).evaluate(
                 "source",
                 (InputCase("case a", {}),),
-                KernelTarget("fake", "fake"),
+                KernelTarget("cuda", "blackwell"),
                 benchmark_repetitions=2,
                 profile={
                     "level": "summary",
-                    "tools": ["proton"],
+                    "tools": ["proton_launch", "native_profiler"],
                     "experiment_id": "baseline",
                     "artifacts_dir": str(artifacts_dir),
                     "reason": "unit test",
@@ -474,7 +474,7 @@ class HarnessTest(unittest.TestCase):
             self.assertEqual(profile["case_id"], "case a")
             self.assertTrue(profile["exists"])
             request = profile["request"]
-            self.assertEqual(request["tools"], ["proton"])
+            self.assertEqual(request["tools"], ["proton_launch", "ncu"])
             self.assertEqual(Path(str(request["artifacts_dir"])).parent, artifacts_dir)
 
     def test_large_profile_spills_to_raw_profile_when_artifacts_dir_available(self) -> None:

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -6,7 +6,9 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
+from unittest.mock import Mock, patch
 
+from . import optimizer as optimizer_module
 from .cli import _parse_args, _resolve_harness_paths, _validate_host_matches_target
 from .harness import StandaloneHarness, SubprocessHarness
 from .models import (
@@ -662,6 +664,79 @@ class KernelOptimizerTest(unittest.TestCase):
             # Profile artifacts written by the optimizer.
             self.assertTrue((Path(directory) / "baseline_profile.json").exists())
             self.assertTrue((Path(directory) / "best_profile.json").exists())
+
+    def test_failed_final_revalidation_restores_baseline_best_profile(self) -> None:
+        baseline_source = "LATENCY_US = 100\nCORRECT = True\n"
+        candidate_source = "LATENCY_US = 80\nCORRECT = True\n"
+        baseline = PerformanceSummary(
+            cases=(
+                CaseEvaluation(
+                    case_id="a",
+                    verification=VerificationResult(True),
+                    timing=TimingSamples((100.0, 100.0)),
+                    profile={"marker": "baseline"},
+                ),
+            )
+        )
+        candidate = PerformanceSummary(
+            cases=(
+                CaseEvaluation(
+                    case_id="a",
+                    verification=VerificationResult(True),
+                    timing=TimingSamples((80.0, 80.0)),
+                    profile={"marker": "candidate"},
+                ),
+            )
+        )
+        rejected_final = PerformanceSummary(
+            cases=(
+                CaseEvaluation(
+                    case_id="a",
+                    verification=VerificationResult(True),
+                    timing=TimingSamples((120.0, 120.0)),
+                    profile={"marker": "rejected-final"},
+                ),
+            )
+        )
+        harness = Mock()
+        harness.evaluate.side_effect = [baseline, candidate, rejected_final]
+        provider = FixedCandidateProvider(
+            [CandidateProposal(candidate_source, "faster before final revalidation")]
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            output_dir = Path(directory)
+            with patch.object(
+                optimizer_module,
+                "SubprocessHarness",
+                return_value=harness,
+            ):
+                result = KernelOptimizer(provider).optimize(
+                    KernelOptimizationRequest(
+                        kernel_source=baseline_source,
+                        harness_path=output_dir / "unused_harness.py",
+                        cases=(InputCase("a", {}),),
+                        target=KernelTarget("fake", "fake"),
+                        budget=OptimizationBudget(
+                            max_rounds=1,
+                            candidates_per_round=1,
+                            min_speedup=1.01,
+                            benchmark_repetitions=2,
+                        ),
+                        output_dir=output_dir,
+                    )
+                )
+            baseline_profile = _read_json(output_dir / "baseline_profile.json")
+            best_profile = _read_json(output_dir / "best_profile.json")
+            final_profile = _read_json(output_dir / "experiments/final/profile.json")
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.stopping_reason, "finalist_revalidation_failed")
+            self.assertEqual(result.best_kernel, baseline_source)
+            self.assertEqual(result.final.cases[0].profile["marker"], "baseline")
+            self.assertEqual((output_dir / "best_kernel.py").read_text(), baseline_source)
+            self.assertEqual(best_profile, baseline_profile)
+            self.assertEqual(final_profile, baseline_profile)
 
     def test_optimizer_uses_profile_policy_and_records_profile_paths(self) -> None:
         provider = FixedCandidateProvider(

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -15,6 +15,7 @@ from .profiling import (
     parse_ncu_query_metrics,
     parse_proton_launch_attribution,
     per_case_profile_request,
+    resolve_profile_request_for_target,
     resolve_profile_tools,
     select_ncu_metric_names,
 )
@@ -78,6 +79,21 @@ class ProfileRequestTest(unittest.TestCase):
         self.assertEqual(
             resolve_profile_tools(("native_profiler",)),
             ("native_profiler",),
+        )
+
+    def test_resolves_native_profiler_for_target_backend(self) -> None:
+        payload = ProfileRequest(
+            tools=("proton_launch", "native_profiler", "ncu"),
+        ).to_json()
+        cuda = resolve_profile_request_for_target(payload, {"backend": "cuda"})
+        assert cuda is not None
+        self.assertEqual(cuda["tools"], ["proton_launch", "ncu"])
+
+        amd = resolve_profile_request_for_target(payload, {"backend": "hip"})
+        assert amd is not None
+        self.assertEqual(
+            amd["tools"],
+            ["proton_launch", "native_profiler", "ncu"],
         )
 
     def test_per_case_profile_request_expands_absolute_dir(self) -> None:

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -148,6 +148,17 @@ class ProfileParsingTest(unittest.TestCase):
         self.assertAlmostEqual(normalized["summary"]["sm_throughput_pct"], 75.5)
         self.assertIsNone(normalized["summary"]["dram_throughput_pct"])
 
+    def test_normalizes_local_memory_load_bytes(self) -> None:
+        metric = "l1tex__t_bytes_pipe_lsu_mem_local_op_ld.sum"
+        selected = select_ncu_metric_names((metric,), "deep")
+        self.assertEqual(selected["metrics"]["local_load_bytes"], metric)
+
+        normalized = normalize_ncu_metrics(
+            {metric: {"value": 4096.0, "unit": "byte"}},
+            "deep",
+        )
+        self.assertEqual(normalized["registers"]["local_load_bytes"], 4096.0)
+
     def test_parse_ncu_query_metrics_accepts_csv_and_plain_text(self) -> None:
         csv_metrics = parse_ncu_query_metrics(
             "Metric Name,Description\n"

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .profiling import (
+    ProfileRequest,
+    compact_profile_summary,
+    extract_ncu_duration_us,
+    ncu_regression_diagnostic,
+    normalize_ncu_metrics,
+    normalize_profile_request,
+    parse_ncu_csv,
+    parse_ncu_query_metrics,
+    parse_proton_launch_attribution,
+    per_case_profile_request,
+    select_ncu_metric_names,
+)
+
+
+class ProfileRequestTest(unittest.TestCase):
+    def test_bool_and_mapping_normalization(self) -> None:
+        self.assertIsNone(normalize_profile_request(False))
+        request = normalize_profile_request(True)
+        self.assertIsInstance(request, ProfileRequest)
+        assert request is not None
+        self.assertEqual(request.level, "summary")
+
+        with tempfile.TemporaryDirectory() as directory:
+            mapped = normalize_profile_request(
+                {
+                    "level": "deep",
+                    "tools": ["ncu"],
+                    "experiment_id": "baseline",
+                    "artifacts_dir": directory,
+                    "reason": "baseline profile",
+                }
+            )
+            assert mapped is not None
+            self.assertEqual(mapped.level, "deep")
+            self.assertEqual(mapped.tools, ("ncu",))
+            self.assertEqual(mapped.artifacts_dir, Path(directory))
+
+    def test_validates_request_shape(self) -> None:
+        with self.assertRaisesRegex(ValueError, "summary.*deep"):
+            ProfileRequest(level="diagnostic")
+        with self.assertRaisesRegex(ValueError, "absolute"):
+            ProfileRequest(artifacts_dir=Path("relative"))
+        with self.assertRaisesRegex(ValueError, "diagnostic_only"):
+            ProfileRequest(tools=("proton_intra_kernel",))
+        with self.assertRaisesRegex(ValueError, "warp"):
+            ProfileRequest(
+                tools=("proton_intra_kernel",),
+                diagnostic_only=True,
+                granularity="warp_group",
+            )
+        request = ProfileRequest(
+            tools=("proton_intra_kernel",),
+            diagnostic_only=True,
+            granularity="warp",
+        )
+        self.assertEqual(request.granularity, "warp")
+
+    def test_per_case_profile_request_expands_absolute_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            payload = ProfileRequest(artifacts_dir=Path(directory)).to_json()
+            request = per_case_profile_request(payload, "shape/128?case")
+            assert request is not None
+            artifacts_dir = Path(str(request["artifacts_dir"]))
+            self.assertTrue(artifacts_dir.is_absolute())
+            self.assertTrue(artifacts_dir.exists())
+            self.assertEqual(artifacts_dir.parent, Path(directory))
+            self.assertNotIn("/", artifacts_dir.name)
+
+
+class ProfileParsingTest(unittest.TestCase):
+    def test_parse_proton_tree_into_launch_attribution_summary(self) -> None:
+        proton = {
+            "name": "root",
+            "children": [
+                {"name": "python wrapper", "time_us": 5.0, "count": 2},
+                {"name": "main kernel launch", "duration_ns": 7000, "count": 1},
+                {"name": "helper kernel", "duration_us": 3.0, "count": 1},
+                {
+                    "name": "nested",
+                    "children": [{"name": "dispatch wrapper", "time_ms": 0.002}],
+                },
+            ],
+        }
+        summary = parse_proton_launch_attribution(proton)
+        self.assertEqual(summary["schema"], "launch_attribution_only")
+        totals = summary["totals"]
+        self.assertAlmostEqual(totals["wrapper_us"], 7.0)
+        self.assertAlmostEqual(totals["main_kernel_us"], 7.0)
+        self.assertAlmostEqual(totals["non_main_kernel_us"], 3.0)
+        self.assertEqual(totals["count"], 5)
+
+    def test_parse_ncu_csv_and_metric_selection(self) -> None:
+        csv_text = (
+            'ID,Metric Name,Metric Unit,Metric Value\n'
+            '0,gpu__time_duration.sum,ns,"2,000"\n'
+            '1,sm__throughput.avg.pct_of_peak_sustained_elapsed,%,75.5\n'
+        )
+        metrics = parse_ncu_csv(csv_text)
+        self.assertEqual(metrics["gpu__time_duration.sum"], {"value": 2000.0, "unit": "ns"})
+        selected = select_ncu_metric_names(metrics.keys(), "summary")
+        self.assertEqual(selected["metrics"]["duration_us"], "gpu__time_duration.sum")
+        self.assertIsNone(selected["metrics"]["dram_throughput_pct"])
+        self.assertTrue(selected["diagnostics"])
+
+        normalized = normalize_ncu_metrics(metrics, "summary")
+        self.assertAlmostEqual(normalized["summary"]["duration_us"], 2.0)
+        self.assertAlmostEqual(normalized["summary"]["sm_throughput_pct"], 75.5)
+        self.assertIsNone(normalized["summary"]["dram_throughput_pct"])
+
+    def test_parse_ncu_query_metrics_accepts_csv_and_plain_text(self) -> None:
+        csv_metrics = parse_ncu_query_metrics(
+            "Metric Name,Description\n"
+            "gpu__time_duration.sum,Duration\n"
+            "sm__throughput.avg.pct_of_peak_sustained_elapsed,SM\n"
+        )
+        self.assertIn("gpu__time_duration.sum", csv_metrics)
+        text_metrics = parse_ncu_query_metrics(
+            "gpu__time_duration.sum\n"
+            "sm__throughput.avg.pct_of_peak_sustained_elapsed some description\n"
+        )
+        self.assertIn("gpu__time_duration.sum", text_metrics)
+
+    def test_duration_extraction_and_regression_diagnostic(self) -> None:
+        old_flat = {"ncu": {"gpu__time_duration.sum": {"value": 1000, "unit": "ns"}}}
+        normalized = {"ncu": {"summary": {"duration_us": 1.02}}}
+        self.assertAlmostEqual(extract_ncu_duration_us(old_flat), 1.0)
+        self.assertAlmostEqual(extract_ncu_duration_us(normalized), 1.02)
+        self.assertIn("regressed", ncu_regression_diagnostic(old_flat, normalized))
+        self.assertEqual(ncu_regression_diagnostic(normalized, old_flat), "")
+
+    def test_compact_profile_summary_omits_raw_blobs(self) -> None:
+        compact = compact_profile_summary(
+            {
+                "level": "summary",
+                "summary": {"duration_us": 1.0},
+                "raw": "x" * 5000,
+                "ncu": {"raw_metrics": {"huge": "blob"}, "summary": {"duration_us": 1.0}},
+                "diagnostic_proton_intra_kernel": {
+                    "summary": {"active_warps": 8},
+                    "trace_events": [{"raw": "event"}],
+                    "artifacts": {"trace": "/tmp/proton.trace"},
+                },
+                "artifacts": {"csv": "/tmp/profile.csv"},
+            }
+        )
+        self.assertEqual(compact["level"], "summary")
+        self.assertNotIn("raw", compact)
+        self.assertNotIn("raw_metrics", compact["ncu"])
+        diagnostic = compact["diagnostic_proton_intra_kernel"]
+        self.assertNotIn("trace_events", diagnostic)
+        self.assertEqual(diagnostic["artifacts"]["trace"], "/tmp/proton.trace")
+        self.assertEqual(compact["artifacts"]["csv"], "/tmp/profile.csv")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -15,6 +15,7 @@ from .profiling import (
     parse_ncu_query_metrics,
     parse_proton_launch_attribution,
     per_case_profile_request,
+    resolve_profile_tools,
     select_ncu_metric_names,
 )
 
@@ -31,7 +32,7 @@ class ProfileRequestTest(unittest.TestCase):
             mapped = normalize_profile_request(
                 {
                     "level": "deep",
-                    "tools": ["ncu"],
+                    "tools": ["native_profiler"],
                     "experiment_id": "baseline",
                     "artifacts_dir": directory,
                     "reason": "baseline profile",
@@ -39,7 +40,7 @@ class ProfileRequestTest(unittest.TestCase):
             )
             assert mapped is not None
             self.assertEqual(mapped.level, "deep")
-            self.assertEqual(mapped.tools, ("ncu",))
+            self.assertEqual(mapped.tools, ("native_profiler",))
             self.assertEqual(mapped.artifacts_dir, Path(directory))
 
     def test_validates_request_shape(self) -> None:
@@ -61,6 +62,23 @@ class ProfileRequestTest(unittest.TestCase):
             granularity="warp",
         )
         self.assertEqual(request.granularity, "warp")
+
+    def test_resolves_native_profiler_and_deduplicates_aliases(self) -> None:
+        self.assertEqual(
+            resolve_profile_tools(
+                ("proton_launch", "native_profiler", "ncu"),
+                native_profiler="ncu",
+            ),
+            ("proton_launch", "ncu"),
+        )
+        self.assertEqual(
+            resolve_profile_tools((), native_profiler="ncu", default=("ncu",)),
+            ("ncu",),
+        )
+        self.assertEqual(
+            resolve_profile_tools(("native_profiler",)),
+            ("native_profiler",),
+        )
 
     def test_per_case_profile_request_expands_absolute_dir(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -142,6 +160,10 @@ class ProfileParsingTest(unittest.TestCase):
                 "summary": {"duration_us": 1.0},
                 "raw": "x" * 5000,
                 "ncu": {"raw_metrics": {"huge": "blob"}, "summary": {"duration_us": 1.0}},
+                "native_profiler": {
+                    "raw": "x" * 5000,
+                    "summary": {"duration_us": 1.0},
+                },
                 "diagnostic_proton_intra_kernel": {
                     "summary": {"active_warps": 8},
                     "trace_events": [{"raw": "event"}],
@@ -153,6 +175,8 @@ class ProfileParsingTest(unittest.TestCase):
         self.assertEqual(compact["level"], "summary")
         self.assertNotIn("raw", compact)
         self.assertNotIn("raw_metrics", compact["ncu"])
+        self.assertIn("native_profiler", compact)
+        self.assertNotIn("raw", compact["native_profiler"])
         diagnostic = compact["diagnostic_proton_intra_kernel"]
         self.assertNotIn("trace_events", diagnostic)
         self.assertEqual(diagnostic["artifacts"]["trace"], "/tmp/proton.trace")

--- a/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from .vcs import ATTRIBUTION, AutoCommitError, commit_winner, prepare_auto_commit
+
+
+def _run(command: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        command, cwd=cwd, text=True, capture_output=True, check=True
+    ).stdout
+
+
+@unittest.skipUnless(shutil.which("git"), "git is required")
+class GitAutoCommitTest(unittest.TestCase):
+    def _repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name)
+        _run(["git", "init", "-q"], root)
+        _run(["git", "config", "user.name", "TLX Test"], root)
+        _run(["git", "config", "user.email", "tlx@example.com"], root)
+        kernel = root / "kernels" / "kernel.py"
+        kernel.parent.mkdir()
+        kernel.write_text("A = 1\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        (root / "other.txt").write_text("base\n")
+        _run(["git", "add", "."], root)
+        _run(["git", "commit", "-qm", "base"], root)
+        return temporary, root, kernel
+
+    def test_commits_only_winner_delta_and_preserves_other_work(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        baseline = kernel.read_text()
+        (root / "other.txt").write_text("staged\n")
+        _run(["git", "add", "other.txt"], root)
+        (root / "dirty.txt").write_text("dirty\n")
+        snapshot = prepare_auto_commit(kernel, baseline)
+
+        result = commit_winner(
+            snapshot, "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n", "Tune kernel"
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(
+            _run(["git", "show", "HEAD:kernels/kernel.py"], root),
+            "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+        )
+        self.assertEqual(
+            kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n"
+        )
+        self.assertIn("other.txt", _run(["git", "diff", "--cached", "--name-only"], root))
+        self.assertEqual(
+            _run(["git", "show", "--format=", "--name-only", "HEAD"], root).strip(),
+            "kernels/kernel.py",
+        )
+        self.assertIn(ATTRIBUTION, _run(["git", "log", "-1", "--format=%B"], root))
+
+    def test_rejects_overlapping_dirty_target(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        snapshot = prepare_auto_commit(kernel, kernel.read_text())
+        before = _run(["git", "rev-parse", "HEAD"], root)
+        with self.assertRaisesRegex(AutoCommitError, "overlaps"):
+            commit_winner(
+                snapshot, "A = 3\nKEEP = 1\nKEEP2 = 1\nB = 1\n", "Tune kernel"
+            )
+        self.assertEqual(before, _run(["git", "rev-parse", "HEAD"], root))
+        self.assertEqual(
+            kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n"
+        )
+
+    def test_rejects_target_change_during_optimization(self) -> None:
+        temporary, _root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        snapshot = prepare_auto_commit(kernel, kernel.read_text())
+        kernel.write_text("A = 9\nB = 1\n")
+        with self.assertRaisesRegex(AutoCommitError, "changed during optimization"):
+            commit_winner(snapshot, "A = 1\nB = 2\n", "Tune kernel")
+
+
+@unittest.skipUnless(shutil.which("hg"), "hg is required")
+class HgAutoCommitTest(unittest.TestCase):
+    def test_commits_only_target_and_preserves_dirty_work(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _run(["hg", "init"], root)
+            kernel = root / "kernel.py"
+            kernel.write_text("A = 1\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+            other = root / "other.txt"
+            other.write_text("base\n")
+            _run(["hg", "add", "kernel.py", "other.txt"], root)
+            _run(["hg", "commit", "-u", "TLX Test", "-m", "base"], root)
+            kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+            other.write_text("dirty\n")
+            snapshot = prepare_auto_commit(kernel, kernel.read_text())
+
+            result = commit_winner(
+                snapshot, "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n", "Tune kernel"
+            )
+
+            self.assertTrue(result.success)
+            self.assertEqual(
+                _run(["hg", "cat", "-r", ".", "kernel.py"], root),
+                "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+            )
+            self.assertEqual(
+                kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n"
+            )
+            status = _run(["hg", "status"], root)
+            self.assertIn("M kernel.py", status)
+            self.assertIn("M other.txt", status)
+            self.assertIn(ATTRIBUTION, _run(["hg", "log", "-r", ".", "--template", "{desc}"], root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
@@ -41,11 +41,19 @@ class GitAutoCommitTest(unittest.TestCase):
         (root / "dirty.txt").write_text("dirty\n")
         snapshot = prepare_auto_commit(kernel, baseline)
 
+        validated: list[str] = []
         result = commit_winner(
-            snapshot, "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n", "Tune kernel"
+            snapshot,
+            "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+            "Tune kernel",
+            validate_committed_source=validated.append,
         )
 
         self.assertTrue(result.success)
+        self.assertEqual(
+            validated,
+            ["A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n"],
+        )
         self.assertEqual(
             _run(["git", "show", "HEAD:kernels/kernel.py"], root),
             "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
@@ -59,6 +67,49 @@ class GitAutoCommitTest(unittest.TestCase):
             "kernels/kernel.py",
         )
         self.assertIn(ATTRIBUTION, _run(["git", "log", "-1", "--format=%B"], root))
+
+    def test_rejects_dirty_target_without_merged_source_validation(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        snapshot = prepare_auto_commit(kernel, kernel.read_text())
+        before = _run(["git", "rev-parse", "HEAD"], root)
+
+        with self.assertRaisesRegex(AutoCommitError, "requires validation"):
+            commit_winner(
+                snapshot,
+                "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+                "Tune kernel",
+            )
+
+        self.assertEqual(before, _run(["git", "rev-parse", "HEAD"], root))
+        self.assertEqual(
+            kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n"
+        )
+
+    def test_rejects_dirty_target_when_merged_source_validation_fails(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        snapshot = prepare_auto_commit(kernel, kernel.read_text())
+        before = _run(["git", "rev-parse", "HEAD"], root)
+
+        def reject(source: str) -> None:
+            self.assertEqual(source, "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n")
+            raise AutoCommitError("merged source failed correctness")
+
+        with self.assertRaisesRegex(AutoCommitError, "failed correctness"):
+            commit_winner(
+                snapshot,
+                "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+                "Tune kernel",
+                validate_committed_source=reject,
+            )
+
+        self.assertEqual(before, _run(["git", "rev-parse", "HEAD"], root))
+        self.assertEqual(
+            kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n"
+        )
 
     def test_rejects_overlapping_dirty_target(self) -> None:
         temporary, root, kernel = self._repo()
@@ -100,11 +151,19 @@ class HgAutoCommitTest(unittest.TestCase):
             other.write_text("dirty\n")
             snapshot = prepare_auto_commit(kernel, kernel.read_text())
 
+            validated: list[str] = []
             result = commit_winner(
-                snapshot, "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n", "Tune kernel"
+                snapshot,
+                "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+                "Tune kernel",
+                validate_committed_source=validated.append,
             )
 
             self.assertTrue(result.success)
+            self.assertEqual(
+                validated,
+                ["A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n"],
+            )
             self.assertEqual(
                 _run(["hg", "cat", "-r", ".", "kernel.py"], root),
                 "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 2\n",

--- a/third_party/tlx/tools/agents/kernel_optimization/vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/vcs.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 from .models import AutoCommitResult
 
@@ -314,10 +314,21 @@ def _commit_hg(
 
 
 def commit_winner(
-    snapshot: AutoCommitSnapshot, winner_source: str, subject: str
+    snapshot: AutoCommitSnapshot,
+    winner_source: str,
+    subject: str,
+    *,
+    validate_committed_source: Callable[[str], None] | None = None,
 ) -> AutoCommitResult:
     _verify_snapshot(snapshot)
     committed_source = merge_winner_delta(snapshot, winner_source)
+    if committed_source != winner_source:
+        if validate_committed_source is None:
+            raise AutoCommitError(
+                "dirty-target winner requires validation of the merged commit source"
+            )
+        validate_committed_source(committed_source)
+    _verify_snapshot(snapshot)
     if snapshot.vcs == "git":
         revision = _commit_git(snapshot, committed_source, winner_source, subject)
     else:

--- a/third_party/tlx/tools/agents/kernel_optimization/vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/vcs.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .models import AutoCommitResult
+
+VcsKind = Literal["git", "hg"]
+ATTRIBUTION = "TLX agent authored"
+
+
+class AutoCommitError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AutoCommitSnapshot:
+    vcs: VcsKind
+    repo_root: Path
+    target_path: Path
+    target_relpath: str
+    base_revision: str
+    parent_source: str
+    baseline_source: str
+    dirty_target_at_start: bool
+    file_mode: str | None = None
+    index_state: str | None = None
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    input_text: str | None = None,
+    environment: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        diagnostics = (completed.stderr or completed.stdout).strip()
+        raise AutoCommitError(f"{' '.join(command[:2])} failed: {diagnostics}")
+    return completed
+
+
+def _discover_root(target: Path, vcs: VcsKind) -> Path | None:
+    if vcs == "git":
+        completed = _run(
+            ["git", "-C", str(target.parent), "rev-parse", "--show-toplevel"],
+            cwd=target.parent,
+            check=False,
+        )
+    else:
+        completed = _run(
+            ["hg", "--cwd", str(target.parent), "root"],
+            cwd=target.parent,
+            check=False,
+        )
+    if completed.returncode != 0:
+        return None
+    root = Path(completed.stdout.strip()).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return None
+    return root
+
+
+def detect_vcs(target_path: Path, requested: str = "auto") -> tuple[VcsKind, Path]:
+    target = target_path.resolve()
+    kinds: tuple[VcsKind, ...] = ("git", "hg")
+    if requested in kinds:
+        root = _discover_root(target, requested)  # type: ignore[arg-type]
+        if root is None:
+            raise AutoCommitError(f"target is not inside the requested {requested} repository")
+        return requested, root  # type: ignore[return-value]
+    if requested != "auto":
+        raise AutoCommitError(f"unsupported VCS selection: {requested}")
+    candidates = [
+        (kind, root)
+        for kind in kinds
+        if (root := _discover_root(target, kind)) is not None
+    ]
+    if not candidates:
+        raise AutoCommitError("no Git or Mercurial repository contains the target kernel")
+    candidates.sort(key=lambda item: len(item[1].parts), reverse=True)
+    if len(candidates) > 1 and len(candidates[0][1].parts) == len(candidates[1][1].parts):
+        raise AutoCommitError("ambiguous VCS repository; pass --vcs git or --vcs hg")
+    return candidates[0]
+
+
+def prepare_auto_commit(
+    target_path: Path, baseline_source: str, requested_vcs: str = "auto"
+) -> AutoCommitSnapshot:
+    target = target_path.resolve()
+    if not target.is_file():
+        raise AutoCommitError(f"target kernel does not exist: {target}")
+    if target.read_text() != baseline_source:
+        raise AutoCommitError("target changed while preparing the optimization baseline")
+    vcs, root = detect_vcs(target, requested_vcs)
+    relpath = target.relative_to(root).as_posix()
+    if vcs == "git":
+        revision = _run(
+            ["git", "rev-parse", "--verify", "HEAD"], cwd=root
+        ).stdout.strip()
+        unmerged = _run(
+            ["git", "ls-files", "-u", "--", relpath], cwd=root
+        ).stdout.strip()
+        if unmerged:
+            raise AutoCommitError("target kernel has unresolved Git conflicts")
+        tree_entry = _run(
+            ["git", "ls-tree", revision, "--", relpath], cwd=root
+        ).stdout.strip()
+        if not tree_entry:
+            raise AutoCommitError("target kernel is not tracked in Git HEAD")
+        mode = tree_entry.split(maxsplit=1)[0]
+        parent_source = _run(
+            ["git", "show", f"{revision}:{relpath}"], cwd=root
+        ).stdout
+        index_state = _run(
+            ["git", "ls-files", "-s", "--", relpath], cwd=root
+        ).stdout
+    else:
+        revision = _run(
+            ["hg", "log", "-r", ".", "--template", "{node}"], cwd=root
+        ).stdout.strip()
+        files = _run(
+            ["hg", "files", "--rev", ".", relpath], cwd=root, check=False
+        )
+        if files.returncode != 0 or not files.stdout.strip():
+            raise AutoCommitError("target kernel is not tracked in the Mercurial parent")
+        unresolved = _run(
+            ["hg", "resolve", "--list", relpath], cwd=root, check=False
+        ).stdout.splitlines()
+        if any(line.startswith("U ") for line in unresolved):
+            raise AutoCommitError("target kernel has unresolved Mercurial conflicts")
+        parent_source = _run(
+            ["hg", "cat", "-r", ".", relpath], cwd=root
+        ).stdout
+        mode = None
+        index_state = None
+    return AutoCommitSnapshot(
+        vcs=vcs,
+        repo_root=root,
+        target_path=target,
+        target_relpath=relpath,
+        base_revision=revision,
+        parent_source=parent_source,
+        baseline_source=baseline_source,
+        dirty_target_at_start=parent_source != baseline_source,
+        file_mode=mode,
+        index_state=index_state,
+    )
+
+
+def merge_winner_delta(snapshot: AutoCommitSnapshot, winner_source: str) -> str:
+    with tempfile.TemporaryDirectory(prefix="tlx-agent-merge-") as directory:
+        root = Path(directory)
+        parent_path = root / "parent.py"
+        baseline_path = root / "baseline.py"
+        winner_path = root / "winner.py"
+        parent_path.write_text(snapshot.parent_source)
+        baseline_path.write_text(snapshot.baseline_source)
+        winner_path.write_text(winner_source)
+        completed = _run(
+            [
+                "git",
+                "merge-file",
+                "--stdout",
+                str(parent_path),
+                str(baseline_path),
+                str(winner_path),
+            ],
+            cwd=root,
+            check=False,
+        )
+    if completed.returncode == 1:
+        raise AutoCommitError("winner overlaps pre-existing target edits")
+    if completed.returncode != 0:
+        diagnostics = (completed.stderr or completed.stdout).strip()
+        raise AutoCommitError(f"three-way merge failed: {diagnostics}")
+    if completed.stdout == snapshot.parent_source:
+        raise AutoCommitError("winner has no commit-worthy delta")
+    return completed.stdout
+
+
+def _commit_message(subject: str) -> str:
+    return f"{subject.rstrip()}\n\n{ATTRIBUTION}\n"
+
+
+def _verify_snapshot(snapshot: AutoCommitSnapshot) -> None:
+    if snapshot.target_path.read_text() != snapshot.baseline_source:
+        raise AutoCommitError("target kernel changed during optimization")
+    if snapshot.vcs == "git":
+        revision = _run(
+            ["git", "rev-parse", "--verify", "HEAD"], cwd=snapshot.repo_root
+        ).stdout.strip()
+        index_state = _run(
+            ["git", "ls-files", "-s", "--", snapshot.target_relpath],
+            cwd=snapshot.repo_root,
+        ).stdout
+        if index_state != snapshot.index_state:
+            raise AutoCommitError("target kernel index state changed during optimization")
+    else:
+        revision = _run(
+            ["hg", "log", "-r", ".", "--template", "{node}"],
+            cwd=snapshot.repo_root,
+        ).stdout.strip()
+    if revision != snapshot.base_revision:
+        raise AutoCommitError("repository parent changed during optimization")
+
+
+def _commit_git(
+    snapshot: AutoCommitSnapshot, committed_source: str, winner_source: str, subject: str
+) -> str:
+    assert snapshot.file_mode is not None
+    root = snapshot.repo_root
+    blob = _run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=root,
+        input_text=committed_source,
+    ).stdout.strip()
+    with tempfile.TemporaryDirectory(prefix="tlx-agent-index-") as directory:
+        index_path = Path(directory) / "index"
+        environment = os.environ.copy()
+        environment["GIT_INDEX_FILE"] = str(index_path)
+        _run(["git", "read-tree", snapshot.base_revision], cwd=root, environment=environment)
+        _run(
+            [
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"{snapshot.file_mode},{blob},{snapshot.target_relpath}",
+            ],
+            cwd=root,
+            environment=environment,
+        )
+        tree = _run(
+            ["git", "write-tree"], cwd=root, environment=environment
+        ).stdout.strip()
+    commit = _run(
+        ["git", "commit-tree", tree, "-p", snapshot.base_revision],
+        cwd=root,
+        input_text=_commit_message(subject),
+    ).stdout.strip()
+    _run(
+        [
+            "git",
+            "update-ref",
+            "-m",
+            "tlx-agent auto-commit winner",
+            "HEAD",
+            commit,
+            snapshot.base_revision,
+        ],
+        cwd=root,
+    )
+    _run(
+        [
+            "git",
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"{snapshot.file_mode},{blob},{snapshot.target_relpath}",
+        ],
+        cwd=root,
+    )
+    snapshot.target_path.write_text(winner_source)
+    committed = _run(
+        ["git", "show", f"HEAD:{snapshot.target_relpath}"], cwd=root
+    ).stdout
+    if committed != committed_source:
+        raise AutoCommitError("Git commit postcondition failed for target source")
+    return commit
+
+
+def _commit_hg(
+    snapshot: AutoCommitSnapshot, committed_source: str, winner_source: str, subject: str
+) -> str:
+    root = snapshot.repo_root
+    snapshot.target_path.write_text(committed_source)
+    succeeded = False
+    try:
+        _run(
+            ["hg", "commit", "-m", _commit_message(subject), snapshot.target_relpath],
+            cwd=root,
+        )
+        succeeded = True
+    finally:
+        snapshot.target_path.write_text(
+            winner_source if succeeded else snapshot.baseline_source
+        )
+    revision = _run(
+        ["hg", "log", "-r", ".", "--template", "{node}"], cwd=root
+    ).stdout.strip()
+    committed = _run(
+        ["hg", "cat", "-r", ".", snapshot.target_relpath], cwd=root
+    ).stdout
+    if committed != committed_source:
+        raise AutoCommitError("Mercurial commit postcondition failed for target source")
+    return revision
+
+
+def commit_winner(
+    snapshot: AutoCommitSnapshot, winner_source: str, subject: str
+) -> AutoCommitResult:
+    _verify_snapshot(snapshot)
+    committed_source = merge_winner_delta(snapshot, winner_source)
+    if snapshot.vcs == "git":
+        revision = _commit_git(snapshot, committed_source, winner_source, subject)
+    else:
+        revision = _commit_hg(snapshot, committed_source, winner_source, subject)
+    return AutoCommitResult(
+        requested=True,
+        success=True,
+        vcs=snapshot.vcs,
+        repo_root=snapshot.repo_root,
+        target_path=snapshot.target_path,
+        target_relpath=snapshot.target_relpath,
+        base_revision=snapshot.base_revision,
+        commit_revision=revision,
+        subject=subject,
+        dirty_target_at_start=snapshot.dirty_target_at_start,
+    )
+
+
+def failed_auto_commit(
+    snapshot: AutoCommitSnapshot | None, subject: str, error: Exception
+) -> AutoCommitResult:
+    return AutoCommitResult(
+        requested=True,
+        success=False,
+        vcs=snapshot.vcs if snapshot else None,
+        repo_root=snapshot.repo_root if snapshot else None,
+        target_path=snapshot.target_path if snapshot else None,
+        target_relpath=snapshot.target_relpath if snapshot else None,
+        base_revision=snapshot.base_revision if snapshot else None,
+        subject=subject,
+        dirty_target_at_start=snapshot.dirty_target_at_start if snapshot else False,
+        diagnostics=f"{type(error).__name__}: {error}",
+    )

--- a/third_party/tlx/tools/agents/kernel_optimization/worker.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/worker.py
@@ -10,6 +10,11 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+try:
+    from .profiling import compact_profile_output, invoke_profile, per_case_profile_request
+except ImportError:  # pragma: no cover - subprocess script execution path
+    from profiling import compact_profile_output, invoke_profile, per_case_profile_request
+
 
 def _load_harness(path: Path) -> ModuleType:
     spec = importlib.util.spec_from_file_location("tlx_kernel_agent_user_harness", path)
@@ -93,19 +98,15 @@ def _main() -> int:
             )
             if request.get("profile") and hasattr(harness, "profile"):
                 try:
-                    raw_profile = harness.profile(artifact, case)
-                    if not isinstance(raw_profile, Mapping):
-                        raise TypeError("profile() must return a mapping")
-                    # Cap inline JSON size to 1MB to keep response bounded.
-                    serialized = json.dumps(dict(raw_profile))
-                    if len(serialized) > 1_000_000:
-                        case_result["profile"] = {
-                            "error": "profile payload exceeded inline limit (1MB)",
-                            "size_bytes": len(serialized),
-                            "truncated_keys": list(raw_profile.keys()),
-                        }
-                    else:
-                        case_result["profile"] = dict(raw_profile)
+                    profile_request = per_case_profile_request(
+                        request.get("profile"), case["case_id"]
+                    )
+                    raw_profile = invoke_profile(
+                        harness.profile, artifact, case, profile_request
+                    )
+                    case_result["profile"] = compact_profile_output(
+                        raw_profile, profile_request
+                    )
                 except Exception as error:  # noqa: BLE001
                     case_result["profile"] = {
                         "error": f"{type(error).__name__}: {error}"

--- a/third_party/tlx/tools/kernel_agent/__init__.py
+++ b/third_party/tlx/tools/kernel_agent/__init__.py
@@ -1,4 +1,0 @@
-# Shim: moved to third_party/tlx/tools/agents/kernel_optimization
-# Kept for backwards compatibility — prefer:
-#   from third_party.tlx.tools.agents.kernel_optimization import ...
-from third_party.tlx.tools.agents.kernel_optimization import *  # noqa: F401,F403

--- a/website/content/tlx-agent.md
+++ b/website/content/tlx-agent.md
@@ -148,7 +148,7 @@ Profiling is staged so expensive evidence is collected where it can change a
 decision:
 
 - Proton attributes wrapper, launch, main-kernel, and non-main-kernel time.
-- NVIDIA NCU summary and deep profiles expose duration, throughput, occupancy, registers, memory traffic, tensor activity, and stall metrics.
+- The portable `native_profiler` request selects the target platform profiler. NVIDIA harnesses map it to NCU for duration, throughput, occupancy, register, memory-traffic, tensor-activity, and stall metrics.
 - Optional per-warp Proton instrumentation can answer intra-kernel attribution questions for warp-specialized pipelines.
 
 An ordinary Proton launch timeline does not prove that `tlx.async_task` regions

--- a/website/content/tlx-agent.md
+++ b/website/content/tlx-agent.md
@@ -1,0 +1,179 @@
+TLX Agent is a harness-driven optimization loop for complete Triton and TLX
+kernel source files. It turns a fixed workload and a trusted measurement
+contract into isolated candidate experiments, then promotes only a correct,
+measured, and revalidated winner.
+
+> The harness owns truth. TLX Agent does not invent correctness criteria or
+> change the benchmark while it searches.
+
+## When to use it
+
+Use TLX Agent when you have an existing kernel and a concrete workload to
+optimize. A request can start through a higher-level coding agent or by invoking
+the public CLI directly.
+
+You provide the kernel path, target workload, hardware, and optional search
+budget. If an exact target bundle does not already exist, the higher-level agent
+prepares and validates one before the optimization loop starts.
+
+## Recommended: run through a coding agent
+
+The recommended entry point is a coding agent that can inspect the repository,
+prepare the measurement contract, and supervise the run. Ask it to use the TLX
+kernel optimization agent rather than asking it to optimize the kernel manually.
+
+For example:
+
+```text
+Use the TLX kernel optimization agent to optimize
+<absolute-kernel-path> for BATCH=4, H=32, N_CTX=8192,
+HEAD_DIM=128, causal=false, mode=bwd on B200.
+Use the repository's authoritative correctness and performance tests,
+return the live-log path when the run starts, and report the validated winner.
+```
+
+The coding agent should then:
+
+- Read the bundled TLX Agent Skill and translate the request into the public CLI contract.
+- Find or prepare the exact target bundle, validate and negative-test it, then freeze it for the run.
+- Launch the public CLI instead of manually reproducing the optimization loop.
+- Return the absolute live-log path as soon as the run starts so progress is observable.
+- Monitor failures and requirements outside the frozen contract while TLX Agent owns candidate generation, profiling, correctness gates, promotion, and the winner commit.
+- Report the final workload, baseline and winner latency, speedup, variance, correctness, artifacts, and commit result.
+
+This route is preferred because the coding agent handles repository-specific setup
+and recovery while the TLX Agent retains one consistent, measurable optimization
+policy. Direct CLI use remains available when you already have a validated frozen
+bundle.
+
+## Input contract
+
+| Input | Purpose |
+|---|---|
+| `kernel.py` | Complete source file under optimization |
+| `harness.py` | Builds, verifies, benchmarks, and optionally profiles a candidate |
+| `cases.json` | Workloads, weights, and protected correctness cases |
+| `target.json` | Backend, architecture, device, environment, and target-specific guidance |
+| `reference_kernel.py` | Optional trusted correctness oracle |
+| `budget.json` | Optional round, timeout, speedup, variance, and repetition limits |
+| `output/` | Fresh directory for logs, candidates, profiles, and final results |
+
+The harness exposes four operations:
+
+```python
+def build(kernel_source: str, target: dict): ...
+def verify(build_artifact, case: dict): ...
+def benchmark(build_artifact, case: dict, repetitions: int): ...
+def profile(build_artifact, case: dict, request: dict | None = None): ...
+```
+
+`profile` is optional. The other operations form the correctness and performance
+boundary for every experiment.
+
+## Prepare and freeze the target bundle
+
+The higher-level coding agent owns target-bundle preparation. It should:
+
+- Find an existing bundle that exactly matches the kernel entry point, workload, mode, backend, and architecture, or derive one from the authoritative correctness test and production benchmark.
+- Run the untouched kernel through build, verification, repeated benchmarking, and summary profiling.
+- Confirm that an invalid candidate fails to build and an incorrect but compilable candidate fails verification.
+- Put kernel-specific invariants, known failed experiments, and profiler-to-knob guidance in `target.json` as `optimization_guidance`.
+- Record absolute paths and content hashes, then freeze `harness.py`, `cases.json`, and `target.json` for the duration of the run.
+
+Candidate generation must not edit the frozen bundle. This prevents the search
+from improving its score by weakening correctness or changing the workload.
+
+## Run the CLI
+
+From the repository root:
+
+```bash
+PYTHONPATH=<repo-root> python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel <absolute-kernel.py> \
+  --harness <absolute-bundle/harness.py> \
+  --cases <absolute-bundle/cases.json> \
+  --target <absolute-bundle/target.json> \
+  --output-dir <absolute-output-dir> \
+  --provider codex \
+  --max-rounds 5 \
+  --candidates-per-round 2 \
+  --max-candidate-seconds 600 \
+  --max-total-seconds 3600 \
+  --min-speedup 1.01 \
+  --max-cv 0.10 \
+  --benchmark-repetitions 10
+```
+
+Add `--reference-kernel`, `--budget`, `--arch`, or `--model` only when the run
+requires them. Winner commits are enabled by default; use
+`--no-commit-winner` for an artifact-only run.
+
+## Optimization loop
+
+Every candidate follows the same closed loop:
+
+```text
+build -> verify -> benchmark -> profile -> decide -> repeat
+```
+
+TLX Agent keeps candidate generation outside the live checkout. Each proposal
+changes one measured subsystem and records its hypothesis, evidence, expected
+effect, and risk. Incorrect, duplicate, unstable, and materially slower
+candidates are rejected. Failed hypotheses and hardware evidence feed the next
+round instead of being silently retried.
+
+The current best candidate receives stronger profiling and final revalidation
+before it can replace the original source.
+
+## Live log and artifacts
+
+Progress is written to stderr so it can be tee'd to a stable live-log path. The
+final structured result is written to stdout and the output directory.
+
+The live log reports:
+
+- Baseline, candidate, promotion, rejection, and final-validation status.
+- The candidate hypothesis, evidence, change, expected effect, and risk.
+- Per-case correctness, median, p95, coefficient of variation, and speedup.
+- Compact Proton and target-profiler evidence when available.
+- Winner-commit status and diagnostics.
+
+Full kernel source is not printed in the live log. Candidate source, raw
+profiler reports, commands, normalized summaries, and the final winner remain in
+the artifact directory for inspection.
+
+## Profiling
+
+Profiling is staged so expensive evidence is collected where it can change a
+decision:
+
+- Proton attributes wrapper, launch, main-kernel, and non-main-kernel time.
+- NVIDIA NCU summary and deep profiles expose duration, throughput, occupancy, registers, memory traffic, tensor activity, and stall metrics.
+- Optional per-warp Proton instrumentation can answer intra-kernel attribution questions for warp-specialized pipelines.
+
+An ordinary Proton launch timeline does not prove that `tlx.async_task` regions
+overlap. Per-warp instrumentation must select aligned logical work across task
+warps, and the instrumented source is diagnostic-only: it is never benchmarked,
+promoted, or committed.
+
+## Promotion and final validation
+
+A candidate is promotable only when every protected case passes, weighted
+speedup reaches the configured threshold, variance stays within budget, and
+hardware profiling shows no material main-kernel regression. It must also beat
+the current best candidate.
+
+The finalist is rebuilt and revalidated with the frozen bundle. A generated
+`best_kernel.py` without final revalidation is not a completed run.
+
+## Version-control behavior
+
+After successful final validation, TLX Agent creates a local winner commit by
+default. It detects Git or Mercurial from the kernel path, commits only the
+baseline-to-winner delta, preserves unrelated staged and dirty work, and adds
+`TLX agent authored` to the commit body.
+
+If the live kernel changed during the run or edits overlap unsafely, the Agent
+keeps the winner artifact and reports a commit failure instead of overwriting
+user work. Submitting, landing, or pushing the commit is always a separate
+explicit action.

--- a/website/content/tlx.md
+++ b/website/content/tlx.md
@@ -9,6 +9,10 @@ Primarily targeting NVIDIA GPUs (for now), TLX extends Triton to support:
 
 While this approach places more responsibility on the user, it reduces the compiler's role as a performance bottleneck. Although it may introduce divergence across hardware platforms, it empowers users to perform deeper, architecture-specific optimizations without relying solely on compiler heuristics.
 
+## Optimize TLX kernels
+
+Use the [TLX Agent](tlx-agent.html) to run a harness-driven optimization loop with isolated candidates, correctness gates, Proton and hardware profiling, final revalidation, and an optional local winner commit. Running it through a coding agent is recommended because the coding agent can prepare and freeze the workload-specific harness before invoking the TLX Agent CLI.
+
 ## Hardware tags
 
 Every operation below is tagged with the targets it runs on, using the

--- a/website/generate_tlx_site.py
+++ b/website/generate_tlx_site.py
@@ -132,8 +132,15 @@ TOOLING_PAGE = Page(
     "Tools for tracing, profiling, validating, and benchmarking Triton kernels.",
     "tooling",
 )
+TLX_AGENT_PAGE = Page(
+    "tlx-agent",
+    "TLX Agent",
+    "Harness-driven optimization for Triton and TLX kernels.",
+    "tooling",
+)
 
 TRITON_PAGES = (TRITON_PAGE, COMPILER_PAGE)
+TOOLING_PAGES = (TOOLING_PAGE, TLX_AGENT_PAGE)
 
 SECTIONS = {
     "triton": TRITON_PAGES,
@@ -141,7 +148,7 @@ SECTIONS = {
     "tlx-ops": (TLX_OPS_PAGE,),
     "torchtlx": (TORCHTLX_PAGE,),
     "ci": (CI_PAGE,),
-    "tooling": (TOOLING_PAGE,),
+    "tooling": TOOLING_PAGES,
 }
 SECTION_PAGES = tuple(pages[0] for pages in SECTIONS.values())
 SECTION_LABELS = {
@@ -152,7 +159,15 @@ SECTION_LABELS = {
     "ci": "CI",
     "tooling": "Tooling",
 }
-PAGES = (HOME_PAGE, *TRITON_PAGES, *TLX_PAGES, TLX_OPS_PAGE, TORCHTLX_PAGE, CI_PAGE, TOOLING_PAGE)
+PAGES = (
+    HOME_PAGE,
+    *TRITON_PAGES,
+    *TLX_PAGES,
+    TLX_OPS_PAGE,
+    TORCHTLX_PAGE,
+    CI_PAGE,
+    *TOOLING_PAGES,
+)
 
 def page_source(page: Page) -> str:
     """Read a page body from website/content/, falling back to guide_content."""

--- a/website/guide_content.py
+++ b/website/guide_content.py
@@ -180,6 +180,7 @@ Triton and TLX development use a small set of complementary tools. Start from th
 | CUTracer | Inspecting SASS-level execution, warp progress, TMA/MMA activity, deadlocks, and race candidates |
 | Compute Sanitizer | Runtime checks for invalid memory access, uninitialized values, synchronization errors, and shared-memory hazards |
 | TritonBench | Reproducible kernel and workload benchmarking across implementations and shapes |
+| [TLX Agent](tlx-agent.html) | Running a harness-driven optimization loop with correctness, profiling, promotion, and winner commits |
 | Proton | Instrumenting Triton kernels and collecting performance data with low-level execution context |
 | triton-lint | Static checks for common Triton correctness and performance anti-patterns |
 
@@ -190,6 +191,7 @@ Triton and TLX development use a small set of complementary tools. Start from th
 - Use Triton-MPP or a hardware profiler to classify the performance limit.
 - Add CUTracer or Compute Sanitizer only when runtime ordering, races, or memory access are suspect.
 - Confirm improvements with TritonBench or the repository's correctness and performance harnesses.
+- Use the [TLX Agent](tlx-agent.html) when you want that validated harness to drive an automated candidate, profiling, and promotion loop.
 
 The [debugging guide](debugging.html) provides symptom-driven workflows for performance and numerical issues.
 """,

--- a/website/tlx-agent.html
+++ b/website/tlx-agent.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Harness-driven optimization for Triton and TLX kernels.">
+  <title>TLX Agent · FBTriton</title>
+  <link rel="stylesheet" href="assets/tlx.css?v=20260824c">
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="../"><span>FBTriton</span></a>
+    <nav class="topnav" aria-label="Top-level sections"><a href="triton.html">Triton</a>
+<a href="tlx.html">TLX</a>
+<a href="tlx-ops.html">tlx.ops</a>
+<a href="torchtlx.html">TorchTLX</a>
+<a href="ci.html">CI</a>
+<a href="tooling.html" data-current="true">Tooling</a></nav>
+    <a class="repo-link" href="https://github.com/facebookexperimental/triton" target="_blank" rel="noreferrer">View on GitHub ↗</a>
+  </header>
+  <div class="shell">
+<aside class="sidebar">
+      <p class="eyebrow">Developer tooling</p>
+      <nav><a href="tooling.html">Overview</a>
+<a href="tlx-agent.html" aria-current="page">TLX Agent</a>
+<a class="sub" href="#when-to-use-it">When to use it</a>
+<a class="sub" href="#recommended-run-through-a-coding-agent">Recommended: run through a coding agent</a>
+<a class="sub" href="#input-contract">Input contract</a>
+<a class="sub" href="#prepare-and-freeze-the-target-bundle">Prepare and freeze the target bundle</a>
+<a class="sub" href="#run-the-cli">Run the CLI</a>
+<a class="sub" href="#optimization-loop">Optimization loop</a>
+<a class="sub" href="#live-log-and-artifacts">Live log and artifacts</a>
+<a class="sub" href="#profiling">Profiling</a>
+<a class="sub" href="#promotion-and-final-validation">Promotion and final validation</a>
+<a class="sub" href="#version-control-behavior">Version-control behavior</a></nav>
+    </aside>
+    <main>
+      <p class="eyebrow">Developer tooling</p>
+      <h1>TLX Agent</h1>
+      <p class="lede">Harness-driven optimization for Triton and TLX kernels.</p>
+      <article><p>TLX Agent is a harness-driven optimization loop for complete Triton and TLX kernel source files. It turns a fixed workload and a trusted measurement contract into isolated candidate experiments, then promotes only a correct, measured, and revalidated winner.</p>
+<blockquote><p>The harness owns truth. TLX Agent does not invent correctness criteria or change the benchmark while it searches.</p></blockquote>
+<h2 id="when-to-use-it">When to use it</h2>
+<p>Use TLX Agent when you have an existing kernel and a concrete workload to optimize. A request can start through a higher-level coding agent or by invoking the public CLI directly.</p>
+<p>You provide the kernel path, target workload, hardware, and optional search budget. If an exact target bundle does not already exist, the higher-level agent prepares and validates one before the optimization loop starts.</p>
+<h2 id="recommended-run-through-a-coding-agent">Recommended: run through a coding agent</h2>
+<p>The recommended entry point is a coding agent that can inspect the repository, prepare the measurement contract, and supervise the run. Ask it to use the TLX kernel optimization agent rather than asking it to optimize the kernel manually.</p>
+<p>For example:</p>
+<pre><code class="language-text">Use the TLX kernel optimization agent to optimize
+&lt;absolute-kernel-path&gt; for BATCH=4, H=32, N_CTX=8192,
+HEAD_DIM=128, causal=false, mode=bwd on B200.
+Use the repository&#x27;s authoritative correctness and performance tests,
+return the live-log path when the run starts, and report the validated winner.</code></pre>
+<p>The coding agent should then:</p>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Read the bundled TLX Agent Skill and translate the request into the public CLI contract.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Find or prepare the exact target bundle, validate and negative-test it, then freeze it for the run.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Launch the public CLI instead of manually reproducing the optimization loop.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Return the absolute live-log path as soon as the run starts so progress is observable.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Monitor failures and requirements outside the frozen contract while TLX Agent owns candidate generation, profiling, correctness gates, promotion, and the winner commit.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Report the final workload, baseline and winner latency, speedup, variance, correctness, artifacts, and commit result.</div></div>
+<p>This route is preferred because the coding agent handles repository-specific setup and recovery while the TLX Agent retains one consistent, measurable optimization policy. Direct CLI use remains available when you already have a validated frozen bundle.</p>
+<h2 id="input-contract">Input contract</h2>
+<table><thead><tr><th>Input</th><th>Purpose</th></tr></thead><tbody><tr><td><code>kernel.py</code></td><td>Complete source file under optimization</td></tr><tr><td><code>harness.py</code></td><td>Builds, verifies, benchmarks, and optionally profiles a candidate</td></tr><tr><td><code>cases.json</code></td><td>Workloads, weights, and protected correctness cases</td></tr><tr><td><code>target.json</code></td><td>Backend, architecture, device, environment, and target-specific guidance</td></tr><tr><td><code>reference_kernel.py</code></td><td>Optional trusted correctness oracle</td></tr><tr><td><code>budget.json</code></td><td>Optional round, timeout, speedup, variance, and repetition limits</td></tr><tr><td><code>output/</code></td><td>Fresh directory for logs, candidates, profiles, and final results</td></tr></tbody></table>
+<p>The harness exposes four operations:</p>
+<pre><code class="language-python">def build(kernel_source: str, target: dict): ...
+def verify(build_artifact, case: dict): ...
+def benchmark(build_artifact, case: dict, repetitions: int): ...
+def profile(build_artifact, case: dict, request: dict | None = None): ...</code></pre>
+<p><code>profile</code> is optional. The other operations form the correctness and performance boundary for every experiment.</p>
+<h2 id="prepare-and-freeze-the-target-bundle">Prepare and freeze the target bundle</h2>
+<p>The higher-level coding agent owns target-bundle preparation. It should:</p>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Find an existing bundle that exactly matches the kernel entry point, workload, mode, backend, and architecture, or derive one from the authoritative correctness test and production benchmark.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Run the untouched kernel through build, verification, repeated benchmarking, and summary profiling.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Confirm that an invalid candidate fails to build and an incorrect but compilable candidate fails verification.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Put kernel-specific invariants, known failed experiments, and profiler-to-knob guidance in <code>target.json</code> as <code>optimization_guidance</code>.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Record absolute paths and content hashes, then freeze <code>harness.py</code>, <code>cases.json</code>, and <code>target.json</code> for the duration of the run.</div></div>
+<p>Candidate generation must not edit the frozen bundle. This prevents the search from improving its score by weakening correctness or changing the workload.</p>
+<h2 id="run-the-cli">Run the CLI</h2>
+<p>From the repository root:</p>
+<pre><code class="language-bash">PYTHONPATH=&lt;repo-root&gt; python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel &lt;absolute-kernel.py&gt; \
+  --harness &lt;absolute-bundle/harness.py&gt; \
+  --cases &lt;absolute-bundle/cases.json&gt; \
+  --target &lt;absolute-bundle/target.json&gt; \
+  --output-dir &lt;absolute-output-dir&gt; \
+  --provider codex \
+  --max-rounds 5 \
+  --candidates-per-round 2 \
+  --max-candidate-seconds 600 \
+  --max-total-seconds 3600 \
+  --min-speedup 1.01 \
+  --max-cv 0.10 \
+  --benchmark-repetitions 10</code></pre>
+<p>Add <code>--reference-kernel</code>, <code>--budget</code>, <code>--arch</code>, or <code>--model</code> only when the run requires them. Winner commits are enabled by default; use <code>--no-commit-winner</code> for an artifact-only run.</p>
+<h2 id="optimization-loop">Optimization loop</h2>
+<p>Every candidate follows the same closed loop:</p>
+<pre><code class="language-text">build -&gt; verify -&gt; benchmark -&gt; profile -&gt; decide -&gt; repeat</code></pre>
+<p>TLX Agent keeps candidate generation outside the live checkout. Each proposal changes one measured subsystem and records its hypothesis, evidence, expected effect, and risk. Incorrect, duplicate, unstable, and materially slower candidates are rejected. Failed hypotheses and hardware evidence feed the next round instead of being silently retried.</p>
+<p>The current best candidate receives stronger profiling and final revalidation before it can replace the original source.</p>
+<h2 id="live-log-and-artifacts">Live log and artifacts</h2>
+<p>Progress is written to stderr so it can be tee'd to a stable live-log path. The final structured result is written to stdout and the output directory.</p>
+<p>The live log reports:</p>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Baseline, candidate, promotion, rejection, and final-validation status.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>The candidate hypothesis, evidence, change, expected effect, and risk.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Per-case correctness, median, p95, coefficient of variation, and speedup.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Compact Proton and target-profiler evidence when available.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Winner-commit status and diagnostics.</div></div>
+<p>Full kernel source is not printed in the live log. Candidate source, raw profiler reports, commands, normalized summaries, and the final winner remain in the artifact directory for inspection.</p>
+<h2 id="profiling">Profiling</h2>
+<p>Profiling is staged so expensive evidence is collected where it can change a decision:</p>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Proton attributes wrapper, launch, main-kernel, and non-main-kernel time.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>NVIDIA NCU summary and deep profiles expose duration, throughput, occupancy, registers, memory traffic, tensor activity, and stall metrics.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Optional per-warp Proton instrumentation can answer intra-kernel attribution questions for warp-specialized pipelines.</div></div>
+<p>An ordinary Proton launch timeline does not prove that <code>tlx.async_task</code> regions overlap. Per-warp instrumentation must select aligned logical work across task warps, and the instrumented source is diagnostic-only: it is never benchmarked, promoted, or committed.</p>
+<h2 id="promotion-and-final-validation">Promotion and final validation</h2>
+<p>A candidate is promotable only when every protected case passes, weighted speedup reaches the configured threshold, variance stays within budget, and hardware profiling shows no material main-kernel regression. It must also beat the current best candidate.</p>
+<p>The finalist is rebuilt and revalidated with the frozen bundle. A generated <code>best_kernel.py</code> without final revalidation is not a completed run.</p>
+<h2 id="version-control-behavior">Version-control behavior</h2>
+<p>After successful final validation, TLX Agent creates a local winner commit by default. It detects Git or Mercurial from the kernel path, commits only the baseline-to-winner delta, preserves unrelated staged and dirty work, and adds <code>TLX agent authored</code> to the commit body.</p>
+<p>If the live kernel changed during the run or edits overlap unsafely, the Agent keeps the winner artifact and reports a commit failure instead of overwriting user work. Submitting, landing, or pushing the commit is always a separate explicit action.</p></article>
+<footer class="pager"><a href="tooling.html">← Tooling</a></footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/website/tlx.html
+++ b/website/tlx.html
@@ -22,6 +22,7 @@
 <aside class="sidebar">
       <p class="eyebrow">TLX documentation</p>
       <nav><a href="tlx.html" aria-current="page">Overview</a>
+<a class="sub" href="#optimize-tlx-kernels">Optimize TLX kernels</a>
 <a class="sub" href="#hardware-tags">Hardware tags</a>
 <a href="buffers.html">Memory</a>
 <a href="global-memory.html">Global memory access</a>
@@ -47,6 +48,8 @@
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Instruction-level scheduling and control</div></div>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Cross-warpgroup synchronization</div></div>
 <p>While this approach places more responsibility on the user, it reduces the compiler's role as a performance bottleneck. Although it may introduce divergence across hardware platforms, it empowers users to perform deeper, architecture-specific optimizations without relying solely on compiler heuristics.</p>
+<h2 id="optimize-tlx-kernels">Optimize TLX kernels</h2>
+<p>Use the <a href="tlx-agent.html">TLX Agent</a> to run a harness-driven optimization loop with isolated candidates, correctness gates, Proton and hardware profiling, final revalidation, and an optional local winner commit. Running it through a coding agent is recommended because the coding agent can prepare and freeze the workload-specific harness before invoking the TLX Agent CLI.</p>
 <h2 id="hardware-tags">Hardware tags</h2>
 <p>Every operation below is tagged with the targets it runs on, using the architecture ids from <code>triton._internal_testing</code> — the same vocabulary the rest of this repo uses:</p>
 <table><thead><tr><th>Tag</th><th>Hardware</th></tr></thead><tbody><tr><td><code>sm90</code></td><td>NVIDIA Hopper</td></tr><tr><td><code>sm100</code></td><td>NVIDIA Blackwell</td></tr><tr><td><code>sm90+</code></td><td>Hopper and newer NVIDIA</td></tr><tr><td><code>gfx942</code></td><td>AMD MI300 (CDNA3)</td></tr><tr><td><code>gfx950</code></td><td>AMD MI350 (CDNA4)</td></tr><tr><td><code>gfx942+</code></td><td>MI300 and newer AMD</td></tr><tr><td><code>gfx1250</code></td><td>AMD RDNA4</td></tr><tr><td><code>amd</code></td><td>All AMD targets</td></tr></tbody></table>

--- a/website/tooling.html
+++ b/website/tooling.html
@@ -21,23 +21,25 @@
   <div class="shell">
 <aside class="sidebar">
       <p class="eyebrow">Developer tooling</p>
-      <nav><a href="tooling.html" aria-current="page">Tooling</a>
-<a class="sub" href="#suggested-workflow">Suggested workflow</a></nav>
+      <nav><a href="tooling.html" aria-current="page">Overview</a>
+<a class="sub" href="#suggested-workflow">Suggested workflow</a>
+<a href="tlx-agent.html">TLX Agent</a></nav>
     </aside>
     <main>
       <p class="eyebrow">Developer tooling</p>
       <h1>Tooling</h1>
       <p class="lede">Tools for tracing, profiling, validating, and benchmarking Triton kernels.</p>
       <article><p>Triton and TLX development use a small set of complementary tools. Start from the question you need to answer rather than collecting every trace at once.</p>
-<table><thead><tr><th>Tool</th><th>Best used for</th></tr></thead><tbody><tr><td>TritonParse</td><td>Capturing compilation and launch events, extracting reproductions, comparing IR, and bisecting compiler regressions</td></tr><tr><td>Triton-MPP</td><td>Classifying compute, memory, occupancy, and latency bottlenecks with targeted profiling passes</td></tr><tr><td>CUTracer</td><td>Inspecting SASS-level execution, warp progress, TMA/MMA activity, deadlocks, and race candidates</td></tr><tr><td>Compute Sanitizer</td><td>Runtime checks for invalid memory access, uninitialized values, synchronization errors, and shared-memory hazards</td></tr><tr><td>TritonBench</td><td>Reproducible kernel and workload benchmarking across implementations and shapes</td></tr><tr><td>Proton</td><td>Instrumenting Triton kernels and collecting performance data with low-level execution context</td></tr><tr><td>triton-lint</td><td>Static checks for common Triton correctness and performance anti-patterns</td></tr></tbody></table>
+<table><thead><tr><th>Tool</th><th>Best used for</th></tr></thead><tbody><tr><td>TritonParse</td><td>Capturing compilation and launch events, extracting reproductions, comparing IR, and bisecting compiler regressions</td></tr><tr><td>Triton-MPP</td><td>Classifying compute, memory, occupancy, and latency bottlenecks with targeted profiling passes</td></tr><tr><td>CUTracer</td><td>Inspecting SASS-level execution, warp progress, TMA/MMA activity, deadlocks, and race candidates</td></tr><tr><td>Compute Sanitizer</td><td>Runtime checks for invalid memory access, uninitialized values, synchronization errors, and shared-memory hazards</td></tr><tr><td>TritonBench</td><td>Reproducible kernel and workload benchmarking across implementations and shapes</td></tr><tr><td><a href="tlx-agent.html">TLX Agent</a></td><td>Running a harness-driven optimization loop with correctness, profiling, promotion, and winner commits</td></tr><tr><td>Proton</td><td>Instrumenting Triton kernels and collecting performance data with low-level execution context</td></tr><tr><td>triton-lint</td><td>Static checks for common Triton correctness and performance anti-patterns</td></tr></tbody></table>
 <h2 id="suggested-workflow">Suggested workflow</h2>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Create a stable single-kernel reproduction with fixed shapes and configuration.</div></div>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Use TritonParse to preserve compilation inputs and compare good and bad builds.</div></div>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Use Triton-MPP or a hardware profiler to classify the performance limit.</div></div>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Add CUTracer or Compute Sanitizer only when runtime ordering, races, or memory access are suspect.</div></div>
 <div class="list-item depth-0"><span aria-hidden="true">•</span><div>Confirm improvements with TritonBench or the repository's correctness and performance harnesses.</div></div>
+<div class="list-item depth-0"><span aria-hidden="true">•</span><div>Use the <a href="tlx-agent.html">TLX Agent</a> when you want that validated harness to drive an automated candidate, profiling, and promotion loop.</div></div>
 <p>The <a href="debugging.html">debugging guide</a> provides symptom-driven workflows for performance and numerical issues.</p></article>
-<footer class="pager"><a href="ci.html">← CI</a></footer>
+<footer class="pager"><a class="next" href="tlx-agent.html">TLX Agent →</a></footer>
     </main>
   </div>
 </body>


### PR DESCRIPTION
Add a repository-integrated workflow for optimizing TLX kernels through the public Agent CLI. The agent builds an immutable baseline, generates candidate kernels in isolated workspaces, verifies correctness, profiles hardware behavior, promotes only measured wins, and preserves complete run artifacts.

Workflow:
    
        User request
             |
             v
        Higher-level coding agent
             |  prepares and validates
             v
        Frozen target bundle + immutable baseline
             |
             v
        Public TLX Agent CLI --------------------------> Live log + artifacts
             |
             v
        Isolated candidate workspace
             |
             +--> build --> verify --> benchmark --> profile --> decide
             |       ^                                      |
             |       +---------- evidence feedback ---------+
             |
             v
        Final winner revalidation
             |
             +--> pass: Git/Hg winner commit
             +--> fail: preserve baseline and diagnostics
    


- Define the target and harness contracts, JSON configuration format, model records, source handling, worker protocol, and CLI entry point.
- Remove the unused legacy tools.kernel_agent compatibility shim; the supported package path is tools.agents.kernel_optimization.
- Run Codex in an isolated temporary workspace and robustly extract candidate source from multi-block responses without printing full kernels to live logs.
- Record each candidate's hypothesis, profiling evidence, source change, correctness result, performance, NCU result, and final decision. Feed prior failures and hardware evidence back into subsequent optimization prompts.
- Add staged performance validation with baseline measurement, candidate benchmarking, deep reprofile, and final winner revalidation. Instrumented diagnostic sources are never eligible for promotion or commit.
- Integrate Proton launch attribution, optional intra-kernel diagnostics, and NVIDIA NCU summary/deep profiling. Surface duration, throughput, occupancy, register, memory-traffic, tensor activity, and stall metrics when available.
- Keep NVIDIA-specific NCU guidance in the target documentation hierarchy.
- Detect Git or Mercurial automatically and commit only the baseline-to-winner delta by default, preserving pre-existing staged and dirty user changes. Support artifact-only runs with --no-commit-winner and log every commit attempt and outcome.
- Keep the Codex prompt kernel-neutral and inject frozen target-specific optimization guidance from the validated target bundle.
- Document the end-to-end workflow and add unit coverage for CLI parsing, profiling policy, candidate extraction, logging, VCS isolation, and frozen target-guidance propagation.
- Add a user-facing TLX Agent page to the generated Tooling site, covering harness preparation, CLI use, live logs, profiling, promotion, and commits.

The tool is designed to be invoked by a higher-level coding agent. The caller should read the bundled Skill, translate the user's target and workload into the public CLI contract, launch the CLI instead of manually reimplementing its optimization loop, and return only the absolute live-log path when the run starts. The TLX Agent then owns candidate isolation, profiling, correctness checks, promotion, and winner commit; the caller monitors the log, reports the final evidence, and intervenes only for failures or requirements outside the declared contract.

For users, the workflow is exposed through either a natural-language request to the higher-level agent or direct use of the public CLI. Users provide the kernel path, target workload, and optional search budget; startup returns the absolute live-log path. The log reports concise per-candidate hypotheses, evidence, correctness, performance, profiling results, and promotion decisions without dumping full kernel sources. Completion reports the validated winner, benchmark and correctness evidence, artifact locations, and the automatic commit outcome.

Target-specific harnesses and diagnostic instrumentation are intentionally kept outside the generic Agent change.