### PR TITLE
[TLX][Agent] Add the gfx942 kernel-optimization harness

### DIFF
--- a/third_party/tlx/doc/kernel_opt/README.md
+++ b/third_party/tlx/doc/kernel_opt/README.md
@@ -1,0 +1,31 @@
+# Curated kernel-optimization knowledge
+
+One file per GPU architecture. These files are the human-curated prior that the
+kernel-optimization agent
+(`third_party/tlx/tools/agents/kernel_optimization/`) is given before it
+proposes anything, so that a round starts from what we already know instead of
+from blind exploration.
+
+| File | Target |
+|---|---|
+| `gfx942.md` | CDNA3 / MI300X |
+
+## Contract
+
+- **Human-write-only.** The agent reads these files; it never edits them. Agent
+  findings land in `experiments/` under the run's output dir and are promoted
+  into a file here only by a human who has read the evidence.
+- **Every entry carries its evidence and its provenance.** A claim with no
+  number behind it does not belong here.
+- **Measured-on-this-arch and ported-from-another-arch are separate sections.**
+  A CDNA4 result is a hypothesis for CDNA3, not a fact about it, and mixing the
+  two is how an agent gets confidently wrong. Moving an entry up from the
+  ported section requires a measurement on the target part.
+- **Concise beats complete.** This text is injected into a prompt. An entry that
+  does not change what a candidate would do is costing tokens for nothing.
+
+## How it is consumed
+
+A harness under `harnesses/<arch>/` reads the file for its own arch and the
+provider injects it into the candidate prompt preamble. Nothing else parses
+these files, so prose is fine; keep the section headings stable.

--- a/third_party/tlx/doc/kernel_opt/gfx942.md
+++ b/third_party/tlx/doc/kernel_opt/gfx942.md
@@ -1,0 +1,117 @@
+# gfx942 — CDNA3 / MI300X
+
+Curated prior for the kernel-optimization agent. Read `README.md` in this
+directory for the contract; the short version is that everything below carries
+its evidence, and "measured on gfx942" and "measured on some other part" are
+kept apart on purpose.
+
+## 1. Hardware facts
+
+- **304 CUs across 8 XCDs** (38 CU/XCD). Consecutive workgroup ids are
+  dispatched **round-robin over the XCDs**, so tiles that should share operands
+  in one L2 land on different chiplets unless the grid is remapped.
+- **64 KB LDS per workgroup.** CDNA4 has 160 KB. Tile sizes ported from a
+  gfx950 kernel will usually not fit: 256x256 with BLOCK_K=64 and two buffers
+  wants ~128 KB, and even 256x128x64 needs 96 KB.
+- **256 MB Infinity Cache.** `torch`'s `L2_cache_size` reports 4 MB, which is
+  the wrong number to size a cache-flush buffer against — using it under-rotates
+  by ~64x and leaves the measurement warm.
+- **fp16 MFMA is `v_mfma_f32_16x16x16_f16` / `v_mfma_f32_32x32x8_f16`** — half
+  the K of CDNA4's `16x16x32` / `32x32x16`. Pass `matrix_instr_nonkdim=16`.
+- **No C launch dispatcher.** It needs the NVIDIA backend's
+  `asm["launch_metadata"]`, which the AMD backend never emits, so every launch
+  goes through Python. Set `TRITON_USE_C_DISPATCHER=0` to skip a branch that
+  cannot succeed.
+
+## 2. Measured on gfx942
+
+**Operand path: register-staged, not direct-to-LDS.**
+`global --tl.load--> VGPR --tlx.local_store--> LDS --tlx.local_load--> MFMA` is
+the fastest path on CDNA3. The gfx950 tutorials all stage with
+`buffer_load_to_local`; that choice does not carry over.
+_Source: `third_party/tlx/ops/kernels/mm/gfx942.py` docstring._
+
+**Per-shape tile selection is the single largest effect — ~1.15x vs 0.35x at
+1024³.** With 304 CUs no single tile serves both ends: a 1024² output is only 16
+tiles of 256x256 and leaves the chip idle (0.35x aten), while the 64x64 tile
+that wins there collapses to 0.54x at 4096³.
+_Source: same docstring._
+
+**Ring depth is not the lever it looks like.** `NUM_BUFFERS=1` wins 8 of the 12
+shape/dtype cases in the perf script, including both 8192³ and both rectangular
+ones; depth 2 takes 2048³ and fp16 4096³. On a 64 KB budget the LDS a second
+buffer costs is usually better spent widening the tile.
+_Source: same docstring._
+
+**XCD remap is neutral once a GROUP_M swizzle exists** — 0.86x aten with the
+remap vs 0.87x without at 4096³, and 0.79x vs 0.79x at 8192³, i.e. inside the
+noise. The swizzle already captures the reuse the remap is meant to restore.
+Keep it as the standard grid transform, but do not expect it to buy anything.
+_Source: same docstring._
+
+**`do_bench` in short bursts is unusable as a gate on this part.** Wrapping
+`do_bench` in bursts separated by sleeps prevents clocks from ever settling;
+burst-to-burst variation measured **14-20%** at 1024³ addmm. Warm continuously,
+then take one timed window, and report p50 with a p20/p80 band.
+_Source: `third_party/tlx/tutorials/testing/gfx942_perf_harness.py` docstring._
+
+**Short shapes measure the launch path, not the kernel.** At 1024³: aten 16.8
+µs/call against TLX 48.1 µs, the gap being the autotuner wrapper plus a Python
+launch. Treat any row whose per-call time is within an order of magnitude of
+~40 µs as launch-bound and do not read it as a statement about the kernel.
+_Source: same docstring._
+
+**Baseline, `tlx.ops.mm` on gfx942 vs aten (`torch.matmul` → hipBLASLt), fp16,
+clocks locked via `denoise.sh`, 2026-08-27, devgpu018.cco5:**
+
+| M | N | K | aten TFLOPS | TLX TFLOPS | vs aten |
+|---|---|---|---|---|---|
+| 1024 | 1024 | 1024 | 86.5 | 38.3 | 0.44x (launch-bound) |
+| 2048 | 2048 | 2048 | 319.6 | 283.3 | 0.89x |
+| 4096 | 4096 | 4096 | 594.2 | 494.9 | 0.83x |
+| 8192 | 8192 | 8192 | 609.8 | 485.5 | 0.80x |
+| 1024 | 8192 | 8192 | 545.0 | 492.0 | 0.90x |
+| 8192 | 1024 | 8192 | 545.7 | 459.9 | 0.84x |
+
+Winning tiles, in table order: 64³/NB1 · 128x128x64/NB2 · 256x256x32/NB2 ·
+256x256x32/NB2 · 128x128x32/NB1 · 128x128x32/NB1.
+
+## 3. Ported from gfx950 (CDNA4) — hypotheses, not yet measured on gfx942
+
+All of these come from `third_party/tlx/tutorials/gfx9_gemm/a16w16/README.md`,
+a v0→v9 ladder measured on MI355 at M=N=4096, K=8192, fp16, 256x256x64 tiles,
+where rocBLAS steady ≈ 1160 TFLOPS. **That ladder stages operands with
+`buffer_load_to_local`, which is the wrong path on CDNA3 (§2), so the load
+mechanism does not port. The scheduling ideas below are separable from it and
+are the reason this section exists.**
+
+- **`tlx.warp_pipeline_stage` (→ `s_setprio`) is the largest hot-loop win
+  there**: v7 913T / 79% → v8 1005T / 86%. Each region is split into an MFMA
+  stage (priority 0, yields) and a memory stage (priority 1, issues first) so
+  loads overlap the math. Needs **8 warps** so accumulators stay in AGPRs.
+- **N-slicing B into halves with a 4-region manual pipeline** (v7): 913T / 79%,
+  up from v6's 859T / 74%.
+- **Step-2 loop unrolling with alternating register sets** (v6): 836T → 859T.
+- **`other=0.0` on `buffer_load` costs ~1.8x** (590T → 319T). The compiler
+  emits register copies to implement the fallback for masked-out lanes, and on
+  AMD `buffer_load` with a mask already returns 0. Never pass it.
+- **`TRITON_DISABLE_POST_MISCHED=1` is worth ~1-2%** on a hand-scheduled hot
+  loop; without it the LLVM post-RA machine scheduler re-orders the interleave.
+- **The remaining gap to rocBLAS there is LLVM instruction scheduling** —
+  Gluon's published best uses custom `llirSched` / `amdgcnSched` passes that the
+  default backend scheduler does not match.
+
+Relative to that ladder, `tlx.ops.mm` on gfx942 today sits at roughly **v4/v5 plus
+v9**: a manual global-prefetch ring and the XCD remap, with none of v6, v7 or
+v8. That is the most concrete statement available about where its headroom is,
+and it is a hypothesis until measured here.
+
+## 4. Open — no measurement either way
+
+- Whether `s_setprio` scheduling helps a *register-staged* hot loop as much as
+  it helps a direct-to-LDS one. The mechanism (issue memory ahead of MFMA) is
+  not obviously tied to the staging path, but nothing has been run.
+- Whether 8 warps is affordable on CDNA3 at these tile sizes, given the AGPR
+  requirement that makes v8 want them.
+- `waves_per_eu` is pinned at 0 in every shipped config and has never been swept.
+- The 48 µs launch cost is not a kernel problem and no work has gone into it.

--- a/third_party/tlx/tools/agents/kernel_optimization/cli.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/cli.py
@@ -32,14 +32,18 @@ def _parse_args(arguments: list[str] | None = None) -> argparse.Namespace:
         description="Optimize a Triton or TLX kernel with a deterministic harness."
     )
     parser.add_argument("--kernel", type=Path, required=True)
