### PR TITLE
Integrate gfx950 TLX inter-wave addmm template

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -228,6 +228,185 @@ class TestTLXTemplates(TestCase):
 
     @unittest.skipIf(
         not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX inter-wave addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("dtype", (torch.float16, torch.bfloat16))
+    @parametrize("k", (256, 328))
+    @parametrize("column_major_b", (False, True))
+    def test_tlx_addmm_interwave(
+        self,
+        dtype: torch.dtype,
+        k: int,
+        column_major_b: bool,
+    ):
+        """The gfx950 inter-wave template handles B layouts and M/K tails."""
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry
+
+        M, K, N = 256, k, 256
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=dtype)
+        torch._dynamo.mark_dynamic(a, 0)
+        b = (
+            torch.randn(N, K, device=GPU_TYPE, dtype=dtype).t()
+            if column_major_b
+            else torch.randn(K, N, device=GPU_TYPE, dtype=dtype)
+        )
+        bias = torch.randn(N, device=GPU_TYPE, dtype=dtype)
+
+        def addmm(bias, a, b):
+            return torch.addmm(bias, a, b)
+
+        def _only_interwave(templates, op_name="mm"):
+            from torch._inductor.kernel.mm import mm_template
+
+            uids = {getattr(t, "uid", None) for t in templates}
+            if op_name == "addmm" and mm_template.uid in uids:
+                template = _tlx_mm.gfx950_addmm_interwave_template
+                if template.uid not in uids:
+                    templates.append(template)
+            return templates
+
+        with (
+            mock.patch.object(_tlx_mm, "append_tlx", _only_interwave),
+            mock.patch.object(
+                _tlx_registry.Gfx950AddMMInterWaveTemplateConfigHeuristic,
+                "INTERWAVE_CONFIGS",
+                [(256, 256, 64, 4, 8, 0, 8)],
+            ),
+            config.patch(
+                {
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }
+            ),
+        ):
+            compiled_addmm = torch.compile(addmm)
+            c_actual, code = run_and_get_code(compiled_addmm, bias, a, b)
+
+            # Reuse the same symbolic-M graph with a non-tile-aligned runtime M.
+            a_tail = torch.randn(M + 8, K, device=GPU_TYPE, dtype=dtype)
+            c_tail_actual = compiled_addmm(bias, a_tail, b)
+
+        c_expected = (a.float() @ b.float() + bias.float()).to(dtype)
+        c_tail_expected = (a_tail.float() @ b.float() + bias.float()).to(dtype)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(
+            c_tail_actual, c_tail_expected, atol=2e-2, rtol=2e-2
+        )
+        self.assertIn("smem_a_top", "\n".join(code))
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX inter-wave addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_addmm_interwave_symbolic_m_xcd(self):
+        """The 8-XCD remap preserves the index type for a symbolic M expression."""
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry
+
+        batch, rows, K, N = 32, 2000, 256, 512
+        a = torch.randn(batch, rows, K, device=GPU_TYPE, dtype=torch.float16)
+        torch._dynamo.mark_dynamic(a, 0)
+        b = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16).t()
+        bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
+
+        def addmm(bias, a, b):
+            return torch.addmm(bias, a.flatten(0, 1), b)
+
+        def _add_interwave(templates, op_name="mm"):
+            from torch._inductor.kernel.mm import mm_template
+
+            uids = {getattr(t, "uid", None) for t in templates}
+            if op_name == "addmm" and mm_template.uid in uids:
+                template = _tlx_mm.gfx950_addmm_interwave_template
+                if template.uid not in uids:
+                    templates.append(template)
+            return templates
+
+        with (
+            mock.patch.object(_tlx_mm, "append_tlx", _add_interwave),
+            mock.patch.object(
+                _tlx_registry.Gfx950AddMMInterWaveTemplateConfigHeuristic,
+                "INTERWAVE_CONFIGS",
+                [(256, 256, 64, 4, 8, 0, 8)],
+            ),
+            config.patch(
+                {
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "autotune_fallback_to_aten": False,
+                    "test_configs.autotune_choice_name_regex": (
+                        "tlx_gfx950_addmm_interwave"
+                    ),
+                    "enable_caching_generated_triton_templates": False,
+                }
+            ),
+        ):
+            c_actual, code = run_and_get_code(torch.compile(addmm), bias, a, b)
+
+        c_expected = addmm(bias, a, b)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+        self.assertIn("smem_a_top", "\n".join(code))
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX inter-wave addmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize("shape", ((1024, 864, 1024), (64000, 256, 256)))
+    def test_tlx_addmm_interwave_real_autotune(self, shape: tuple[int, int, int]):
+        """The registered inter-wave choice competes on production B layouts."""
+        from torch._inductor.select_algorithm import TritonTemplateCaller
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry  # noqa: F401
+
+        M, K, N = shape
+        a = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
+        b = torch.randn(N, K, device=GPU_TYPE, dtype=torch.float16).t()
+        bias = torch.randn(N, device=GPU_TYPE, dtype=torch.float16)
+
+        benchmarked = []
+        benchmark = TritonTemplateCaller.benchmark
+
+        def record_benchmark(choice, *args, out):
+            benchmarked.append(choice.name)
+            return benchmark(choice, *args, out=out)
+
+        with (
+            mock.patch.object(TritonTemplateCaller, "benchmark", record_benchmark),
+            config.patch(
+                {
+                    "triton.tlx_mode": "allow",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "ATEN,TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }
+            ),
+        ):
+            c_actual, code = run_and_get_code(
+                torch.compile(torch.addmm), bias, a, b
+            )
+
+        c_expected = torch.addmm(bias, a, b)
+        torch.testing.assert_close(c_actual, c_expected, atol=2e-2, rtol=2e-2)
+        self.assertTrue(code)
+        self.assertTrue(
+            any("tlx_gfx950_addmm_interwave" in name for name in benchmarked),
+            benchmarked,
+        )
+        self.assertTrue(
+            any(name.startswith("triton_mm") for name in benchmarked), benchmarked
+        )
+
+    @unittest.skipIf(
+        not is_gfx950(),
         "Need AMD MI350X (gfx950) for the TLX warp-pipe addmm template",
     )
     @unittest.skipIf(not has_tlx(), "TLX not available")
@@ -695,6 +874,35 @@ class TestTLXTemplates(TestCase):
         code_str = "\n".join(code)
         self.assertIn("split_k_ws", code_str)
         self.assertIn("_reduce_k", code_str)
+
+
+class TestInterWaveTemplateCodegen(TestCase):
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_interwave_template_renders_four_quadrants(self):
+        import jinja2
+        from triton.language.extra.tlx.inductor.mm_templates import load_tlx_template
+
+        source = load_tlx_template("gfx950_addmm_interwave")
+        stores = []
+
+        def store_output(indices, val, mask, **kwargs):
+            stores.append((indices, val, mask, kwargs["val_shape"]))
+            return f"tl.store(A, {val}, mask={mask})"
+
+        hooks = {
+            "def_kernel": lambda *args, **kwargs: "def _kernel(A, B):",
+            "size": lambda *args, **kwargs: "256",
+            "stride": lambda *args, **kwargs: "1",
+            "store_output": store_output,
+        }
+        rendered = jinja2.Environment().from_string(source).render(**hooks)
+
+        compile(rendered, "<gfx950_addmm_interwave>", "exec")
+        self.assertEqual(4, len(stores))
+        self.assertCountEqual(
+            ["acc_tl", "acc_bl", "acc_tr", "acc_br"],
+            [store[1] for store in stores],
+        )
 
 
 class TestWarpPipeSplitKCodegen(TestCase):

--- a/third_party/tlx/language/tlx/inductor/gfx950_addmm_interwave.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/gfx950_addmm_interwave.py.jinja
@@ -1,0 +1,456 @@
+{{def_kernel("A", "B")}}
+    # gfx950 8-wave inter-wave addmm. This is intentionally a separate template
+    # from the general warp-pipe: it requires row-major A, a square 128 or 256
+    # tile, BLOCK_K=64, and exactly two LDS buffers. B remains logically [K, N]
+    # in LDS for both physical layouts; the swizzle's contiguous axis follows
+    # the globally contiguous B dimension.
+    M = {{size("A", 0)}}
+    N = {{size("B", 1)}}
+    K = {{size("A", 1)}}
+    if M * N == 0:
+        return
+
+    stride_am = {{stride("A", 0)}}
+    stride_ak = {{stride("A", 1)}}
+    stride_bk = {{stride("B", 0)}}
+    stride_bn = {{stride("B", 1)}}
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_bn > 0)
+
+    pid = tl.program_id(0).to(INDEX_DTYPE)
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    grid_mn = grid_m * grid_n
+
+    if NUM_XCDS != 1:
+        pids_per_xcd = (grid_mn + NUM_XCDS - 1) // NUM_XCDS
+        tall_xcds = grid_mn % NUM_XCDS
+        # Keep both dynamic branches in the grid index's dtype. Backed symbolic
+        # M uses i64, while a bare NUM_XCDS literal is inferred as i32.
+        tall_xcds = (
+            tall_xcds + NUM_XCDS if tall_xcds == 0 else tall_xcds
+        )
+        xcd = pid % NUM_XCDS
+        local_pid = pid // NUM_XCDS
+        if xcd < tall_xcds:
+            pid = xcd * pids_per_xcd + local_pid
+        else:
+            pid = (
+                tall_xcds * pids_per_xcd
+                + (xcd - tall_xcds) * (pids_per_xcd - 1)
+                + local_pid
+            )
+
+    if GROUP_M == 1:
+        pid_m = pid // grid_n
+        pid_n = pid % grid_n
+    else:
+        num_pid_in_group = GROUP_M * grid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_M
+        group_size_m = min(grid_m - first_pid_m, GROUP_M)
+        pid_m = first_pid_m + (pid % num_pid_in_group) % group_size_m
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+    HALF_M: tl.constexpr = BLOCK_M // 2
+    HALF_N: tl.constexpr = BLOCK_N // 2
+
+    if BLOCK_M == 256:
+        a_bases: tl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+        ]
+    else:
+        a_bases: tl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+        ]
+{% if B_COL_MAJOR %}
+    if BLOCK_N == 256:
+        # Match the tutorial kernel: K is physically contiguous, so put B's K
+        # dimension in the low register bits while preserving logical [K, N].
+        b_bases: tl.constexpr = [
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+        ]
+    else:
+        b_bases: tl.constexpr = [
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [0, 16],
+            [0, 32],
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+        ]
+{% else %}
+    if BLOCK_N == 256:
+        # Keep B's row-major N dimension in the low register bits so the
+        # direct-to-LDS path emits contiguous 128-bit global loads.
+        b_bases: tl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+        ]
+    else:
+        b_bases: tl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [16, 0],
+            [32, 0],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+        ]
+{% endif %}
+
+    a_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 16)], a_bases, [HALF_M, BLOCK_K]
+    )
+    smem_a_top = tlx.local_alloc(
+        (HALF_M, BLOCK_K), tlx.dtype_of(A), 2, layout=a_shared
+    )
+    smem_a_bot = tlx.local_alloc(
+        (HALF_M, BLOCK_K), tlx.dtype_of(A), 2, layout=a_shared
+    )
+    b_shared: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 16)], b_bases, [BLOCK_K, HALF_N]
+    )
+    smem_b_left = tlx.local_alloc(
+        (BLOCK_K, HALF_N), tlx.dtype_of(B), 2, layout=b_shared
+    )
+    smem_b_right = tlx.local_alloc(
+        (BLOCK_K, HALF_N), tlx.dtype_of(B), 2, layout=b_shared
+    )
+
+    # Backed dynamic dimensions arrive as i64. The registry guards the largest
+    # A/B byte offsets below INT32_MAX, so narrowing the direct-to-LDS indices is
+    # safe and satisfies TLX's buffer-load offset contract.
+    offs_am = (pid_m * BLOCK_M + tl.arange(0, HALF_M)).to(tl.int32)
+    offs_bn = (pid_n * BLOCK_N + tl.arange(0, HALF_N)).to(tl.int32)
+    offs_k = tl.arange(0, BLOCK_K)
+
+{% if HAS_M_TAIL %}
+    # Async direct-to-LDS loads cannot be masked inside a warp-pipeline stage.
+    # Redirect out-of-range rows to row zero; their accumulators are discarded
+    # by the masked output store.
+    offs_am_top = tl.where(offs_am < M, offs_am, 0)
+    offs_am_bot = offs_am + HALF_M
+    offs_am_bot = tl.where(offs_am_bot < M, offs_am_bot, 0)
+    a_top_off = offs_am_top[:, None] * stride_am + offs_k[None, :] * stride_ak
+    a_bot_off = offs_am_bot[:, None] * stride_am + offs_k[None, :] * stride_ak
+{% else %}
+    a_top_off = offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+    a_bot_off = a_top_off + HALF_M * stride_am
+{% endif %}
+    b_left_off = offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+    b_right_off = b_left_off + HALF_N * stride_bn
+
+    a_top_off_n = a_top_off + BLOCK_K * stride_ak
+    a_bot_off_n = a_bot_off + BLOCK_K * stride_ak
+    b_left_off_n = b_left_off + BLOCK_K * stride_bk
+    b_right_off_n = b_right_off + BLOCK_K * stride_bk
+
+    ka = tl.zeros([], dtype=tl.int32)
+    kb = tl.zeros([], dtype=tl.int32)
+
+    acc_tl = tl.zeros((HALF_M, HALF_N), dtype=ACC_TYPE)
+    acc_bl = tl.zeros((HALF_M, HALF_N), dtype=ACC_TYPE)
+    acc_tr = tl.zeros((HALF_M, HALF_N), dtype=ACC_TYPE)
+    acc_br = tl.zeros((HALF_M, HALF_N), dtype=ACC_TYPE)
+
+    n_full = K // BLOCK_K
+    n_pipe = (n_full // 2) * 2
+
+    tlx.buffer_load_to_local(smem_b_left[0], B, b_left_off + kb)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[0], A, a_top_off + ka)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[0], A, a_bot_off + ka)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[0], B, b_right_off + kb)
+    tlx.async_load_commit_group()
+
+    tlx.buffer_load_to_local(smem_b_left[1], B, b_left_off_n + kb)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_top[1], A, a_top_off_n + ka)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_a_bot[1], A, a_bot_off_n + ka)
+    tlx.async_load_commit_group()
+    tlx.buffer_load_to_local(smem_b_right[1], B, b_right_off_n + kb)
+    tlx.async_load_commit_group()
+
+    ka += 2 * BLOCK_K * stride_ak
+    kb += 2 * BLOCK_K * stride_bk
+
+    tlx.async_load_wait_group(6)
+    b_left = tlx.local_load(smem_b_left[0], relaxed=True)
+    a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+
+    # Triton TR011: make the dot precision/performance contract explicit.
+    for _k in tl.range(0, n_pipe - 2, 2, num_stages=1):
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot(
+                a_top, b_left, acc_tl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
+            tlx.buffer_load_to_local(smem_b_left[0], B, b_left_off + kb)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot(
+                a_bot, b_left, acc_bl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(smem_b_right[0], relaxed=True)
+            tlx.buffer_load_to_local(smem_a_top[0], A, a_top_off + ka)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot(
+                a_top, b_right, acc_tr, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(smem_b_left[1], relaxed=True)
+            tlx.buffer_load_to_local(smem_a_bot[0], A, a_bot_off + ka)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot(
+                a_bot, b_right, acc_br, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[1], relaxed=True)
+            tlx.buffer_load_to_local(smem_b_right[0], B, b_right_off + kb)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tl = tl.dot(
+                a_top, b_left, acc_tl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
+            tlx.buffer_load_to_local(smem_b_left[1], B, b_left_off_n + kb)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_bl = tl.dot(
+                a_bot, b_left, acc_bl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_right = tlx.local_load(smem_b_right[1], relaxed=True)
+            tlx.buffer_load_to_local(smem_a_top[1], A, a_top_off_n + ka)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_tr = tl.dot(
+                a_top, b_right, acc_tr, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            b_left = tlx.local_load(smem_b_left[0], relaxed=True)
+            tlx.buffer_load_to_local(smem_a_bot[1], A, a_bot_off_n + ka)
+            tlx.async_load_commit_group()
+
+        tlx.async_load_wait_group(5)
+        with tlx.warp_pipeline_stage("mfma", priority=0):
+            acc_br = tl.dot(
+                a_bot, b_right, acc_br, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+            )
+        with tlx.warp_pipeline_stage("mem", priority=1):
+            a_top = tlx.local_load(smem_a_top[0], relaxed=True)
+            tlx.buffer_load_to_local(smem_b_right[1], B, b_right_off_n + kb)
+            tlx.async_load_commit_group()
+            ka += 2 * BLOCK_K * stride_ak
+            kb += 2 * BLOCK_K * stride_bk
+
+    acc_tl = tl.dot(
+        a_top, b_left, acc_tl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(5)
+    a_bot = tlx.local_load(smem_a_bot[0], relaxed=True)
+
+    acc_bl = tl.dot(
+        a_bot, b_left, acc_bl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(4)
+    b_right = tlx.local_load(smem_b_right[0], relaxed=True)
+
+    acc_tr = tl.dot(
+        a_top, b_right, acc_tr, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(3)
+    b_left = tlx.local_load(smem_b_left[1], relaxed=True)
+
+    acc_br = tl.dot(
+        a_bot, b_right, acc_br, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(2)
+    a_top = tlx.local_load(smem_a_top[1], relaxed=True)
+
+    acc_tl = tl.dot(
+        a_top, b_left, acc_tl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(1)
+    a_bot = tlx.local_load(smem_a_bot[1], relaxed=True)
+
+    acc_bl = tl.dot(
+        a_bot, b_left, acc_bl, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    tlx.async_load_wait_group(0)
+    b_right = tlx.local_load(smem_b_right[1], relaxed=True)
+
+    acc_tr = tl.dot(
+        a_top, b_right, acc_tr, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+    acc_br = tl.dot(
+        a_bot, b_right, acc_br, allow_tf32=ALLOW_TF32, out_dtype=ACC_TYPE
+    )
+
+    if HAS_REGISTER_TAIL:
+        offs_am_bot = offs_am + HALF_M
+        offs_bn_right = offs_bn + HALF_N
+        for kk in tl.range(n_pipe * BLOCK_K, K, BLOCK_K, num_stages=1):
+            offs_kt = kk + offs_k
+            k_mask = offs_kt < K
+            a_top_t = tl.load(
+                A + offs_am[:, None] * stride_am + offs_kt[None, :] * stride_ak,
+                mask=(offs_am[:, None] < M) & k_mask[None, :],
+                other=0.0,
+            )
+            a_bot_t = tl.load(
+                A
+                + offs_am_bot[:, None] * stride_am
+                + offs_kt[None, :] * stride_ak,
+                mask=(offs_am_bot[:, None] < M) & k_mask[None, :],
+                other=0.0,
+            )
+            b_left_t = tl.load(
+                B + offs_kt[:, None] * stride_bk + offs_bn[None, :] * stride_bn,
+                mask=k_mask[:, None] & (offs_bn[None, :] < N),
+                other=0.0,
+            )
+            b_right_t = tl.load(
+                B
+                + offs_kt[:, None] * stride_bk
+                + offs_bn_right[None, :] * stride_bn,
+                mask=k_mask[:, None] & (offs_bn_right[None, :] < N),
+                other=0.0,
+            )
+            acc_tl = tl.dot(
+                a_top_t,
+                b_left_t,
+                acc_tl,
+                allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
+            )
+            acc_bl = tl.dot(
+                a_bot_t,
+                b_left_t,
+                acc_bl,
+                allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
+            )
+            acc_tr = tl.dot(
+                a_top_t,
+                b_right_t,
+                acc_tr,
+                allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
+            )
+            acc_br = tl.dot(
+                a_bot_t,
+                b_right_t,
+                acc_br,
+                allow_tf32=ALLOW_TF32,
+                out_dtype=ACC_TYPE,
+            )
+
+    rows_top = pid_m * BLOCK_M + tl.arange(0, HALF_M).to(tl.int32)
+    rows_bot = rows_top + HALF_M
+    cols_left = pid_n * BLOCK_N + tl.arange(0, HALF_N).to(tl.int32)
+    cols_right = cols_left + HALF_N
+    idx_m_top = rows_top[:, None]
+    idx_m_bot = rows_bot[:, None]
+    idx_n_left = cols_left[None, :]
+    idx_n_right = cols_right[None, :]
+
+    if HALF_M == 128 and HALF_N == 128:
+        c_layout: tl.constexpr = tlx.layout(
+            shape=((16, 4, 8), (8, 4)),
+            stride=((8, 128, 512), (1, 4096)),
+        )
+        acc_tl = tlx.require_layout(acc_tl, c_layout)
+        acc_bl = tlx.require_layout(acc_bl, c_layout)
+        acc_tr = tlx.require_layout(acc_tr, c_layout)
+        acc_br = tlx.require_layout(acc_br, c_layout)
+    mask_tl = (idx_m_top < M) & (idx_n_left < N)
+    mask_bl = (idx_m_bot < M) & (idx_n_left < N)
+    mask_tr = (idx_m_top < M) & (idx_n_right < N)
+    mask_br = (idx_m_bot < M) & (idx_n_right < N)
+
+    {{store_output(("idx_m_top", "idx_n_left"), "acc_tl", "mask_tl", val_shape=("HALF_M", "HALF_N"))}}
+    {{store_output(("idx_m_bot", "idx_n_left"), "acc_bl", "mask_bl", val_shape=("HALF_M", "HALF_N"))}}
+    {{store_output(("idx_m_top", "idx_n_right"), "acc_tr", "mask_tr", val_shape=("HALF_M", "HALF_N"))}}
+    {{store_output(("idx_m_bot", "idx_n_right"), "acc_br", "mask_br", val_shape=("HALF_M", "HALF_N"))}}

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -83,6 +83,15 @@ gfx950_addmm_warppipe_template = TritonTemplate(
     source=load_tlx_template("gfx950_addmm_warppipe"),
 )
 
+# gfx950-only inter-wave addmm candidate derived from the a16w16 tutorial. The
+# tutorial is tuned for K-contiguous (column-major) B; the Inductor integration
+# also supports N-contiguous B with a layout-specific shared-memory swizzle.
+gfx950_addmm_interwave_template = TritonTemplate(
+    name="tlx_gfx950_addmm_interwave",
+    grid=mm_grid,
+    source=load_tlx_template("gfx950_addmm_interwave"),
+)
+
 # TLX warp-pipelined bmm template (MI350X/gfx950). Same warp-pipe core as the addmm, plus a
 # batch axis on the grid + a per-batch int64 base advance. B is the standard torch.bmm [BATCH,K,N]
 # row-major layout (loaded as (BLOCK_K, BLOCK_N) tiles, no transpose). Selection via TLX_MODE.
@@ -127,6 +136,9 @@ def _append_tlx_amd(templates, op_name):
 
         uids = {getattr(t, "uid", None) for t in templates}
         if mm_template.uid in uids:
+            # Inter-wave candidate for contiguous row- or column-major B.
+            if gfx950_addmm_interwave_template.uid not in uids:
+                templates.append(gfx950_addmm_interwave_template)
             # per-tile warp-pipe (existing candidate)
             if gfx950_addmm_warppipe_template.uid not in uids:
                 templates.append(gfx950_addmm_warppipe_template)

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -26,6 +26,7 @@ from typing import Any, Generator
 
 log = logging.getLogger(__name__)
 
+import sympy
 import torch
 from torch._inductor import config
 from torch._inductor.kernel_inputs import KernelInputs, MMKernelInputs
@@ -74,6 +75,7 @@ from .mm_templates import (
     gfx950_addmm_warppipe_template,
     gfx950_bmm_warppipe_template,
     blackwell_gemm_ws_template,
+    gfx950_addmm_interwave_template,
 )
 
 
@@ -110,6 +112,15 @@ def _amd_num_xcds() -> int:
     classes in ``tlx.hw.resources``.
     """
     return current_target().num_xcds
+
+
+def _is_gfx950() -> bool:
+    if not torch.version.hip:
+        return False
+    try:
+        return "gfx950" in torch.cuda.get_device_properties(0).gcnArchName
+    except (AssertionError, AttributeError, RuntimeError):
+        return False
 
 
 def _select_group_size_m(M: int, N: int, block_m: int) -> int:
@@ -1072,6 +1083,121 @@ class BlackwellGemmWSConfigMixin(TMATemplateConfigMixin):
 
 
 @register_template_heuristic(
+    gfx950_addmm_interwave_template.uid,
+    "cuda",
+    register=IS_ROCM,
+    op_name="addmm",
+)
+class Gfx950AddMMInterWaveTemplateConfigHeuristic(
+    AddMMConfigMixin, ROCmMMTemplateConfigHeuristic
+):
+    """Narrow config gate for the gfx950 a16w16 inter-wave kernel.
+
+    The reference kernel consumes row-major A directly and relies on a fixed
+    two-buffer, four-quadrant LDS layout. It accepts either row-major B or the
+    column-major B view produced by nn.Linear weights.
+    """
+
+    # (BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, waves_per_eu, NUM_XCDS)
+    INTERWAVE_CONFIGS = [
+        (256, 256, 64, 4, 8, 0, 8),
+        (256, 256, 64, 4, 8, 0, 1),
+        (128, 256, 64, 1, 8, 0, 1),
+        (128, 128, 64, 4, 8, 0, 8),
+        (128, 128, 64, 1, 4, 0, 1),
+        (128, 128, 64, 1, 4, 1, 1),
+        (128, 128, 64, 8, 4, 0, 1),
+        (128, 128, 64, 16, 4, 0, 1),
+    ]
+
+    def _get_template_configs_impl(self, kernel_inputs, op_name):
+        if not isinstance(kernel_inputs, MMKernelInputs) or not _is_gfx950():
+            return
+        if kernel_inputs.dtype(kernel_inputs._mat1_idx) not in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            return
+
+        m, n, k = kernel_inputs.mnk_symbolic()
+        strides = kernel_inputs.strides_hinted()
+        a_strides = strides[kernel_inputs._mat1_idx]
+        b_strides = strides[kernel_inputs._mat2_idx]
+        static_values = (n, k, *a_strides[-2:], *b_strides[-2:])
+        if not all(isinstance(value, (int, sympy.Integer)) for value in static_values):
+            return
+
+        sizevars = V.graph.sizevars
+        m_is_static = isinstance(m, (int, sympy.Integer))
+        m_int = _sizevar_hint(sizevars, m, -1)
+        if m_int <= 0:
+            return
+        n_int, k_int, stride_am, stride_ak, stride_bk, stride_bn = (
+            int(value) for value in static_values
+        )
+        b_is_row_major = stride_bn == 1
+        b_is_col_major = stride_bk == 1
+        if stride_ak != 1 or not (b_is_row_major or b_is_col_major):
+            return
+
+        itemsize = torch.finfo(kernel_inputs.dtype(kernel_inputs._mat1_idx)).bits // 8
+        b_row_stride = stride_bk if b_is_row_major else stride_bn
+        if stride_am * itemsize % 16 != 0 or b_row_stride * itemsize % 16 != 0:
+            return
+
+        int32_max = 2**31 - 1
+        max_a_offset = (m_int - 1) * stride_am + (k_int - 1) * stride_ak
+        max_b_offset = (k_int - 1) * stride_bk + (n_int - 1) * stride_bn
+        if (
+            max_a_offset >= int32_max
+            or max_b_offset >= int32_max
+            or not sizevars.guard_or_false(
+                sympy.Lt((m - 1) * stride_am + (k_int - 1) * stride_ak, int32_max)
+            )
+        ):
+            return
+
+        out_dtype = kernel_inputs.out_dtype()
+        for (
+            block_m,
+            block_n,
+            block_k,
+            group_m,
+            num_warps,
+            waves_per_eu,
+            config_num_xcds,
+        ) in self.INTERWAVE_CONFIGS:
+            if n_int % block_n != 0 or k_int < 2 * block_k:
+                continue
+
+            selected_group_m = (
+                4
+                if m_int == n_int and k_int >= 8192
+                else (2 if m_int <= 1024 and n_int >= 16384 else group_m)
+            )
+            num_xcds = 1 if m_int == n_int and k_int >= 8192 else config_num_xcds
+            triton_config = self.triton_config(
+                1,
+                num_warps,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+                BLOCK_K=block_k,
+                GROUP_M=selected_group_m,
+                NUM_XCDS=num_xcds,
+                B_COL_MAJOR=b_is_col_major and not b_is_row_major,
+                HAS_M_TAIL=not m_is_static or m_int % block_m != 0,
+                HAS_REGISTER_TAIL=k_int % (2 * block_k) != 0,
+                matrix_instr_nonkdim=16,
+                waves_per_eu=waves_per_eu,
+                kpack=get_default_kpack(block_k),
+                llvm_fn_attrs=(("amdgpu-agpr-alloc", "0,0"),),
+            )
+            yield self._convert_config_to_template_kwargs(
+                triton_config, m, n, k, out_dtype
+            )
+
+
+@register_template_heuristic(
     gfx950_addmm_warppipe_template.uid, "cuda", register=IS_ROCM, op_name="addmm"
 )
 class Gfx950AddMMWarpPipeConfigHeuristic(
@@ -1695,6 +1821,14 @@ def _tlx_store_output(  # type: ignore[no-untyped-def]
         # the regular TMA mode that OSS store_output will select.
         self._tlx_async_tma_store_active = True
     try:
+        if not hasattr(V.interpreter, "current_node") and hasattr(
+            V.graph, "current_node"
+        ):
+            # Template choices can be materialized during GraphLowering, before
+            # the separate interpreter virtual is installed. CSEProxy still
+            # needs the active FX node while rendering the addmm epilogue.
+            with V.set_interpreter_handler(V.graph):
+                return _orig_store_output(self, *args, **kwargs)
         return _orig_store_output(self, *args, **kwargs)
     finally:
         self._tlx_async_tma_store_active = False


### PR DESCRIPTION
Summary: Remove the erroneous row-major-only B restriction from the gfx950 inter-wave addmm integration. The reference tutorial natively uses K-contiguous (column-major) B, so the Inductor template reproduces its swizzle for that layout while retaining an N-contiguous row-major branch; the tutorial source itself remains unchanged. Backed symbolic M is accepted with guarded int32 offsets and safe M-tail redirection, and the 8-XCD remap keeps a consistent index type. Focused tests cover FP16/BF16, both B layouts, K/M tails, symbolic product M with XCD scheduling, and production-shaped autotune participation. Authored with Codex (AI).

Reviewed By: htyu

Differential Revision: D117562876


