### PR TITLE
[triton][tlx] Round-trip software-pipelined prefetch predicates in TTGIR-to-TLX

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-barriers.mlir
+++ b/test/TLX/print-ttgir-to-tlx-barriers.mlir
@@ -80,6 +80,43 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     ttng.wait_barrier %view, %c0_i32, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     tt.return
   }
+
+  // An arrive count is an attribute, not an operand, and is emitted positionally.
+  // CHECK-LABEL: def arrive_with_count(
+  // CHECK: tlx.barrier_arrive({{.*}}, 2)
+  tt.func public @arrive_with_count() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A predicate is an optional operand and must be named, not passed
+  // positionally into the arrive_count slot.
+  // CHECK-LABEL: def arrive_with_predicate(
+  // CHECK: tlx.barrier_arrive({{.*}}, pred=
+  tt.func public @arrive_with_predicate() attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %pid = tt.get_program_id x : i32
+    %pred = arith.cmpi sgt, %pid, %c0_i32 : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // A perThread arrive needs no keyword: barrier_arrive picks the per-thread
+  // lowering off the barrier, which alloc_warp_barrier restores.
+  // CHECK-LABEL: def per_thread_arrive(
+  // CHECK: tlx.alloc_warp_barrier(1, 4)
+  // CHECK: tlx.barrier_arrive(
+  // CHECK-NOT: per_thread=
+  tt.func public @per_thread_arrive() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 128 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.arrive_barrier %bar, 1 {perThread} : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
 }
 
 // -----
@@ -124,6 +161,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %v1 = ttg.memdesc_index %bar[%c1_i32] : !ttg.memdesc<2x1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %v0, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
     ttng.init_barrier %v1, 2 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A multicast arrive signals every CTA in its equivalence class; emitting it
+// as a local arrive would silently drop the multicast. It needs more than one
+// CTA and the identity CGA layout, hence a separate module.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttg.cluster-dim-x" = 2 : i32} {
+
+  // CHECK-LABEL: def multicast_arrive(
+  // CHECK: # unsupported: multicast arrive_barrier (ctaMask=1)
+  // CHECK-NOT: tlx.barrier_arrive(
+  tt.func public @multicast_arrive() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<2xi64, #shared, #smem, mutable>
+    // expected-error @+1 {{multicast arrive_barrier does not round-trip to TLX}}
+    ttng.arrive_barrier %bar, 1 {ctaMask = 1 : i32} : !ttg.memdesc<2xi64, #shared, #smem, mutable>
     tt.return
   }
 }

