### PR TITLE
[BUILD] Initialize submodules before dev LLVM build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ dev-install: dev-install-requires dev-install-triton
 .PHONY: dev-install-llvm
 .NOPARALLEL: dev-install-llvm
 dev-install-llvm:
+	git submodule update --init --recursive
 	LLVM_BUILD_PATH=$(LLVM_BUILD_PATH) scripts/build-llvm-project.sh
 	LLVM_INCLUDE_DIRS=$(LLVM_BUILD_PATH)/include \
 		LLVM_LIBRARY_DIR=$(LLVM_BUILD_PATH)/lib \


### PR DESCRIPTION
Summary:
The CPU backend includes the SLEEF library as a submodule. So, a plain git clone leaves SLEEF uninitialized. It requires a recursive clone. So, let's initialize recursive submodules before starting the LLVM build so `make dev-install-llvm` works from a fresh checkout and reports fetch failures early.

Test Plan:
Fresh non-recursive checkout verified the target initializes SLEEF first:

```
Submodule path 'third_party/sleef': checked out '93f04d869471ce4d007abaebb8c6a7bc62749f61'
```

Fresh build and CPU smoke test:

```
LLVM: 7518/7518 targets built
Triton/SLEEF: 787/787 targets built
backend=cpu
correct=True
```