### PR TITLE
[AutoWS] Drop the tt.autows 2-CTA boolean switches (#3421)

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h
@@ -1,0 +1,24 @@
+#ifndef TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_
+#define TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_
+
+#include "mlir/IR/Operation.h"
+
+// Helpers that interpret the contents of an inline-PTX asm block well enough to
+// answer a specific structural question about it. The instruction mnemonics
+// recognized here are NVIDIA-specific; the callers live in target-independent
+// TritonGPU transforms, which is why these are declared alongside them rather
+// than in third_party/nvidia.
+
+namespace mlir {
+
+// Return true if the op multiplies its two operands and does nothing else, so
+// that a zero operand forces a zero result. Covers arith.mulf and the packed
+// mul.f32x2 emitted as elementwise inline PTX (see
+// third_party/nvidia/language/cuda/inline_ptx_lib.py). Callers depend on the
+// zero-propagation property, so an asm block that multiplies and then performs
+// further arithmetic must NOT match.
+bool isMulOp(Operation *op);
+
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_PTXINTERPUTILS_H_

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_triton_library(TritonGPUTransforms
   Pipeliner/PipeliningUtility.cpp
   Pipeliner/Schedule.cpp
   Prefetch.cpp
+  PtxInterpUtils.cpp
   RemoveLayoutConversions.cpp
   ReorderInstructions.cpp
   CoalesceAsyncCopy.cpp

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -3,6 +3,7 @@
 #include "triton/Dialect/Triton/IR/OpInterfaces.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
@@ -133,7 +134,12 @@ std::optional<std::pair<Operation *, int>>
 findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
   Value v = accUse;
   if (auto arg = dyn_cast<BlockArgument>(v)) {
-    assert(arg.getOwner() == forOp.getBody());
+    // A zero-preserving op can also consume a value captured from an outer
+    // block (for example the scale operand of a packed multiply).  Such a
+    // value is not the accumulator loop argument and does not establish a
+    // zero origin.
+    if (arg.getOwner() != forOp.getBody())
+      return std::nullopt;
     if (isConstantZeroTensor(forOp.getInitArgs()[arg.getArgNumber() - 1])) {
       loopArgIsZero = true;
     }
@@ -145,6 +151,37 @@ findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
     return std::nullopt;
   }
   if (auto selOp = dyn_cast<arith::SelectOp>(defOp)) {
+    // A select can preserve the same zero-initialized loop accumulator along
+    // both arms without either arm being a literal zero.  Attention's
+    // conditional rescale is the canonical example:
+    //
+    //   scaled = acc * alpha
+    //   acc = select should_rescale, scaled, acc
+    //
+    // Both arms are zero on the first iteration, so the first MMA can
+    // initialize operand D directly.  Trace the arms independently: sharing
+    // loopArgIsZero while visiting the first arm would otherwise make an
+    // unsupported second arm look zero-preserving.
+    bool trueLoopArgIsZero = false;
+    bool falseLoopArgIsZero = false;
+    auto trueOrigin =
+        findZeroInitOp(selOp.getTrueValue(), forOp, trueLoopArgIsZero);
+    auto falseOrigin =
+        findZeroInitOp(selOp.getFalseValue(), forOp, falseLoopArgIsZero);
+    if (!trueOrigin && !falseOrigin && trueLoopArgIsZero &&
+        falseLoopArgIsZero) {
+      loopArgIsZero = true;
+      return std::nullopt;
+    }
+    // The asymmetric case is deliberately not propagated: one arm preserving
+    // the zero loop arg says nothing about the other, so the select as a whole
+    // is not zero-preserving. Discarding the per-arm flags and falling through
+    // to the scalar-condition path below is the conservative choice.
+
+    // Rewriting a conditional zero into a scalar use-accumulator flag requires
+    // a scalar condition.  Tensor conditions are nevertheless safe in the
+    // both-arms-preserve-zero case handled above because the condition itself
+    // does not affect first-iteration initialization.
     if (!selOp.getCondition().getType().isInteger(1))
       return std::nullopt;
     if (isConstantZeroTensor(selOp.getTrueValue()) ||
@@ -166,7 +203,7 @@ findZeroInitOp(Value accUse, scf::ForOp forOp, bool &loopArgIsZero) {
       return std::make_pair(ifOp, resultIndex);
     }
   }
-  if (auto multOp = dyn_cast<arith::MulFOp>(defOp)) {
+  if (isMulOp(defOp)) {
     auto output1 = findZeroInitOp(defOp->getOperand(0), forOp, loopArgIsZero);
     if (output1.has_value()) {
       return output1;

--- a/lib/Dialect/TritonGPU/Transforms/PtxInterpUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/PtxInterpUtils.cpp
@@ -1,0 +1,62 @@
+#include "triton/Dialect/TritonGPU/Transforms/PtxInterpUtils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+
+using namespace triton;
+
+// Is this PTX instruction only moving data around, rather than computing?
+// Register declarations and moves cannot change a zero into a non-zero.
+static bool isPtxDataMovement(StringRef instr) {
+  // Match "mov." rather than "mov" so a future mnemonic that merely starts
+  // with those three letters is treated as arithmetic (and so rejected) rather
+  // than silently assumed zero-preserving. Every real PTX mov variant is
+  // dotted: mov.b64, mov.u32, ...
+  return instr.starts_with(".reg") || instr.starts_with("mov.");
+}
+
+// Recognize a packed mul.f32x2 written as elementwise inline PTX. The kernels
+// emit it as a small block, e.g.
+//
+//   { .reg .b64 ra, rb, rc;
+//     mov.b64 ra, { $2, $3 };
+//     mov.b64 rb, { $4, $5 };
+//     mul.f32x2 rc, ra, rb;
+//     mov.b64 { $0, $1 }, rc; }
+//
+// so a single-instruction match is too strict (it would reject every real
+// producer) and a substring match is too loose: a block that multiplies and
+// then adds still contains "mul.f32x2" but does not propagate zero. Split the
+// block into instructions and require that the multiply is the ONLY arithmetic
+// performed; everything else must be a declaration or a data move.
+static bool isPackedF32Mul(Operation *op) {
+  auto inlineAsm = dyn_cast<ElementwiseInlineAsmOp>(op);
+  if (!inlineAsm || !inlineAsm.getPure() || inlineAsm.getPackedElement() != 2 ||
+      op->getNumOperands() != 2 || op->getNumResults() != 1)
+    return false;
+
+  SmallVector<StringRef> instrs;
+  inlineAsm.getAsmString().split(instrs, ';');
+  bool sawMul = false;
+  for (StringRef instr : instrs) {
+    // Strip the block braces and surrounding whitespace/newlines so the
+    // matching is insensitive to how the asm was indented in Python.
+    instr = instr.trim(" \t\n\r{}");
+    if (instr.empty())
+      continue;
+    if (isPtxDataMovement(instr))
+      continue;
+    if (!instr.starts_with("mul.f32x2") || sawMul)
+      return false;
+    sawMul = true;
+  }
+  return sawMul;
+}
+
+bool isMulOp(Operation *op) {
+  return isa<arith::MulFOp>(op) || isPackedF32Mul(op);
+}
+
+} // namespace mlir

--- a/test/Hopper/TwoCTA/insert_2cta_sync.mlir
+++ b/test/Hopper/TwoCTA/insert_2cta_sync.mlir
@@ -38,6 +38,118 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+// A software-pipelined persistent kernel can leave MMA copies directly in a
+// warp-specialized scf.while body. The cross-CTA barrier lives outside the
+// warp-specialize op, so its phase must rotate with the while iteration.
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+// CHECK-LABEL: @test_persistent_while_phase
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32} {
+  tt.func @test_persistent_while_phase(
+      %a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token) {
+    ttg.warp_specialize(%a, %b, %acc, %acc_tok)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%part_a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+               %part_b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+               %part_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+               %part_acc_tok: !ttg.async.token) num_warps(4) {
+      %true = arith.constant true
+      %false = arith.constant false
+      %c0_i32 = arith.constant 0 : i32
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      // CHECK: scf.while
+      // CHECK: ^bb0(%{{.*}}: i32, %[[WHILE_ITER:.*]]: i64):
+      // CHECK: %[[PHASE_STRIDE:.*]] = arith.constant 1 : i64
+      // CHECK: %[[LINEAR_ITER:.*]] = arith.muli %[[WHILE_ITER]], %[[PHASE_STRIDE]] : i64
+      // CHECK: %[[TWO:.*]] = arith.constant 2 : i64
+      // CHECK: %[[REM:.*]] = arith.remui %[[LINEAR_ITER]], %[[TWO]] : i64
+      // CHECK: %[[PHASE:.*]] = arith.trunci %[[REM]] : i64 to i32
+      // CHECK: ttng.wait_barrier %{{.*}}, %[[PHASE]]
+      // CHECK: ttng.tc_gen5_mma
+      %result:2 = scf.while (%keep_going = %true, %tile = %c0_i32, %iter = %c0_i64) : (i1, i32, i64) -> (i32, i64) {
+        scf.condition(%keep_going) %tile, %iter : i32, i64
+      } do {
+      ^bb0(%tile_arg: i32, %iter_arg: i64):
+        %tok = ttng.tc_gen5_mma %part_a, %part_b, %part_acc[%part_acc_tok], %true, %true {two_ctas} :
+          !ttg.memdesc<128x64xf16, #shared, #smem>,
+          !ttg.memdesc<64x128xf16, #shared1, #smem>,
+          !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        %next_iter = arith.addi %iter_arg, %c1_i64 : i64
+        scf.yield %false, %tile_arg, %next_iter : i1, i32, i64
+      }
+      ttg.warp_return
+    } : (!ttg.memdesc<128x64xf16, #shared, #smem>,
+         !ttg.memdesc<64x128xf16, #shared1, #smem>,
+         !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+         !ttg.async.token) -> ()
+    tt.return
+  }
+
+  // CHECK-LABEL: @test_persistent_while_inner_loop_phase
+  tt.func @test_persistent_while_inner_loop_phase(
+      %a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+      %b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+      %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+      %acc_tok: !ttg.async.token) {
+    ttg.warp_specialize(%a, %b, %acc, %acc_tok)
+    default {
+      ttg.warp_yield
+    }
+    partition0(%part_a: !ttg.memdesc<128x64xf16, #shared, #smem>,
+               %part_b: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+               %part_acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+               %part_acc_tok: !ttg.async.token) num_warps(4) {
+      %true = arith.constant true
+      %false = arith.constant false
+      %c0_i32 = arith.constant 0 : i32
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c3 = arith.constant 3 : index
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      // CHECK: scf.while
+      // CHECK: ^bb0(%{{.*}}: i32, %[[OUTER_ITER:.*]]: i64):
+      // CHECK: scf.for
+      // CHECK: %[[OUTER_CONTRIB:.*]] = arith.muli %[[OUTER_ITER]], %[[INNER_TRIP:.*]] : i64
+      // CHECK: %[[LINEAR_ITER:.*]] = arith.addi %[[OUTER_CONTRIB]], %{{.*}} : i64
+      // CHECK: %[[REM:.*]] = arith.remui %[[LINEAR_ITER]], %{{.*}} : i64
+      // CHECK: %[[PHASE:.*]] = arith.trunci %[[REM]] : i64 to i32
+      // CHECK: ttng.wait_barrier %{{.*}}, %[[PHASE]]
+      // CHECK: ttng.tc_gen5_mma
+      %result:2 = scf.while (%keep_going = %true, %tile = %c0_i32, %iter = %c0_i64) : (i1, i32, i64) -> (i32, i64) {
+        scf.condition(%keep_going) %tile, %iter : i32, i64
+      } do {
+      ^bb0(%tile_arg: i32, %iter_arg: i64):
+        scf.for %inner = %c0 to %c3 step %c1 {
+          %tok = ttng.tc_gen5_mma %part_a, %part_b, %part_acc[%part_acc_tok], %true, %true {two_ctas} :
+            !ttg.memdesc<128x64xf16, #shared, #smem>,
+            !ttg.memdesc<64x128xf16, #shared1, #smem>,
+            !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        }
+        %next_iter = arith.addi %iter_arg, %c1_i64 : i64
+        scf.yield %false, %tile_arg, %next_iter : i1, i32, i64
+      }
+      ttg.warp_return
+    } : (!ttg.memdesc<128x64xf16, #shared, #smem>,
+         !ttg.memdesc<64x128xf16, #shared1, #smem>,
+         !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+         !ttg.async.token) -> ()
+    tt.return
+  }
+}
+
+// -----
+
 // Test that the pass skips when no cluster (cluster_dim < 2).
 
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>

--- a/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero.mlir
+++ b/test/Hopper/WarpSpecialization/ws_remove_redundant_tmem_zero.mlir
@@ -39,7 +39,8 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
     %n_tile_num = arith.constant 127 : i32
     %c64_i32 = arith.constant 64 : i32
     %true = arith.constant true
-    %cst_28 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
+    %cst_28 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %cst_28_layout = ttg.convert_layout %cst_28 : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blocked1>
     %n_tile_num_29 = arith.addi %N_CTX, %n_tile_num : i32
     %n_tile_num_30 = arith.divsi %n_tile_num_29, %c128_i32 : i32
     %prog_id = tt.get_program_id x : i32
@@ -88,8 +89,8 @@ module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32,
       %dv, %dv_50 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
       %dq, %dq_51 = ttng.tmem_alloc {ttg.partition = array<i32: 0>} : () -> (!ttg.memdesc<64x128xf32, #tmem2, #ttng.tensor_memory, mutable>, !ttg.async.token)
       %dk, %dk_52 = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>, !ttg.async.token)
-      %dk_53 = ttng.tmem_store %cst_28, %dk[%dk_52], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
-      %dv_54 = ttng.tmem_store %cst_28, %dv[%dv_50], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %dk_53 = ttng.tmem_store %cst_28_layout, %dk[%dk_52], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
+      %dv_54 = ttng.tmem_store %cst_28_layout, %dv[%dv_50], %true {ttg.partition = array<i32: 0>} : tensor<128x128xf32, #blocked1> -> !ttg.memdesc<128x128xf32, #tmem1, #ttng.tensor_memory, mutable>
       %curr_m:7 = scf.for %curr_m_68 = %c0_i32 to %num_steps step %c1_i32 iter_args(%arg47 = %c0_i32, %arg48 = %false, %qkT_69 = %qkT_48, %dpT_70 = %dpT_49, %dv_71 = %dv_54, %dq_72 = %dq_51, %dk_73 = %dk_53) -> (i32, i1, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token, !ttg.async.token)  : i32 {
         %q = arith.extsi %arg47 {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : i32 to i64
         %q_74 = arith.addi %off_bh_40, %q {loop.cluster = 1 : i32, loop.stage = 0 : i32, ttg.partition = array<i32: 0>} : i64

--- a/test/TritonGPU/accumulator-init.mlir
+++ b/test/TritonGPU/accumulator-init.mlir
@@ -311,6 +311,87 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return %17 : tensor<128x16xf32, #mma1>
   }
 
+// CHECK-LABEL: @packed_mul_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: tt.elementwise_inline_asm {{.*}} %[[ACC]], {{.*}}
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %[[USE_ACC]]
+  tt.func @packed_mul_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// CHECK-LABEL: @select_preserves_packed_mul_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: %[[SCALED:.+]] = tt.elementwise_inline_asm {{.*}} %[[ACC]], {{.*}}
+// CHECK: %[[SELECTED:.+]] = arith.select {{.*}}, %[[SCALED]], %[[ACC]]
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, %[[SELECTED]], %[[USE_ACC]]
+  tt.func @select_preserves_packed_mul_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>, %condition: tensor<128x16xi1, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %selected = arith.select %condition, %scaled, %acc : tensor<128x16xi1, #mma1>, tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %selected : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// The packed mul as the kernels actually emit it: movs around a single
+// mul.f32x2 (see inline_ptx_lib.py _mul_f32x2). Zero still propagates, so the
+// init must fold -- a matcher insisting on one instruction would reject every
+// real producer and silently disable this optimization.
+// CHECK-LABEL: @packed_mul_block_zero_init
+// CHECK-DAG: %[[FALSE:.+]] = arith.constant false
+// CHECK: scf.for {{.*}} iter_args(%[[ACC:.+]] = {{.*}}, %[[USE_ACC:.+]] = %[[FALSE]])
+// CHECK: ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %[[USE_ACC]]
+  tt.func @packed_mul_block_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "{\0A  .reg .b64 ra, rb, rc;\0A  mov.b64 ra, { $2, $3 };\0A  mov.b64 rb, { $4, $5 };\0A  mul.f32x2 rc, ra, rb;\0A  mov.b64 { $0, $1 }, rc;\0A}" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
+// This asm multiplies and THEN adds, so 0 * scale + 1.0 = 1.0 and the zero is
+// NOT preserved. It still contains the mul.f32x2 token and satisfies every
+// structural check, so a substring match would wrongly fold the init and
+// corrupt the first iteration. The accumulator must stay explicit: no
+// use-accumulator flag is threaded through the loop.
+// CHECK-LABEL: @packed_mul_then_add_no_zero_init
+// CHECK-NOT: arith.constant false
+// CHECK: scf.for {{.*}} iter_args({{.*}}) ->
+// CHECK: ttng.warp_group_dot
+  tt.func @packed_mul_then_add_no_zero_init(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %scale: tensor<128x16xf32, #mma1>) -> tensor<128x16xf32, #mma1> {
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %result = scf.for %i = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x16xf32, #mma1>) : i32 {
+      %scaled = tt.elementwise_inline_asm "mul.f32x2 $0, $2, $4;\0Aadd.f32x2 $0, $0, $0;" {constraints = "=r,=r,r,r,r,r", packed_element = 2 : i32, pure = true} %acc, %scale : tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1> -> tensor<128x16xf32, #mma1>
+      %next = ttng.warp_group_dot %A, %B, %scaled : !ttg.memdesc<128x64xf16, #shared, #smem> * !ttg.memdesc<64x16xf16, #shared1, #smem> -> tensor<128x16xf32, #mma1>
+      scf.yield %next : tensor<128x16xf32, #mma1>
+    }
+    tt.return %result : tensor<128x16xf32, #mma1>
+  }
+
 // CHECK-LABEL: @if_defines_alternative
 // CHECK: %[[ACC_NEXT:.+]] = ttng.warp_group_dot {{.*}}, {{.*}}, {{.*}}, %arg{{.*}} : !ttg.memdesc
   tt.func @if_defines_alternative(%A: !ttg.memdesc<128x64xf16, #shared, #smem>, %B: !ttg.memdesc<64x16xf16, #shared1, #smem>, %arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %ext: i32, %inc: tensor<64x16xi32, #blocked> {tt.divisibility = 16 : i32}) -> tensor<128x16xf32, #mma1> {

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -90,19 +90,77 @@ static Value computeLoopTripCount(OpBuilder &builder, Location loc,
   return castToI64(builder, loc, tripCount);
 }
 
-static Value computeLinearizedLoopPhase(OpBuilder &builder, Location loc,
-                                        scf::ForOp forOp) {
-  Value linearIter = computeLoopIterIndex(builder, loc, forOp);
-  Value stride = computeLoopTripCount(builder, loc, forOp);
-  for (auto parentFor = forOp->getParentOfType<scf::ForOp>(); parentFor;
-       parentFor = parentFor->getParentOfType<scf::ForOp>()) {
-    Value parentIter = computeLoopIterIndex(builder, loc, parentFor);
-    Value scaledParent =
-        arith::MulIOp::create(builder, loc, parentIter, stride);
-    linearIter = arith::AddIOp::create(builder, loc, scaledParent, linearIter);
-    Value parentTripCount = computeLoopTripCount(builder, loc, parentFor);
-    stride = arith::MulIOp::create(builder, loc, stride, parentTripCount);
+// Find an scf.while after-region argument which advances by one on every
+// iteration. AutoWS adds such an accumulation counter to persistent loops.
+// The condition can forward only an ordered subset of the before-region
+// arguments, so map the after argument back through scf.condition before
+// looking up its corresponding scf.yield operand.
+static Value findWhileIterationCounter(scf::WhileOp whileOp) {
+  auto forwarded = whileOp.getConditionOp().getArgs();
+  auto yielded = whileOp.getYieldedValues();
+  for (BlockArgument afterArg : whileOp.getAfterArguments()) {
+    unsigned afterIdx = afterArg.getArgNumber();
+    if (afterIdx >= forwarded.size())
+      continue;
+    auto beforeArg = dyn_cast<BlockArgument>(forwarded[afterIdx]);
+    if (!beforeArg || beforeArg.getOwner() != whileOp.getBeforeBody() ||
+        beforeArg.getArgNumber() >= yielded.size())
+      continue;
+
+    auto add = yielded[beforeArg.getArgNumber()].getDefiningOp<arith::AddIOp>();
+    if (!add)
+      continue;
+    Value increment;
+    if (add.getLhs() == afterArg)
+      increment = add.getRhs();
+    else if (add.getRhs() == afterArg)
+      increment = add.getLhs();
+    else
+      continue;
+    auto one = increment.getDefiningOp<arith::ConstantIntOp>();
+    if (one && one.value() == 1)
+      return afterArg;
   }
+  return {};
+}
+
+// Compute the rendezvous phase from loops that execute within the lifetime of
+// the barrier. phaseScope is the operation containing the barrier allocation;
+// loops outside it reinitialize the barrier and must not affect its phase.
+static Value computeBarrierPhase(OpBuilder &builder, Location loc,
+                                 Operation *mma, Operation *phaseScope) {
+  Value linearIter;
+  Value stride = arith::ConstantIntOp::create(builder, loc, 1, 64);
+  for (Operation *parent = mma->getParentOp(); parent && parent != phaseScope;
+       parent = parent->getParentOp()) {
+    Value iter;
+    Value tripCount;
+    if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+      iter = computeLoopIterIndex(builder, loc, forOp);
+      tripCount = computeLoopTripCount(builder, loc, forOp);
+    } else if (auto whileOp = dyn_cast<scf::WhileOp>(parent)) {
+      Value counter = findWhileIterationCounter(whileOp);
+      if (!counter) {
+        LDBG("Could not derive persistent while iteration for MMA at " << loc);
+        break;
+      }
+      iter = castToI64(builder, loc, counter);
+    } else {
+      continue;
+    }
+
+    Value contribution = arith::MulIOp::create(builder, loc, iter, stride);
+    linearIter = linearIter ? arith::AddIOp::create(builder, loc, contribution,
+                                                    linearIter)
+                                  .getResult()
+                            : contribution;
+    if (!tripCount)
+      break;
+    stride = arith::MulIOp::create(builder, loc, stride, tripCount);
+  }
+
+  if (!linearIter)
+    return arith::ConstantIntOp::create(builder, loc, 0, 32);
 
   Value two = arith::ConstantIntOp::create(builder, loc, 2, 64);
   Value rem = arith::RemUIOp::create(builder, loc, linearIter, two);
@@ -113,6 +171,7 @@ static Value computeLinearizedLoopPhase(OpBuilder &builder, Location loc,
 // MMA. The barrier must be allocated externally (before the containing loop
 // if the MMA is in a loop).
 static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
+                                Operation *phaseScope,
                                 unsigned barrierIdx = 0) {
   MLIRContext *ctx = mma.getContext();
   Location loc = mma.getLoc();
@@ -146,14 +205,9 @@ static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
   // Both CTAs arrive on leader's barrier (count=1 each, total=2).
   ttng::ArriveBarrierOp::create(builder, loc, remoteBar, /*count=*/1u);
 
-  // Compute phase from loop induction variable.
+  // Compute phase from iterations within the barrier's lifetime.
   // WaitBarrierOp expects I32 for the phase parameter.
-  Value phase;
-  if (auto forOp = mma->getParentOfType<scf::ForOp>()) {
-    phase = computeLinearizedLoopPhase(builder, loc, forOp);
-  } else {
-    phase = arith::ConstantIntOp::create(builder, loc, 0, 32);
-  }
+  Value phase = computeBarrierPhase(builder, loc, mma, phaseScope);
 
   // Only leader CTA waits: pred = (ctaRank % 2 == 0).
   Value two = arith::ConstantIntOp::create(builder, loc, 2, 32);
@@ -226,12 +280,14 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
       // alloc+init must be placed BEFORE the WarpSpecializeOp (so thread 0
       // from the producer warp group initializes it).
       Value barrierAlloc;
+      Operation *phaseScope;
       unsigned numBarriers = mmas.size();
       auto wsOp = forOp->getParentOfType<ttg::WarpSpecializeOp>();
       if (!wsOp) {
         // Pre-WS path: standard alloc before the for loop.
         barrierAlloc =
             triton::createBarrierAlloc(forOp, numBarriers, /*arriveCount=*/2);
+        phaseScope = forOp->getParentOp();
       } else if (isInDefaultRegion(mmas[0], wsOp)) {
         // Post-WS path, MMA in default region: The default region can
         // implicitly capture values defined before the WarpSpecializeOp,
@@ -255,6 +311,7 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
           rewriter.create<ttng::InvalBarrierOp>(invalView);
         }
         rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+        phaseScope = wsOp->getParentOp();
       } else {
         // Post-WS path, MMA in a partition region (IsolatedFromAbove):
         // Must capture the barrier explicitly into the partition.
@@ -288,15 +345,17 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
         }
         assert(capturedBarrier && "MMA not found in any partition region");
         barrierAlloc = capturedBarrier;
+        phaseScope = wsOp->getParentOp();
       }
 
       for (unsigned i = 0; i < numBarriers; ++i)
-        insertSyncBeforeMMA(mmas[i], barrierAlloc, i);
+        insertSyncBeforeMMA(mmas[i], barrierAlloc, phaseScope, i);
     }
 
     // Process standalone MMAs (rare: single-iteration epilogue).
     for (auto mma : nonLoopMMAs) {
       Value barrierAlloc;
+      Operation *phaseScope;
       auto wsOp = mma->getParentOfType<ttg::WarpSpecializeOp>();
       if (wsOp) {
         // A software-pipelined loop can leave prologue/epilogue MMA copies
@@ -312,6 +371,7 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
           lifetimeAnchor = lifetimeAnchor->getParentOp();
         barrierAlloc = triton::createBarrierAlloc(
             lifetimeAnchor, /*numBarriers=*/1, /*arriveCount=*/2);
+        phaseScope = lifetimeAnchor->getParentOp();
 
         if (!isInDefaultRegion(mma, wsOp)) {
           auto partOp = wsOp.getPartitionOp();
@@ -329,8 +389,9 @@ struct Insert2CTASync : public impl::NVGPUInsert2CTASyncBase<Insert2CTASync> {
       } else {
         barrierAlloc = triton::createBarrierAlloc(mma, /*numBarriers=*/1,
                                                   /*arriveCount=*/2);
+        phaseScope = mma->getParentOp();
       }
-      insertSyncBeforeMMA(mma, barrierAlloc);
+      insertSyncBeforeMMA(mma, barrierAlloc, phaseScope);
     }
   }
 };

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.cpp
@@ -22,39 +22,6 @@ namespace mlir {
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
-SmallVector<bool> getAutoWSBooleanFlags(triton::FuncOp funcOp,
-                                        ArrayRef<StringRef> keys) {
-  SmallVector<bool> flags(keys.size(), false);
-  unsigned pending = keys.size();
-  if (pending == 0)
-    return flags;
-  funcOp.walk([&](Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>(tt::kAutoWSAnnotationAttrName);
-    if (!attr)
-      return WalkResult::advance();
-    auto parsed = llvm::json::parse(attr.getValue());
-    if (!parsed) {
-      llvm::consumeError(parsed.takeError());
-      return WalkResult::advance();
-    }
-    auto *object = parsed->getAsObject();
-    if (!object)
-      return WalkResult::advance();
-    for (unsigned i = 0; i < keys.size(); ++i) {
-      if (flags[i] || !object->getBoolean(keys[i]).value_or(false))
-        continue;
-      flags[i] = true;
-      --pending;
-    }
-    return pending == 0 ? WalkResult::interrupt() : WalkResult::advance();
-  });
-  return flags;
-}
-
-bool getAutoWSBooleanFlag(triton::FuncOp funcOp, StringRef key) {
-  return getAutoWSBooleanFlags(funcOp, {key}).front();
-}
-
 void removeWarpSpecMetadata(triton::FuncOp funcOp) {
   // The canonical set of attributes AutoWS stamps on ops/loops. `removeAttr` is
   // a no-op when the attribute is absent, so a single walk over every op

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -29,25 +29,6 @@ namespace tt = mlir::triton;
 constexpr llvm::StringLiteral kAtomicBroadcastCopiesAttrName =
     "ttg.atomic_broadcast_copies";
 
-// Boolean opt-in switches carried by the `tt.autows` JSON annotation
-// (tt::kAutoWSAnnotationAttrName). Named here so every pass that reads one
-// shares a single source of truth for the spelling.
-constexpr llvm::StringLiteral kAutoWSFuseFinalStatsKey =
-    "two_cta_fuse_final_stats";
-constexpr llvm::StringLiteral kAutoWSFuseAccSlicesKey =
-    "two_cta_fuse_acc_slices";
-constexpr llvm::StringLiteral kAutoWSTwoCTADirectWaitKey =
-    "two_cta_tma_direct_wait";
-
-// Answer a set of `tt.autows` boolean switches with one walk over funcOp: each
-// annotated op's JSON is parsed once for all keys, and the walk stops as soon
-// as every key has been seen set. Returns one entry per requested key, in the
-// order the keys were given. A switch is on when any annotation in the
-// function sets it to true.
-SmallVector<bool> getAutoWSBooleanFlags(triton::FuncOp funcOp,
-                                        ArrayRef<StringRef> keys);
-bool getAutoWSBooleanFlag(triton::FuncOp funcOp, StringRef key);
-
 // Strip every warp-specialization metadata attribute that AutoWS stamps on
 // ops/loops. Every graceful-reject path must call this so the downstream
 // tritongpu-pipeline pass sees a plain, compilable non-WS kernel; a leftover WS
@@ -357,8 +338,7 @@ optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                  Value phase, Operation *headProducer, Operation *headConsumer,
                  Operation *headConsumerSameLevel,
                  ArrayRef<int> additionalConsumerTaskIds = {},
-                 DictionaryAttr consumerWaitConstraints = {},
-                 bool twoCTADirectWait = false);
+                 DictionaryAttr consumerWaitConstraints = {});
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
                        Value idx);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -2446,11 +2446,6 @@ void insertAsyncComm(
     const DenseMap<Channel *, std::pair<Operation *, Operation *>> &copyOpMap,
     DenseSet<Operation *> &regionsWithChannels, ReuseConfig *config) {
 
-  // The `tt.autows` switches are fixed for the whole function, so read them
-  // once here instead of re-walking and re-parsing per fused TMA barrier.
-  const bool twoCTADirectWait =
-      getAutoWSBooleanFlag(funcOp, kAutoWSTwoCTADirectWaitKey);
-
   // SubtiledRegionOp is a sequencing marker, not a control flow boundary.
   // Skip it when walking parent chains so that ops inside it are treated
   // as being at the same nesting level as the parent block.
@@ -4529,10 +4524,10 @@ void insertAsyncComm(
               funcOp.getContext(), masterChannel->relation.first,
               WSBarrierAttr::kDirectionForward)
               .build(funcOp.getContext());
-      optimizeTMALoads(
-          builder, tmaLoads, *commChannel.producerBarrier, bufferIdx, bufferIdx,
-          phase, tmaHeadProducer, headConsumer, consumerWaitPoint,
-          additionalConsumerTaskIds, waitConstraints, twoCTADirectWait);
+      optimizeTMALoads(builder, tmaLoads, *commChannel.producerBarrier,
+                       bufferIdx, bufferIdx, phase, tmaHeadProducer,
+                       headConsumer, consumerWaitPoint,
+                       additionalConsumerTaskIds, waitConstraints);
     }
   }
 
@@ -5578,82 +5573,6 @@ void doCodePartition(triton::FuncOp funcOp, unsigned numBuffers) {
     }
   }
 
-  // Collapse an ordered run of single-buffer TMEM channels onto its first
-  // member: the representative absorbs the consumer lists of every later
-  // channel whose endpoints pair up with its own, so the whole run needs one
-  // handshake instead of one per channel. `hasFusableEndpoints` picks the
-  // producer/consumer op kinds a run is made of; `requireSameAlloc`
-  // additionally pins the run to one TMEM allocation. Both 2-CTA fusions below
-  // differ only in those two knobs, so a change to the merge rules applies to
-  // both.
-  auto fuseOrderedTmemChannels =
-      [&](ArrayRef<Channel *> candidates,
-          llvm::function_ref<bool(Channel *)> hasFusableEndpoints,
-          bool requireSameAlloc) {
-        auto isFusable = [&](Channel *ch) {
-          return ch->channelKind == DataChannelKind::TMEMAlloc &&
-                 ch->getNumBuffers() == 1 && hasFusableEndpoints(ch);
-        };
-        for (size_t i = 0; i < candidates.size(); ++i) {
-          Channel *rep = candidates[i];
-          if (mergedChannels.contains(rep) || !isFusable(rep))
-            continue;
-          auto repIt = channelsGroupedByConsumers.find(rep);
-          if (repIt == channelsGroupedByConsumers.end())
-            continue;
-          for (size_t j = i + 1; j < candidates.size(); ++j) {
-            Channel *ch = candidates[j];
-            if (mergedChannels.contains(ch) || !isFusable(ch) ||
-                ch->relation != rep->relation ||
-                (requireSameAlloc && ch->getAllocOp() != rep->getAllocOp()) ||
-                ch->getSrcOp()->getBlock() != rep->getSrcOp()->getBlock() ||
-                ch->getDstOp()->getBlock() != rep->getDstOp()->getBlock())
-              continue;
-            auto chIt = channelsGroupedByConsumers.find(ch);
-            if (chIt == channelsGroupedByConsumers.end())
-              continue;
-            repIt->second.append(chIt->second.begin(), chIt->second.end());
-            channelsGroupedByConsumers.erase(chIt);
-            mergedChannels.insert(ch);
-          }
-        }
-      };
-
-  SmallVector<bool> autoWSFuseFlags = getAutoWSBooleanFlags(
-      funcOp, {kAutoWSFuseFinalStatsKey, kAutoWSFuseAccSlicesKey});
-
-  // The 2-CTA FA forward schedule stores its final softmax sum and maximum in
-  // adjacent slots of one physical TMEM allocation, then loads both in the
-  // default partition.  Their producer and consumer ops differ, so the exact
-  // consumer matching above leaves two token handshakes.  TLX uses one: wait
-  // before the first load, release after the last load, acquire before the
-  // first store, and commit after the last store.  Form the same ordered group
-  // only for opted-in, single-buffer TMEM store/load channels whose endpoints
-  // are in the same blocks and tasks.
-  if (autoWSFuseFlags[0]) {
-    auto isStoreToLoad = [](Channel *ch) {
-      return isa<ttng::TMEMStoreOp>(ch->getSrcOp()) &&
-             isa<ttng::TMEMLoadOp>(ch->getDstOp());
-    };
-    for (auto &group : config.groups)
-      fuseOrderedTmemChannels(group.channels, isStoreToLoad,
-                              /*requireSameAlloc=*/false);
-  }
-
-  // A subtiled accumulator has one MMAv5 producer and one TMEM-load consumer
-  // per slice. The slices share an allocation and advance in lockstep, so a
-  // single completion handshake can cover the ordered producer/consumer
-  // range: completion is attached to the last MMA and the wait is placed
-  // before the first load. This matches TLX's one accumulator barrier per
-  // compute group instead of one pair per slice.
-  if (autoWSFuseFlags[1]) {
-    auto isMmaToLoad = [](Channel *ch) {
-      return isa<ttng::MMAv5OpInterface>(ch->getSrcOp()) &&
-             isa<ttng::TMEMLoadOp>(ch->getDstOp());
-    };
-    fuseOrderedTmemChannels(orderedChannels, isMmaToLoad,
-                            /*requireSameAlloc=*/true);
-  }
   orderedChannels.erase(
       llvm::remove_if(orderedChannels,
                       [&](Channel *ch) { return mergedChannels.count(ch); }),

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -334,8 +334,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Operation *headProducer, Operation *headConsumer,
                             Operation *headConsumerSameLevel,
                             ArrayRef<int> additionalConsumerTaskIds,
-                            DictionaryAttr consumerWaitConstraints,
-                            bool twoCTADirectWait) {
+                            DictionaryAttr consumerWaitConstraints) {
   // Callers group at least one load behind each fused barrier. Make the
   // precondition explicit instead of dereferencing front() blind below.
   if (tmaLoads.empty())
@@ -417,18 +416,15 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
       loc, builder.getI32Type(), phase);
   Value waitPred =
       builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
-  bool directTwoCTAWait = twoCTA && twoCTADirectWait;
   Value followerWaitPred;
   Value peerBarrier;
   if (twoCTA) {
     TwoCTAPairRank rank = buildTwoCTAPairRank(builder, loc);
     waitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
         loc, arith::CmpIPredicate::eq, rank.rankInPair, rank.zero);
-    if (!directTwoCTAWait) {
-      followerWaitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::ne, rank.rankInPair, rank.zero);
-      peerBarrier = mapBarrierTo2CTAPeer(builder, loc, consBarrier, rank.ctaId);
-    }
+    followerWaitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
+        loc, arith::CmpIPredicate::ne, rank.rankInPair, rank.zero);
+    peerBarrier = mapBarrierTo2CTAPeer(builder, loc, consBarrier, rank.ctaId);
   }
 
   // Create one WaitBarrierOp per consumer task ID.