-    parser.add_argument("--reference-kernel", type=Path, default=None, help="Optional reference kernel source used as correctness oracle (harness verify can compare candidate vs reference).")
+    parser.add_argument(
+        "--reference-kernel", type=Path, default=None, help=
+        "Optional reference kernel source used as correctness oracle (harness verify can compare candidate vs reference)."
+    )
     parser.add_argument("--harness", type=Path, default=None)
     parser.add_argument("--cases", type=Path, default=None)
     parser.add_argument("--target", type=Path, default=None)
     parser.add_argument(
         "--arch",
         default=None,
-        help="Target arch under harnesses/<arch>/targets/<kernel> (e.g. blackwell, hopper, host). Defaults to first available.",
+        help=
+        "Target arch under harnesses/<arch>/targets/<kernel> (e.g. blackwell, hopper, host). Defaults to first available.",
     )
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--max-rounds", type=int, default=5)
@@ -110,20 +114,12 @@ def _budget_from_args(args: argparse.Namespace) -> OptimizationBudget:
         payload = _load_json(args.budget)
         return OptimizationBudget(
             max_rounds=int(payload.get("max_rounds", args.max_rounds)),
-            candidates_per_round=int(
-                payload.get("candidates_per_round", args.candidates_per_round)
-            ),
-            max_candidate_seconds=float(
-                payload.get("max_candidate_seconds", args.max_candidate_seconds)
-            ),
-            max_total_seconds=float(
-                payload.get("max_total_seconds", args.max_total_seconds)
-            ),
+            candidates_per_round=int(payload.get("candidates_per_round", args.candidates_per_round)),
+            max_candidate_seconds=float(payload.get("max_candidate_seconds", args.max_candidate_seconds)),
+            max_total_seconds=float(payload.get("max_total_seconds", args.max_total_seconds)),
             min_speedup=float(payload.get("min_speedup", args.min_speedup)),
             max_cv=float(payload.get("max_cv", args.max_cv)),
-            benchmark_repetitions=int(
-                payload.get("benchmark_repetitions", args.benchmark_repetitions)
-            ),
+            benchmark_repetitions=int(payload.get("benchmark_repetitions", args.benchmark_repetitions)),
         )
     return OptimizationBudget(
         max_rounds=args.max_rounds,
@@ -136,7 +132,8 @@ def _budget_from_args(args: argparse.Namespace) -> OptimizationBudget:
     )
 
 
-def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | None, target: Path | None, arch: str | None) -> tuple[Path, Path, Path]:
+def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | None, target: Path | None,
+                           arch: str | None) -> tuple[Path, Path, Path]:
     # Kernel-only invocation: infer harness/cases/target from
     # harnesses/<arch>/targets/<stem>/
     # e.g. --kernel gemm.py -> harnesses/blackwell/targets/gemm/{harness.py,cases.json,target.json}
@@ -144,11 +141,7 @@ def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | Non
     base = Path(__file__).resolve().parent / "harnesses"
     stem = kernel.stem  # gemm, vector_add, etc.
     if base.exists() and (harness is None or cases is None or target is None):
-        archs = sorted(
-            p.name
-            for p in base.iterdir()
-            if p.is_dir() and (p / "targets" / stem).is_dir()
-        )
+        archs = sorted(p.name for p in base.iterdir() if p.is_dir() and (p / "targets" / stem).is_dir())
         chosen = arch or (archs[0] if archs else None)
         if chosen is None:
             chosen = "blackwell" if harness is None else None
@@ -162,7 +155,9 @@ def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | Non
                 target = tdir / "target.json"
     if harness is None or cases is None or target is None:
         missing = [n for n, v in [("harness", harness), ("cases", cases), ("target", target)] if v is None]
-        raise SystemExit(f"missing required {'/'.join(missing)}; pass them explicitly or use a kernel with harnesses/<arch>/targets/<name>/")
+        raise SystemExit(
+            f"missing required {'/'.join(missing)}; pass them explicitly or use a kernel with harnesses/<arch>/targets/<name>/"
+        )
     return harness, cases, target
 
 
@@ -175,13 +170,43 @@ def _expected_cuda_major(arch: str) -> int | None:
     return None
 
 
+def _expected_gcn_arch(arch: str) -> str | None:
+    normalized = arch.lower().replace("-", "_").replace(" ", "_")
+    return {
+        "gfx942": "gfx942",
+        "mi300": "gfx942",
+        "mi300x": "gfx942",
+        "cdna3": "gfx942",
+        "gfx950": "gfx950",
+        "mi350": "gfx950",
+        "mi355": "gfx950",
+        "cdna4": "gfx950",
+        "gfx1250": "gfx1250",
+    }.get(normalized)
+
+
+def _probe_gcn_arch(device: str | None) -> str:
+    try:
+        import torch
+    except ImportError as error:
+        raise SystemExit("HIP target validation requires torch to be importable") from error
+    if not torch.cuda.is_available():
+        raise SystemExit("HIP target selected, but no ROCm device is available")
+    if not getattr(torch.version, "hip", None):
+        raise SystemExit("HIP target selected, but this torch is not a ROCm build")
+    torch_device = torch.device(device or "cuda")
+    index = torch_device.index
+    if index is None:
+        index = torch.cuda.current_device()
+    # e.g. "gfx942:sramecc+:xnack-" -- the feature suffix is not part of the target.
+    return torch.cuda.get_device_properties(index).gcnArchName.split(":")[0]
+
+
 def _probe_cuda_compute_capability(device: str | None) -> tuple[int, int]:
     try:
         import torch
     except ImportError as error:
-        raise SystemExit(
-            "CUDA target validation requires torch to be importable"
-        ) from error
+        raise SystemExit("CUDA target validation requires torch to be importable") from error
     if not torch.cuda.is_available():
         raise SystemExit("CUDA target selected, but no CUDA device is available")
     torch_device = torch.device(device or "cuda")
@@ -197,31 +222,40 @@ def _validate_host_matches_target(
     target: KernelTarget,
     arch: str | None,
     capability_probe: Callable[[str | None], tuple[int, int]] = _probe_cuda_compute_capability,
+    gcn_probe: Callable[[str | None], str] = _probe_gcn_arch,
 ) -> None:
-    if target.backend != "cuda":
+    if target.backend not in {"cuda", "hip"}:
         return
-    expected_major = _expected_cuda_major(arch or target.architecture)
-    if expected_major is None:
+    requested = arch or target.architecture
+    if target.backend == "cuda":
+        expected: object | None = _expected_cuda_major(requested)
+    else:
+        expected = _expected_gcn_arch(requested)
+    if expected is None:
         return
     previous_environment: dict[str, str | None] = {}
     try:
         for key, value in target.environment.items():
             previous_environment[key] = os.environ.get(key)
             os.environ[key] = value
-        actual_major, actual_minor = capability_probe(target.device)
+        if target.backend == "cuda":
+            actual_major, actual_minor = capability_probe(target.device)
+            actual: str = f"sm_{actual_major}{actual_minor}"
+            matched = actual_major == expected
+            expected_label = f"sm_{expected}x"
+        else:
+            actual = gcn_probe(target.device)
+            matched = actual == expected
+            expected_label = str(expected)
     finally:
         for key, value in previous_environment.items():
             if value is None:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
-    if actual_major != expected_major:
-        expected = f"sm_{expected_major}x"
-        actual = f"sm_{actual_major}{actual_minor}"
-        raise SystemExit(
-            f"--arch {arch or target.architecture} expects {expected}, "
-            f"but {target.device or 'cuda'} is {actual}"
-        )
+    if not matched:
+        raise SystemExit(f"--arch {requested} expects {expected_label}, "
+                         f"but {target.device or target.backend} is {actual}")
 
 
 def _report_commit(commit_result: object) -> None:
@@ -247,7 +281,8 @@ def _report_commit(commit_result: object) -> None:
 
 def main() -> int:
     args = _parse_args()