--- a/test/TLX/print-ttgir-to-tlx-clc.mlir
+++ b/test/TLX/print-ttgir-to-tlx-clc.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that Cluster Launch Control ops round-trip to their TLX spellings.
+//
+// A persistent CLC kernel issues a cancel request into a response buffer,
+// waits on an mbarrier, then decodes the stolen tile out of the response.
+// None of those ops have a generic mapping: the response buffer's ui128
+// element type is unnameable in TLX, and the issue and query ops take
+// different operand orders and result counts than the printer's default.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The ui128 response buffer gets its own allocator rather than a local_alloc
+  // of an element type TLX cannot name.
+  // CHECK-LABEL: def clc_response_alloc(
+  // CHECK: tlx._alloc_clc_responses(1)
+  // CHECK-NOT: tlx.local_alloc(
+  tt.func public @clc_response_alloc() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The issue op takes (mbarrier, response) in TTGIR but (response, barrier)
+  // in TLX, so the operands are swapped rather than printed in order.
+  // Binding each name where it is defined is what makes the swap observable:
+  // the barrier is allocated first, so a call emitted in source order would
+  // read _clc_issue([[BAR]], [[RESP]]) and fail here.
+  // CHECK-LABEL: def clc_issue(
+  // CHECK: [[BAR:[a-zA-Z_0-9]+]] = tlx.alloc_barriers(1)
+  // CHECK: [[RESP:[a-zA-Z_0-9]+]] = tlx._alloc_clc_responses(1)
+  // CHECK: tlx._clc_issue([[RESP]], [[BAR]])
+  tt.func public @clc_issue() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_clc_try_cancel %bar, %resp : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The query decodes three results, which are bound as one tuple.
+  // CHECK-LABEL: def clc_query(
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = tlx._clc_query(
+  tt.func public @clc_query() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    %x, %y, %z = ttng.clc_query_cancel %resp : (!ttg.memdesc<1xui128, #shared, #smem, mutable>) -> (i32, i32, i32)
+    tt.return
+  }
+
+  // The CLC lowering replaces tl.program_id(0) with the cluster id; emitting
+  // program_id back re-derives the same value on recompile.
+  // CHECK-LABEL: def cluster_id(
+  // CHECK: tl.program_id(axis=0)
+  tt.func public @cluster_id() attributes {noinline = false} {
+    %cid = "nvg.cluster_id"() : () -> i32
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-predicates.mlir
+++ b/test/TLX/print-ttgir-to-tlx-predicates.mlir
@@ -1,0 +1,158 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx -split-input-file %s | FileCheck %s
+
+// Test that the predicates the software pipeliner puts on its prefetched ops
+// round-trip, and that a constant-true one is left implicit.
+//
+// The pipeliner predicates the prefetched wait and dot with `k < k_tiles - 1`
+// so the drain iteration neither waits on a buffer that is never filled nor
+// runs a dot on unloaded operands. A constant-true predicate is the default
+// and carries no information, so only a real one is emitted.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // A real predicate guards whether the wait executes, so it must survive.
+  // CHECK-LABEL: def wait_with_predicate(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.barrier_wait({{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, pred=[[PRED]])
+  tt.func public @wait_with_predicate(%k: i32, %k_tiles: i32, %phase: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A constant-true predicate is the default, so it is left implicit.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_constant_true(
+  // CHECK: tlx.barrier_wait(
+  // CHECK-NOT: pred=
+  tt.func public @wait_with_constant_true(%phase: i32) attributes {noinline = false} {
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The same holds for the dot: dropping its predicate would let the drain
+// iteration accumulate garbage into the tmem accumulator.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def dot_with_predicate(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.async_dot({{.*}}pred=[[PRED]]{{.*}})
+  tt.func public @dot_with_predicate(%k: i32, %k_tiles: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %pred, %bar[%true] {is_async} : !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A constant-true dot predicate is likewise left implicit. This is the half of
+// the dot change that is observable: a real predicate was already emitted
+// before, a constant-true one was emitted too and should not be.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def dot_with_constant_true(
+  // CHECK: tlx.async_dot(
+  // CHECK-NOT: pred=
+  tt.func public @dot_with_constant_true() attributes {noinline = false} {
+    %false = arith.constant false
+    %true = arith.constant true
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The predicate is found by skipping the variadic memdesc dependency buffers,
+// which are a scheduling hint rather than something the wait's behavior
+// depends on, so they are not emitted.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_predicate_and_deps(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.barrier_wait({{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, pred=[[PRED]])
+  tt.func public @wait_with_predicate_and_deps(%k: i32, %k_tiles: i32, %phase: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %pred deps %a : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Deps with no predicate: nothing is emitted for either.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_deps_only(
+  // CHECK: tlx.barrier_wait(
+  // CHECK-NOT: pred=
+  tt.func public @wait_with_deps_only(%phase: i32) attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase deps %a : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -26,7 +26,8 @@
 
 // Verify MMA operations are replaced
 // CHECK-DAG: tlx.async_dot(
-// CHECK-DAG: use_acc=False, pred=True, mBarriers=[{{[^]]+}}], two_ctas=True, force_async=True
+// A constant-true predicate is the default and is elided.
+// CHECK-DAG: use_acc=False, mBarriers=[{{[^]]+}}], two_ctas=True, force_async=True
 // CHECK-DAG: tlx.tcgen05_commit({{[^,)]+}}, two_ctas=True)
 
 // Verify TMA operations are replaced

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -370,6 +370,17 @@ StringRef getCmpFOperator(int64_t predicate) {
   }
 }
 
+// True if `v` is a constant-true i1. Such a predicate is the default, so it is
+// elided rather than emitted.
+bool isConstantTrue(Value v) {
+  Operation *def = v.getDefiningOp();
+  if (!def || def->getName().getStringRef() != "arith.constant")
+    return false;
+  if (auto intAttr = def->getAttrOfType<IntegerAttr>("value"))
+    return intAttr.getValue().isOne();
+  return false;
+}
+
 // Build a lookup map for fast operation name lookup
 llvm::StringMap<StringRef> buildOpNameMap() {
   llvm::StringMap<StringRef> map;
@@ -1590,11 +1601,25 @@ void printSimplifiedOp(
     return;
   }
 
-  // ttng.wait_barrier: emit barrier_wait(bar, phase) without pred
+  // ttng.wait_barrier: emit barrier_wait(bar, phase[, pred=...]).
   if (opName == "ttng.wait_barrier" && op->getNumOperands() >= 2) {
     os << "tlx.barrier_wait("
        << getValueName(op->getOperand(0), argSubstitutionMap) << ", "
-       << getValueName(op->getOperand(1), argSubstitutionMap) << ")";
+       << getValueName(op->getOperand(1), argSubstitutionMap);
+    // After (alloc, phase) come an optional i1 predicate and variadic memdesc
+    // dependency buffers. Only the predicate changes whether the wait executes,
+    // so emit that and skip the deps.
+    Value pred;
+    for (unsigned i = 2; i < op->getNumOperands(); ++i) {
+      Value v = op->getOperand(i);
+      if (!isa<ttg::MemDescType>(v.getType())) {
+        pred = v;
+        break;
+      }
+    }
+    if (pred && !isConstantTrue(pred))
+      os << ", pred=" << getValueName(pred, argSubstitutionMap);
+    os << ")";
     printLocComment(op, os);
     return;
   }
@@ -1762,9 +1787,12 @@ void printSimplifiedOp(
       int idx = 3 + sizes[3]; // skip a,b,d,acc_dep
       os << ", use_acc="
          << getValueName(op->getOperand(idx), argSubstitutionMap);
-      ++idx;
-      os << ", pred=" << getValueName(op->getOperand(idx), argSubstitutionMap);
-      ++idx;
+      // The predicate operand follows useD, and guards whether the dot runs
+      // at all.
+      Value mmaPred = op->getOperand(idx + 1);
+      idx += 2; // skip useD, pred
+      if (!isConstantTrue(mmaPred))
+        os << ", pred=" << getValueName(mmaPred, argSubstitutionMap);
       int numBarriers = sizes[6];
       if (numBarriers > 0) {
         os << ", mBarriers=[";

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1392,6 +1392,20 @@ void printSimplifiedOp(
 
   // Special handling for local_alloc
   if (opName == "ttg.local_alloc") {
+    // A ui128 buffer is a CLC response allocation; that element type has no
+    // TLX spelling, so emit the dedicated allocator.
+    if (auto memDescType =
+            dyn_cast<ttg::MemDescType>(op->getResult(0).getType())) {
+      if (memDescType.getElementType().isUnsignedInteger(128)) {
+        os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+        int64_t num = 1;
+        for (int64_t dim : memDescType.getShape())
+          num *= dim;
+        os << "tlx._alloc_clc_responses(" << num << ")";
+        printLocComment(op, os);
+        return;
+      }
+    }
     auto it = allocInfoMap.find(op);
     if (it != allocInfoMap.end()) {
       const LocalAllocInfo &info = it->second;
@@ -1900,6 +1914,40 @@ void printSimplifiedOp(
     if (op->getNumOperands() >= 2)
       os << ", pred=" << getValueName(op->getOperand(1), argSubstitutionMap);
     os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // nvg.cluster_id: the CLC-persistent lowering replaces the source's
+  // tl.program_id(0) with the cluster id, identical for single-CTA clusters.
+  if (opName == "nvg.cluster_id") {
+    if (op->getNumResults() > 0)
+      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+    os << "tl.program_id(axis=0)";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.async_clc_try_cancel(mbar, response): TLX takes (response, barrier).
+  if (opName == "ttng.async_clc_try_cancel") {
+    os << "tlx._clc_issue("
+       << getValueName(op->getOperand(1), argSubstitutionMap) << ", "
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.clc_query_cancel(response): decodes the stolen tile's 3D CTA id,
+  // or (-1, -1, -1) when no work was claimed.
+  if (opName == "ttng.clc_query_cancel") {
+    unsigned nres = op->getNumResults();
+    for (unsigned i = 0; i < nres; ++i)
+      os << (i ? ", " : "")
+         << getValueName(op->getResult(i), argSubstitutionMap);
+    if (nres > 0)
+      os << " = ";
+    os << "tlx._clc_query("
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
     printLocComment(op, os);
     return;
   }

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1876,6 +1876,34 @@ void printSimplifiedOp(
     return;
   }
 
+  // ttng.arrive_barrier: `count` is an attribute and `pred` an optional
+  // operand, but the generic mapping printed both positionally.
+  if (opName == "ttng.arrive_barrier") {
+    // A multicast arrive has no TLX spelling; leave a marker instead of an
+    // arrive that would look local but mean something else.
+    auto ctaMask = op->getAttrOfType<IntegerAttr>("ctaMask");
+    if (ctaMask && ctaMask.getInt() != 0) {
+      op->emitError("multicast arrive_barrier does not round-trip to TLX");
+      os << "# unsupported: multicast arrive_barrier (ctaMask="
+         << ctaMask.getInt() << ")";
+      printLocComment(op, os);
+      return;
+    }
+    os << "tlx.barrier_arrive("
+       << getValueName(op->getOperand(0), argSubstitutionMap);
+    // count is required on this op, but tolerate its absence on hand-written
+    // IR rather than crash; 1 is the value the op defaults to anyway.
+    auto countAttr = op->getAttrOfType<IntegerAttr>("count");
+    int64_t count = countAttr ? countAttr.getInt() : 1;
+    if (count != 1)
+      os << ", " << count;
+    if (op->getNumOperands() >= 2)
+      os << ", pred=" << getValueName(op->getOperand(1), argSubstitutionMap);
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
   // Get the TLX name or use original
   auto it = opNameMap.find(opName);
   StringRef tlxName = (it != opNameMap.end()) ? it->second : opName;

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -493,7 +493,9 @@ def async_dot(
         handles = [t.handle for t in mBarriers]
         is_async = force_async or len(handles) > 0
         use_acc_handle = _get_use_acc_handle(use_acc, _semantic.builder)
-        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred,
+        # The builder wants an ir.value or None, so unwrap a tl.tensor pred.
+        pred_handle = pred.handle if isinstance(pred, tl.tensor) else pred
+        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred_handle,
                                                      bool(two_ctas), handles, bool(is_async))
         return tl.tensor(output, tl.void)
     else:
@@ -658,6 +660,8 @@ def async_dot_scaled(
     bar_handles = [t.handle for t in mBarriers]
     is_async = force_async or len(bar_handles) > 0
     use_acc_handle = _get_use_acc_handle(use_acc, _semantic.builder)
+    # The builder wants an ir.value or None, so unwrap a tl.tensor pred.
+    pred_handle = pred.handle if isinstance(pred, tl.tensor) else pred
     output = _semantic.builder.create_tcgen5_dot_scaled(
         A_handle,
         B_handle,
@@ -667,7 +671,7 @@ def async_dot_scaled(
         A_type,
         B_type,
         use_acc_handle,
-        pred,
+        pred_handle,
         bool(two_ctas),
         bar_handles,
         bool(is_async),


### PR DESCRIPTION
Summary:
This is the last change in the stack that gets `blackwell_fa_ws_persistent` to round-trip through the TTGIR-to-TLX converter: the generated TLX kernel compiles, runs, and matches the performance of the original Triton kernel.

Round-tripping TTGIR back to readable TLX has been a longstanding goal. Per the Triton warp-specialization roadmap: //"We plan to convert Triton TTGIR to readable TLX kernels for easier debugging and further performance hand-tuning."// (https://pytorch.org/blog/warp-specialization-in-triton-design-and-roadmap/)

`blackwell_fa_ws_persistent` is a reasonably challenging target because it is warp-specialized. `blackwell_gemm_clc` and the plain matmul kernel do not round-trip yet, but this establishes the foundation to reach them later.

---

This change round-trips the predicates the software pipeliner puts on its prefetched ops. Two ops carry one:

- `ttng.wait_barrier` takes an optional `i1` predicate before its variadic memdesc dependency buffers. The emitter kept only the memdescs, so every predicated wait defaulted to true.
- `ttng.tc_gen5_mma` takes a predicate right after `useD`.

The pipeliner predicates the prefetched wait and dot with `k < k_tiles - 1` so the drain iteration neither waits on a buffer that is never filled nor runs a dot on unloaded operands. Dropping the wait predicate leaves the drain waiting on a barrier nothing will signal, which deadlocks the kernel; dropping the dot predicate accumulates garbage into the tmem accumulator.

The fix emits the predicate as `pred=`, eliding a constant-true one since that is already the default. It also unwraps `pred.handle` in `tlx.async_dot`, whose builtin passed `pred` straight to `create_tcgen5_dot`, which wants an `ir.value` or `None`, so a real `tl.tensor` predicate raised `incompatible function arguments`. `tlx.async_dot_scaled` had the same unguarded hand-off and gets the same unwrap; scaled MMA is not a round-trip target yet, so that path is untested here, but leaving one sibling fixed and the other not would just defer the identical crash.

The memdesc dependency buffers on `wait_barrier` are a scheduling hint for the recompiler rather than something the wait's behavior depends on, so they are left out instead of growing a `deps` parameter on `tlx.barrier_wait`.

Authored with Claude.

Differential Revision: D113334247