@@ -436,7 +432,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
   builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
       loc, consBarrier, phase, waitPred, /*deps=*/ValueRange{},
       consumerWaitConstraints);
-  if (twoCTA && !directTwoCTAWait) {
+  if (twoCTA) {
     // The hardware CTA-group TMA transaction completes the leader's local
     // mbarrier. Relay that completion to the follower's corresponding local
     // barrier, then let the follower wait on it. A cluster barrier is not
@@ -455,7 +451,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
         loc, consBarrier, phase, waitPred,
         /*deps=*/ValueRange{}, consumerWaitConstraints);
-    if (twoCTA && !directTwoCTAWait) {
+    if (twoCTA) {
       builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
           loc, /*bCluster=*/false);
       builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(

--- a/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
+++ b/third_party/tlx/tutorials/fused_attention_ws_device_tma.py
@@ -121,9 +121,6 @@ def _attn_fwd_subtile(
                 "opndD,tmem,1,0",
             ],
             "two_cta_interleave_role": "qk" if TWO_CTAS else None,
-            "two_cta_tma_direct_wait": TWO_CTAS,
-            "two_cta_fuse_final_stats": TWO_CTAS,
-            "two_cta_fuse_acc_slices": TWO_CTAS,
         } if MMA_SLICES == 2 else None),
         two_ctas=TWO_CTAS,
     )
