### PR TITLE
[AMD][TLX] Extend packed variable-length D128 backward to GQA

### DIFF
--- a/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
+++ b/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
@@ -2,6 +2,7 @@
 
 import inspect
 import re
+
 import pytest
 import torch
 from triton.language.extra.tlx.tutorials import amd_fa_bwd, amd_fa_varlen_bwd
@@ -93,32 +94,35 @@ def _assert_scratch_free(name, compiled):
     }, (name, resources)
 
 
-def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, heads, seed):
+def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, q_heads, kv_heads, seed):
+    assert q_heads > 0 and kv_heads > 0 and q_heads % kv_heads == 0
+    group_size = q_heads // kv_heads
     generator = torch.Generator(device="cuda")
     generator.manual_seed(seed)
     total_q = sum(q_lengths)
     total_kv = sum(kv_lengths)
     scale = 128**-0.5
-    q = torch.randn((total_q, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    k = torch.randn((total_kv, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    v = torch.randn((total_kv, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    do = torch.randn((total_q, heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    q = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    k = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    v = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    do = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
     out = torch.empty_like(q)
-    lse = torch.empty((heads, total_q), dtype=torch.float32, device="cuda")
+    lse = torch.empty((q_heads, total_q), dtype=torch.float32, device="cuda")
     expected_dq = torch.empty_like(q)
-    expected_dk = torch.empty_like(k)
-    expected_dv = torch.empty_like(v)
+    expected_dk = torch.zeros_like(k, dtype=torch.float32)
+    expected_dv = torch.zeros_like(v, dtype=torch.float32)
 
     q_begin = 0
     kv_begin = 0
     for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True):
         q_end = q_begin + q_length
         kv_end = kv_begin + kv_length
-        for head in range(heads):
-            q_tile = q[q_begin:q_end, head].float()
-            k_tile = k[kv_begin:kv_end, head].float()
-            v_tile = v[kv_begin:kv_end, head].float()
-            do_tile = do[q_begin:q_end, head].float()
+        for q_head in range(q_heads):
+            kv_head = q_head // group_size
+            q_tile = q[q_begin:q_end, q_head].float()
+            k_tile = k[kv_begin:kv_end, kv_head].float()
+            v_tile = v[kv_begin:kv_end, kv_head].float()
+            do_tile = do[q_begin:q_end, q_head].float()
             scores = q_tile @ k_tile.mT * scale
             lse_tile = torch.logsumexp(scores, dim=1)
             p = torch.exp(scores - lse_tile[:, None])
@@ -126,17 +130,21 @@ def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, heads, seed):
             delta = torch.sum(out_tile.float() * do_tile, dim=1)
             dp = do_tile @ v_tile.mT
             ds = (p * (dp - delta[:, None])).to(torch.bfloat16).float()
-            out[q_begin:q_end, head] = out_tile
-            lse[head, q_begin:q_end] = lse_tile
-            expected_dq[q_begin:q_end, head] = (ds @ k_tile * scale).to(torch.bfloat16)
-            expected_dk[kv_begin:kv_end, head] = (ds.mT @ q_tile * scale).to(torch.bfloat16)
-            expected_dv[kv_begin:kv_end, head] = (p.to(torch.bfloat16).float().mT @ do_tile).to(torch.bfloat16)
+            out[q_begin:q_end, q_head] = out_tile
+            lse[q_head, q_begin:q_end] = lse_tile
+            expected_dq[q_begin:q_end, q_head] = (ds @ k_tile * scale).to(torch.bfloat16)
+            expected_dk[kv_begin:kv_end, kv_head].add_(ds.mT @ q_tile * scale)
+            expected_dv[kv_begin:kv_end, kv_head].add_(p.to(torch.bfloat16).float().mT @ do_tile)
         q_begin = q_end
         kv_begin = kv_end
 
     cu_q = torch.tensor([0, *torch.tensor(q_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
     cu_kv = torch.tensor([0, *torch.tensor(kv_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
-    return q, k, v, out, do, lse, cu_q, cu_kv, scale, (expected_dq, expected_dk, expected_dv)
+    return q, k, v, out, do, lse, cu_q, cu_kv, scale, (
+        expected_dq,
+        expected_dk.to(torch.bfloat16),
+        expected_dv.to(torch.bfloat16),
+    )
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
@@ -236,59 +244,6 @@ def test_varlen_d128_plan_owns_offsets_and_compact_schedules():
     assert plan.cu_seqlens_k.tolist() == [0, 33, 162, 169]
 
 
-def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, q_heads, kv_heads, seed):
-    assert q_heads > 0 and kv_heads > 0 and q_heads % kv_heads == 0
-    group_size = q_heads // kv_heads
-    generator = torch.Generator(device="cuda")
-    generator.manual_seed(seed)
-    total_q = sum(q_lengths)
-    total_kv = sum(kv_lengths)
-    scale = 128**-0.5
-    q = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    k = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    v = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    do = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
-    out = torch.empty_like(q)
-    lse = torch.empty((q_heads, total_q), dtype=torch.float32, device="cuda")
-    expected_dq = torch.empty_like(q)
-    expected_dk = torch.zeros_like(k, dtype=torch.float32)
-    expected_dv = torch.zeros_like(v, dtype=torch.float32)
-
-    q_begin = 0
-    kv_begin = 0
-    for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True):
-        q_end = q_begin + q_length
-        kv_end = kv_begin + kv_length
-        for q_head in range(q_heads):
-            kv_head = q_head // group_size
-            q_tile = q[q_begin:q_end, q_head].float()
-            k_tile = k[kv_begin:kv_end, kv_head].float()
-            v_tile = v[kv_begin:kv_end, kv_head].float()
-            do_tile = do[q_begin:q_end, q_head].float()
-            scores = q_tile @ k_tile.mT * scale
-            lse_tile = torch.logsumexp(scores, dim=1)
-            p = torch.exp(scores - lse_tile[:, None])
-            out_tile = (p @ v_tile).to(torch.bfloat16)
-            delta = torch.sum(out_tile.float() * do_tile, dim=1)
-            dp = do_tile @ v_tile.mT
-            ds = (p * (dp - delta[:, None])).to(torch.bfloat16).float()
-            out[q_begin:q_end, q_head] = out_tile
-            lse[q_head, q_begin:q_end] = lse_tile
-            expected_dq[q_begin:q_end, q_head] = (ds @ k_tile * scale).to(torch.bfloat16)
-            expected_dk[kv_begin:kv_end, kv_head].add_(ds.mT @ q_tile * scale)
-            expected_dv[kv_begin:kv_end, kv_head].add_(p.to(torch.bfloat16).float().mT @ do_tile)
-        q_begin = q_end
-        kv_begin = kv_end
-
-    cu_q = torch.tensor([0, *torch.tensor(q_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
-    cu_kv = torch.tensor([0, *torch.tensor(kv_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
-    return q, k, v, out, do, lse, cu_q, cu_kv, scale, (
-        expected_dq,
-        expected_dk.to(torch.bfloat16),
-        expected_dv.to(torch.bfloat16),
-    )
-
-
 def _make_seeded_extend_attention_lengths(batch, max_context, seed):
     generator = torch.Generator()
     generator.manual_seed(seed)
@@ -311,6 +266,7 @@ def test_varlen_d128_seeded_extend_attention_lengths_are_reproducible():
     assert len(set(q_lengths)) > 1
     assert all(q_length > 0 for q_length in q_lengths)
     assert all(q_length < kv_length for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True))
+
 
 @pytest.mark.parametrize(
     ("max_q", "group_size", "expected"),
@@ -482,36 +438,6 @@ def test_varlen_d128_plan_rejects_invalid_offsets():
         with pytest.raises(ValueError, match=message):
             amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
-
-def test_varlen_d128_address_space_requires_i32_offsets():
-    # One D128 BF16 head fits at most 2**30 elements in the signed i32
-    # byte-offset range used by AMD buffer instructions.
-    max_tokens = 2**23
-
-    amd_fa_varlen_bwd._validate_i32_buffer_offsets(
-        total_q=max_tokens - 15,
-        total_kv=max_tokens,
-        batch=1,
-        q_heads=1,
-        kv_heads=1,
-    )
-
-    with pytest.raises(ValueError, match="KV tensor size exceeds the signed 32-bit byte-offset range"):
-        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
-            total_q=1,
-            total_kv=max_tokens + 1,
-            batch=1,
-            q_heads=1,
-            kv_heads=1,
-        )
-    with pytest.raises(ValueError, match="padded dQ size exceeds the signed 32-bit byte-offset range"):
-        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
-            total_q=max_tokens - 14,
-            total_kv=1,
-            batch=1,
-            q_heads=1,
-            kv_heads=1,
-        )
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_varlen_d128_backward_rejects_unsupported_signature():

--- a/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
+++ b/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
@@ -344,16 +344,19 @@ def test_varlen_d128_kernel_block_selection(group_size, kv_splits, expected):
 
 def test_varlen_d128_kv_partial_workspace_shapes():
     k = torch.empty((257, 2, 128), device="meta", dtype=torch.bfloat16)
-    max_size_k = torch.empty((2**23, 1, 128), device="meta", dtype=torch.bfloat16)
+    max_size_k = torch.empty((2**20, 1, 128), device="meta", dtype=torch.bfloat16)
+    oversized_k = torch.empty((2**20 + 1, 1, 128), device="meta", dtype=torch.bfloat16)
 
     direct_dk, direct_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(k, 1)
     split_dk, split_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(k, 3)
-    oversized_dk, oversized_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(max_size_k, 4)
+    max_size_dk, max_size_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(max_size_k, 4)
+    oversized_dk, oversized_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(oversized_k, 4)
 
     assert direct_dk is direct_dv is None
+    assert max_size_dk is not None and max_size_dv is not None
     assert oversized_dk is oversized_dv is None
     assert split_dk.shape == split_dv.shape == (257, 2, 3, 128)
-    assert split_dk.dtype is split_dv.dtype is torch.bfloat16
+    assert split_dk.dtype is split_dv.dtype is torch.float32
     assert split_dk.device.type == split_dv.device.type == "meta"
 
 

--- a/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
+++ b/python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
@@ -1,4 +1,6 @@
 """TLX AMD tests -- CDNA4 (gfx950)."""
+
+import inspect
 import re
 import pytest
 import torch
@@ -222,6 +224,11 @@ def test_varlen_d128_plan_owns_offsets_and_compact_schedules():
     assert plan.num_full_kv_blocks == 1
     assert plan.kv_block_sequence.tolist() == [1, 0, 1, 2]
     assert plan.kv_block_start.tolist() == [0, 0, 128, 0]
+    assert plan.wide_kv_start.tolist() == [162, 33, 0]
+    assert plan.wide_q_start.tolist() == [48, 17, 0]
+    assert plan.wide_dq_start.tolist() == [78, 32, 0]
+    assert plan.wide_q_len.tolist() == [40, 31, 17]
+    assert plan.wide_kv_valid.tolist() == [7, 129, 33]
 
     cu_q.fill_(0)
     cu_kv.fill_(0)
@@ -229,17 +236,184 @@ def test_varlen_d128_plan_owns_offsets_and_compact_schedules():
     assert plan.cu_seqlens_k.tolist() == [0, 33, 162, 169]
 
 
+def _make_varlen_d128_reference_case(q_lengths, kv_lengths, *, q_heads, kv_heads, seed):
+    assert q_heads > 0 and kv_heads > 0 and q_heads % kv_heads == 0
+    group_size = q_heads // kv_heads
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    total_q = sum(q_lengths)
+    total_kv = sum(kv_lengths)
+    scale = 128**-0.5
+    q = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    k = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    v = torch.randn((total_kv, kv_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    do = torch.randn((total_q, q_heads, 128), dtype=torch.bfloat16, device="cuda", generator=generator)
+    out = torch.empty_like(q)
+    lse = torch.empty((q_heads, total_q), dtype=torch.float32, device="cuda")
+    expected_dq = torch.empty_like(q)
+    expected_dk = torch.zeros_like(k, dtype=torch.float32)
+    expected_dv = torch.zeros_like(v, dtype=torch.float32)
+
+    q_begin = 0
+    kv_begin = 0
+    for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True):
+        q_end = q_begin + q_length
+        kv_end = kv_begin + kv_length
+        for q_head in range(q_heads):
+            kv_head = q_head // group_size
+            q_tile = q[q_begin:q_end, q_head].float()
+            k_tile = k[kv_begin:kv_end, kv_head].float()
+            v_tile = v[kv_begin:kv_end, kv_head].float()
+            do_tile = do[q_begin:q_end, q_head].float()
+            scores = q_tile @ k_tile.mT * scale
+            lse_tile = torch.logsumexp(scores, dim=1)
+            p = torch.exp(scores - lse_tile[:, None])
+            out_tile = (p @ v_tile).to(torch.bfloat16)
+            delta = torch.sum(out_tile.float() * do_tile, dim=1)
+            dp = do_tile @ v_tile.mT
+            ds = (p * (dp - delta[:, None])).to(torch.bfloat16).float()
+            out[q_begin:q_end, q_head] = out_tile
+            lse[q_head, q_begin:q_end] = lse_tile
+            expected_dq[q_begin:q_end, q_head] = (ds @ k_tile * scale).to(torch.bfloat16)
+            expected_dk[kv_begin:kv_end, kv_head].add_(ds.mT @ q_tile * scale)
+            expected_dv[kv_begin:kv_end, kv_head].add_(p.to(torch.bfloat16).float().mT @ do_tile)
+        q_begin = q_end
+        kv_begin = kv_end
+
+    cu_q = torch.tensor([0, *torch.tensor(q_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
+    cu_kv = torch.tensor([0, *torch.tensor(kv_lengths).cumsum(0).tolist()], dtype=torch.int32, device="cuda")
+    return q, k, v, out, do, lse, cu_q, cu_kv, scale, (
+        expected_dq,
+        expected_dk.to(torch.bfloat16),
+        expected_dv.to(torch.bfloat16),
+    )
+
+
+def _make_seeded_extend_attention_lengths(batch, max_context, seed):
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    prefix = torch.randint(1, max_context // 2, (batch, ), generator=generator)
+    extend = torch.randint(1, max_context // 2, (batch, ), generator=generator)
+    return extend.tolist(), (prefix + extend).tolist()
+
+
+def test_varlen_d128_backward_api_is_noncausal():
+    assert "causal" not in inspect.signature(amd_fa_varlen_bwd.fa_varlen_backward).parameters
+
+
+def test_varlen_d128_seeded_extend_attention_lengths_are_reproducible():
+    first = _make_seeded_extend_attention_lengths(batch=19, max_context=12331, seed=42)
+    second = _make_seeded_extend_attention_lengths(batch=19, max_context=12331, seed=42)
+    q_lengths, kv_lengths = first
+
+    assert first == second
+    assert len(q_lengths) == len(kv_lengths) == 19
+    assert len(set(q_lengths)) > 1
+    assert all(q_length > 0 for q_length in q_lengths)
+    assert all(q_length < kv_length for q_length, kv_length in zip(q_lengths, kv_lengths, strict=True))
+
 @pytest.mark.parametrize(
-    ("q_lengths", "kv_lengths"),
+    ("max_q", "group_size", "expected"),
     (
-        pytest.param([7, 31, 65], [33, 257, 7], id="mixed-full-tail"),
-        pytest.param([1, 17], [1, 127], id="all-tail"),
-        pytest.param([16, 32], [128, 256], id="all-full"),
+        pytest.param(5460, 3, 3, id="long-gqa3"),
+        pytest.param(4096, 4, 4, id="long-gqa4"),
+        pytest.param(4096, 6, 3, id="long-gqa6"),
+        pytest.param(2048, 8, 4, id="long-gqa8"),
+        pytest.param(5456, 3, 1, id="short-gqa3"),
+        pytest.param(2032, 8, 1, id="short-gqa8"),
+        pytest.param(16384, 1, 1, id="mha"),
+        pytest.param(16384, 5, 1, id="unsupported-gqa5"),
+    ),
+)
+def test_varlen_d128_kv_split_selection(max_q, group_size, expected):
+    assert amd_fa_varlen_bwd._select_varlen_kv_splits(max_q, group_size) == expected
+
+
+@pytest.mark.parametrize(
+    ("group_size", "kv_splits", "expected"),
+    (
+        pytest.param(3, 3, (32, 256), id="split-gqa3"),
+        pytest.param(8, 4, (32, 256), id="split-gqa8"),
+        pytest.param(1, 1, (16, 128), id="mha"),
+        pytest.param(3, 1, (16, 128), id="unsplit-gqa"),
+    ),
+)
+def test_varlen_d128_kernel_block_selection(group_size, kv_splits, expected):
+    assert amd_fa_varlen_bwd._select_varlen_kernel_blocks(group_size, kv_splits) == expected
+
+
+def test_varlen_d128_kv_partial_workspace_shapes():
+    k = torch.empty((257, 2, 128), device="meta", dtype=torch.bfloat16)
+    max_size_k = torch.empty((2**23, 1, 128), device="meta", dtype=torch.bfloat16)
+
+    direct_dk, direct_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(k, 1)
+    split_dk, split_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(k, 3)
+    oversized_dk, oversized_dv = amd_fa_varlen_bwd._allocate_varlen_dkdv_partials(max_size_k, 4)
+
+    assert direct_dk is direct_dv is None
+    assert oversized_dk is oversized_dv is None
+    assert split_dk.shape == split_dv.shape == (257, 2, 3, 128)
+    assert split_dk.dtype is split_dv.dtype is torch.bfloat16
+    assert split_dk.device.type == split_dv.device.type == "meta"
+
+
+@pytest.mark.parametrize(
+    ("q_lengths", "kv_lengths", "q_heads", "kv_heads"),
+    (
+        pytest.param([7, 31, 65], [33, 257, 7], 2, 2, id="mha-mixed-full-tail"),
+        pytest.param([1, 17], [1, 127], 2, 2, id="mha-all-tail"),
+        pytest.param([16, 32], [128, 256], 2, 2, id="mha-all-full"),
+        pytest.param([7, 31, 65], [33, 257, 7], 6, 2, id="gqa3-mixed"),
+        pytest.param([1, 17], [1, 129], 8, 1, id="gqa8-tail"),
+        pytest.param([5460], [17], 3, 1, id="gqa3-long-split3"),
+        pytest.param([5460], [17], 12, 4, id="gqa3-multi-kv-long-split3"),
+        pytest.param([2048], [17], 8, 1, id="gqa8-long-split4"),
+        pytest.param(
+            *_make_seeded_extend_attention_lengths(batch=5, max_context=96, seed=443),
+            12,
+            4,
+            id="gqa3-seeded-prefix-extend",
+        ),
     ),
 )
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_varlen_d128_interleaved_mixed_lengths_gfx950(q_lengths, kv_lengths):
-    case = _make_varlen_d128_reference_case(q_lengths, kv_lengths, heads=2, seed=401)
+def test_varlen_d128_interleaved_lengths_gfx950(q_lengths, kv_lengths, q_heads, kv_heads):
+    case = _make_varlen_d128_reference_case(
+        q_lengths,
+        kv_lengths,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        seed=431,
+    )
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+
+    actual = amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+
+    for name, result, reference in zip(("dq", "dk", "dv"), actual, expected, strict=True):
+        assert torch.isfinite(result).all(), name
+        relative_l2 = torch.linalg.vector_norm(result.float() - reference.float()) / torch.linalg.vector_norm(
+            reference.float())
+        assert relative_l2.item() < 1e-2, (name, relative_l2.item())
+
+
+@pytest.mark.parametrize(
+    ("q_lengths", "q_heads", "kv_heads"),
+    (
+        pytest.param([1, 17, 31, 32, 33, 5460], 3, 1, id="gqa3"),
+        pytest.param([1, 17, 31, 32, 33, 2048], 8, 1, id="gqa8"),
+    ),
+)
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_bm32_boundaries_gfx950(q_lengths, q_heads, kv_heads):
+    kv_lengths = [1, 255, 256, 257, 511, 17]
+    case = _make_varlen_d128_reference_case(
+        q_lengths,
+        kv_lengths,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        seed=487 + q_heads,
+    )
     q, k, v, out, do, lse, cu_q, cu_kv, scale, expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
@@ -262,7 +436,7 @@ def test_varlen_d128_runtime_totals_reuse_specialization_gfx950():
         kernel.device_caches.clear()
 
     for q_length in (17, 33):
-        case = _make_varlen_d128_reference_case([q_length], [128], heads=1, seed=419 + q_length)
+        case = _make_varlen_d128_reference_case([q_length], [128], q_heads=1, kv_heads=1, seed=419 + q_length)
         q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
         plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
@@ -272,6 +446,25 @@ def test_varlen_d128_runtime_totals_reuse_specialization_gfx950():
     device = torch.cuda.current_device()
     for kernel in kernels:
         assert len(kernel.device_caches[device][0]) == 1, kernel.fn.__name__
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_bm32_runtime_totals_reuse_specialization_gfx950():
+    kernel = getattr(amd_fa_varlen_bwd, "_varlen_bwd_interleaved_bm32_kernel", None)
+    assert kernel is not None
+    kernel.device_caches.clear()
+
+    # Keep Triton's ordinary integer divisibility specialization identical;
+    # only the packed token count should differ.
+    for q_length in (5460, 5476):
+        case = _make_varlen_d128_reference_case([q_length], [17], q_heads=3, kv_heads=1, seed=503 + q_length)
+        q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+        plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+        amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+        torch.cuda.synchronize()
+
+    device = torch.cuda.current_device()
+    assert len(kernel.device_caches[device][0]) == 1
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
@@ -287,9 +480,39 @@ def test_varlen_d128_plan_rejects_invalid_offsets():
             amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
 
+def test_varlen_d128_address_space_requires_i32_offsets():
+    # One D128 BF16 head fits at most 2**30 elements in the signed i32
+    # byte-offset range used by AMD buffer instructions.
+    max_tokens = 2**23
+
+    amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+        total_q=max_tokens - 15,
+        total_kv=max_tokens,
+        batch=1,
+        q_heads=1,
+        kv_heads=1,
+    )
+
+    with pytest.raises(ValueError, match="KV tensor size exceeds the signed 32-bit byte-offset range"):
+        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+            total_q=1,
+            total_kv=max_tokens + 1,
+            batch=1,
+            q_heads=1,
+            kv_heads=1,
+        )
+    with pytest.raises(ValueError, match="padded dQ size exceeds the signed 32-bit byte-offset range"):
+        amd_fa_varlen_bwd._validate_i32_buffer_offsets(
+            total_q=max_tokens - 14,
+            total_kv=1,
+            batch=1,
+            q_heads=1,
+            kv_heads=1,
+        )
+
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_varlen_d128_backward_rejects_unsupported_signature():
-    case = _make_varlen_d128_reference_case([16], [128], heads=1, seed=407)
+    case = _make_varlen_d128_reference_case([16], [128], q_heads=1, kv_heads=1, seed=407)
     q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
 
@@ -306,7 +529,7 @@ def test_varlen_d128_backward_rejects_unsupported_signature():
             plan,
             scale,
         )
-    with pytest.raises(ValueError, match="positive head count"):
+    with pytest.raises(ValueError, match="positive Q and KV head counts"):
         amd_fa_varlen_bwd.fa_varlen_backward(
             q[:, :0],
             k[:, :0],
@@ -317,25 +540,36 @@ def test_varlen_d128_backward_rejects_unsupported_signature():
             plan,
             scale,
         )
+    with pytest.raises(ValueError, match="positive Q and KV head counts"):
+        amd_fa_varlen_bwd.fa_varlen_backward(
+            q,
+            k[:, :0],
+            v[:, :0],
+            out,
+            do,
+            lse,
+            plan,
+            scale,
+        )
     with pytest.raises(ValueError, match="sm_scale must be finite"):
         amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, float("nan"))
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
-def test_varlen_d128_backward_rejects_gqa():
-    case = _make_varlen_d128_reference_case([16], [128], heads=2, seed=411)
+def test_varlen_d128_backward_rejects_nondivisible_gqa():
+    case = _make_varlen_d128_reference_case([16], [128], q_heads=4, kv_heads=2, seed=411)
     q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
-    gqa_k = k[:, :1].contiguous()
-    gqa_v = v[:, :1].contiguous()
+    invalid_k = torch.empty((k.shape[0], 3, 128), dtype=k.dtype, device=k.device)
+    invalid_v = torch.empty_like(invalid_k)
 
-    with pytest.raises(ValueError, match="equal Q and KV head counts"):
-        amd_fa_varlen_bwd.fa_varlen_backward(q, gqa_k, gqa_v, out, do, lse, plan, scale)
+    with pytest.raises(ValueError, match="divisible"):
+        amd_fa_varlen_bwd.fa_varlen_backward(q, invalid_k, invalid_v, out, do, lse, plan, scale)
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_varlen_d128_backward_rejects_noncontiguous_lse():
-    case = _make_varlen_d128_reference_case([16], [128], heads=2, seed=413)
+    case = _make_varlen_d128_reference_case([16], [128], q_heads=2, kv_heads=2, seed=413)
     q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
     plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
     lse_storage = torch.empty((2, 32), dtype=torch.float32, device="cuda")
@@ -349,9 +583,6 @@ def test_varlen_d128_backward_rejects_noncontiguous_lse():
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
-    case = _make_varlen_d128_reference_case([16], [129], heads=1, seed=409)
-    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
-    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
     kernels = (
         amd_fa_varlen_bwd._varlen_bwd_preprocess,
         amd_fa_varlen_bwd._varlen_bwd_interleaved_kernel,
@@ -360,6 +591,9 @@ def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
     for kernel in kernels:
         kernel.device_caches.clear()
 
+    case = _make_varlen_d128_reference_case([17], [129], q_heads=3, kv_heads=1, seed=409)
+    q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+    plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
     amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
     torch.cuda.synchronize()
 
@@ -376,3 +610,31 @@ def test_varlen_d128_interleaved_codegen_is_scratch_free_gfx950():
 
     for interleaved in kernels[1].device_caches[device][0].values():
         assert "buffer_atomic_pk_add_bf16" in interleaved.asm["amdgcn"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_varlen_d128_split_codegen_is_scratch_free_gfx950():
+    kernels = (
+        amd_fa_varlen_bwd._varlen_bwd_interleaved_bm32_kernel,
+        amd_fa_varlen_bwd._varlen_dkdv_reduce_kernel,
+    )
+    for kernel in kernels:
+        kernel.device_caches.clear()
+
+    for q_length, q_heads in ((5460, 3), (2048, 8)):
+        case = _make_varlen_d128_reference_case([q_length], [129], q_heads=q_heads, kv_heads=1, seed=463 + q_heads)
+        q, k, v, out, do, lse, cu_q, cu_kv, scale, _expected = case
+        plan = amd_fa_varlen_bwd.prepare_varlen_backward(cu_q, cu_kv)
+        amd_fa_varlen_bwd.fa_varlen_backward(q, k, v, out, do, lse, plan, scale)
+    torch.cuda.synchronize()
+
+    device = torch.cuda.current_device()
+    for kernel, expected_shared, specialization_count in zip(kernels, (117_536, 0), (2, 2), strict=True):
+        compiled_objects = tuple(kernel.device_caches[device][0].values())
+        assert len(compiled_objects) == specialization_count
+        for compiled in compiled_objects:
+            _assert_scratch_free(kernel.fn.__name__, compiled)
+            assert compiled.metadata.num_warps == 4
+            assert compiled.metadata.shared == expected_shared
+    for compiled in kernels[0].device_caches[device][0].values():
+        assert "buffer_atomic_pk_add_bf16" in compiled.asm["amdgcn"]

--- a/python/test/unit/language/test_tlx_codegen.py
+++ b/python/test/unit/language/test_tlx_codegen.py
@@ -3346,7 +3346,8 @@ def test_varlen_d128_address_space_requires_i32_offsets():
         total_q=max_tokens - 15,
         total_kv=max_tokens,
         batch=1,
-        heads=1,
+        q_heads=1,
+        kv_heads=1,
     )
 
     with pytest.raises(ValueError, match="KV tensor size exceeds the signed 32-bit byte-offset range"):
@@ -3354,14 +3355,16 @@ def test_varlen_d128_address_space_requires_i32_offsets():
             total_q=1,
             total_kv=max_tokens + 1,
             batch=1,
-            heads=1,
+            q_heads=1,
+            kv_heads=1,
         )
     with pytest.raises(ValueError, match="padded dQ size exceeds the signed 32-bit byte-offset range"):
         amd_fa_varlen_bwd._validate_i32_buffer_offsets(
             total_q=max_tokens - 14,
             total_kv=1,
             batch=1,
-            heads=1,
+            q_heads=1,
+            kv_heads=1,
         )
 
 

--- a/third_party/tlx/tutorials/README.md
+++ b/third_party/tlx/tutorials/README.md
@@ -33,9 +33,9 @@ correctness/performance driver.
 ## Packed variable-length FlashAttention backward
 
 [`amd_fa_varlen_bwd.py`](amd_fa_varlen_bwd.py) provides a gfx950 specialization
-for packed BF16 THD, non-causal MHA backward with head dimension 128.  Prepare a
-plan once for immutable cumulative sequence offsets, then reuse it for every
-backward invocation with the same packing:
+for packed BF16 THD, non-causal MHA/GQA backward with head dimension 128 and
+`Hq % Hkv == 0`.  Prepare a plan once for immutable cumulative sequence
+offsets, then reuse it for every backward invocation with the same packing:
 
 ```python
 from triton.language.extra.tlx.tutorials.amd_fa_varlen_bwd import (
@@ -48,9 +48,14 @@ dq, dk, dv = fa_varlen_backward(q, k, v, out, do, lse, plan, sm_scale)
 ```
 
 Plan preparation validates and copies `cu_seqlens_q` and `cu_seqlens_k` to the
-host once to build compact BM16/BN128 schedules, then owns cloned device
-offsets.  The frozen plan prevents field rebinding, but its PyTorch tensors are
-still mutable; treat every plan-owned offset and schedule tensor as immutable
-after preparation.  Keep plan construction outside the timed or repeated
-execution path.  Every sequence must have at least one query and one key/value
-token.  `lse` is contiguous FP32 with shape `(heads, total_q)`.
+host once to build compact BM16/BN128 schedules plus a masked BM32/BN256
+schedule for long non-causal split-GQA, then owns cloned device offsets.  The
+frozen plan prevents field rebinding, but its PyTorch tensors are still mutable;
+treat every plan-owned offset and schedule tensor as immutable after
+preparation.  Keep plan construction outside the timed or repeated execution
+path.  Every sequence must have at least one query and one key/value token.
+`lse` is contiguous FP32 with shape `(query_heads, total_q)`.
+
+The Q and KV offsets are independent.  To model an extend-attention workload,
+pack only the extend tokens in Q and pack the full context in K/V, using
+`q_len = extend_len` and `kv_len = prefix_len + extend_len` for each request.

--- a/third_party/tlx/tutorials/amd_fa_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_bwd.py
@@ -1290,8 +1290,9 @@ def _attn_bwd_gqa_front(
     QT_LAYOUT: tl.constexpr,
     P_ND_LAYOUT: tl.constexpr,
     Q_OUT_LAYOUT: tl.constexpr,
+    UPDATE_DV_FIRST_HALF: tl.constexpr = True,
 ):
-    """Apply the optional causal scaled-score mask, then publish current dS to LDS."""
+    """Publish current dS to LDS and optionally update the first dV fragments."""
     dv = tlx.require_layout(dv, MMA_ND, pin=False)
     v_operand = tlx.require_layout(v_operand, K_NM_LAYOUT, pin=False)
     k_nm = tlx.local_load(
@@ -1407,15 +1408,16 @@ def _attn_bwd_gqa_front(
     p_nd = tl.permute(p_nd, (0, 2, 3, 1, 4, 5))
     p_nd = tl.reshape(p_nd, (BLOCK_N, BLOCK_M))
     p_nd = tlx.require_layout(p_nd, P_ND_LAYOUT, pin=False)
-    dv = _attn_bwd_gqa_dv_fragmented_half(
-        p_nd,
-        do_out,
-        dv,
-        MMA_ND,
-        P_ND_LAYOUT,
-        Q_OUT_LAYOUT,
-        True,
-    )
+    if UPDATE_DV_FIRST_HALF:
+        dv = _attn_bwd_gqa_dv_fragmented_half(
+            p_nd,
+            do_out,
+            dv,
+            MMA_ND,
+            P_ND_LAYOUT,
+            Q_OUT_LAYOUT,
+            True,
+        )
 
     ds_bf16 = ds.to(tl.bfloat16)
     tlx.local_store(ds_stage, tl.trans(ds_bf16))

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -1,9 +1,10 @@
 """Packed variable-length BF16 D128 attention backward for gfx950.
 
-Each workgroup owns one 128-row KV tile and walks the corresponding sequence
-in 16-row query phases.  The current phase accumulates dK/dV and publishes dS
-through LDS; the preceding dS phase is consumed for dQ.  Independent KV owners
-combine their dQ contributions with BF16 atomics in a guarded native layout,
+Each workgroup owns a KV tile and a subset of its mapped query heads.  The
+baseline path uses BN128/BM16 phases; long non-causal split-GQA uses masked
+BN256/BM32 phases and forms dQ as two native BM16 accumulator chains.  Split
+workgroups reduce their BF16 dK/dV partials in FP32.  Independent KV owners
+combine dQ contributions with BF16 atomics in a guarded native layout,
 followed by a conversion to packed THD order.
 
 Call :func:`prepare_varlen_backward` once and reuse the resulting plan with
@@ -23,10 +24,15 @@ import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
 
+from triton.language.extra.tlx.tutorials.amd_fa_bwd import _attn_bwd_gqa_front
+
 _BLOCK_M = 16
 _BLOCK_N = 128
+_WIDE_BLOCK_M = 32
+_WIDE_BLOCK_N = 256
 _HEAD_DIM = 128
 _I32_BUFFER_BF16_ELEMENTS = 1 << 30
+_VARLEN_GQA_SPLIT_WORK_THRESHOLD = 1024
 
 
 @dataclass(frozen=True)
@@ -44,6 +50,11 @@ class VarlenBackwardPlan:
     q_block_start: torch.Tensor
     kv_block_sequence: torch.Tensor
     kv_block_start: torch.Tensor
+    wide_kv_start: torch.Tensor
+    wide_q_start: torch.Tensor
+    wide_dq_start: torch.Tensor
+    wide_q_len: torch.Tensor
+    wide_kv_valid: torch.Tensor
     batch: int
     total_q: int
     total_kv: int
@@ -101,6 +112,33 @@ def _make_partitioned_block_schedule(lengths: list[int], block: int,
     )
 
 
+def _make_wide_kv_schedule(q_offsets: list[int], k_offsets: list[int],
+                           device: torch.device) -> tuple[torch.Tensor, ...]:
+    """Build masked BN256 tasks, front-loading sequences with the most Q work."""
+    tasks: list[tuple[int, int, int, int, int]] = []
+    sequences = sorted(
+        range(len(q_offsets) - 1),
+        key=lambda sequence: q_offsets[sequence + 1] - q_offsets[sequence],
+        reverse=True,
+    )
+    for sequence in sequences:
+        q_start = q_offsets[sequence]
+        q_len = q_offsets[sequence + 1] - q_start
+        kv_start = k_offsets[sequence]
+        kv_len = k_offsets[sequence + 1] - kv_start
+        dq_start = q_start + sequence * (_BLOCK_M - 1)
+        for block_start in range(0, kv_len, _WIDE_BLOCK_N):
+            tasks.append((
+                kv_start + block_start,
+                q_start,
+                dq_start,
+                q_len,
+                min(_WIDE_BLOCK_N, kv_len - block_start),
+            ))
+    columns = tuple(zip(*tasks, strict=True))
+    return tuple(torch.tensor(column, dtype=torch.int32, device=device) for column in columns)
+
+
 def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tensor) -> VarlenBackwardPlan:
     """Prepare reusable compact schedules for immutable packed offsets."""
     if cu_seqlens_q.device != cu_seqlens_k.device:
@@ -115,6 +153,8 @@ def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tens
     q_block_sequence, q_block_start = _make_block_schedule(q_lengths, _BLOCK_M, cu_seqlens_q.device)
     kv_block_sequence, kv_block_start, num_full_kv_blocks = _make_partitioned_block_schedule(
         k_lengths, _BLOCK_N, cu_seqlens_q.device)
+    wide_kv_start, wide_q_start, wide_dq_start, wide_q_len, wide_kv_valid = _make_wide_kv_schedule(
+        q_offsets, k_offsets, cu_seqlens_q.device)
 
     return VarlenBackwardPlan(
         cu_seqlens_q=owned_q,
@@ -123,6 +163,11 @@ def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tens
         q_block_start=q_block_start,
         kv_block_sequence=kv_block_sequence,
         kv_block_start=kv_block_start,
+        wide_kv_start=wide_kv_start,
+        wide_q_start=wide_q_start,
+        wide_dq_start=wide_dq_start,
+        wide_q_len=wide_q_len,
+        wide_kv_valid=wide_kv_valid,
         batch=len(q_lengths),
         total_q=q_offsets[-1],
         total_kv=k_offsets[-1],
@@ -131,12 +176,36 @@ def prepare_varlen_backward(cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tens
     )
 
 
-def _validate_i32_buffer_offsets(*, total_q: int, total_kv: int, batch: int, heads: int) -> None:
-    if total_kv * heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
+def _validate_i32_buffer_offsets(*, total_q: int, total_kv: int, batch: int, q_heads: int, kv_heads: int) -> None:
+    if total_kv * kv_heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
         raise ValueError("KV tensor size exceeds the signed 32-bit byte-offset range")
     total_q_padded = total_q + batch * (_BLOCK_M - 1)
-    if total_q_padded * heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
+    if total_q_padded * q_heads * _HEAD_DIM > _I32_BUFFER_BF16_ELEMENTS:
         raise ValueError("padded dQ size exceeds the signed 32-bit byte-offset range")
+
+
+def _select_varlen_kv_splits(max_q: int, group_size: int) -> int:
+    query_blocks = (max_q + _BLOCK_M - 1) // _BLOCK_M
+    if group_size <= 1 or group_size * query_blocks < _VARLEN_GQA_SPLIT_WORK_THRESHOLD:
+        return 1
+    for kv_splits in range(min(group_size, 4), 1, -1):
+        if group_size % kv_splits == 0:
+            return kv_splits
+    return 1
+
+
+def _select_varlen_kernel_blocks(group_size: int, kv_splits: int) -> tuple[int, int]:
+    if group_size > 1 and kv_splits > 1:
+        return _WIDE_BLOCK_M, _WIDE_BLOCK_N
+    return _BLOCK_M, _BLOCK_N
+
+
+def _allocate_varlen_dkdv_partials(k: torch.Tensor, kv_splits: int) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    if kv_splits == 1 or k.numel() * kv_splits > _I32_BUFFER_BF16_ELEMENTS:
+        return None, None
+    total_kv, kv_heads, head_dim = k.shape
+    dk_part = torch.empty((total_kv, kv_heads, kv_splits, head_dim), dtype=k.dtype, device=k.device)
+    return dk_part, torch.empty_like(dk_part)
 
 
 @triton.jit
@@ -174,16 +243,16 @@ def _issue_qdo_async(
     DO,
     q_start,
     q_len,
-    head,
+    q_head,
     step,
-    HEADS: tl.constexpr,
+    HQ: tl.constexpr,
     D: tl.constexpr,
     BLOCK_M: tl.constexpr,
 ):
     rows = step * BLOCK_M + tl.arange(0, BLOCK_M)
     dims = tl.arange(0, D)
     global_rows = q_start + rows
-    offsets = (global_rows[:, None] * HEADS + head) * D + dims[None, :]
+    offsets = (global_rows[:, None] * HQ + q_head) * D + dims[None, :]
     valid = rows[:, None] < q_len
     q_token = tlx.async_load(Q + offsets, q_dst, mask=valid, other=0.0)
     do_token = tlx.async_load(DO + offsets, do_dst, mask=valid, other=0.0)
@@ -235,6 +304,505 @@ def _store_dq_native(
 
 
 @triton.jit
+def _issue_qdo_bm32_async(
+    q_dst,
+    do_dst,
+    Q,
+    DO,
+    q_start,
+    q_len,
+    q_head,
+    outer_block,
+    HQ: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    ASYNC_LAYOUT: tl.constexpr,
+):
+    outer_slice = tl.arange(0, 1)
+    rows = outer_block * BLOCK_M + outer_slice[:, None] * BLOCK_M + tl.arange(0, BLOCK_M)[None, :]
+    dims = tl.arange(0, D)
+    valid = tl.broadcast_to((rows < q_len)[:, :, None], (1, BLOCK_M, D))
+    valid = tlx.require_layout(valid, ASYNC_LAYOUT, pin=False)
+    qdo_base = (q_start * HQ + q_head.to(tl.int64)) * D
+    offsets = (rows[:, :, None] * HQ * D + dims[None, None, :]).to(tl.int32)
+    offsets = tlx.require_layout(offsets, ASYNC_LAYOUT, pin=False)
+    other = tlx.zeros((1, BLOCK_M, D), tl.bfloat16, layout=ASYNC_LAYOUT)
+    q_token = tlx.buffer_load_to_local(
+        q_dst,
+        tl.multiple_of(Q + qdo_base, 16),
+        offsets,
+        mask=valid,
+        other=other,
+    )
+    tlx.async_load_commit_group([q_token])
+    do_token = tlx.buffer_load_to_local(
+        do_dst,
+        tl.multiple_of(DO + qdo_base, 16),
+        offsets,
+        mask=valid,
+        other=other,
+    )
+    tlx.async_load_commit_group([do_token])
+
+
+@triton.jit
+def _varlen_gqa_phase_bm32(
+    q_tiles,
+    do_tiles,
+    ds_buffer,
+    k_buffer,
+    v_operand,
+    dk,
+    dv,
+    outer_block,
+    LSE,
+    Delta,
+    q_start,
+    q_len,
+    q_head,
+    TOTAL_Q,
+    SM_SCALE: tl.constexpr,
+    HQ: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    MMA_NM: tl.constexpr,
+    MMA_ND: tl.constexpr,
+    K_NM_LAYOUT: tl.constexpr,
+    QT_LAYOUT: tl.constexpr,
+    P_ND_LAYOUT: tl.constexpr,
+    Q_OUT_LAYOUT: tl.constexpr,
+):
+    q_slice = tlx.local_view(q_tiles, 0)
+    do_slice = tlx.local_view(do_tiles, 0)
+    rows = outer_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    valid = rows < q_len
+    global_rows = q_start + rows
+    lse_values = tl.load(
+        LSE + q_head * TOTAL_Q + global_rows,
+        mask=valid,
+        other=float("inf"),
+    )
+    delta_values = tl.load(
+        Delta + global_rows * HQ + q_head,
+        mask=valid,
+        other=0.0,
+    )
+    dv, dk_lhs, dk_rhs, dv_lhs, dv_rhs = _attn_bwd_gqa_front(
+        dv,
+        q_slice,
+        do_slice,
+        k_buffer,
+        v_operand,
+        ds_buffer,
+        lse_values,
+        delta_values,
+        0,
+        0,
+        SM_SCALE,
+        BLOCK_M,
+        BLOCK_M,
+        BLOCK_N,
+        False,
+        MMA_NM,
+        MMA_ND,
+        K_NM_LAYOUT,
+        QT_LAYOUT,
+        P_ND_LAYOUT,
+        Q_OUT_LAYOUT,
+        False,
+    )
+    dv_lhs = tlx.require_layout(dv_lhs, P_ND_LAYOUT, pin=False)
+    dv_rhs = tlx.require_layout(dv_rhs, Q_OUT_LAYOUT, pin=False)
+    dv = tlx.require_layout(dv, MMA_ND, pin=False)
+    dv = tl.dot(dv_lhs, dv_rhs, dv)
+    dk_lhs = tlx.require_layout(dk_lhs, P_ND_LAYOUT, pin=False)
+    dk_rhs = tlx.require_layout(dk_rhs, Q_OUT_LAYOUT, pin=False)
+    dk = tlx.require_layout(dk, MMA_ND, pin=False)
+    dk = tl.dot(dk_lhs, dk_rhs, dk)
+    tl.debug_barrier()
+    return (
+        tlx.require_layout(dk, MMA_ND, pin=False),
+        tlx.require_layout(dv, MMA_ND, pin=False),
+        tlx.require_layout(v_operand, K_NM_LAYOUT, pin=False),
+    )
+
+
+@triton.jit
+def _varlen_gqa_dq_bm32(
+    ds_buffer,
+    k_buffer,
+    v_operand,
+    MMA_MD: tl.constexpr,
+    DS_MD_LAYOUT: tl.constexpr,
+    K_MD_LAYOUT: tl.constexpr,
+    V_LAYOUT: tl.constexpr,
+):
+    v_operand = tlx.require_layout(v_operand, V_LAYOUT, pin=False)
+    k = tlx.local_load(k_buffer, layout=K_MD_LAYOUT, relaxed=True)
+    ds_lo = tlx.local_load(
+        tlx.local_slice(ds_buffer, [0, 0], [16, 256]),
+        layout=DS_MD_LAYOUT,
+        relaxed=True,
+    )
+    ds_hi = tlx.local_load(
+        tlx.local_slice(ds_buffer, [16, 0], [16, 256]),
+        layout=DS_MD_LAYOUT,
+        relaxed=True,
+    )
+    dq_lo = tlx.amd_scheduled_mfma(
+        ds_lo,
+        k,
+        tlx.zeros((16, 128), tl.float32, layout=MMA_MD),
+        resident_operand=1,
+        accumulator_role="transient",
+        initialize=True,
+    )
+    dq_hi = tlx.amd_scheduled_mfma(
+        ds_hi,
+        k,
+        tlx.zeros((16, 128), tl.float32, layout=MMA_MD),
+        resident_operand=1,
+        accumulator_role="transient",
+        initialize=True,
+    )
+    dq_lo, dq_hi, v_operand = tlx.amd_mfma_commit((dq_lo, dq_hi), v_operand)
+    return (
+        tlx.require_layout(dq_lo, MMA_MD, pin=False),
+        tlx.require_layout(dq_hi, MMA_MD, pin=False),
+        tlx.require_layout(v_operand, V_LAYOUT, pin=False),
+    )
+
+
+@triton.jit
+def _store_dq_bm32_native(
+    dq_lo,
+    dq_hi,
+    DQ_ACC,
+    dq_base,
+    q_len,
+    outer_block,
+    SM_SCALE: tl.constexpr,
+    D: tl.constexpr,
+    MMA_MD: tl.constexpr,
+):
+    _store_dq_native(dq_lo, DQ_ACC, dq_base, q_len, outer_block * 2, SM_SCALE, D, 16, MMA_MD)
+    _store_dq_native(dq_hi, DQ_ACC, dq_base, q_len, outer_block * 2 + 1, SM_SCALE, D, 16, MMA_MD)
+
+
+@triton.jit
+def _varlen_bwd_interleaved_bm32_kernel(
+    Q,
+    K,
+    V,
+    DO,
+    LSE,
+    Delta,
+    KVGlobalStart,
+    QStart,
+    DQScratchStart,
+    QLen,
+    KVValidRows,
+    DQ_ACC,
+    DK,
+    DV,
+    SM_SCALE: tl.constexpr,
+    TOTAL_Q,
+    TOTAL_Q_PADDED,
+    HQ: tl.constexpr,
+    HKV: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    KV_SPLITS: tl.constexpr,
+):
+    """Process masked BN256 KV owners in BM32 phases with two native BM16 dQ chains."""
+    tl.static_assert(D == 128)
+    tl.static_assert(BLOCK_M == 32)
+    tl.static_assert(BLOCK_N == 256)
+    tl.static_assert(HQ % HKV == 0)
+    tl.static_assert(HQ // HKV > 1)
+    tl.static_assert(KV_SPLITS > 1)
+    tl.static_assert(KV_SPLITS <= 4)
+    tl.static_assert((HQ // HKV) % KV_SPLITS == 0)
+
+    task = tl.program_id(1)
+    kv_head_split = tl.program_id(0)
+    kv_head = kv_head_split // KV_SPLITS
+    split = kv_head_split % KV_SPLITS
+    group_size: tl.constexpr = HQ // HKV
+    heads_per_split: tl.constexpr = group_size // KV_SPLITS
+    kv_global_start = tl.load(KVGlobalStart + task).to(tl.int64)
+    q_start = tl.load(QStart + task).to(tl.int64)
+    q_scratch_start = tl.load(DQScratchStart + task).to(tl.int64)
+    q_len = tl.load(QLen + task)
+    kv_valid_rows = tl.load(KVValidRows + task)
+    outer_blocks = (q_len + BLOCK_M - 1) // BLOCK_M
+    total_outer_steps = heads_per_split * outer_blocks
+    first_q_head = kv_head * group_size + split * heads_per_split
+
+    mma_nm: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[4, 1],
+    )
+    mma_nd: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[32, 32, 16],
+        transposed=True,
+        warps_per_cta=[4, 1],
+    )
+    mma_md: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    k_nm_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_nm, k_width=8)
+    qt_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_nm, k_width=8)
+    p_nd_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_nd, k_width=8)
+    q_out_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_nd, k_width=8)
+    ds_md_layout: tl.constexpr = tlx.dot_operand_layout(0, mma_md, k_width=8)
+    k_md_layout: tl.constexpr = tlx.dot_operand_layout(1, mma_md, k_width=8)
+
+    qdo_async_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2)),
+        stride=((8, 16, 32, 128, 64, 512, 256, 1024), (1, 2, 4, 2048)),
+    )
+    qdo_smem_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 32), (1024, 16)],
+        [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32], [0, 1, 0], [0, 0, 64], [0, 4, 0],
+         [0, 2, 0], [0, 8, 0], [0, 16, 0]],
+        [1, BLOCK_M, D],
+    )
+    qdo_slice_smem_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 32), (1024, 16)],
+        [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [1, 0], [0, 64], [4, 0], [2, 0], [8, 0], [16, 0]],
+        [BLOCK_M, D],
+    )
+    ds_smem_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 16)],
+        [[1, 0], [2, 0], [0, 1], [0, 2], [4, 0], [0, 8], [8, 0], [0, 32], [0, 16], [0, 4], [0, 64], [0, 128], [16, 0]],
+        [BLOCK_M, BLOCK_N],
+    )
+    k_raw_smem_layout: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [1, 0, 0], [2, 0, 0],
+                      [4, 0, 0], [8, 0, 0], [16, 0, 0], [32, 0, 0], [64, 0, 0], [128, 0, 0]],
+        block_bases=[],
+        alignment=16,
+    )
+    k_smem_layout: tl.constexpr = tlx.shared_linear_layout_encoding(
+        offset_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 64], [1, 0], [2, 0], [4, 0], [8, 64], [0, 16], [0, 32],
+                      [16, 0], [32, 0], [64, 0], [128, 0]],
+        block_bases=[],
+        alignment=16,
+    )
+    k_raw_async_layout: tl.constexpr = tlx.layout(
+        shape=((64, 4), (8, 8, 2)),
+        stride=((8, 512), (1, 2048, 16384)),
+    )
+    kv_native_layout: tl.constexpr = tlx.layout(
+        shape=((2, 2, 2, 2, 2, 2, 2, 2), (2, 2, 2, 2, 2, 2, 2)),
+        stride=((128, 256, 512, 1024, 8192, 4, 2048, 4096), (1, 2, 8, 16, 32, 64, 16384)),
+    )
+
+    k_raw_buffer = tlx.local_alloc((BLOCK_N, D // 8, 8), tl.bfloat16, 1, layout=k_raw_smem_layout)
+    k_buffer = tlx.local_reinterpret(
+        tlx.local_view(k_raw_buffer, 0),
+        tl.bfloat16,
+        [BLOCK_N, D],
+        layout=k_smem_layout,
+    )
+    q_buffers = tlx.local_alloc((1, BLOCK_M, D), tl.bfloat16, 2, layout=qdo_smem_layout)
+    do_buffers = tlx.local_alloc((1, BLOCK_M, D), tl.bfloat16, 2, layout=qdo_smem_layout)
+    ds_buffers = tlx.local_alloc((BLOCK_M, BLOCK_N), tl.bfloat16, 1, layout=ds_smem_layout)
+
+    raw_n = tl.arange(0, BLOCK_N)
+    raw_dg = tl.arange(0, D // 8)
+    raw_v = tl.arange(0, 8)
+    k_phys = raw_n[:, None, None] * D + raw_dg[None, :, None] * 8
+    k_d_base = ((k_phys & 0x8) | (((k_phys >> 9) & 0x3) << 4) | ((((k_phys >> 4) ^ (k_phys >> 8)) & 0x1) << 6))
+    k_n = (((k_phys >> 5) & 0x7) | (((k_phys >> 8) & 0x1) << 3) | (((k_phys >> 11) & 0xf) << 4))
+    kv_tile_base = (kv_global_start * HKV + kv_head.to(tl.int64)) * D
+    k_ptr = tl.multiple_of(K + kv_tile_base, 16)
+    v_ptr = tl.multiple_of(V + kv_tile_base, 16)
+    k_offsets = (k_n * HKV * D + k_d_base + raw_v[None, None, :]).to(tl.int32)
+    k_offsets = tl.multiple_of(k_offsets, [1, 1, 8])
+    k_offsets = tl.max_contiguous(k_offsets, [1, 1, 8])
+    k_offsets = tlx.require_layout(k_offsets, k_raw_async_layout, pin=False)
+    k_valid = tl.broadcast_to(k_n < kv_valid_rows, (BLOCK_N, D // 8, 8))
+    k_valid = tlx.require_layout(k_valid, k_raw_async_layout, pin=False)
+    k_zero = tlx.zeros((BLOCK_N, D // 8, 8), tl.bfloat16, layout=k_raw_async_layout)
+    k_token = tlx.buffer_load_to_local(
+        tlx.local_view(k_raw_buffer, 0),
+        k_ptr,
+        k_offsets,
+        mask=k_valid,
+        other=k_zero,
+    )
+    tlx.async_load_commit_group([k_token])
+
+    _issue_qdo_bm32_async(
+        tlx.local_view(q_buffers, 0),
+        tlx.local_view(do_buffers, 0),
+        Q,
+        DO,
+        q_start,
+        q_len,
+        first_q_head,
+        0,
+        HQ,
+        D,
+        BLOCK_M,
+        qdo_async_layout,
+    )
+    second_step = tl.minimum(1, total_outer_steps - 1)
+    second_group = second_step // outer_blocks
+    second_outer = second_step % outer_blocks
+    _issue_qdo_bm32_async(
+        tlx.local_view(q_buffers, 1),
+        tlx.local_view(do_buffers, 1),
+        Q,
+        DO,
+        q_start,
+        q_len,
+        first_q_head + second_group,
+        second_outer,
+        HQ,
+        D,
+        BLOCK_M,
+        qdo_async_layout,
+    )
+    tlx.async_load_wait_group(2)
+    tl.debug_barrier()
+
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, D)
+    v_offsets = (offs_n[:, None] * HKV * D + offs_d[None, :]).to(tl.int32)
+    v_offsets = tlx.require_layout(v_offsets, k_nm_layout, pin=False)
+    v_valid = tl.broadcast_to((offs_n < kv_valid_rows)[:, None], (BLOCK_N, D))
+    v_valid = tlx.require_layout(v_valid, k_nm_layout, pin=False)
+    v_zero = tlx.zeros((BLOCK_N, D), tl.bfloat16, layout=k_nm_layout)
+    v_operand = tlx.buffer_load(v_ptr, v_offsets, mask=v_valid, other=v_zero)
+    v_operand = tlx.require_layout(v_operand, k_nm_layout, pin=False)
+    dk = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
+    dv = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
+    DQ_ACC = DQ_ACC + q_scratch_start * D
+
+    for outer_step in tl.range(0, total_outer_steps, loop_unroll_factor=1):
+        outer_stage = outer_step % 2
+        group_index = outer_step // outer_blocks
+        outer_block = outer_step % outer_blocks
+        q_head = first_q_head + group_index
+        q_outer = tlx.local_view(q_buffers, outer_stage)
+        do_outer = tlx.local_view(do_buffers, outer_stage)
+        q_tiles = tlx.local_reinterpret(
+            q_outer,
+            tl.bfloat16,
+            [1, BLOCK_M, D],
+            layout=qdo_slice_smem_layout,
+        )
+        do_tiles = tlx.local_reinterpret(
+            do_outer,
+            tl.bfloat16,
+            [1, BLOCK_M, D],
+            layout=qdo_slice_smem_layout,
+        )
+        dq_base = (q_head.to(tl.int64) * TOTAL_Q_PADDED * D).to(tl.int32)
+        dk, dv, v_operand = _varlen_gqa_phase_bm32(
+            q_tiles,
+            do_tiles,
+            tlx.local_view(ds_buffers, 0),
+            k_buffer,
+            v_operand,
+            dk,
+            dv,
+            outer_block,
+            LSE,
+            Delta,
+            q_start,
+            q_len,
+            q_head,
+            TOTAL_Q,
+            SM_SCALE,
+            HQ,
+            D,
+            BLOCK_M,
+            BLOCK_N,
+            mma_nm,
+            mma_nd,
+            k_nm_layout,
+            qt_layout,
+            p_nd_layout,
+            q_out_layout,
+        )
+        next_step = (outer_step + 2) % total_outer_steps
+        next_group = next_step // outer_blocks
+        next_outer = next_step % outer_blocks
+        _issue_qdo_bm32_async(
+            q_outer,
+            do_outer,
+            Q,
+            DO,
+            q_start,
+            q_len,
+            first_q_head + next_group,
+            next_outer,
+            HQ,
+            D,
+            BLOCK_M,
+            qdo_async_layout,
+        )
+        dq_lo, dq_hi, v_operand = _varlen_gqa_dq_bm32(
+            tlx.local_view(ds_buffers, 0),
+            k_buffer,
+            v_operand,
+            mma_md,
+            ds_md_layout,
+            k_md_layout,
+            k_nm_layout,
+        )
+        _store_dq_bm32_native(
+            dq_lo,
+            dq_hi,
+            DQ_ACC,
+            dq_base,
+            q_len,
+            outer_block,
+            SM_SCALE,
+            D,
+            mma_md,
+        )
+        tlx.async_load_wait_group(2)
+        tl.debug_barrier()
+
+    tlx.async_load_wait_group(0)
+    dk = tlx.require_layout(dk, mma_nd, pin=False)
+    dv = tlx.require_layout(dv, mma_nd, pin=False)
+    dk = tl.reshape(dk, (2, 2, 2, 2, 16, D))
+    dk = tl.permute(dk, (0, 3, 1, 2, 4, 5))
+    dk = tl.reshape(dk, (BLOCK_N, D))
+    dk = tlx.require_layout(dk, kv_native_layout, pin=False)
+    dk *= SM_SCALE
+    dv = tl.reshape(dv, (2, 2, 2, 2, 16, D))
+    dv = tl.permute(dv, (0, 3, 1, 2, 4, 5))
+    dv = tl.reshape(dv, (BLOCK_N, D))
+    dv = tlx.require_layout(dv, kv_native_layout, pin=False)
+    store_n = tlx.rematerialized_range(0, BLOCK_N, 30)
+    store_d = tlx.rematerialized_range(0, D, 31)
+    partial_base = ((kv_global_start * HKV + kv_head.to(tl.int64)) * KV_SPLITS + split) * D
+    output_ptr = tl.multiple_of(DK + partial_base, 16)
+    output_v_ptr = tl.multiple_of(DV + partial_base, 16)
+    output_offsets = (store_n[:, None] * HKV * KV_SPLITS * D + store_d[None, :]).to(tl.int32)
+    output_offsets = tlx.require_layout(output_offsets, kv_native_layout, pin=False)
+    output_mask = tl.broadcast_to((store_n < kv_valid_rows)[:, None], (BLOCK_N, D))
+    output_mask = tlx.require_layout(output_mask, kv_native_layout, pin=False)
+    tlx.buffer_store(dk.to(tl.bfloat16), output_ptr, output_offsets, mask=output_mask)
+    tlx.buffer_store(dv.to(tl.bfloat16), output_v_ptr, output_offsets, mask=output_mask)
+
+
+@triton.jit
 def _varlen_bwd_interleaved_kernel(
     Q,
     K,
@@ -253,19 +821,29 @@ def _varlen_bwd_interleaved_kernel(
     SM_SCALE: tl.constexpr,
     TOTAL_Q,
     TOTAL_Q_PADDED,
-    HEADS: tl.constexpr,
+    HQ: tl.constexpr,
+    HKV: tl.constexpr,
     D: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     FULL_KV_TILE: tl.constexpr,
+    KV_SPLITS: tl.constexpr,
 ):
     """Compute current dK/dV while consuming the preceding dS phase for dQ."""
     tl.static_assert(D == 128)
     tl.static_assert(BLOCK_M == 16)
     tl.static_assert(BLOCK_N == 128)
+    tl.static_assert(HQ % HKV == 0)
+    tl.static_assert(KV_SPLITS > 0)
+    tl.static_assert(KV_SPLITS <= 4)
+    tl.static_assert((HQ // HKV) % KV_SPLITS == 0)
 
     task = tl.program_id(0) + TASK_OFFSET
-    head = tl.program_id(1)
+    kv_head_split = tl.program_id(1)
+    kv_head = kv_head_split // KV_SPLITS
+    split = kv_head_split % KV_SPLITS
+    group_size: tl.constexpr = HQ // HKV
+    heads_per_split: tl.constexpr = group_size // KV_SPLITS
     batch = tl.load(KVBlockSequence + task)
     n0 = tl.load(KVBlockStart + task)
     q_start = tl.load(CuQ + batch).to(tl.int64)
@@ -274,6 +852,8 @@ def _varlen_bwd_interleaved_kernel(
     kv_end = tl.load(CuKV + batch + 1).to(tl.int64)
     q_len = (q_end - q_start).to(tl.int32)
     kv_len = (kv_end - kv_start).to(tl.int32)
+    q_blocks = (q_len + BLOCK_M - 1) // BLOCK_M
+    total_steps = heads_per_split * q_blocks
 
     qdo_layout: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
         [(512, 32)],
@@ -324,7 +904,7 @@ def _varlen_bwd_interleaved_kernel(
     offs_n = n0 + tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, D)
     global_n = kv_start + offs_n
-    kv_offsets = (global_n[:, None] * HEADS + head) * D + offs_d[None, :]
+    kv_offsets = (global_n[:, None] * HKV + kv_head) * D + offs_d[None, :]
     if FULL_KV_TILE:
         k_token = tlx.async_load(K + kv_offsets, tlx.local_view(k_buffer, 0))
     else:
@@ -338,9 +918,9 @@ def _varlen_bwd_interleaved_kernel(
         DO,
         q_start,
         q_len,
-        head,
+        kv_head * group_size + split * heads_per_split,
         0,
-        HEADS,
+        HQ,
         D,
         BLOCK_M,
     )
@@ -357,14 +937,26 @@ def _varlen_bwd_interleaved_kernel(
     v_tile = tlx.require_layout(v_tile, k_nm_layout, pin=False)
     dk = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
     dv = tlx.zeros((BLOCK_N, D), tl.float32, layout=mma_nd)
-    q_blocks = (q_len + BLOCK_M - 1) // BLOCK_M
     q_scratch_start = q_start + batch.to(tl.int64) * (BLOCK_M - 1)
-    dq_acc_base = ((head.to(tl.int64) * TOTAL_Q_PADDED + q_scratch_start) * D).to(tl.int32)
     log2e: tl.constexpr = 1.4426950408889634
 
-    for step in tl.range(0, q_blocks, num_stages=1):
+    for step in tl.range(0, total_steps, num_stages=1):
         current_slot = step % 2
         next_slot = 1 - current_slot
+        if KV_SPLITS > 1 and heads_per_split == 1:
+            q_step = step
+            q_head = kv_head * group_size + split
+            next_step = tl.minimum(step + 1, total_steps - 1)
+            next_q_step = next_step
+            next_q_head = q_head
+        else:
+            group_index = step // q_blocks
+            q_step = step % q_blocks
+            q_head = kv_head * group_size + split * heads_per_split + group_index
+            next_step = tl.minimum(step + 1, total_steps - 1)
+            next_group_index = next_step // q_blocks
+            next_q_step = next_step % q_blocks
+            next_q_head = kv_head * group_size + split * heads_per_split + next_group_index
         _issue_qdo_async(
             tlx.local_view(q_buffers, next_slot),
             tlx.local_view(do_buffers, next_slot),
@@ -372,9 +964,9 @@ def _varlen_bwd_interleaved_kernel(
             DO,
             q_start,
             q_len,
-            head,
-            step + 1,
-            HEADS,
+            next_q_head,
+            next_q_step,
+            HQ,
             D,
             BLOCK_M,
         )
@@ -390,10 +982,10 @@ def _varlen_bwd_interleaved_kernel(
         k_tile = tlx.local_load(tlx.local_view(k_buffer, 0), token=initial_wait, layout=k_nm_layout)
         score_acc = tlx.zeros((BLOCK_N, BLOCK_M), tl.float32, layout=mma_nm)
         scores_t = tl.dot(k_tile, q_t, acc=score_acc, out_dtype=score_acc.dtype)
-        rows = step * BLOCK_M + tl.arange(0, BLOCK_M)
+        rows = q_step * BLOCK_M + tl.arange(0, BLOCK_M)
         global_m = q_start + rows
-        lse = tl.load(LSE + head * TOTAL_Q + global_m, mask=rows < q_len, other=0.0)
-        delta = tl.load(Delta + global_m * HEADS + head, mask=rows < q_len, other=0.0)
+        lse = tl.load(LSE + q_head * TOTAL_Q + global_m, mask=rows < q_len, other=0.0)
+        delta = tl.load(Delta + global_m * HQ + q_head, mask=rows < q_len, other=0.0)
         score_scale = tlx.require_layout(
             tl.full((BLOCK_N, BLOCK_M), SM_SCALE * log2e, tl.float32),
             mma_nm,
@@ -428,6 +1020,15 @@ def _varlen_bwd_interleaved_kernel(
         dk = tl.dot(ds_nd, q_tile, acc=dk, out_dtype=dk.dtype)
 
         if step > 0:
+            previous_step = step - 1
+            if KV_SPLITS > 1 and heads_per_split == 1:
+                previous_q_step = previous_step
+                previous_q_head = kv_head * group_size + split
+            else:
+                previous_group_index = previous_step // q_blocks
+                previous_q_step = previous_step % q_blocks
+                previous_q_head = kv_head * group_size + split * heads_per_split + previous_group_index
+            previous_dq_acc_base = ((previous_q_head.to(tl.int64) * TOTAL_Q_PADDED + q_scratch_start) * D).to(tl.int32)
             previous_ds = tlx.local_load(tlx.local_view(ds_buffers, 1 - current_slot), layout=ds_md_layout)
             k_for_dq = tlx.local_load(tlx.local_view(k_buffer, 0), token=initial_wait, layout=k_md_layout)
             dq_acc = tlx.zeros((BLOCK_M, D), tl.float32, layout=mma_md)
@@ -435,9 +1036,9 @@ def _varlen_bwd_interleaved_kernel(
             _store_dq_native(
                 dq_part,
                 DQ_ACC,
-                dq_acc_base,
+                previous_dq_acc_base,
                 q_len,
-                step - 1,
+                previous_q_step,
                 SM_SCALE,
                 D,
                 BLOCK_M,
@@ -447,16 +1048,25 @@ def _varlen_bwd_interleaved_kernel(
 
     tlx.async_load_wait_group(0)
     tl.debug_barrier()
-    last_ds = tlx.local_load(tlx.local_view(ds_buffers, (q_blocks - 1) % 2), layout=ds_md_layout)
+    last_step = total_steps - 1
+    if KV_SPLITS > 1 and heads_per_split == 1:
+        last_q_step = last_step
+        last_q_head = kv_head * group_size + split
+    else:
+        last_group_index = last_step // q_blocks
+        last_q_step = last_step % q_blocks
+        last_q_head = kv_head * group_size + split * heads_per_split + last_group_index
+    last_dq_acc_base = ((last_q_head.to(tl.int64) * TOTAL_Q_PADDED + q_scratch_start) * D).to(tl.int32)
+    last_ds = tlx.local_load(tlx.local_view(ds_buffers, last_step % 2), layout=ds_md_layout)
     k_for_dq = tlx.local_load(tlx.local_view(k_buffer, 0), layout=k_md_layout)
     dq_acc = tlx.zeros((BLOCK_M, D), tl.float32, layout=mma_md)
     dq_part = tl.dot(last_ds, k_for_dq, acc=dq_acc, out_dtype=dq_acc.dtype)
     _store_dq_native(
         dq_part,
         DQ_ACC,
-        dq_acc_base,
+        last_dq_acc_base,
         q_len,
-        q_blocks - 1,
+        last_q_step,
         SM_SCALE,
         D,
         BLOCK_M,
@@ -465,7 +1075,11 @@ def _varlen_bwd_interleaved_kernel(
 
     dk_scale = tlx.require_layout(tl.full((BLOCK_N, D), SM_SCALE, dtype=tl.float32), mma_nd, pin=False)
     dk *= dk_scale
-    output_offsets = tlx.require_layout(kv_offsets.to(tl.int32), mma_nd, pin=False)
+    if KV_SPLITS == 1:
+        output_offsets = tlx.require_layout(kv_offsets.to(tl.int32), mma_nd, pin=False)
+    else:
+        partial_offsets = (((global_n[:, None] * HKV + kv_head) * KV_SPLITS + split) * D + offs_d[None, :])
+        output_offsets = tlx.require_layout(partial_offsets.to(tl.int32), mma_nd, pin=False)
     if FULL_KV_TILE:
         tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets)
         tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets)
@@ -473,6 +1087,36 @@ def _varlen_bwd_interleaved_kernel(
         output_mask = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), mma_nd, pin=False)
         tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets, mask=output_mask)
         tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets, mask=output_mask)
+
+
+@triton.jit
+def _varlen_dkdv_reduce_kernel(
+    DK_PART,
+    DV_PART,
+    DK,
+    DV,
+    TOTAL_KV,
+    HKV: tl.constexpr,
+    D: tl.constexpr,
+    KV_SPLITS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    tl.static_assert(KV_SPLITS > 1)
+    tl.static_assert(KV_SPLITS <= 4)
+    pid_n = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_d = tl.arange(0, D)
+    valid = tl.broadcast_to((offs_n < TOTAL_KV)[:, None], (BLOCK_N, D))
+    partial_base = ((offs_n[:, None] * HKV + kv_head) * KV_SPLITS) * D + offs_d[None, :]
+    dk = tl.zeros((BLOCK_N, D), tl.float32)
+    dv = tl.zeros((BLOCK_N, D), tl.float32)
+    for split in tl.static_range(0, KV_SPLITS):
+        dk += tl.load(DK_PART + partial_base + split * D, mask=valid, other=0.0).to(tl.float32)
+        dv += tl.load(DV_PART + partial_base + split * D, mask=valid, other=0.0).to(tl.float32)
+    output_offsets = (offs_n[:, None] * HKV + kv_head) * D + offs_d[None, :]
+    tl.store(DK + output_offsets, dk.to(tl.bfloat16), mask=valid)
+    tl.store(DV + output_offsets, dv.to(tl.bfloat16), mask=valid)
 
 
 @triton.jit
@@ -525,17 +1169,18 @@ def _validate_backward_inputs(q, k, v, o, do, lse, plan, sm_scale):
     total_kv, kv_heads, kv_dim = k.shape
     if (total_q, total_kv) != (plan.total_q, plan.total_kv):
         raise ValueError("q and k token counts must match the prepared plan")
-    if heads != kv_heads:
-        raise ValueError("packed D128 backward currently requires equal Q and KV head counts")
-    if heads == 0:
-        raise ValueError("packed backward requires a positive head count")
+    if heads == 0 or kv_heads == 0:
+        raise ValueError("packed backward requires positive Q and KV head counts")
+    if heads % kv_heads != 0:
+        raise ValueError("packed D128 backward requires Q heads divisible by KV heads")
     if head_dim != 128 or kv_dim != 128:
         raise ValueError("packed backward currently requires head dimension 128")
     _validate_i32_buffer_offsets(
         total_q=total_q,
         total_kv=total_kv,
         batch=plan.batch,
-        heads=heads,
+        q_heads=heads,
+        kv_heads=kv_heads,
     )
     q_tensors = {"q": q, "o": o, "do": do}
     for name, tensor in q_tensors.items():
@@ -560,13 +1205,22 @@ def _validate_backward_inputs(q, k, v, o, do, lse, plan, sm_scale):
 
 
 def fa_varlen_backward(q, k, v, o, do, lse, plan, sm_scale):
-    """Run packed BF16 D128 non-causal MHA backward using a prepared plan."""
+    """Run packed BF16 D128 non-causal MHA/GQA backward using a prepared plan."""
     _validate_backward_inputs(q, k, v, o, do, lse, plan, sm_scale)
     total_q, heads, head_dim = q.shape
+    total_kv, kv_heads, _ = k.shape
+    group_size = heads // kv_heads
+    kv_splits = _select_varlen_kv_splits(plan.max_q, group_size)
     total_q_padded = total_q + plan.batch * (_BLOCK_M - 1)
     dq = torch.empty_like(q)
     dk = torch.empty_like(k)
     dv = torch.empty_like(v)
+    dk_part, dv_part = _allocate_varlen_dkdv_partials(k, kv_splits)
+    if dk_part is None:
+        kv_splits = 1
+    block_m, block_n = _select_varlen_kernel_blocks(group_size, kv_splits)
+    dk_target = dk if dk_part is None else dk_part
+    dv_target = dv if dv_part is None else dv_part
     delta = torch.empty((total_q, heads), dtype=torch.float32, device=q.device)
     dq_acc = torch.zeros((heads, total_q_padded, head_dim), dtype=torch.bfloat16, device=q.device)
 
@@ -580,39 +1234,84 @@ def fa_varlen_backward(q, k, v, o, do, lse, plan, sm_scale):
         BLOCK_M=64,
         num_warps=4,
     )
-    kv_launches = (
-        (0, plan.num_full_kv_blocks, True),
-        (plan.num_full_kv_blocks, plan.kv_block_sequence.numel() - plan.num_full_kv_blocks, False),
-    )
-    for task_offset, task_count, full_kv_tile in kv_launches:
-        if task_count == 0:
-            continue
-        _varlen_bwd_interleaved_kernel[(task_count, heads)](
+    if (block_m, block_n) == (_WIDE_BLOCK_M, _WIDE_BLOCK_N):
+        _varlen_bwd_interleaved_bm32_kernel[(kv_heads * kv_splits, plan.wide_kv_start.numel())](
             q,
             k,
             v,
             do,
             lse,
             delta,
-            plan.cu_seqlens_q,
-            plan.cu_seqlens_k,
-            plan.kv_block_sequence,
-            plan.kv_block_start,
+            plan.wide_kv_start,
+            plan.wide_q_start,
+            plan.wide_dq_start,
+            plan.wide_q_len,
+            plan.wide_kv_valid,
             dq_acc,
-            dk,
-            dv,
-            task_offset,
+            dk_target,
+            dv_target,
             SM_SCALE=sm_scale,
             TOTAL_Q=total_q,
             TOTAL_Q_PADDED=total_q_padded,
-            HEADS=heads,
+            HQ=heads,
+            HKV=kv_heads,
             D=head_dim,
-            BLOCK_M=_BLOCK_M,
-            BLOCK_N=_BLOCK_N,
-            FULL_KV_TILE=full_kv_tile,
+            BLOCK_M=_WIDE_BLOCK_M,
+            BLOCK_N=_WIDE_BLOCK_N,
+            KV_SPLITS=kv_splits,
             num_warps=4,
             num_stages=1,
             matrix_instr_nonkdim=16,
+        )
+    else:
+        kv_launches = (
+            (0, plan.num_full_kv_blocks, True),
+            (plan.num_full_kv_blocks, plan.kv_block_sequence.numel() - plan.num_full_kv_blocks, False),
+        )
+        for task_offset, task_count, full_kv_tile in kv_launches:
+            if task_count == 0:
+                continue
+            _varlen_bwd_interleaved_kernel[(task_count, kv_heads * kv_splits)](
+                q,
+                k,
+                v,
+                do,
+                lse,
+                delta,
+                plan.cu_seqlens_q,
+                plan.cu_seqlens_k,
+                plan.kv_block_sequence,
+                plan.kv_block_start,
+                dq_acc,
+                dk_target,
+                dv_target,
+                task_offset,
+                SM_SCALE=sm_scale,
+                TOTAL_Q=total_q,
+                TOTAL_Q_PADDED=total_q_padded,
+                HQ=heads,
+                HKV=kv_heads,
+                D=head_dim,
+                BLOCK_M=_BLOCK_M,
+                BLOCK_N=_BLOCK_N,
+                FULL_KV_TILE=full_kv_tile,
+                KV_SPLITS=kv_splits,
+                num_warps=4,
+                num_stages=1,
+                matrix_instr_nonkdim=16,
+            )
+    if kv_splits > 1:
+        _varlen_dkdv_reduce_kernel[(triton.cdiv(total_kv, _BLOCK_M), kv_heads)](
+            dk_part,
+            dv_part,
+            dk,
+            dv,
+            total_kv,
+            HKV=kv_heads,
+            D=head_dim,
+            KV_SPLITS=kv_splits,
+            BLOCK_N=_BLOCK_M,
+            num_warps=4,
         )
     _varlen_dq_convert_kernel[(plan.q_block_sequence.numel(), heads)](
         dq_acc,

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -3,9 +3,9 @@
 Each workgroup owns a KV tile and a subset of its mapped query heads.  The
 baseline path uses BN128/BM16 phases; long non-causal split-GQA uses masked
 BN256/BM32 phases and forms dQ as two native BM16 accumulator chains.  Split
-workgroups reduce their BF16 dK/dV partials in FP32.  Independent KV owners
-combine dQ contributions with BF16 atomics in a guarded native layout,
-followed by a conversion to packed THD order.
+workgroups preserve FP32 dK/dV partials through their final reduction.
+Independent KV owners combine dQ contributions with BF16 atomics in a guarded
+native layout, followed by a conversion to packed THD order.
 
 Call :func:`prepare_varlen_backward` once and reuse the resulting plan with
 :func:`fa_varlen_backward`.  Plan creation performs one device-to-host
@@ -32,6 +32,11 @@ _WIDE_BLOCK_M = 32
 _WIDE_BLOCK_N = 256
 _HEAD_DIM = 128
 _I32_BUFFER_BF16_ELEMENTS = 1 << 30
+_I32_BUFFER_FP32_ELEMENTS = _I32_BUFFER_BF16_ELEMENTS // 2
+# Local gfx950 sweeps found that the BM32/BN256 split kernel's wider tiles and
+# dK/dV reduction amortize their overhead at roughly 1024 query-head/BM16-block
+# phases per KV head.  This keeps max-Q 300/400 workloads on BM16/BN128 while
+# the max-Q 5662 SGLang-like GQA3/GQA8 workloads use the split path.
 _VARLEN_GQA_SPLIT_WORK_THRESHOLD = 1024
 
 
@@ -201,10 +206,10 @@ def _select_varlen_kernel_blocks(group_size: int, kv_splits: int) -> tuple[int, 
 
 
 def _allocate_varlen_dkdv_partials(k: torch.Tensor, kv_splits: int) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    if kv_splits == 1 or k.numel() * kv_splits > _I32_BUFFER_BF16_ELEMENTS:
+    if kv_splits == 1 or k.numel() * kv_splits > _I32_BUFFER_FP32_ELEMENTS:
         return None, None
     total_kv, kv_heads, head_dim = k.shape
-    dk_part = torch.empty((total_kv, kv_heads, kv_splits, head_dim), dtype=k.dtype, device=k.device)
+    dk_part = torch.empty((total_kv, kv_heads, kv_splits, head_dim), dtype=torch.float32, device=k.device)
     return dk_part, torch.empty_like(dk_part)
 
 
@@ -798,8 +803,8 @@ def _varlen_bwd_interleaved_bm32_kernel(
     output_offsets = tlx.require_layout(output_offsets, kv_native_layout, pin=False)
     output_mask = tl.broadcast_to((store_n < kv_valid_rows)[:, None], (BLOCK_N, D))
     output_mask = tlx.require_layout(output_mask, kv_native_layout, pin=False)
-    tlx.buffer_store(dk.to(tl.bfloat16), output_ptr, output_offsets, mask=output_mask)
-    tlx.buffer_store(dv.to(tl.bfloat16), output_v_ptr, output_offsets, mask=output_mask)
+    tlx.buffer_store(dk, output_ptr, output_offsets, mask=output_mask)
+    tlx.buffer_store(dv, output_v_ptr, output_offsets, mask=output_mask)
 
 
 @triton.jit
@@ -1080,13 +1085,16 @@ def _varlen_bwd_interleaved_kernel(
     else:
         partial_offsets = (((global_n[:, None] * HKV + kv_head) * KV_SPLITS + split) * D + offs_d[None, :])
         output_offsets = tlx.require_layout(partial_offsets.to(tl.int32), mma_nd, pin=False)
+    if KV_SPLITS == 1:
+        dk = dk.to(tl.bfloat16)
+        dv = dv.to(tl.bfloat16)
     if FULL_KV_TILE:
-        tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets)
-        tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets)
+        tlx.buffer_store(dk, DK, output_offsets)
+        tlx.buffer_store(dv, DV, output_offsets)
     else:
         output_mask = tlx.require_layout(tl.broadcast_to(kv_mask, (BLOCK_N, D)), mma_nd, pin=False)
-        tlx.buffer_store(dk.to(tl.bfloat16), DK, output_offsets, mask=output_mask)
-        tlx.buffer_store(dv.to(tl.bfloat16), DV, output_offsets, mask=output_mask)
+        tlx.buffer_store(dk, DK, output_offsets, mask=output_mask)
+        tlx.buffer_store(dv, DV, output_offsets, mask=output_mask)
 
 
 @triton.jit

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -331,13 +331,18 @@ def _issue_qdo_bm32_async(
     qdo_base = (q_start * HQ + q_head.to(tl.int64)) * D
     offsets = (rows[:, :, None] * HQ * D + dims[None, None, :]).to(tl.int32)
     offsets = tlx.require_layout(offsets, ASYNC_LAYOUT, pin=False)
-    other = tlx.zeros((1, BLOCK_M, D), tl.bfloat16, layout=ASYNC_LAYOUT)
+    if (outer_block + 1) * BLOCK_M > q_len:
+        # Masked direct-to-LDS copies leave OOB rows untouched. Clear the tail
+        # tile first so those rows remain zero without materializing an OOB
+        # buffer offset for every lane in each async load.
+        tlx.local_store(q_dst, tl.zeros((1, BLOCK_M, D), tl.bfloat16))
+        tlx.local_store(do_dst, tl.zeros((1, BLOCK_M, D), tl.bfloat16))
+        tl.debug_barrier()
     q_token = tlx.buffer_load_to_local(
         q_dst,
         tl.multiple_of(Q + qdo_base, 16),
         offsets,
         mask=valid,
-        other=other,
     )
     tlx.async_load_commit_group([q_token])
     do_token = tlx.buffer_load_to_local(
@@ -345,7 +350,6 @@ def _issue_qdo_bm32_async(
         tl.multiple_of(DO + qdo_base, 16),
         offsets,
         mask=valid,
-        other=other,
     )
     tlx.async_load_commit_group([do_token])
 

--- a/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_varlen_bwd.py
@@ -33,10 +33,10 @@ _WIDE_BLOCK_N = 256
 _HEAD_DIM = 128
 _I32_BUFFER_BF16_ELEMENTS = 1 << 30
 _I32_BUFFER_FP32_ELEMENTS = _I32_BUFFER_BF16_ELEMENTS // 2
-# Local gfx950 sweeps found that the BM32/BN256 split kernel's wider tiles and
-# dK/dV reduction amortize their overhead at roughly 1024 query-head/BM16-block
-# phases per KV head.  This keeps max-Q 300/400 workloads on BM16/BN128 while
-# the max-Q 5662 SGLang-like GQA3/GQA8 workloads use the split path.
+# This is an empirical gfx950 crossover, not a hardware limit.  The work metric
+# is group_size * ceil(max_q / 16), the BM16 query-block phases per KV head.
+# Local sweeps kept max-Q 300/400 on BM16/BN128, while max-Q 5662 GQA3/GQA8
+# amortized the BM32/BN256 split kernel and its dK/dV reduction overhead.
 _VARLEN_GQA_SPLIT_WORK_THRESHOLD = 1024
 
 
@@ -1127,6 +1127,9 @@ def _varlen_dkdv_reduce_kernel(
         dk += tl.load(DK_PART + partial_base + split * D, mask=valid, other=0.0).to(tl.float32)
         dv += tl.load(DV_PART + partial_base + split * D, mask=valid, other=0.0).to(tl.float32)
     output_offsets = (offs_n[:, None] * HKV + kv_head) * D + offs_d[None, :]
+    # Match the FP32 load layout so the BF16 stores do not introduce a
+    # whole-tile cross-warp conversion through LDS.
+    output_offsets = tl.max_contiguous(output_offsets, [1, 4])
     tl.store(DK + output_offsets, dk.to(tl.bfloat16), mask=valid)
     tl.store(DV + output_offsets, dv.to(tl.bfloat16), mask=valid)
 


### PR DESCRIPTION
## Summary

This follow-up to #3311 extends the gfx950 packed BF16 D128 non-causal attention backward tutorial from MHA to GQA.
It also adds a split-GQA specialization for long workloads using public Triton/TLX operations only.

The existing BM16/BN128 path handles MHA and short or unsplit GQA. Long GQA uses compact per-sequence BM32/BN256 tasks,
splits the query heads mapped to each KV head across workgroups, and reduces their dK/dV partials afterward.

## Workloads

The performance results separate three workload groups:

- The five TritonBench #1247 cross-attention configurations use their exact BF16 MHA shapes and balanced Q/KV offsets.
- The derived GQA3 configurations retain those five aggregate `(total_q,total_kv,max_q,max_kv)` summaries, but change
  the head topology to `Hq=12`, `Hkv=4` and use seed 42 to generate varied prefix/extend-style lengths. They are synthetic
  workloads rather than configurations supplied by TritonBench; their attention-pair counts are 0.22–0.59% higher than
  the balanced-offset inputs.
- The SGLang-like GQA3/GQA8 configurations use the production-scale `B=19`, `N_CTX=12331` prefix/extend initialization:

```python
generator = torch.Generator().manual_seed(42)
prefix_len = torch.randint(1, N_CTX // 2, (B,), generator=generator)
extend_len = torch.randint(1, N_CTX // 2, (B,), generator=generator)

q_lengths = extend_len
kv_lengths = prefix_len + extend_len
```

Q packs only extension tokens, while K/V packs the complete prefix-plus-extension context. The cumulative Q and KV
offsets are stored independently. This does not add paged-KV lookup.

## Implementation

- Plan construction validates and owns the cumulative offsets and builds both the baseline and wide task schedules
  outside the repeated execution path.
- The wide kernel double-buffers Q/dO, accumulates dK/dV directly, and publishes dS through LDS.
- BM32 dQ is expressed as two native BM16 `amd_scheduled_mfma` chains, followed by one `amd_mfma_commit` boundary that
  preserves the live V operand.
- Independent KV owners accumulate dQ through the existing native-layout packed BF16 atomic path; the final conversion
  produces packed THD output.
- Runtime token counts remain ordinary kernel arguments and therefore do not create one JIT specialization per packed
  batch.

The implementation does not add compiler changes, custom LLVM attributes, thread-ID access, or workload-specific
GQA3/GQA8 constants.

## Performance on MI350X

All rows use BF16 and `D=128`, with 15 warmups and 100 HIP-event samples. Both provider orders were measured. TFLOP/s
uses the five backward GEMMs:
`10 * Hq * D * sum(q_len[i] * kv_len[i]) / time`.

### TritonBench #1247 MHA (`B=768`, `Hq=Hkv=4`)

| Config `(total_q,total_kv,max_q,max_kv)` | TLX ms / TFLOP/s | AITER ASM v3 ms / speedup | CK ms / speedup |
| --- | ---: | ---: | ---: |
| `(62780,946279,300,3200)` | 1.886 / 211.22 | 2.045 / **1.0845x** | 3.046 / **1.6155x** |
| `(80900,940737,300,3200)` | 2.083 / 244.50 | 2.249 / **1.0794x** | 3.246 / **1.5582x** |
| `(88660,944840,300,3200)` | 2.237 / 250.50 | 2.362 / **1.0559x** | 3.419 / **1.5287x** |
| `(101900,946104,300,3200)` | 2.445 / 263.61 | 2.507 / **1.0256x** | 3.631 / **1.4855x** |
| `(84880,945242,400,3200)` | 2.106 / 255.33 | 2.308 / **1.0960x** | 3.266 / **1.5507x** |
| **Geometric-mean speedup** | | **1.0680x** | **1.5471x** |

The reverse provider order reproduced geometric-mean speedups of **1.0670x** over AITER ASM v3 and **1.5405x** over CK.

These configurations dispatch to the existing BM16/BN128 path.

### Derived varied GQA3 (`B=768`, `Hq=12`, `Hkv=4`)

| Config `(total_q,total_kv,max_q,max_kv)` | TLX ms / TFLOP/s | AITER ASM v3 ms / speedup | CK ms / speedup |
| --- | ---: | ---: | ---: |
| `(62780,946279,300,3200)` | 3.998 / 299.48 | 8.530 / **2.1336x** | 11.059 / **2.7661x** |
| `(80900,940737,300,3200)` | 4.796 / 319.84 | 9.146 / **1.9069x** | 11.838 / **2.4681x** |
| `(88660,944840,300,3200)` | 5.195 / 325.05 | 9.554 / **1.8390x** | 12.295 / **2.3665x** |
| `(101900,946104,300,3200)` | 5.766 / 337.24 | 10.169 / **1.7636x** | 13.035 / **2.2606x** |
| `(84880,945242,400,3200)` | 5.032 / 321.96 | 9.479 / **1.8837x** | 12.120 / **2.4084x** |
| **Geometric-mean speedup** | | **1.9014x** | **2.4483x** |

The reverse provider order reproduced geometric-mean speedups of **1.8887x** over AITER ASM v3 and **2.4358x** over CK.

These configurations dispatch to BM16/BN128 because their maximum query lengths are only 300 or 400.

### SGLang-like split GQA (`B=19`, `D=128`, `total_q=50754`, `total_kv=100696`)

Both rows use `max_q=5662` and `max_kv=10414`.

| Config `(Hq,Hkv,kv_splits)` | TLX ms / TFLOP/s | AITER ASM v3 ms / speedup | CK ms / speedup |
| --- | ---: | ---: | ---: |
| GQA3 `(12,4,3)` | 7.304 / 630.51 | 8.405 / **1.1507x** | 10.198 / **1.3961x** |
| GQA8 `(64,8,4)` | 38.309 / 641.16 | 42.613 / **1.1124x** | 54.086 / **1.4118x** |
| **Geometric-mean speedup** | | **1.1314x** | **1.4039x** |

The reverse provider order reproduced geometric-mean speedups of **1.1379x** over AITER ASM v3 and **1.4062x** over CK.

The BM32/BN256 kernel uses 117,536 bytes of LDS and has no spills or global scratch in the tested specializations.

## Testing

```text
TRITON_BACKENDS_IN_TREE=1 \
PYTHONPATH=python \
python -m pytest -s --tb=short \
  python/test/unit/language/test_tlx_amd_fa_bwd_gfx950.py
# 40 passed
```

Coverage includes MHA, GQA3, GQA8, SGLang-style prefix/extend length distributions, BM16/BM32 and BN128/BN256
boundaries, multiple sequences, split dK/dV reduction, runtime token-count cache reuse, packed BF16 dQ atomics, and
scratch/LDS checks.

## Limitations

- The specialization requires gfx950, contiguous BF16 THD tensors, D128, and `Hq % Hkv == 0`.
- Causal attention and paged KV-cache lookup are not supported.
- Plan construction performs one host synchronization and should be reused for calls with the same packing.
- BF16 dQ atomic accumulation is nondeterministic and uses an internal padded scratch tensor.
