### PR TITLE
[AutoWS] Split truncated B loads for 2CTA MMA

### DIFF
--- a/python/test/unit/language/test_dot_2cta.py
+++ b/python/test/unit/language/test_dot_2cta.py
@@ -210,6 +210,28 @@ def _tl_dot_2cta_persistent_meta_ws_kernel(
         c_desc.store([offs_m, offs_n], acc.to(tl.bfloat16))
 
 
+@triton.jit
+def _tl_dot_2cta_truncated_b_kernel(a_desc, b_desc, c_desc):
+    """Exercise a descriptor-fed B producer before a 2CTA dot."""
+    start_pid = tl.program_id(0)
+    for tile_id in tl.range(
+            start_pid,
+            2,
+            2,
+            warp_specialize=True,
+            data_partition_factor=1,
+    ):
+        offs_m = tile_id * 128
+        acc = tl.zeros([128, 256], dtype=tl.float32)
+        for offs_k in range(0, 128, 64):
+            a = a_desc.load([offs_m, offs_k])
+            # Preserve the explicit producer rounding point.  The 2CTA load
+            # transform must split the descriptor before recreating this cast.
+            b = b_desc.load([offs_k, 0]).to(tl.bfloat16)
+            acc = tl.dot(a, b, acc, two_ctas=True)
+        c_desc.store([offs_m, 0], acc.to(tl.bfloat16))
+
+
 @pytest.mark.parametrize("DATA_PARTITION_FACTOR", [1, 2])
 @pytest.mark.parametrize("m", [512, 384])
 def test_tl_dot_2cta_persistent_meta_ws(DATA_PARTITION_FACTOR, m, device):
@@ -277,6 +299,42 @@ def test_tl_dot_2cta_persistent_meta_ws(DATA_PARTITION_FACTOR, m, device):
     ttgir = kernel.asm["ttgir"]
     assert "ttg.warp_specialize" in ttgir
     assert "two_ctas" in ttgir
+
+
+def test_tl_dot_2cta_truncated_b(device):
+    torch.manual_seed(0)
+    a = torch.randn((256, 128), device=device, dtype=torch.bfloat16)
+    b = torch.randn((128, 256), device=device, dtype=torch.float32)
+    c = torch.empty((256, 256), device=device, dtype=torch.bfloat16)
+
+    a_desc = TensorDescriptor(a, a.shape, a.stride(), [128, 64])
+    b_desc = TensorDescriptor(b, b.shape, b.stride(), [64, 256])
+    c_desc = TensorDescriptor(c, c.shape, c.stride(), [128, 256])
+
+    def alloc_fn(size: int, align: int, stream: Optional[int]):
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+    with triton.knobs.nvidia.scope():
+        triton.knobs.nvidia.use_meta_ws = True
+        compiled = _tl_dot_2cta_truncated_b_kernel[(2, )](
+            a_desc,
+            b_desc,
+            c_desc,
+            num_warps=8,
+            num_stages=4,
+            ctas_per_cga=(2, 1, 1),
+        )
+
+    reference = torch.matmul(a.float(), b.to(torch.bfloat16).float()).to(
+        torch.bfloat16
+    )
+    torch.testing.assert_close(c, reference, atol=1.0, rtol=2e-2)
+
+    ttgir = compiled.asm["ttgir"]
+    assert "ttg.warp_specialize" in ttgir
+    assert "two_ctas" in ttgir
+    assert "!tt.tensordesc<64x128xf32" in ttgir
 def test_tl_dot_2cta_sliced_dependent_chain(device):
     torch.manual_seed(0)
     q = torch.randn((256, 128), device=device, dtype=torch.bfloat16)

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -126,6 +126,7 @@ struct BLoadTrace {
   ttg::LocalAllocOp localAlloc;
   ttg::MemDescTransOp memDescTrans;
   tt::TransOp trans;
+  arith::TruncFOp trunc;
   unsigned splitDim = 1;
 };
 
@@ -155,6 +156,17 @@ static FailureOr<BLoadTrace> traceToDescriptorLoad(Value bMemDesc) {
   while (auto cvt = tensor.getDefiningOp<ttg::ConvertLayoutOp>())
     tensor = cvt.getSrc();
 
+  // A producer-fused B operand can load FP32 through TMA and explicitly round
+  // it to BF16 before the dot.  Preserve that rounding, but move it after the
+  // per-CTA descriptor split so each CTA converts and stages only its N half.
+  arith::TruncFOp trunc;
+  if (auto truncOp = tensor.getDefiningOp<arith::TruncFOp>()) {
+    trunc = truncOp;
+    tensor = trunc.getIn();
+    while (auto cvt = tensor.getDefiningOp<ttg::ConvertLayoutOp>())
+      tensor = cvt.getSrc();
+  }
+
   tt::TransOp trans;
   if (auto transOp = tensor.getDefiningOp<tt::TransOp>()) {
     trans = transOp;
@@ -172,7 +184,7 @@ static FailureOr<BLoadTrace> traceToDescriptorLoad(Value bMemDesc) {
   if (!descLoad)
     return failure();
 
-  return BLoadTrace{descLoad, localAlloc, memDescTrans, trans, splitDim};
+  return BLoadTrace{descLoad, localAlloc, memDescTrans, trans, trunc, splitDim};
 }
 
 struct Transform2CTALoads
@@ -419,6 +431,7 @@ struct Transform2CTALoads
     auto localAlloc = trace->localAlloc;
     auto memDescTrans = trace->memDescTrans;
     auto trans = trace->trans;
+    auto trunc = trace->trunc;
     unsigned splitDim = trace->splitDim;
 
     // Use the descriptor's original type. Host-side TMA descriptor arguments
@@ -519,13 +532,24 @@ struct Transform2CTALoads
       allocSrc = tt::TransOp::create(builder, trans.getLoc(), allocSrc,
                                      trans.getOrder());
     }
+    if (trunc) {
+      builder.setInsertionPoint(localAlloc);
+      auto srcType = cast<RankedTensorType>(allocSrc.getType());
+      auto oldResultType = cast<RankedTensorType>(trunc.getOut().getType());
+      auto truncType = RankedTensorType::get(
+          srcType.getShape(), oldResultType.getElementType(),
+          srcType.getEncoding());
+      allocSrc = arith::TruncFOp::create(builder, trunc.getLoc(), truncType,
+                                         allocSrc);
+    }
 
     auto origMemDescType = cast<ttg::MemDescType>(localAlloc.getType());
     auto allocSrcType = cast<RankedTensorType>(allocSrc.getType());
     auto newMemDescEncoding = shrinkSwizzleForShape(
         origMemDescType.getEncoding(), allocSrcType.getShape());
     auto newMemDescType = ttg::MemDescType::get(
-        allocSrcType.getShape(), elemType, newMemDescEncoding,
+        allocSrcType.getShape(), allocSrcType.getElementType(),
+        newMemDescEncoding,
         origMemDescType.getMemorySpace(), origMemDescType.getMutableMemory());
 
     builder.setInsertionPoint(localAlloc);
@@ -550,6 +574,9 @@ struct Transform2CTALoads
     // Clean up old transpose if no other users.
     if (trans && trans.getResult().use_empty())
       trans.erase();
+
+    if (trunc && trunc.getResult().use_empty())
+      trunc.erase();
 
     // Clean up old descriptor_load if no other users.
     if (descLoad.getResult().use_empty())


### PR DESCRIPTION
## Summary

Teach `Transform2CTALoads` to trace the simple `descriptor load FP32 -> arith.truncf BF16 -> local allocation -> 2CTA dot` RHS path. The pass creates the per-CTA half-width descriptor load first, then recreates the truncation on the split tile.

Without this, the descriptor load was treated as cooperative but the value feeding the 2CTA MMA remained full-width, producing incorrect output.

## Correctness

- Before: representative 2CTA cast case relative-L2 approximately `0.895`.
- After: focused unit case relative-L2 approximately `3.68e-4`; production-size proxy `2.60e-5`, bitwise repeatable.
- Ordinary materialized-B 2CTA performance was unchanged within measurement noise.

## Tests

`python -m pytest -q python/test/unit/language/test_dot_2cta.py::test_tl_dot_2cta_truncated_b python/test/unit/language/test_dot_2cta.py::test_tl_dot_2cta_persistent_meta_ws`

5 passed.

## Scope

This is intentionally narrow: it handles a single descriptor-load-to-`arith.truncf` path only. It does not yet propagate 2CTA ownership through arbitrary multi-input pointwise producers.