@@ -215,12 +212,6 @@ def _attn_fwd_subtile(
             attrs={
                 "two_cta_interleave_role": "pv" if TWO_CTAS else None,
                 "channels": ["opndA,tmem,1,0,64"],
-                # Inner-warp-specialized (non-persistent) schedules keep both
-                # slices adjacent in one partition, so the first rendezvous
-                # covers the second.  Persistent schedules pipeline the
-                # shared V allocation across iterations and need the second
-                # rendezvous before that slot can rotate.
-                "two_cta_sync_covered_by_prior": TWO_CTAS and INNER_WARP_SPECIALIZE,
             },
             two_ctas=TWO_CTAS,
         )


### PR DESCRIPTION
Summary:

The 2-CTA FA forward kernel carried three opt-in switches in the `tt.autows` JSON on its `qk` contraction. Each made the AutoWS scheduler drop synchronization the compiler would otherwise emit, on a premise nothing verifies, and none earns its keep. Remove all three, plus the now-unused `getAutoWSBooleanFlags`/`getAutoWSBooleanFlag` helpers and the `twoCTADirectWait` parameter threaded from `insertAsyncComm` into `optimizeTMALoads`.

What each did, and what it was worth on the forward path (B=4 H=48 D=128 fp16, GB200, denoise-locked idle device, rep 3000, medians of 5 runs, positive = the switch helped):

  two_cta_tma_direct_wait   +1.49% / +1.73% / +1.23% at N_CTX 2048 / 4096 / 8192
      A cooperative CTA-group TMA completes only the leader's mbarrier, so the follower's completion is relayed: fence_async_shared, arrive on the peer barrier, then the follower waits. The switch deleted that relay and left only the leader waiting, asserting the follower was already ordered by something else. The only switch whose gain separated from run-to-run noise at every length.

  two_cta_fuse_final_stats  +0.60% / +0.39% / -0.19%
      The final softmax sum and maximum occupy adjacent slots of one TMEM allocation but have distinct producer and consumer ops, so exact consumer matching leaves two token handshakes. The switch collapsed them into one. Only the shortest sequence separated from noise; the longest is negative.

  two_cta_fuse_acc_slices   +0.04% / -0.24% / -0.46%
      A subtiled accumulator has one MMAv5 producer and one TMEM-load consumer per slice. The switch collapsed the per-slice handshakes into one for the group, on the premise that slices advance in lockstep. Never separated from noise, negative at both larger lengths.

