### PR TITLE
[TLX] Raise error for causal=False for hstu attn

### DIFF
--- a/python/test/unit/tlx_ops/test_hstu_attn.py
+++ b/python/test/unit/tlx_ops/test_hstu_attn.py
@@ -4,10 +4,8 @@ No compile-time cap as in test_mm.py: this kernel has no shape heuristic, so the
 correctness caller autotunes a small space and wall-clock says nothing about
 compile time.
 
-TODO(causal flag ignored): the non-causal shape is commented out of SHAPES
-because it FAILS. `causal=False` returns output bit-identical to `causal=True`,
-so the kernel is always causal and the flag is silently dropped. Re-enable the
-shape once it is honoured -- it is the regression test for it.
+The op is causal-only, so every shape here is causal and `causal=False` is a
+rejection case rather than a numerics case -- see `test_non_causal_rejected`.
 """
 
 import pytest
@@ -32,8 +30,6 @@ SHAPES = [
     [2, 1024, 4, 128, True],
     [8, 128, 4, 128, True],
     [2, 256, 16, 64, True],
-    # TODO(causal flag ignored): fails, see module docstring.
-    # [2, 512, 4, 128, False],
     [1, 2048, 2, 128, True],
 ]
 
@@ -78,3 +74,18 @@ def test_hstu_attn(Z, MAX_SEQ_LEN, H, HEAD_DIM, causal, dtype):
     ref = _float_ref(q, k, v, offsets, attn_scale, alpha, causal).to(out.dtype)
     precision = REL_PRECISION[dtype]
     torch.testing.assert_close(out, ref, atol=precision * ref.abs().max().item(), rtol=precision)
+
+
+def test_non_causal_rejected():
+    """`causal=False` must raise rather than return the causal answer.
+
+    Causality is structural -- the KV block range and the score mask are both
+    unconditionally causal, and the flag reaches neither -- so a dropped flag is
+    bit-identical to an honoured one and nothing downstream can notice.
+    """
+    from triton.tlx.ops import InvalidInput
+    from triton.tlx.ops import hstu_attn as tlx_hstu_attn
+
+    q, k, v, offsets, attn_scale = _inputs(2, 512, 4, 128, torch.bfloat16)
+    with pytest.raises(InvalidInput, match="causal"):
+        tlx_hstu_attn(q, k, v, offsets, 512, attn_scale, alpha=1.0 / 128, causal=False, arch=ARCH, space="smoke")

--- a/third_party/tlx/ops/__init__.py
+++ b/third_party/tlx/ops/__init__.py
@@ -53,9 +53,12 @@ def hstu_attn(q, k, v, seq_offsets, max_seq_len, attn_scale, alpha=None, causal=
     Scores are SiLU-scaled rather than softmaxed, which is why this is its own
     op. `seq_offsets` is `(B + 1,)` prefix offsets; `alpha` defaults to
     `1 / HEAD_DIM`.
+
+    Causal-only: `causal=False` raises `InvalidInput`. The argument is kept so
+    the intent is stated at the call site rather than assumed.
     """
     fn, spec = impl_for("hstu_attn", arch)
-    check_inputs(spec, dtype=q.dtype, HEAD_DIM=q.shape[-1])
+    check_inputs(spec, dtype=q.dtype, HEAD_DIM=q.shape[-1], causal=causal)
     return fn(q, k, v, seq_offsets, max_seq_len, alpha if alpha is not None else 1.0 / q.shape[-1], causal=causal,
               attn_scale=attn_scale, num_targets=num_targets, max_attn_len=max_attn_len,
               contextual_seq_len=contextual_seq_len, space=space)

--- a/third_party/tlx/ops/_catalog.py
+++ b/third_party/tlx/ops/_catalog.py
@@ -65,6 +65,8 @@ CATALOG: tuple[OpSpec, ...] = (
         variant="ws",
         impl="kernels.hstu_attn.sm100:hstu_attn",
         dtypes=_FP16,
+        # Causal-only, non-causal is not supported yet
+        accepts=lambda d: bool(d.get("causal", True)),
         requires=frozenset({"tma", "tmem"}),
     ),
     OpSpec(

--- a/third_party/tlx/ops/kernels/hstu_attn/sm100.py
+++ b/third_party/tlx/ops/kernels/hstu_attn/sm100.py
@@ -5224,7 +5224,7 @@ class _AttentionFunction(torch.autograd.Function):
             stride_mm=stride_mm,
             num_softmax_heads=num_softmax_heads,
             num_targets=num_targets,
-            causal=True,
+            causal=causal,
             max_attn_len=max_attn_len,
             full_attn_size=full_attn_size,
             contextual_seq_len=contextual_seq_len,
@@ -5402,7 +5402,11 @@ def hstu_attn(
 
     `seq_offsets` is `(B + 1,)` prefix offsets. `space` is "full" for perf or
     "smoke" for correctness; not exposed on `tlx.ops.hstu_attn`.
+
+    Causal-only; see the `causal=False` rejection below.
     """
+    if not causal:
+        raise ValueError("hstu_attn is causal-only; causal=False is not implemented")
     global _SPACE
     _SPACE = space
     return _AttentionFunction.apply(

--- a/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
+++ b/third_party/tlx/tutorials/hstu_self_attn/tlx_bw_hstu_attention.py
@@ -5219,7 +5219,7 @@ class _AttentionFunction(torch.autograd.Function):
             stride_mm=stride_mm,
             num_softmax_heads=num_softmax_heads,
             num_targets=num_targets,
-            causal=True,
+            causal=causal,
             max_attn_len=max_attn_len,
             full_attn_size=full_attn_size,
             contextual_seq_len=contextual_seq_len,
@@ -5323,6 +5323,8 @@ def tlx_bw_hstu_mha(
     contextual_seq_len: int = 0,
     causal: bool = True,
 ) -> torch.Tensor:
+    if not causal:
+        raise ValueError("tlx_bw_hstu_mha is causal-only; causal=False is not implemented")
     return _AttentionFunction.apply(
         max_seq_len,
         alpha,


### PR DESCRIPTION
The TLX and ref implementations both only have causal=True cases. Raise an error for causal=False to avoid silently spilling out wrong results.