### PR TITLE
[triton][beta] CSE after the terminal remove_layout_conversions

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1093,6 +1093,8 @@ class CUDABackend(BaseBackend):
         # after all other passes that may introduce layout conversions.
         terminal_smem_budget = (0 if knobs.nvidia.disable_budget_aware_layout_conversion else smem_budget)
         passes.ttgpuir.add_remove_layout_conversions(pm, terminal_smem_budget)
+        # add_remove_layout_conversions needs a CSE after it.
+        passes.ttir.add_loop_aware_cse(pm)
         # Retire user-pinned register layout markers (#tlx.user_layout) only after
         # ALL layout-rewriting passes have run (optimize_tmem_layouts reads the
         # marker; every remove_layout_conversions / reduce_data_duplication above


### PR DESCRIPTION
Summary:
Port of D118301185 to the `beta` channel. `beta` carries the identical
budget-aware terminal `add_remove_layout_conversions` call with no CSE behind
it, so it has the same gap.

`remove_layout_conversions` eliminates a `convert_layout` by rematerializing the
converted value's operand chain into the target layout, which leaves
structurally identical chains behind when two consumers want the same layout.
Every other call site in `make_ttgir` pairs the pass with a CSE on the next
line; this terminal one does not, and it is the last thing to touch TTGIR — the
next `add_cse` runs after `ConvertTritonGPUToLLVM`, by which point the
duplicates are LLVM-dialect ops that neither `CSEPass` nor LLVM `-O3` merges.

See D118301185 for the measurements. This is a code-size and memory-traffic
fix, not a latency fix; register allocation is unchanged.

Differential Revision: D118301572