Removing all three costs 1.0-1.8% of forward throughput, essentially all of it `two_cta_tma_direct_wait`:

  N_CTX   AutoWS before -> after     TLX control        AutoWS as % of TLX
   2048   1199.8 -> 1178.8 (-1.76%)  1272.3 -> 1272.5   94.30% -> 92.63%
   4096   1273.8 -> 1248.8 (-1.97%)  1429.7 -> 1413.3   89.09% -> 88.36%
   8192   1315.4 -> 1301.9 (-1.03%)  1459.4 -> 1460.4   90.14% -> 89.15%

The TLX column is a cross-build control; it moves at most 1.15%, so the normalized last column is the honest read of the cost. That cost is accepted deliberately: two of the three switches are worthless or negative, and the third buys ~1.5% for an unverified synchronization elision whose failure mode is a silent race.

Also drops `two_cta_sync_covered_by_prior` from the second PV contraction. Its only reader lived in `Insert2CTASync.cpp` and arrived with D116999847, which is not in this stack, so the kernel was writing a key nothing consumed. Nothing reported it: unknown `tt.autows` keys are ignored, so an orphan is indistinguishable from a switch that is off. It elided a cross-CTA rendezvous for the second V slice when both slices sat adjacent in one inner-warp-specialized partition; with no reader the rendezvous is simply always emitted. If D116999847 later lands, the switch and its reader should come back together.

`two_cta_interleave_role` is deliberately kept. It is not a boolean switch and elides no synchronization: `WSDataPartition` reads it to rewrite the `stage` and `order` keys once each contraction has a concrete partition index, which is how the QK0/PV1/QK1/PV0 interleave is expressed at all.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D118001970