-    harness_path, cases_path, target_path = _resolve_harness_paths(args.kernel, args.harness, args.cases, args.target, args.arch)
+    harness_path, cases_path, target_path = _resolve_harness_paths(args.kernel, args.harness, args.cases, args.target,
+                                                                   args.arch)
     case_payloads = _load_json(cases_path)
     target_payload = _load_json(target_path)
     cases = tuple(
@@ -256,9 +291,7 @@ def main() -> int:
             parameters=case.get("parameters", {}),
             weight=float(case.get("weight", 1.0)),
             protected=bool(case.get("protected", True)),
-        )
-        for case in case_payloads
-    )
+        ) for case in case_payloads)
     target = KernelTarget(
         backend=str(target_payload["backend"]),
         architecture=str(target_payload["architecture"]),

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/att.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/att.py
@@ -1,0 +1,487 @@
+"""rocprofv3 Advanced Thread Trace (ATT) driver for the gfx942 harnesses.
+
+Invoked by ``harness.profile()``, which the optimizer calls once per candidate
+per round -- automatically, not on request from the prompt.
+
+ATT is the only profiler on this part that reports *per-instruction* hitcount,
+latency, stall and idle. That is the raw data the optimization loop needs: a
+kernel-level TFLOP/s number tells you that you are 0.83x aten but not which
+instruction class is holding the pipe.
+
+Two structural facts drive the design here.
+
+**ATT cannot be collected in-process.** It needs the application launched under
+``rocprofv3 -- <app>``. The harness ``profile()`` hook, by contrast, is called
+inside an already-running worker that is holding a live candidate module. So
+``collect()`` re-execs :mod:`att_child` as a fresh child under rocprofv3 rather
+than tracing the caller.
+
+**The ATT CLI is conditionally present.** Older rocprofv3 drivers hide the
+entire ``--att*`` option group unless they find a legacy decoder on
+``ROCPROF_ATT_LIBRARY_PATH``. Newer drivers bundle
+``librocprof-trace-decoder`` and expose ATT directly. ``TLX_ROCPROFV3`` can
+select a compatible driver when the system default is older than the runtime.
+When ATT is absent, :func:`collect` degrades to counters rather than failing
+the optimization round.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# The exact names rocprofv3's search_path() regex accepts. Only "trace" is
+# needed for the stats CSV we consume; the others enable extra parse modes.
+LEGACY_DECODER_NAMES = (
+    "libatt_decoder_trace.so",
+    "libatt_decoder_summary.so",
+    "libatt_decoder_debug.so",
+    "libatt_decoder_testing.so",
+)
+DECODER_GLOBS = (*LEGACY_DECODER_NAMES, "librocprof-trace-decoder.so*")
+
+# Counter fallback for when ATT is unavailable. Deliberately small: rocprofv3
+# fails the whole job if the set cannot be collected in one pass, so this is
+# scoped to wave occupancy, MFMA utilisation and memory stalls.
+FALLBACK_PMC = (
+    "SQ_WAVES",
+    "SQ_BUSY_CYCLES",
+    "SQ_WAIT_ANY",
+    "SQ_INSTS_MFMA",
+    "SQ_INSTS_VALU",
+    "SQ_INSTS_LDS",
+)
+
+_HELP_CACHE: dict[str, Any] | None = None
+
+
+def _rocprofv3() -> str | None:
+    override = os.environ.get("TLX_ROCPROFV3")
+    if override:
+        return shutil.which(override)
+    return shutil.which("rocprofv3")
+
+
+def capability() -> dict[str, Any]:
+    """Probe whether this rocprofv3 exposes ATT, and if not, say why.
+
+    Cached per process: it shells ``rocprofv3 --help``, which is not free and
+    cannot change underneath a single worker.
+    """
+    global _HELP_CACHE
+    if _HELP_CACHE is not None:
+        return _HELP_CACHE
+    binary = _rocprofv3()
+    if binary is None:
+        _HELP_CACHE = {
+            "att_available":
+            False,
+            "reason": (f"TLX_ROCPROFV3={os.environ['TLX_ROCPROFV3']!r} is not executable"
+                       if os.environ.get("TLX_ROCPROFV3") else "rocprofv3 not on PATH"),
+            "searched": [],
+        }
+        return _HELP_CACHE
+    try:
+        help_text = subprocess.run([binary, "--help"], capture_output=True, text=True, timeout=60, check=False).stdout
+    except (OSError, subprocess.SubprocessError) as error:
+        _HELP_CACHE = {
+            "att_available": False,
+            "reason": f"could not run rocprofv3 --help: {error}",
+            "searched": [],
+        }
+        return _HELP_CACHE
+    available = "--att" in help_text
+    searched = _decoder_search_path()
+    found = sorted(
+        str(path)
+        for directory in searched
+        for pattern in DECODER_GLOBS
+        for path in directory.glob(pattern)
+        if path.is_file())
+    _HELP_CACHE = {
+        "att_available": available,
+        "rocprofv3": binary,
+        "decoders_found": found,
+        "searched": [str(p) for p in searched],
+    }
+    if not available:
+        _HELP_CACHE["reason"] = (f"{binary} does not expose ATT. Set TLX_ROCPROFV3 to a newer "
+                                 "rocprofv3 with librocprof-trace-decoder, or install the legacy "
+                                 "libatt_decoder_trace.so at the top level of a directory on "
+                                 "ROCPROF_ATT_LIBRARY_PATH.")
+    return _HELP_CACHE
+
+
+def _decoder_search_path() -> list[Path]:
+    """Mirror rocprofv3's own search order, so our diagnostics match its behaviour."""
+    explicit = os.environ.get("ROCPROF_ATT_LIBRARY_PATH")
+    if explicit:
+        raw = explicit.split(":")
+    else:
+        raw = os.environ.get("LD_LIBRARY_PATH", "").split(":")
+        binary = _rocprofv3()
+        if binary is not None:
+            rocm_root = Path(binary).resolve().parent.parent
+            raw.append(str(rocm_root / "lib"))
+    seen: list[Path] = []
+    for entry in raw:
+        if not entry:
+            continue
+        path = Path(entry)
+        if path not in seen:
+            seen.append(path)
+    return seen
+
+
+def collect(
+    *,
+    kernel_path: Path,
+    case: dict[str, Any],
+    output_dir: Path,
+    entry_point: str = "matmul",
+    kernel_regex: str = ".*matmul.*",
+    warmup: int = 3,
+    pin_config: dict[str, Any] | None = None,
+    timeout_s: float = 900.0,
+) -> dict[str, Any]:
+    """Trace one dispatch of ``kernel_path`` and return a compact summary.
+
+    Falls back to counter collection when ATT is unavailable, and reports which
+    mode ran so a reader never mistakes counters for a thread trace.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = Path(tempfile.mkdtemp(prefix="run-", dir=output_dir))
+    cap = capability()
+    if cap["att_available"]:
+        result = _run(
+            mode="att",
+            kernel_path=kernel_path,
+            case=case,
+            output_dir=run_dir,
+            entry_point=entry_point,
+            kernel_regex=kernel_regex,
+            warmup=warmup,
+            pin_config=pin_config,
+            timeout_s=timeout_s,
+        )
+    else:
+        result = _run(
+            mode="counters",
+            kernel_path=kernel_path,
+            case=case,
+            output_dir=run_dir,
+            entry_point=entry_point,
+            kernel_regex=kernel_regex,
+            warmup=warmup,
+            pin_config=pin_config,
+            timeout_s=timeout_s,
+        )
+        result["att_unavailable_reason"] = cap.get("reason", "")
+    result["capability"] = cap
+    return result
+
+
+def _run(
+    *,
+    mode: str,
+    kernel_path: Path,
+    case: dict[str, Any],
+    output_dir: Path,
+    entry_point: str,
+    kernel_regex: str,
+    warmup: int,
+    pin_config: dict[str, Any] | None,
+    timeout_s: float,
+) -> dict[str, Any]:
+    binary = _rocprofv3()
+    if binary is None:
+        return {"mode": "unavailable", "error": "rocprofv3 not on PATH"}
+    child = Path(__file__).with_name("att_child.py")
+
+    profiler_args = [binary, "-d", str(output_dir), "-o", "run"]
+    if mode == "att":
+        profiler_args += [
+            "--att",
+            # Keep a dispatch record beside the trace. Among other things, its
+            # global dispatch id lets us audit the iteration-range selection.
+            "--kernel-trace",
+            # gfx9-only shorthand that turns on the SQ perfcounter tokens; 8 is
+            # AMD's own Instinct example value.
+            "--att-activity",
+            "8",
+            # CU 1 produced an activity-only, header-only trace for the
+            # one-workgroup-per-CU 256x256 tile on MI300X. CU 0 produced the
+            # full instruction trace for both protected GEMM shapes.
+            "--att-target-cu",
+            os.environ.get("TLX_ATT_TARGET_CU", "0"),
+            "--att-shader-engine-mask",
+            "0x1",
+            "--att-simd-select",
+            "0xF",  # gfx9 default: all four SIMDs
+            "--kernel-include-regex",
+            kernel_regex,
+            # One dispatch only. With the config pinned there is no autotune
+            # search, so dispatch (warmup + 1) is the steady-state call.
+            "--kernel-iteration-range",
+            f"[{warmup + 1}]",
+        ]
+    else:
+        profiler_args += [
+            "--kernel-trace",
+            "--stats",
+            "--pmc",
+            *FALLBACK_PMC,
+            "--kernel-include-regex",
+            kernel_regex,
+            "--output-format",
+            "csv",
+        ]
+
+    environment = os.environ.copy()
+    environment["TLX_ATT_CASE"] = json.dumps(case)
+    environment["TLX_ATT_KERNEL"] = str(kernel_path)
+    environment["TLX_ATT_ENTRY"] = entry_point
+    environment["TLX_ATT_WARMUP"] = str(warmup)
+    if pin_config:
+        environment["TLX_AGENT_PIN_CONFIG"] = json.dumps(pin_config)
+
+    command = [*profiler_args, "--", sys.executable, str(child)]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=environment,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"mode": mode, "error": f"rocprofv3 timed out after {timeout_s:.0f}s"}
+
+    summary: dict[str, Any] = {
+        "mode": mode,
+        "returncode": completed.returncode,
+        "output_dir": str(output_dir),
+        "command": " ".join(command),
+    }
+    if completed.returncode != 0:
+        summary["error"] = (completed.stderr or completed.stdout)[-4000:]
+        return summary
+
+    if mode == "att":
+        summary.update(_summarize_att(output_dir))
+    else:
+        summary.update(_summarize_counters(output_dir))
+    summary["viewer_dirs"] = [
+        str(p.relative_to(output_dir)) for p in sorted(output_dir.rglob("ui_output_agent_*_dispatch_*")) if p.is_dir()
+    ]
+    summary["traced_dispatches"] = len(summary["viewer_dirs"])
+    if mode == "att" and summary["traced_dispatches"] != 1:
+        summary["collection_error"] = ("expected exactly one ATT dispatch, found "
+                                       f"{summary['traced_dispatches']}")
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+_TOP_N_SITES = 20
+_TOP_N_OPCODES = 15
+_ATT_REQUIRED_COLUMNS = {
+    "vaddr",
+    "instruction",
+    "hitcount",
+    "latency",
+    "stall",
+    "idle",
+    "source",
+}
+_ATT_NUMERIC_COLUMNS = ("hitcount", "latency", "stall", "idle")
+
+
+def _summarize_att(output_dir: Path) -> dict[str, Any]:
+    """Roll the per-instruction stats CSV up into something promptable.
+
+    The raw CSV is one row per instruction address; a 256x256 GEMM hot loop
+    produces thousands. Two views are kept: an opcode-class rollup (where is
+    the stall going?) and the worst individual sites (which instruction?).
+    Everything else stays on disk for the Compute Viewer.
+    """
+    stats_files = sorted(output_dir.rglob("*stats*.csv"))
+    instruction_files = [path for path in stats_files if _has_columns(path, _ATT_REQUIRED_COLUMNS)]
+    if not instruction_files:
+        return {
+            "parse_error": "no stats CSV with the required ATT columns found",
+            "csv_files": [str(p.relative_to(output_dir)) for p in stats_files],
+            "csv_headers": {str(path.relative_to(output_dir)): _header(path)
+                            for path in stats_files},
+        }
+
+    rows: list[dict[str, Any]] = []
+    for path in instruction_files:
+        with path.open(newline="") as stream:
+            for raw in csv.DictReader(stream):
+                normalized = {(key or "").strip().lower(): (value or "").strip() for key, value in raw.items()}
+                rows.append(normalized)
+
+    if not rows:
+        return {
+            "parse_error": "ATT stats CSV contains a header but no instruction rows",
+            "csv_files": [str(p.relative_to(output_dir)) for p in instruction_files],
+        }
+
+    invalid_numeric: list[dict[str, str]] = []
+    for row in rows:
+        for field in _ATT_NUMERIC_COLUMNS:
+            value = row.get(field, "")
+            try:
+                float(value or 0.0)
+            except ValueError:
+                invalid_numeric.append({"field": field, "value": value})
+                if len(invalid_numeric) == 5:
+                    break
+        if len(invalid_numeric) == 5:
+            break
+    if invalid_numeric:
+        return {
+            "parse_error": "ATT stats CSV contains non-numeric metric values",
+            "examples": invalid_numeric,
+            "csv_files": [str(p.relative_to(output_dir)) for p in instruction_files],
+        }
+
+    def number(row: dict[str, Any], key: str) -> float:
+        try:
+            return float(row.get(key) or 0.0)
+        except ValueError as error:  # validated above; keep the invariant local
+            raise AssertionError(f"invalid ATT {key}: {row.get(key)!r}") from error
+
+    totals = {field: sum(number(row, field) for row in rows) for field in ("hitcount", "latency", "stall", "idle")}
+
+    by_opcode: dict[str,
+                    dict[str,
+                         float]] = defaultdict(lambda: {"hitcount": 0.0, "latency": 0.0, "stall": 0.0, "idle": 0.0})
+    for row in rows:
+        opcode = _opcode_class(row.get("instruction", ""))
+        for field in ("hitcount", "latency", "stall", "idle"):
+            by_opcode[opcode][field] += number(row, field)
+
+    stall_total = totals["stall"] or 1.0
+    opcode_rollup = sorted(
+        ({
+            "opcode": opcode,
+            "stall": values["stall"],
+            "stall_pct": 100.0 * values["stall"] / stall_total,
+            "latency": values["latency"],
+            "hitcount": values["hitcount"],
+        } for opcode, values in by_opcode.items()),
+        key=lambda entry: entry["stall"],
+        reverse=True,
+    )[:_TOP_N_OPCODES]
+
+    top_sites = sorted(rows, key=lambda row: number(row, "stall"), reverse=True)[:_TOP_N_SITES]
+    return {
+        "totals":
+        totals,
+        "stall_by_opcode":
+        opcode_rollup,
+        "top_stall_sites": [{
+            "vaddr": row.get("vaddr", ""),
+            "instruction": row.get("instruction", ""),
+            "hitcount": number(row, "hitcount"),
+            "latency": number(row, "latency"),
+            "stall": number(row, "stall"),
+            "idle": number(row, "idle"),
+            "source": row.get("source", ""),
+        } for row in top_sites],
+        "instruction_rows":
+        len(rows),
+        "csv_files": [str(p.relative_to(output_dir)) for p in instruction_files],
+    }
+
+
+def _has_columns(path: Path, required: set[str]) -> bool:
+    return required.issubset(set(_header(path)))
+
+
+def _header(path: Path) -> list[str]:
+    try:
+        with path.open(newline="") as stream:
+            header = next(csv.reader(stream), [])
+    except (OSError, StopIteration):
+        return []
+    return [column.strip().lower() for column in header]
+
+
+_OPCODE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _opcode_class(instruction: str) -> str:
+    """Bucket an instruction to its mnemonic, then to a coarse family.
+
+    Families are what an optimization decision actually turns on -- MFMA versus
+    LDS versus global versus wait -- so the rollup groups by family and keeps
+    the mnemonic only when it does not fit one.
+    """
+    match = _OPCODE_RE.match(instruction)
+    if not match:
+        return "unknown"
+    mnemonic = match.group(1).lower()
+    for prefix, family in (
+        ("v_mfma", "mfma"),
+        ("ds_read", "lds_read"),
+        ("ds_write", "lds_write"),
+        ("buffer_load", "global_load"),
+        ("global_load", "global_load"),
+        ("flat_load", "global_load"),
+        ("buffer_store", "global_store"),
+        ("global_store", "global_store"),
+        ("s_waitcnt", "waitcnt"),
+        ("s_barrier", "barrier"),
+        ("v_accvgpr", "accvgpr_move"),
+        ("s_setprio", "setprio"),
+    ):
+        if mnemonic.startswith(prefix):
+            return family
+    if mnemonic.startswith("v_"):
+        return "valu_other"
+    if mnemonic.startswith("s_"):
+        return "salu_other"
+    return mnemonic
+
+
+def _summarize_counters(output_dir: Path) -> dict[str, Any]:
+    """Fallback summary: whatever --pmc produced, plus kernel durations."""
+    result: dict[str, Any] = {}
+    counter_files = sorted(output_dir.rglob("*counter_collection*.csv"))
+    if counter_files:
+        aggregate: dict[str, float] = defaultdict(float)
+        for path in counter_files:
+            with path.open(newline="") as stream:
+                for row in csv.DictReader(stream):
+                    name = (row.get("Counter_Name") or "").strip()
+                    if not name:
+                        continue
+                    try:
+                        aggregate[name] += float(row.get("Counter_Value") or 0.0)
+                    except ValueError:
+                        continue
+        result["counters"] = dict(sorted(aggregate.items()))
+        result["counter_files"] = [str(p.relative_to(output_dir)) for p in counter_files]
+    stats_files = sorted(output_dir.rglob("*kernel_stats*.csv"))
+    if stats_files:
+        with stats_files[0].open(newline="") as stream:
+            result["kernel_stats"] = list(csv.DictReader(stream))[:10]
+    if not result:
+        result["parse_error"] = "no counter or kernel-stats CSV found"
+        result["files"] = [str(p.relative_to(output_dir)) for p in sorted(output_dir.rglob("*.csv"))]
+    return result

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/att_child.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/att_child.py
@@ -1,0 +1,86 @@
+"""Traced child process: launched by :mod:`att` under ``rocprofv3 -- ...``.
+
+Runs once per ``att.collect()``, so once per profiled candidate.
+
+Deliberately tiny and side-effect free. Its whole job is to issue a
+deterministic number of dispatches so that ``--kernel-iteration-range`` can name
+exactly one of them:
+
+    warmup dispatches 1..W, then the traced dispatch W+1.
+
+That determinism only holds while the autotuner is pinned to a single config
+(``TLX_AGENT_PIN_CONFIG``); an unpinned run issues one dispatch per config
+during the search and the iteration range would land somewhere arbitrary inside
+it. :mod:`att` always sets the pin for this reason.
+
+Everything arrives by environment variable rather than argv because rocprofv3
+owns the command line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("tlx_att_candidate", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load candidate from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tlx_att_candidate"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    import torch
+
+    kernel_path = Path(os.environ["TLX_ATT_KERNEL"])
+    case = json.loads(os.environ["TLX_ATT_CASE"])
+    entry_point = os.environ.get("TLX_ATT_ENTRY", "matmul")
+    warmup = int(os.environ.get("TLX_ATT_WARMUP", "3"))
+
+    parameters = case["parameters"]
+    device = parameters.get("device", "cuda")
+    dtype = getattr(torch, parameters.get("dtype", "float16"))
+    generator = torch.Generator(device=device)
+    generator.manual_seed(int(parameters.get("seed", 0)))
+    a = torch.randn(
+        (int(parameters["m"]), int(parameters["k"])),
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+    b = torch.randn(
+        (int(parameters["k"]), int(parameters["n"])),
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+
+    module = _load(kernel_path)
+    pin_config = os.environ.get("TLX_AGENT_PIN_CONFIG")
+    if pin_config:
+        import pinning  # same directory; sys.path[0] is this script's dir
+
+        pinning.pin(module, json.loads(pin_config))
+    call = getattr(module, entry_point)
+
+    # Warmup also absorbs JIT compilation, so the traced dispatch measures the
+    # steady-state kernel rather than a cold-cache first launch.
+    for _ in range(warmup):
+        call(a, b)
+    torch.cuda.synchronize()
+
+    call(a, b)  # <- the traced dispatch
+    torch.cuda.synchronize()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/pinning.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/pinning.py
@@ -1,0 +1,99 @@
+"""Pin a candidate's Triton autotuner to one config, without touching the kernel.
+
+Applied around every ``build``/``verify``/``benchmark``/``profile`` call in the
+gfx942 harness, and restored afterwards.
+
+`tlx.ops.mm` at `space="full"` searches 42 configs per (M, N, K). Left alone that makes the
+promote/reject gate measure *tile selection* rather than the structural change
+the candidate actually made -- two candidates can differ only in which tile the
+autotuner happened to pick -- and it makes every evaluation pay the search.
+
+Pinning is done by filtering the `Autotuner` object's own `configs` list, found
+by scanning module globals for the type. Doing it that way rather than through a
+kernel-side env hook means it keeps working when the agent renames functions,
+restructures `_configs()`, or drops a hook it was told to preserve -- none of
+which are things a candidate generator can be relied on not to do.
+
+Both the in-process harness and the rocprofv3 child use this, so the traced
+dispatch is the same one the gate timed.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any
+
+
+def _autotuners(module: ModuleType) -> list[Any]:
+    try:
+        from triton.runtime.autotuner import Autotuner
+    except ImportError:  # pragma: no cover - triton always present in practice
+        return []
+    return [value for value in vars(module).values() if isinstance(value, Autotuner)]
+
+
+def _matches(config: Any, pin: dict[str, Any]) -> bool:
+    """True when ``config`` agrees with every key in ``pin``.
+
+    `num_warps` / `num_stages` live on the Config object; everything else lives
+    in its `kwargs`, so both namespaces are checked.
+    """
+    for key, wanted in pin.items():
+        if key in ("num_warps", "num_stages", "num_ctas"):
+            if getattr(config, key, None) != wanted:
+                return False
+        elif config.kwargs.get(key) != wanted:
+            return False
+    return True
+
+
+def pin(module: ModuleType, pin_config: dict[str, Any] | None) -> dict[str, Any]:
+    """Restrict every autotuner in ``module`` to configs matching ``pin_config``.
+
+    Returns a report -- never raises. A candidate that cannot be pinned is still
+    a candidate; the caller decides what to do about a gate measured unpinned,
+    and `pinned` in the report is how it finds out.
+    """
+    tuners = _autotuners(module)
+    report: dict[str, Any] = {
+        "autotuners_found": len(tuners),
+        "requested": dict(pin_config or {}),
+        "pinned": False,
+    }
+    if not pin_config:
+        report["configs_before"] = [len(t.configs) for t in tuners]
+        return report
+    if not tuners:
+        report["note"] = "no triton Autotuner in candidate module; nothing to pin"
+        return report
+
+    before: list[int] = []
+    after: list[int] = []
+    for tuner in tuners:
+        before.append(len(tuner.configs))
+        kept = [config for config in tuner.configs if _matches(config, pin_config)]
+        if kept:
+            tuner.configs = kept
+            # A stale entry would replay the pre-pin winner and silently defeat
+            # the pin, so drop whatever the tuner already decided.
+            getattr(tuner, "cache", {}).clear()
+        after.append(len(tuner.configs))
+    report["configs_before"] = before
+    report["configs_after"] = after
+    report["pinned"] = all(count == 1 for count in after)
+    if not report["pinned"]:
+        report["note"] = ("pin_config did not reduce every autotuner to a single config; "
+                          "the gate measurement includes an autotune search")
+    return report
+
+
+def restore(module: ModuleType, saved: list[list[Any]]) -> None:
+    """Put back the config lists captured by :func:`snapshot`."""
+    for tuner, configs in zip(_autotuners(module), saved):
+        tuner.configs = configs
+        getattr(tuner, "cache", {}).clear()
+
+
+def snapshot(module: ModuleType) -> list[list[Any]]:
+    """Copy every autotuner's config list, so :func:`pin` can be undone."""
+    return [list(tuner.configs) for tuner in _autotuners(module)]

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/cases.json
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/cases.json
@@ -1,0 +1,28 @@
+[
+  {
+    "case_id": "square_4096",
+    "parameters": {
+      "m": 4096, "n": 4096, "k": 4096, "dtype": "float16", "seed": 0,
+      "pin_config": {
+        "BLOCK_M": 256, "BLOCK_N": 256, "BLOCK_K": 32,
+        "GROUP_M": 4, "NUM_BUFFERS": 2, "NUM_XCDS": 8,
+        "num_warps": 8
+      }
+    },
+    "weight": 2.0,
+    "protected": true
+  },
+  {
+    "case_id": "square_8192",
+    "parameters": {
+      "m": 8192, "n": 8192, "k": 8192, "dtype": "float16", "seed": 1,
+      "pin_config": {
+        "BLOCK_M": 256, "BLOCK_N": 256, "BLOCK_K": 32,
+        "GROUP_M": 8, "NUM_BUFFERS": 2, "NUM_XCDS": 8,
+        "num_warps": 8
+      }
+    },
+    "weight": 1.0,
+    "protected": true
+  }
+]

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/harness.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/harness.py
@@ -1,0 +1,295 @@
+"""Optimization harness for the TLX MI300X (gfx942 / CDNA3) GEMM tutorial.
+
+Differs from the blackwell/hopper GEMM harnesses in three ways that are all
+forced by the part rather than by taste:
+
+**Timing method.** `do_bench` is not used. Its burst-and-sleep pattern was
+measured at 14-20% burst-to-burst variation on this part, which would swamp the
+1.01 default promotion threshold and make promotion a coin flip. This harness
+reuses `gfx942_perf_harness.measure_samples` -- warm continuously until clocks
+settle, then one timed window -- so the samples the optimizer computes its
+median and CV over are the real per-call distribution.
+
+**Pinned gate, autotuned report.** The kernel searches 42 configs per shape. The
+gate runs pinned to the tile the baseline autotuner chose, so a candidate is
+judged on its structural change and not on which tile it happened to win with;
+`profile()` separately runs the search unpinned and reports that number, which
+is what a user would actually get.
+
+**ATT profiling.** `profile()` shells rocprofv3 rather than profiling in
+process, because ATT requires the application to be launched underneath it. See
+`../../att.py`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import torch
+
+# Set before the first kernel launch, matching the standalone perf script. The
+# AMD backend never emits `asm["launch_metadata"]`, so the C dispatcher can
+# never be built and every launch would warn; post-misched would re-order a
+# hand-scheduled hot loop.
+os.environ.setdefault("TRITON_DISABLE_POST_MISCHED", "1")
+os.environ.setdefault("TRITON_USE_C_DISPATCHER", "0")
+
+# `harnesses/gfx942/`, which holds the shared att/pinning modules. The harness
+# is loaded by file path with no package context, so this is how they resolve.
+_ARCH_DIR = Path(__file__).resolve().parents[2]
+if str(_ARCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_ARCH_DIR))
+
+import att  # noqa: E402
+import pinning  # noqa: E402
+
+from triton.language.extra.tlx.tutorials.testing.gfx942_perf_harness import (  # noqa: E402
+    measure_samples, )
+
+ENTRY_POINT = "matmul"
+
+# Enough samples for a meaningful median and CV without bloating the response
+# JSON; a 2 s window at these shapes produces thousands.
+MAX_SAMPLES = 2000
+
+
+def build(kernel_source: str, target: dict[str, Any]) -> dict[str, Any]:
+    if target["backend"] != "hip":
+        return {
+            "success": False,
+            "diagnostics": f"gfx942 harness requires backend 'hip', got {target['backend']!r}",
+        }
+    directory = tempfile.TemporaryDirectory(prefix="tlx-gfx942-candidate-")
+    source_path = Path(directory.name) / "candidate.py"
+    source_path.write_text(kernel_source)
+    try:
+        module = _load_module(source_path)
+    except Exception as error:  # noqa: BLE001
+        directory.cleanup()
+        return {
+            "success": False,
+            "diagnostics": f"candidate import failed: {type(error).__name__}: {error}",
+        }
+    if not callable(getattr(module, ENTRY_POINT, None)):
+        directory.cleanup()
+        return {
+            "success": False,
+            "diagnostics": f"candidate must define {ENTRY_POINT}(a, b)",
+        }
+    # Captured before anything pins, because pinning mutates the autotuner in
+    # place and `verify` runs first. Snapshotting later would capture the pinned
+    # single config and make `profile`'s "autotuned" number a second pinned run.
+    return {
+        "success": True,
+        "artifact": (directory, module, str(source_path), pinning.snapshot(module)),
+    }
+
+
+def verify(artifact: tuple[Any, ...], case: dict[str, Any]) -> dict[str, Any]:
+    _, module, source_path, original_configs = artifact
+    a, b = _inputs(case)
+    report = _apply_pin(module, case)
+    try:
+        expected = torch.matmul(a, b)
+        pinned = getattr(module, ENTRY_POINT)(a, b)
+        torch.testing.assert_close(pinned, expected)
+    except Exception as error:  # noqa: BLE001
+        return {
+            "passed": False,
+            "diagnostics": f"pinned correctness: {type(error).__name__}: {error}",
+            "metrics": {"pin": report},
+        }
+    finally:
+        pinning.restore(module, original_configs)
+
+    # The performance gate is deliberately pinned and disables post-misched,
+    # but users and the repository correctness suite execute the autotuner in a
+    # default environment. Validate that path in a fresh process so the harness'
+    # performance settings and compiled-kernel cache cannot hide a bad config.
+    default_check = _verify_default_environment(Path(source_path), case)
+    if not default_check["passed"]:
+        return {
+            "passed": False,
+            "diagnostics": f"autotuned correctness: {default_check['diagnostics']}",
+            "metrics": {"pin": report, "autotuned_verified": False},
+        }
+
+    metrics: dict[str, Any] = {"pin": report, "autotuned_verified": True}
+    reference = _reference_module()
+    if reference is not None:
+        # An oracle beyond torch: if the trusted kernel and the candidate agree
+        # more tightly than either agrees with torch, a torch-only check can hide
+        # a real regression inside the tolerance band.
+        try:
+            reference_output = getattr(reference, ENTRY_POINT)(a, b)
+            metrics["max_abs_diff_vs_reference"] = float((pinned.float() - reference_output.float()).abs().max())
+        except Exception as error:  # noqa: BLE001
+            metrics["reference_error"] = f"{type(error).__name__}: {error}"
+    return {"passed": True, "metrics": metrics}
+
+
+def _verify_default_environment(kernel_path: Path, case: dict[str, Any], timeout_s: float = 300.0) -> dict[str, Any]:
+    child = Path(__file__).with_name("verify_child.py")
+    environment = os.environ.copy()
+    environment.pop("TRITON_DISABLE_POST_MISCHED", None)
+    environment.pop("TRITON_USE_C_DISPATCHER", None)
+    environment["TLX_VERIFY_KERNEL"] = str(kernel_path)
+    environment["TLX_VERIFY_CASE"] = json.dumps(case)
+    environment["TLX_VERIFY_ENTRY"] = ENTRY_POINT
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(child)],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=environment,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "passed": False,
+            "diagnostics": f"default-environment check timed out after {timeout_s:.0f}s",
+        }
+    if completed.returncode != 0:
+        return {
+            "passed": False,
+            "diagnostics": (completed.stderr or completed.stdout)[-4000:],
+        }
+    return {"passed": True}
+
+
+def benchmark(artifact: tuple[Any, ...], case: dict[str, Any], repetitions: int) -> dict[str, Any]:
+    del repetitions  # the settled-clock window sizes itself; see module docstring
+    _, module, _, _ = artifact
+    a, b = _inputs(case)
+    _apply_pin(module, case)
+    call = getattr(module, ENTRY_POINT)
+    samples_ms = measure_samples(lambda: call(a, b))
+    stride = max(1, len(samples_ms) // MAX_SAMPLES)
+    return {
+        "samples_us": [value * 1000.0 for value in samples_ms[::stride]],
+        "warmup_count": 0,  # continuous warmup, not a fixed iteration count
+        "cache_policy": "warm",
+    }
+
+
+def profile(artifact: tuple[Any, ...], case: dict[str, Any]) -> dict[str, Any]:
+    _, module, source_path, original_configs = artifact
+    a, b = _inputs(case)
+    call = getattr(module, ENTRY_POINT)
+    m, k = a.shape
+    _, n = b.shape
+    flops = 2.0 * m * n * k
+    pin_config = _pin_config(case)
+
+    result: dict[str, Any] = {}
+    try:
+        # 1. Gate conditions: pinned to one tile.
+        _apply_pin(module, case)
+        pinned_ms = _median_ms(lambda: call(a, b))
+        result["pinned"] = {
+            "config": pin_config,
+            "latency_ms": pinned_ms,
+            "tflops": flops * 1e-12 / (pinned_ms * 1e-3),
+        }
+
+        # 2. What a user would actually get: full autotune search.
+        pinning.restore(module, original_configs)
+        autotuned_ms = _median_ms(lambda: call(a, b))
+        result["autotuned"] = {
+            "latency_ms": autotuned_ms,
+            "tflops": flops * 1e-12 / (autotuned_ms * 1e-3),
+        }
+    finally:
+        pinning.restore(module, original_configs)
+
+    # 3. Per-instruction thread trace, in a fresh process under rocprofv3.
+    trace_root = Path(os.environ.get("TLX_ATT_OUTPUT_ROOT", tempfile.gettempdir())) / "tlx-att" / str(case["case_id"])
+    result["att"] = att.collect(
+        kernel_path=Path(source_path),
+        case=case,
+        output_dir=trace_root,
+        entry_point=ENTRY_POINT,
+        kernel_regex=os.environ.get("TLX_ATT_KERNEL_REGEX", ".*matmul.*"),
+        pin_config=pin_config,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _median_ms(fn) -> float:
+    samples = sorted(measure_samples(fn))
+    return samples[len(samples) // 2]
+
+
+def _pin_config(case: dict[str, Any]) -> dict[str, Any] | None:
+    config = case.get("parameters", {}).get("pin_config")
+    return dict(config) if config else None
+
+
+def _apply_pin(module: ModuleType, case: dict[str, Any]) -> dict[str, Any]:
+    return pinning.pin(module, _pin_config(case))
+
+
+_REFERENCE: ModuleType | None | bool = False
+
+
+def _reference_module() -> ModuleType | None:
+    """Load the optional oracle kernel once, if the CLI supplied one."""
+    global _REFERENCE
+    if _REFERENCE is not False:
+        return _REFERENCE  # type: ignore[return-value]
+    path = os.environ.get("TLX_REFERENCE_KERNEL_PATH")
+    if not path or not Path(path).is_file():
+        _REFERENCE = None
+        return None
+    try:
+        _REFERENCE = _load_module(Path(path), name="tlx_gfx942_reference")
+    except Exception:  # noqa: BLE001
+        _REFERENCE = None
+    return _REFERENCE  # type: ignore[return-value]
+
+
+def _load_module(path: Path, name: str | None = None) -> ModuleType:
+    module_name = name or f"tlx_gfx942_candidate_{path.parent.name}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load candidate from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _inputs(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    parameters = case["parameters"]
+    device = parameters.get("device", "cuda")
+    dtype = getattr(torch, parameters.get("dtype", "float16"))
+    torch.manual_seed(int(parameters.get("seed", 0)))
+    # Match testing/test_correctness.py's GEMM input distribution and default
+    # assert_close tolerance. Large unscaled random inputs plus atol/rtol=1e-2
+    # let schedule changes through the agent gate that the repository's real
+    # correctness test rejects.
+    a = (torch.randn(
+        (int(parameters["m"]), int(parameters["k"])),
+        device=device,
+        dtype=dtype,
+    ) + 1) / int(parameters["k"])
+    b = (torch.randn(
+        (int(parameters["k"]), int(parameters["n"])),
+        device=device,
+        dtype=dtype,
+    ) + 1) / int(parameters["k"])
+    return a, b

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/target.json
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/target.json
@@ -1,0 +1,9 @@
+{
+  "backend": "hip",
+  "architecture": "gfx942",
+  "device": "cuda:0",
+  "environment": {
+    "TRITON_DISABLE_POST_MISCHED": "1",
+    "TRITON_USE_C_DISPATCHER": "0"
+  }
+}

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/verify_child.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx942/targets/gfx942/verify_child.py
@@ -1,0 +1,44 @@
+"""Check an agent candidate through the default, unpinned user launch path.
+
+Spawned by ``harness._verify_default_environment()`` on every ``verify`` call, so a
+candidate is also checked without the autotuner pin the rest of the harness applies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    import torch
+
+    kernel_path = Path(os.environ["TLX_VERIFY_KERNEL"])
+    case = json.loads(os.environ["TLX_VERIFY_CASE"])
+    entry_point = os.environ.get("TLX_VERIFY_ENTRY", "matmul")
+
+    spec = importlib.util.spec_from_file_location("tlx_verify_candidate", kernel_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load candidate from {kernel_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tlx_verify_candidate"] = module
+    spec.loader.exec_module(module)
+
+    parameters = case["parameters"]
+    device = parameters.get("device", "cuda")
+    dtype = getattr(torch, parameters.get("dtype", "float16"))
+    k = int(parameters["k"])
+    torch.manual_seed(int(parameters.get("seed", 0)))
+    a = (torch.randn((int(parameters["m"]), k), device=device, dtype=dtype) + 1) / k
+    b = (torch.randn((k, int(parameters["n"])), device=device, dtype=dtype) + 1) / k
+
+    actual = getattr(module, entry_point)(a, b)
+    torch.testing.assert_close(actual, torch.matmul(a, b))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/third_party/tlx/tools/agents/kernel_optimization/providers.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -10,6 +11,35 @@ from typing import Protocol
 from .models import KernelOptimizationRequest, PerformanceSummary
 from .profiling import compact_profile_summary
 from .source import validate_replacement_source
+
+# third_party/tlx/doc/kernel_opt/<arch>.md -- one human-curated file per
+# architecture. See that directory's README for the contract; the short version
+# is that a human writes it and the agent only ever reads it.
+_KNOWLEDGE_DIR = Path(
+    os.environ.get(
+        "TLX_KERNEL_OPT_KNOWLEDGE_DIR",
+        Path(__file__).resolve().parents[3] / "doc" / "kernel_opt",
+    ))
+
+# target.architecture as written in target.json -> knowledge file stem.
+_ARCH_TO_KNOWLEDGE = {
+    "gfx942": "gfx942",
+    "gfx950": "gfx950",
+    "mi300x": "gfx942",
+    "mi355x": "gfx950",
+}
+
+
+def knowledge_for(architecture: str) -> str | None:
+    """Curated prior for ``architecture``, or None when none has been written."""
+    stem = _ARCH_TO_KNOWLEDGE.get(architecture.strip().lower())
+    if stem is None:
+        return None
+    path = _KNOWLEDGE_DIR / f"{stem}.md"
+    if not path.is_file():
+        return None
+    return path.read_text()
+
 
 TLX_PROMPT_PREAMBLE = """You are optimizing one Triton or TLX kernel against an external deterministic harness.
 The candidate is a complete replacement source file. Preserve every public entry point,
@@ -66,11 +96,13 @@ class CandidateContext:
 
 
 class CandidateProvider(Protocol):
+
     def propose(
         self,
         request: KernelOptimizationRequest,
         context: CandidateContext,
-    ) -> CandidateProposal: ...
+    ) -> CandidateProposal:
+        ...
 
 
 @dataclass
@@ -222,12 +254,29 @@ def _build_prompt(
         if guidance
         else ""
     )
-    return f"""{TLX_PROMPT_PREAMBLE}{guidance_block}{reference_block}
+    # Appended to the generic preamble rather than replacing it: the preamble is
+    # arch-agnostic workflow, this is arch-specific fact. Its two sections are
+    # not equally trustworthy, so the prompt says which is which -- an untested
+    # hypothesis presented as measurement is worse than no prior at all.
+    knowledge = knowledge_for(request.target.architecture)
+    knowledge_block = (
+        f"\nHuman-curated knowledge base for {request.target.architecture}. Treat its\n"
+        "'measured on' section as established fact and its 'ported from' section as\n"
+        "untested hypotheses. Prefer an optimization it supports over one it does not,\n"
+        f"and say which entry you are acting on.\n\n{knowledge}\n"
+        if knowledge
+        else ""
+    )
+    return f"""{TLX_PROMPT_PREAMBLE}{knowledge_block}{guidance_block}{reference_block}
 You are proposing one candidate for the closed loop `build -> verify -> benchmark -> profile -> propose -> repeat`.
 Edit `candidate.py` directly. Do not return source or a diff, and do not claim correctness
 or performance; an external deterministic harness reads the file and decides both.
 Preserve the public entry points expected by the harness. Make one coherent optimization
 that can be diagnosed if it fails.
+
+Base your proposal on the profile data below, not on general intuition. State which
+measurement motivates the change; if the profile does not support any change you are
+confident in, say so and make the smallest well-motivated one.
 
 Target: backend={request.target.backend}, architecture={request.target.architecture}
 Round: {context.round_index}, candidate: {context.candidate_index}

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -6,11 +6,13 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
+from unittest import mock
 from unittest.mock import Mock, patch
 
 from . import optimizer as optimizer_module
 from .cli import _parse_args, _resolve_harness_paths, _validate_host_matches_target
 from .harness import StandaloneHarness, SubprocessHarness
+from .harnesses.gfx942 import att
 from .models import (
     CaseEvaluation,
     InputCase,
@@ -32,6 +34,7 @@ from .providers import (
     FixedCandidateProvider,
     MockLLMProvider,
     _build_prompt,
+    knowledge_for,
 )
 from .source import (
     apply_candidate_diff,
@@ -43,6 +46,7 @@ from .source import (
 
 
 class ScoringTest(unittest.TestCase):
+
     def test_weighted_geometric_speedup(self) -> None:
         cases = (
             InputCase("large", {}, weight=3.0),
@@ -52,7 +56,7 @@ class ScoringTest(unittest.TestCase):
         candidate = _performance(("large", 50.0), ("small", 80.0))
         self.assertAlmostEqual(
             weighted_geometric_speedup(baseline, candidate, cases),
-            (2.0**3 * 0.5) ** 0.25,
+            (2.0**3 * 0.5)**0.25,
         )
 
     def test_per_case_speedups(self) -> None:
@@ -66,19 +70,17 @@ class ScoringTest(unittest.TestCase):
     def test_per_case_speedups_none_for_failed_case(self) -> None:
         cases = (InputCase("a", {}), InputCase("b", {}, protected=False))
         baseline = _performance(("a", 100.0), ("b", 40.0))
-        candidate = PerformanceSummary(
-            cases=(
-                CaseEvaluation(
-                    case_id="a",
-                    verification=VerificationResult(True),
-                    timing=TimingSamples((50.0, 50.0, 50.0)),
-                ),
-                CaseEvaluation(
-                    case_id="b",
-                    verification=VerificationResult(False),
-                ),
-            )
-        )
+        candidate = PerformanceSummary(cases=(
+            CaseEvaluation(
+                case_id="a",
+                verification=VerificationResult(True),
+                timing=TimingSamples((50.0, 50.0, 50.0)),
+            ),
+            CaseEvaluation(
+                case_id="b",
+                verification=VerificationResult(False),
+            ),
+        ))
         result = per_case_speedups(baseline, candidate, cases)
         self.assertEqual(result["b"], None)
 
@@ -224,13 +226,11 @@ class ScoringTest(unittest.TestCase):
 
     def test_failed_protected_case_is_not_promotable(self) -> None:
         summary = PerformanceSummary(
-            cases=(
-                CaseEvaluation(
-                    case_id="case",
-                    verification=VerificationResult(False),
-                    timing=None,
-                ),
-            ),
+            cases=(CaseEvaluation(
+                case_id="case",
+                verification=VerificationResult(False),
+                timing=None,
+            ), ),
             aggregate_speedup=2.0,
         )
         self.assertFalse(is_promotable(summary, OptimizationBudget()))
@@ -241,19 +241,17 @@ class ScoringTest(unittest.TestCase):
             InputCase("diagnostic", {}, protected=False),
         )
         baseline = _performance(("required", 100.0), ("diagnostic", 100.0))
-        candidate = PerformanceSummary(
-            cases=(
-                CaseEvaluation(
-                    case_id="required",
-                    verification=VerificationResult(True),
-                    timing=TimingSamples((50.0, 50.0, 50.0)),
-                ),
-                CaseEvaluation(
-                    case_id="diagnostic",
-                    verification=VerificationResult(False),
-                ),
-            )
-        )
+        candidate = PerformanceSummary(cases=(
+            CaseEvaluation(
+                case_id="required",
+                verification=VerificationResult(True),
+                timing=TimingSamples((50.0, 50.0, 50.0)),
+            ),
+            CaseEvaluation(
+                case_id="diagnostic",
+                verification=VerificationResult(False),
+            ),
+        ))
         speedup = weighted_geometric_speedup(baseline, candidate, cases)
         candidate = PerformanceSummary(candidate.cases, speedup)
         self.assertEqual(speedup, 2.0)
@@ -261,13 +259,11 @@ class ScoringTest(unittest.TestCase):
 
     def test_noisy_timing_is_not_promotable(self) -> None:
         summary = PerformanceSummary(
-            cases=(
-                CaseEvaluation(
-                    case_id="case",
-                    verification=VerificationResult(True),
-                    timing=TimingSamples((1.0, 10.0, 1.0)),
-                ),
-            ),
+            cases=(CaseEvaluation(
+                case_id="case",
+                verification=VerificationResult(True),
+                timing=TimingSamples((1.0, 10.0, 1.0)),
+            ), ),
             aggregate_speedup=2.0,
         )
         self.assertFalse(is_promotable(summary, OptimizationBudget(max_cv=0.1)))
@@ -311,6 +307,7 @@ class CliTest(unittest.TestCase):
 
 
 class HarnessTest(unittest.TestCase):
+
     def test_cuda_arch_validation_rejects_mismatched_host(self) -> None:
         target = KernelTarget("cuda", "B200", device="cuda:0")
         with self.assertRaisesRegex(SystemExit, "expects sm_10x.*is sm_90"):
@@ -336,42 +333,45 @@ class HarnessTest(unittest.TestCase):
 
         _validate_host_matches_target(target, "host", capability_probe=fail_probe)
 
+    def test_hip_arch_validation_accepts_matching_host(self) -> None:
+        target = KernelTarget("hip", "gfx942", device="cuda:0")
+        _validate_host_matches_target(
+            target,
+            "gfx942",
+            gcn_probe=lambda device: "gfx942",
+        )
+
+    def test_hip_arch_validation_rejects_mismatched_host(self) -> None:
+        target = KernelTarget("hip", "gfx942", device="cuda:0")
+        with self.assertRaisesRegex(SystemExit, "expects gfx942.*is gfx950"):
+            _validate_host_matches_target(
+                target,
+                "gfx942",
+                gcn_probe=lambda device: "gfx950",
+            )
+
     def test_resolves_arch_first_harness_layout(self) -> None:
         kernel = Path("gemm.py")
-        harness, cases, target = _resolve_harness_paths(
-            kernel, None, None, None, "hopper"
-        )
+        harness, cases, target = _resolve_harness_paths(kernel, None, None, None, "hopper")
         self.assertEqual(
             harness,
-            Path(__file__).with_name("harnesses")
-            / "hopper"
-            / "targets"
-            / "gemm"
-            / "harness.py",
+            Path(__file__).with_name("harnesses") / "hopper" / "targets" / "gemm" / "harness.py",
         )
         self.assertEqual(cases.name, "cases.json")
         self.assertEqual(target.name, "target.json")
 
     def test_default_arch_only_uses_arches_with_matching_target(self) -> None:
         kernel = Path("vector_add.py")
-        harness, cases, target = _resolve_harness_paths(
-            kernel, None, None, None, None
-        )
+        harness, cases, target = _resolve_harness_paths(kernel, None, None, None, None)
         self.assertEqual(
             harness,
-            Path(__file__).with_name("harnesses")
-            / "host"
-            / "targets"
-            / "vector_add"
-            / "harness.py",
+            Path(__file__).with_name("harnesses") / "host" / "targets" / "vector_add" / "harness.py",
         )
         self.assertEqual(cases.name, "cases.json")
         self.assertEqual(target.name, "target.json")
 
     def test_standalone_harness_evaluates_fake_kernel(self) -> None:
-        harness = StandaloneHarness(
-            Path(__file__).with_name("testdata") / "fake_harness.py"
-        )
+        harness = StandaloneHarness(Path(__file__).with_name("testdata") / "fake_harness.py")
         cases = (InputCase("a", {"scale": 1.0}), InputCase("b", {"scale": 2.0}))
         target = KernelTarget("fake", "fake")
         performance = harness.evaluate(
@@ -509,10 +509,8 @@ class HarnessTest(unittest.TestCase):
             self.assertGreater(profile["size_bytes"], 1_000_000)
 
     def test_standalone_harness_reports_build_error(self) -> None:
-        harness = StandaloneHarness(
-            Path(__file__).with_name("testdata") / "fake_harness.py"
-        )
-        cases = (InputCase("a", {}),)
+        harness = StandaloneHarness(Path(__file__).with_name("testdata") / "fake_harness.py")
+        cases = (InputCase("a", {}), )
         target = KernelTarget("fake", "fake")
         with self.assertRaisesRegex(Exception, "missing fake kernel controls"):
             harness.evaluate(
@@ -523,16 +521,14 @@ class HarnessTest(unittest.TestCase):
             )
 
     def test_mock_provider_replays_canned_candidates(self) -> None:
-        provider = MockLLMProvider(
-            canned=(
-                CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "first"),
-                CandidateProposal("LATENCY_US = 60\nCORRECT = True\n", "second"),
-            )
-        )
+        provider = MockLLMProvider(canned=(
+            CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "first"),
+            CandidateProposal("LATENCY_US = 60\nCORRECT = True\n", "second"),
+        ))
         request = KernelOptimizationRequest(
             kernel_source="LATENCY_US = 100\nCORRECT = True\n",
             harness_path=Path(__file__).with_name("testdata") / "fake_harness.py",
-            cases=(InputCase("a", {"scale": 1.0}),),
+            cases=(InputCase("a", {"scale": 1.0}), ),
             target=KernelTarget("fake", "fake"),
         )
         from .models import PerformanceSummary as PS
@@ -553,6 +549,37 @@ class HarnessTest(unittest.TestCase):
         )
         self.assertEqual(first.source, "LATENCY_US = 80\nCORRECT = True\n")
         self.assertEqual(second.source, "LATENCY_US = 60\nCORRECT = True\n")
+
+    def test_knowledge_is_returned_for_a_curated_arch_and_not_invented(self) -> None:
+        self.assertIn("gfx942", knowledge_for("gfx942") or "")
+        self.assertIsNone(knowledge_for("sm100"), "no curated file exists for sm100 yet")
+
+    def test_knowledge_is_appended_to_the_generic_preamble(self) -> None:
+        # Append, not replace: the preamble is arch-agnostic workflow and the
+        # knowledge file is arch-specific fact. An earlier version substituted
+        # one for the other and silently dropped the workflow rules.
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("a", {}), ),
+            target=KernelTarget("hip", "gfx942"),
+        )
+        dummy_perf = PerformanceSummary(cases=(), aggregate_speedup=1.0)
+        prompt = _build_prompt(request, CandidateContext(0, 0, request.kernel_source, dummy_perf, ()))
+        self.assertIn("Evidence-driven optimization workflow", prompt)
+        self.assertIn("Human-curated knowledge base for gfx942", prompt)
+
+    def test_prompt_has_no_knowledge_block_for_an_uncurated_arch(self) -> None:
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("a", {}), ),
+            target=KernelTarget("cuda", "sm100"),
+        )
+        dummy_perf = PerformanceSummary(cases=(), aggregate_speedup=1.0)
+        prompt = _build_prompt(request, CandidateContext(0, 0, request.kernel_source, dummy_perf, ()))
+        self.assertIn("Evidence-driven optimization workflow", prompt)
+        self.assertNotIn("Human-curated knowledge base", prompt)
 
 
 class KernelOptimizerTest(unittest.TestCase):
@@ -681,20 +708,17 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertEqual(result.experiments[2].status, "promoted")
 
     def test_rejects_incorrect_candidate_and_promotes_faster_candidate(self) -> None:
-        provider = FixedCandidateProvider(
-            [
-                CandidateProposal("LATENCY_US = 1\nCORRECT = False\n", "wrong"),
-                CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster"),
-                CandidateProposal("LATENCY_US = 90\nCORRECT = True\n", "slower"),
-                CandidateProposal("LATENCY_US = 70\nCORRECT = True\n", "faster again"),
-            ]
-        )
+        provider = FixedCandidateProvider([
+            CandidateProposal("LATENCY_US = 1\nCORRECT = False\n", "wrong"),
+            CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster"),
+            CandidateProposal("LATENCY_US = 90\nCORRECT = True\n", "slower"),
+            CandidateProposal("LATENCY_US = 70\nCORRECT = True\n", "faster again"),
+        ])
         with tempfile.TemporaryDirectory() as directory:
             result = KernelOptimizer(provider).optimize(
                 KernelOptimizationRequest(
                     kernel_source="LATENCY_US = 100\nCORRECT = True\n",
-                    harness_path=Path(__file__).with_name("testdata")
-                    / "fake_harness.py",
+                    harness_path=Path(__file__).with_name("testdata") / "fake_harness.py",
                     cases=(
                         InputCase("a", {"scale": 1.0}, weight=2.0),
                         InputCase("b", {"scale": 2.0}),
@@ -707,8 +731,7 @@ class KernelOptimizerTest(unittest.TestCase):
                         benchmark_repetitions=3,
                     ),
                     output_dir=Path(directory),
-                )
-            )
+                ))
             self.assertTrue(result.success)
             self.assertEqual(result.best_kernel, "LATENCY_US = 70\nCORRECT = True\n")
             self.assertAlmostEqual(result.final.aggregate_speedup, 100 / 70)
@@ -1093,27 +1116,23 @@ class KernelOptimizerTest(unittest.TestCase):
 
     def test_profile_payload_caps_large_values(self) -> None:
         # Use a harness that returns a >1MB profile to exercise spill logic.
-        provider = FixedCandidateProvider(
-            [CandidateProposal("LATENCY_US = 100\nCORRECT = True\n", "same")]
-        )
+        provider = FixedCandidateProvider([CandidateProposal("LATENCY_US = 100\nCORRECT = True\n", "same")])
         with tempfile.TemporaryDirectory() as tmp:
             harness_path = Path(tmp) / "big_profile_harness.py"
-            harness_path.write_text(
-                "def build(kernel_source, target):\n"
-                "    return {'success': True, 'artifact': {}}\n"
-                "def verify(artifact, case):\n"
-                "    return {'passed': True}\n"
-                "def benchmark(artifact, case, repetitions):\n"
-                "    return {'samples_us': [10.0]*repetitions}\n"
-                "def profile(artifact, case):\n"
-                "    return {'big': 'x' * 2000000}\n"
-            )
+            harness_path.write_text("def build(kernel_source, target):\n"
+                                    "    return {'success': True, 'artifact': {}}\n"
+                                    "def verify(artifact, case):\n"
+                                    "    return {'passed': True}\n"
+                                    "def benchmark(artifact, case, repetitions):\n"
+                                    "    return {'samples_us': [10.0]*repetitions}\n"
+                                    "def profile(artifact, case):\n"
+                                    "    return {'big': 'x' * 2000000}\n")
             with tempfile.TemporaryDirectory() as directory:
                 result = KernelOptimizer(provider).optimize(
                     KernelOptimizationRequest(
                         kernel_source="LATENCY_US = 100\nCORRECT = True\n",
                         harness_path=harness_path,
-                        cases=(InputCase("a", {}),),
+                        cases=(InputCase("a", {}), ),
                         target=KernelTarget("fake", "fake"),
                         budget=OptimizationBudget(
                             max_rounds=1,
@@ -1121,10 +1140,63 @@ class KernelOptimizerTest(unittest.TestCase):
                             benchmark_repetitions=2,
                         ),
                         output_dir=Path(directory),
-                    )
-                )
+                    ))
                 # Optimizer should complete without error even with oversized profile.
-                self.assertIsNotNone(result)
+        self.assertIsNotNone(result)
+
+
+class Gfx942AttTest(unittest.TestCase):
+
+    def test_parser_rejects_header_only_stats(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stats = Path(directory) / "stats_dispatch.csv"
+            stats.write_text('"CodeObj","Vaddr","Instruction","Hitcount","Latency",'
+                             '"Stall","Idle","Source"\n')
+            result = att._summarize_att(Path(directory))
+        self.assertIn("header but no instruction rows", result["parse_error"])
+
+    def test_parser_accepts_real_att_columns(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            stats = Path(directory) / "stats_dispatch.csv"
+            stats.write_text('"CodeObj","Vaddr","Instruction","Hitcount","Latency",'
+                             '"Stall","Idle","Source"\n'
+                             '1,100,"s_barrier",2,20,12,1,"kernel.py:10"\n'
+                             '1,104,"v_mfma_f32_16x16x16_f16 v[0:3]",4,30,8,0,'
+                             '"kernel.py:11"\n')
+            result = att._summarize_att(Path(directory))
+        self.assertEqual(result["instruction_rows"], 2)
+        self.assertEqual(result["totals"]["stall"], 20.0)
+        self.assertEqual(
+            [row["opcode"] for row in result["stall_by_opcode"]],
+            ["barrier", "mfma"],
+        )
+
+    def test_att_command_selects_one_based_warm_dispatch(self) -> None:
+        completed = __import__("subprocess").CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+                att, "_rocprofv3",
+                return_value="/opt/rocprofv3"), mock.patch.object(att.subprocess, "run", return_value=completed) as run:
+            att._run(
+                mode="att",
+                kernel_path=Path("kernel.py"),
+                case={"case_id": "case", "parameters": {}},
+                output_dir=Path(directory),
+                entry_point="matmul",
+                kernel_regex=".*matmul.*",
+                warmup=3,
+                pin_config=None,
+                timeout_s=1,
+            )
+        command = run.call_args.args[0]
+        self.assertIn("--kernel-trace", command)
+        self.assertEqual(command[command.index("--kernel-iteration-range") + 1], "[4]")
+        self.assertEqual(command[command.index("--att-target-cu") + 1], "0")
+
+    def test_rocprofv3_override(self) -> None:
+        with mock.patch.dict("os.environ", {"TLX_ROCPROFV3": "/opt/rocm-dev/bin/rocprofv3"}), mock.patch.object(
+                att.shutil, "which", return_value="/opt/rocm-dev/bin/rocprofv3") as which:
+            self.assertEqual(att._rocprofv3(), "/opt/rocm-dev/bin/rocprofv3")
+        which.assert_called_once_with("/opt/rocm-dev/bin/rocprofv3")
 
 
 def _write_policy_harness(directory: Path) -> Path:
@@ -1191,16 +1263,12 @@ def _read_json(path: Path) -> dict[str, object]:
 
 
 def _performance(*values: tuple[str, float]) -> PerformanceSummary:
-    return PerformanceSummary(
-        cases=tuple(
-            CaseEvaluation(
-                case_id=case_id,
-                verification=VerificationResult(True),
-                timing=TimingSamples((latency, latency, latency)),
-            )
-            for case_id, latency in values
-        )
-    )
+    return PerformanceSummary(cases=tuple(
+        CaseEvaluation(
+            case_id=case_id,
+            verification=VerificationResult(True),
+            timing=TimingSamples((latency, latency, latency)),
+        ) for case_id, latency in values))
 
 
 if __name__ == "__main__":

--- a/third_party/tlx/tutorials/testing/gfx942_perf_harness.py
+++ b/third_party/tlx/tutorials/testing/gfx942_perf_harness.py
@@ -109,8 +109,14 @@ class Measurement(NamedTuple):
         return 100.0 * (self.hi_ms - self.lo_ms) / self.ms if self.ms > 0 else float("nan")
 
 
-def measure(fn, warmup_s=DEFAULT_WARMUP_S, rep_s=DEFAULT_REP_S) -> Measurement:
-    """Time ``fn`` over one continuous window after a settling warmup."""
+def measure_samples(fn, warmup_s=DEFAULT_WARMUP_S, rep_s=DEFAULT_REP_S) -> list[float]:
+    """Per-iteration times (ms, in execution order) from one continuous window.
+
+    The raw form of :func:`measure`, split out so callers that want the whole
+    distribution -- the kernel-optimization harness computes its own median and
+    coefficient of variation -- get it from the same settling method rather than
+    reimplementing it and drifting.
+    """
     fn()
     torch.cuda.synchronize()
 
@@ -139,12 +145,17 @@ def measure(fn, warmup_s=DEFAULT_WARMUP_S, rep_s=DEFAULT_REP_S) -> Measurement:
         ends[i].record()
     torch.cuda.synchronize()
 
-    times = sorted(s.elapsed_time(e) for s, e in zip(starts, ends))
+    return [s.elapsed_time(e) for s, e in zip(starts, ends)]
+
+
+def measure(fn, warmup_s=DEFAULT_WARMUP_S, rep_s=DEFAULT_REP_S) -> Measurement:
+    """Time ``fn`` over one continuous window after a settling warmup."""
+    times = sorted(measure_samples(fn, warmup_s=warmup_s, rep_s=rep_s))
 
     def q(frac):
         return times[min(len(times) - 1, max(0, int(frac * len(times))))]
 
-    return Measurement(ms=q(QUANTILES[0]), lo_ms=q(QUANTILES[1]), hi_ms=q(QUANTILES[2]), iters=n_iters)
+    return Measurement(ms=q(QUANTILES[0]), lo_ms=q(QUANTILES[1]), hi_ms=q(QUANTILES[2]), iters=len(times))
 
 
 def add_measurement_args(parser):
@@ -169,7 +180,7 @@ class OpSpec(NamedTuple):
     bias or a batch dimension just returns more tensors.
     """
 
-    name: str  # e.g. "amd_gemm_gfx942", used in the table title and plot name
+    name: str  # e.g. "amd_addmm_gfx942", used in the table title and plot name
     axes: tuple  # shape axis labels, e.g. ("M", "N", "K")
     shapes: list  # list of tuples, each matching `axes`
     make_inputs: Callable  # (shape, dtype) -> tuple of tensors


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3431
* #3430

An MI300X target for the kernel-optimization agent: rocprofv3 ATT profiling,
autotuner pinning, and unpinned re-verification in a subprocess.

`harnesses/gfx942/att.py` is the bulk. ATT is the only profiler on this part
reporting per-instruction hitcount, latency, stall and idle -- a kernel-level
TFLOP/s number says you are 0.83x aten but not which instruction class holds the
pipe. It sits under the arch directory rather than beside the ncu support in
`profiling.py` because the shared layer is NVIDIA-only: `native_profiler = "ncu"
if backend in {"cuda", "nvidia"} else None`, with no AMD hook to attach to. That
asymmetry is worth closing, and is not closed here.

`pinning.py` is genuinely arch-specific. `tlx.ops.mm` at `space="full"` searches
42 configs per shape on this part, so without a pin the promote/reject gate
measures tile selection rather than the change the candidate made.

`cli.py` gains HIP target validation against `gcnArchName`; `providers.py` gains
`knowledge_for()`, which appends a per-arch curated file from `doc/kernel_opt/`
to the prompt. Appended rather than substituted: the preamble is arch-agnostic
workflow and the knowledge file is arch-specific fact.

`gfx942_perf_harness.measure_samples` factors the raw per-iteration list out of
`measure`, which is unchanged, so the harness computes its own median and CV
from the same settling method rather than reimplementing it.

Nothing in `tlx.ops` or the perf suite imports any of this; the dependency runs
one way. Tests: 56 in test_kernel_agent.py.

Authored with Claude.

Differential Revision: [D118515641](https://our.internmc.facebook.com/intern/diff/D118515641)