### PR TITLE
[TLX][AMD] Vectorize unaligned global loads on gfx950 (#3439)

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -304,6 +304,7 @@ public:
   unsigned getAlignment(Value offsetsValue, unsigned elementBitWidth);
 
   unsigned getMaskAlignment(Value mask);
+  unsigned getMaskAlignment(Value mask, unsigned axis);
 
 private:
   void initialize(FunctionOpInterface funcOp, AxisInfoAnalysis::LoadCallback);

--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -353,6 +353,14 @@ int getNVIDIAComputeCapability(Operation *module);
 // Read the amd target from the module attributes
 std::optional<StringRef> getAMDArch(Operation *module);
 
+// Return true when a global load may legally use a vector instruction whose
+// base address is aligned only to the element size. The caller must still
+// enforce contiguity, logical-extent, and vector-width limits. For masked
+// loads, it must also clamp the width to mask constancy along the pointer's
+// vectorized axis.
+bool canUseUnalignedVectorizedLoad(Operation *op);
+bool canUseUnalignedVectorizedLoad(Operation *op, StringRef targetArch);
+
 std::optional<mlir::triton::gpu::SwizzledSharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val, bool &incompatible);
 

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1461,13 +1461,18 @@ unsigned ModuleAxisInfoAnalysis::getMaskAlignment(Value mask) {
   auto tensorTy = dyn_cast<RankedTensorType>(mask.getType());
   if (!tensorTy)
     return 1;
+  return getMaskAlignment(mask, gpu::getOrder(tensorTy)[0]);
+}
+
+unsigned ModuleAxisInfoAnalysis::getMaskAlignment(Value mask, unsigned axis) {
+  auto tensorTy = dyn_cast<RankedTensorType>(mask.getType());
+  if (!tensorTy || axis >= tensorTy.getRank())
+    return 1;
   auto *axisInfo = getAxisInfo(mask);
   if (!axisInfo)
     return 1;
-  auto maskOrder = gpu::getOrder(tensorTy);
-  auto alignment = std::max<unsigned>(axisInfo->getConstancy(maskOrder[0]), 1);
-  LDBG("getMaskAlignment maskOrder[0] " << maskOrder[0] << " alignment "
-                                        << alignment);
+  auto alignment = std::max<unsigned>(axisInfo->getConstancy(axis), 1);
+  LDBG("getMaskAlignment axis " << axis << " alignment " << alignment);
   LLVM_DEBUG({
     std::string axisStr;
     llvm::raw_string_ostream os(axisStr);

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
@@ -60,8 +60,10 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
   int numElems = product<int64_t>(shapePerCTA);
   int numThreads = numWarps * threadsPerWarp;
 
-  unsigned perThread = getNumElementsPerThread(op, order, axisInfoAnalysis,
-                                               shapePerCTA, maxVecBits);
+  unsigned opPerThread = getNumElementsPerThread(op, order, axisInfoAnalysis,
+                                                 shapePerCTA, maxVecBits);
+  unsigned perThread = opPerThread;
+  bool hasRelatedUnalignedVectorizedLoad = false;
   LDBG("perThread for op: " << perThread);
 
   for (Operation *opSameOrder : memAccessesSameOrder) {
@@ -71,21 +73,24 @@ buildCoalescedEncoding(ModuleAxisInfoAnalysis &axisInfoAnalysis, Operation *op,
         opSameOrder, order, axisInfoAnalysis, shapePerCTA, maxVecBits);
     LDBG("perThread for opSameOrder: " << currPerThread);
     perThread = std::max(perThread, currPerThread);
+    hasRelatedUnalignedVectorizedLoad |=
+        canUseUnalignedVectorizedLoad(opSameOrder);
   }
 
   perThread = std::min<int>(perThread, std::max(numElems / numThreads, 1));
   LDBG("perThread: " << perThread);
 
-  if (!dyn_cast<triton::LoadOp>(op)) {
+  auto load = dyn_cast<triton::LoadOp>(op);
+  if (!load || (hasRelatedUnalignedVectorizedLoad &&
+                (load.getIsVolatile() || load.getMask()))) {
     // For ops that can result in a global memory write, we should enforce
     // that each thread handles at most maxVecBits bits, which is the widest
     // available vectorized store op; otherwise, the store will have "gaps"
     // in the memory write at the warp level, resulting in worse performance.
     // For loads, we can expect that the gaps won't matter due to the L1
-    // cache.
-    perThread = std::min<int>(
-        perThread, getNumElementsPerThread(op, order, axisInfoAnalysis,
-                                           shapePerCTA, maxVecBits));
+    // cache. Masked and volatile loads must retain their own safe transaction
+    // width when a related unaligned load selects a wider layout.
+    perThread = std::min(perThread, opPerThread);
   }
   SmallVector<unsigned> sizePerThread(refTensorType.getRank(), 1);
   sizePerThread[order[0]] = perThread;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -192,6 +192,18 @@ static unsigned getMaxElementsPerThread(Operation *op, unsigned maxVecBits) {
   return maxElementsPerThread;
 }
 
+static bool hasDotOperandLayoutUser(Operation *op) {
+  for (Operation *user : op->getUsers()) {
+    for (Value result : user->getResults()) {
+      auto resultType = dyn_cast<RankedTensorType>(result.getType());
+      if (resultType &&
+          isa<ttg::DotOperandEncodingAttr>(resultType.getEncoding()))
+        return true;
+    }
+  }
+  return false;
+}
+
 unsigned getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                  ArrayRef<int64_t> shapePerCTA,
@@ -206,6 +218,19 @@ unsigned getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
   unsigned maxContig =
       std::min(valInfo.getContiguity(order[0]), shapePerCTA[order[0]]);
   unsigned alignment = std::min(maxMultiple, maxContig);
+  // Some targets implement byte-aligned global vector loads in hardware, so no
+  // residual element-alignment proof is required. Axis analysis must still
+  // prove the elements contiguous, and the normal logical-extent and width
+  // caps remain. A mask additionally limits the width to groups with one
+  // shared predicate.
+  if (canUseUnalignedVectorizedLoad(op) && !hasDotOperandLayoutUser(op)) {
+    unsigned unalignedAlignment = maxContig;
+    if (auto load = dyn_cast<triton::LoadOp>(op); load && load.getMask())
+      unalignedAlignment =
+          std::min(unalignedAlignment,
+                   axisInfoAnalysis.getMaskAlignment(load.getMask(), order[0]));
+    alignment = std::max(alignment, unalignedAlignment);
+  }
   unsigned maxElementsPerThread = getMaxElementsPerThread(op, maxVecBits);
   unsigned currPerThread = std::min(alignment, maxElementsPerThread);
   LDBG("elemNumBytes: " << elemNumBytes
@@ -1302,6 +1327,25 @@ std::optional<StringRef> getAMDArch(Operation *module) {
   }
 
   return ref.drop_front(4); // drop the "hip:"
+}
+
+bool canUseUnalignedVectorizedLoad(Operation *op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  if (!module)
+    return false;
+  auto arch = getAMDArch(module);
+  return arch && canUseUnalignedVectorizedLoad(op, *arch);
+}
+
+bool canUseUnalignedVectorizedLoad(Operation *op, StringRef targetArch) {
+  auto load = dyn_cast<triton::LoadOp>(op);
+  if (!load || load.getIsVolatile())
+    return false;
+
+  // Keep this restricted to gfx950 so future targets must opt in through an
+  // explicit capability update. Ignore target feature suffixes when matching
+  // the processor name.
+  return targetArch.split(':').first == "gfx950";
 }
 
 static inline ttg::SwizzledSharedEncodingAttr

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -1460,6 +1460,101 @@ def test_buffer_load_contiguity_vectorizes_gfx950():
 
 
 @triton.jit
+def _plain_unaligned_vector_load_kernel(
+    x_ptr,
+    y_ptr,
+    OFFSET: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    values = tl.load(x_ptr + OFFSET + offsets)
+    tl.store(y_ptr + offsets, values)
+
+
+@triton.jit
+def _masked_unaligned_vector_load_kernel(
+    x_ptr,
+    y_ptr,
+    OFFSET: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    VALID_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < VALID_SIZE
+    values = tl.load(x_ptr + OFFSET + offsets, mask=mask, other=0)
+    tl.store(y_ptr + offsets, values)
+
+
+@pytest.mark.parametrize(
+    "pointer_type,block_size,expected_load",
+    [
+        ("*fp16", 1024, "buffer_load_dwordx2"),
+        ("*fp16", 2048, "buffer_load_dwordx4"),
+        ("*i8", 4096, "buffer_load_dwordx4"),
+    ],
+)
+def test_plain_unaligned_vector_load_is_automatic_gfx950(
+    pointer_type, block_size, expected_load
+):
+    """A plain gfx950 load vectorizes without a per-kernel opt-in."""
+    compiled = compile_for_gfx950(
+        _plain_unaligned_vector_load_kernel,
+        signature={"x_ptr": pointer_type, "y_ptr": pointer_type},
+        constexprs={"OFFSET": 1, "BLOCK_SIZE": block_size},
+    )
+
+    assert expected_load in compiled.asm["amdgcn"]
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+@pytest.mark.parametrize(
+    "dtype,block_size",
+    [
+        (torch.float16, 1024),
+        (torch.float16, 2048),
+        (torch.uint8, 4096),
+    ],
+)
+@pytest.mark.parametrize("offset", [1, 2, 3, 7])
+def test_plain_unaligned_vector_load_correctness_gfx950(
+    device, offset, dtype, block_size
+):
+    """Exercise several naturally aligned but non-vector-aligned addresses."""
+    x = torch.arange(block_size + 8, device=device, dtype=dtype)
+    actual = torch.empty(block_size, device=device, dtype=dtype)
+    _plain_unaligned_vector_load_kernel[(1, )](
+        x,
+        actual,
+        OFFSET=offset,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    torch.testing.assert_close(
+        actual, x[offset:offset + block_size], atol=0.0, rtol=0.0
+    )
+
+
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_masked_unaligned_vector_load_correctness_gfx950(device):
+    block_size = 2048
+    valid_size = block_size - 8
+    x = torch.arange(block_size + 1, device=device, dtype=torch.float16)
+    actual = torch.empty(block_size, device=device, dtype=torch.float16)
+    compiled = _masked_unaligned_vector_load_kernel[(1, )](
+        x,
+        actual,
+        OFFSET=1,
+        BLOCK_SIZE=block_size,
+        VALID_SIZE=valid_size,
+        num_warps=4,
+    )
+    expected = torch.zeros_like(actual)
+    expected[:valid_size] = x[1:1 + valid_size]
+    torch.testing.assert_close(actual, expected, atol=0.0, rtol=0.0)
+    assert "buffer_load_dwordx4" in compiled.asm["amdgcn"]
+
+
+@triton.jit
 def _buffer_atomic_contiguity_layout_anchor_kernel(x_ptr, atomic_ptr, y_ptr):
     contiguous_layout: tl.constexpr = tlx.layout(
         shape=((64, 4), (4, )),

--- a/test/TritonGPU/amd/amd-coalesce-unaligned-vector-load.mlir
+++ b/test/TritonGPU/amd/amd-coalesce-unaligned-vector-load.mlir
@@ -1,0 +1,221 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-coalesce | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32,
+                   ttg.target = "hip:gfx950",
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK: #[[$WIDE:.*]] = #ttg.blocked<{sizePerThread = [4]
+  // CHECK-LABEL: @exact_gfx950
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  tt.func @exact_gfx950(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                        %unaligned: i32) -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %value = tt.load %ptrs : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+
+  // gfx950 supports byte-aligned vector accesses, so no residual element-size
+  // alignment proof is required.
+  // CHECK-LABEL: @byte_aligned_gfx950
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  tt.func @byte_aligned_gfx950(
+      %base: !tt.ptr<f16> {tt.divisibility = 1 : i32})
+      -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %range : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %value = tt.load %ptrs : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+
+  // A masked access remains alignment-conservative. The compiler cannot
+  // widen it merely because gfx950 supports unaligned vector instructions:
+  // the mask still has to describe a legal vector transaction.
+  // CHECK-LABEL: @masked_gfx950
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  tt.func @masked_gfx950(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                          %unaligned: i32,
+                          %mask: tensor<1024xi1, #blocked>)
+      -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<1024xf16, #blocked>
+    %value = tt.load %ptrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+
+  // A mask whose predicate is constant across four adjacent elements permits
+  // the same four-element vector width as the contiguous pointer.
+  // CHECK-LABEL: @aligned_mask_gfx950
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  tt.func @aligned_mask_gfx950(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %unaligned: i32,
+      %mask: tensor<1024xi1, #blocked> {tt.constancy = 4 : i32})
+      -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<1024xf16, #blocked>
+    %value = tt.load %ptrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+
+  // Volatile accesses also retain the generic alignment rule.
+  // CHECK-LABEL: @volatile_gfx950
+  // CHECK: tt.load {{.*}}isVolatile = true{{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  tt.func @volatile_gfx950(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                            %unaligned: i32) -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %value = tt.load %ptrs {isVolatile = true} : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+
+  // A related relaxed load must not widen masked or volatile loads that share
+  // its pointer slice.
+  // CHECK-LABEL: @mixed_loads_gfx950
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  // CHECK: tt.load {{.*}}isVolatile = true{{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  tt.func @mixed_loads_gfx950(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %unaligned: i32,
+      %mask: tensor<1024xi1, #blocked>) -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<1024xf16, #blocked>
+    %wide = tt.load %ptrs : tensor<1024x!tt.ptr<f16>, #blocked>
+    %masked = tt.load %ptrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked>
+    %volatile = tt.load %ptrs {isVolatile = true} : tensor<1024x!tt.ptr<f16>, #blocked>
+    %sum0 = arith.addf %wide, %masked : tensor<1024xf16, #blocked>
+    %sum1 = arith.addf %sum0, %volatile : tensor<1024xf16, #blocked>
+    tt.return %sum1 : tensor<1024xf16, #blocked>
+  }
+
+  // A masked load must not count itself as a related relaxed load. It may
+  // share the wider layout selected by an aligned store while retaining its
+  // own scalar transaction width during lowering.
+  // CHECK-LABEL: @masked_load_with_aligned_store
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  // CHECK: tt.store {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$WIDE]]>
+  tt.func @masked_load_with_aligned_store(
+      %input: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %output: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %unaligned: i32,
+      %mask: tensor<1024xi1, #blocked>) {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %inputIndices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %inputBases = tt.splat %input : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %inputPtrs = tt.addptr %inputBases, %inputIndices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<1024xf16, #blocked>
+    %loaded = tt.load %inputPtrs, %mask, %other : tensor<1024x!tt.ptr<f16>, #blocked>
+    %outputBases = tt.splat %output : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %outputPtrs = tt.addptr %outputBases, %range : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    tt.store %outputPtrs, %loaded : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+
+  // Stores are not covered by the load-only hardware capability.
+  // CHECK-LABEL: @store_gfx950
+  // CHECK: tt.store {{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  tt.func @store_gfx950(%base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+                         %unaligned: i32,
+                         %value: tensor<1024xf16, #blocked>) {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    tt.store %ptrs, %value : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32,
+                   ttg.target = "hip:gfx942",
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @gfx942_is_conservative
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #blocked>
+  tt.func @gfx942_is_conservative(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %unaligned: i32) -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %value = tt.load %ptrs : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [4], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32,
+                   ttg.target = "hip:gfx950:sramecc+:xnack-",
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK: #[[$FEATURE_WIDE:.*]] = #ttg.blocked<{sizePerThread = [4]
+  // CHECK-LABEL: @gfx950_with_features
+  // CHECK: tt.load {{.*}} : tensor<1024x!tt.ptr<f16>, #[[$FEATURE_WIDE]]>
+  tt.func @gfx950_with_features(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+      %unaligned: i32) -> tensor<1024xf16, #blocked> {
+    %range = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32, #blocked>
+    %offset = tt.splat %unaligned : i32 -> tensor<1024xi32, #blocked>
+    %indices = arith.addi %range, %offset : tensor<1024xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<1024x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<1024x!tt.ptr<f16>, #blocked>, tensor<1024xi32, #blocked>
+    %value = tt.load %ptrs : tensor<1024x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<1024xf16, #blocked>
+  }
+}
+
+// -----
+
+#ptr = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [1, 4], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32,
+                   ttg.target = "hip:gfx950",
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // Axis analysis makes dimension 0 the pointer's vectorized axis even though
+  // dimension 1 is the layout's fastest axis. The mask is constant only along
+  // dimension 1, so it cannot permit a vector load along dimension 0.
+  // CHECK: #[[$MASK_SCALAR:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4]
+  // CHECK-LABEL: @mask_uses_pointer_axis
+  // CHECK: tt.load {{.*}} : tensor<16x64x!tt.ptr<f16>, #[[$MASK_SCALAR]]>
+  tt.func @mask_uses_pointer_axis(
+      %ptr: tensor<16x64x!tt.ptr<f16>, #ptr>
+          {tt.contiguity = dense<[4, 1]> : tensor<2xi32>,
+           tt.divisibility = dense<[2, 2]> : tensor<2xi32>},
+      %maskValue: tensor<16x64xi1, #ptr>
+          {tt.constancy = dense<[1, 4]> : tensor<2xi32>})
+      -> tensor<16x64xf16, #ptr> {
+    %other = arith.constant dense<0.0> : tensor<16x64xf16, #ptr>
+    %value = tt.load %ptr, %maskValue, %other : tensor<16x64x!tt.ptr<f16>, #ptr>
+    tt.return %value : tensor<16x64xf16, #ptr>
+  }
+}

--- a/test/TritonGPU/amd/amd-convert-unaligned-vector-load.mlir
+++ b/test/TritonGPU/amd/amd-convert-unaligned-vector-load.mlir
@@ -1,0 +1,116 @@
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx942 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=GFX942
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-convert-buffer-ops="gfx-arch=gfx950 analyze-small-tensor-ofst=true" | FileCheck %s --check-prefix=GFX950
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32,
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // The first address is base + one f16, so axis analysis can only guarantee
+  // 2-byte alignment. gfx950 may still use the four contiguous elements owned
+  // by each thread; older targets retain scalar contiguity.
+  // GFX942-LABEL: @plain_unaligned_load
+  // GFX942: amdg.buffer_load
+  // GFX942-NOT: contiguity
+  // GFX942: tt.return
+  // GFX950-LABEL: @plain_unaligned_load
+  // GFX950: amdg.buffer_load {{.*}} {contiguity = 4 : i32}
+  tt.func @plain_unaligned_load(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32,
+                           tt.pointer_range = 32 : i32})
+      -> tensor<256xf16, #blocked> {
+    %range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %one = arith.constant dense<1> : tensor<256xi32, #blocked>
+    %indices = arith.addi %range, %one : tensor<256xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xi32, #blocked>
+    %value = tt.load %ptrs : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<256xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32,
+                   ttg.target = "hip:gfx950",
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // The module target is authoritative when it is present, including when it
+  // differs from the standalone pass option.
+  // GFX942-LABEL: @module_target_overrides_pass_option
+  // GFX942: amdg.buffer_load {{.*}} {contiguity = 4 : i32}
+  // GFX950-LABEL: @module_target_overrides_pass_option
+  // GFX950: amdg.buffer_load {{.*}} {contiguity = 4 : i32}
+  tt.func @module_target_overrides_pass_option(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32,
+                           tt.pointer_range = 32 : i32})
+      -> tensor<256xf16, #blocked> {
+    %range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %one = arith.constant dense<1> : tensor<256xi32, #blocked>
+    %indices = arith.addi %range, %one : tensor<256xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xi32, #blocked>
+    %value = tt.load %ptrs : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<256xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32,
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // An aligned mask permits one predicate for all four loaded elements.
+  // GFX942-LABEL: @aligned_mask_unaligned_load
+  // GFX942: amdg.buffer_load
+  // GFX942-NOT: contiguity
+  // GFX942: tt.return
+  // GFX950-LABEL: @aligned_mask_unaligned_load
+  // GFX950: amdg.buffer_load {{.*}} {contiguity = 4 : i32}
+  tt.func @aligned_mask_unaligned_load(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32,
+                           tt.pointer_range = 32 : i32},
+      %mask: tensor<256xi1, #blocked> {tt.constancy = 4 : i32})
+      -> tensor<256xf16, #blocked> {
+    %range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %one = arith.constant dense<1> : tensor<256xi32, #blocked>
+    %indices = arith.addi %range, %one : tensor<256xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<256xf16, #blocked>
+    %value = tt.load %ptrs, %mask, %other : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<256xf16, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32,
+                   "ttg.threads-per-warp" = 64 : i32} {
+  // A mask keeps the normal alignment and mask-granularity checks even on
+  // gfx950, so this access remains scalar.
+  // GFX942-LABEL: @masked_unaligned_load
+  // GFX942: amdg.buffer_load
+  // GFX942-NOT: contiguity
+  // GFX942: tt.return
+  // GFX950-LABEL: @masked_unaligned_load
+  // GFX950: amdg.buffer_load
+  // GFX950-NOT: contiguity
+  // GFX950: tt.return
+  tt.func @masked_unaligned_load(
+      %base: !tt.ptr<f16> {tt.divisibility = 16 : i32,
+                           tt.pointer_range = 32 : i32},
+      %mask: tensor<256xi1, #blocked>) -> tensor<256xf16, #blocked> {
+    %range = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked>
+    %one = arith.constant dense<1> : tensor<256xi32, #blocked>
+    %indices = arith.addi %range, %one : tensor<256xi32, #blocked>
+    %bases = tt.splat %base : !tt.ptr<f16> -> tensor<256x!tt.ptr<f16>, #blocked>
+    %ptrs = tt.addptr %bases, %indices : tensor<256x!tt.ptr<f16>, #blocked>, tensor<256xi32, #blocked>
+    %other = arith.constant dense<0.0> : tensor<256xf16, #blocked>
+    %value = tt.load %ptrs, %mask, %other : tensor<256x!tt.ptr<f16>, #blocked>
+    tt.return %value : tensor<256xf16, #blocked>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -754,6 +754,23 @@ unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass) {
   return clampVecSizeForNpot(vec, tensorTy);
 }
 
+unsigned
+getVectorSizeIgnoringAlignment(Value ptr,
+                               ModuleAxisInfoAnalysis &axisAnalysisPass) {
+  auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
+  if (!tensorTy)
+    return 1;
+  auto order = triton::gpu::getOrder(tensorTy);
+  unsigned contiguity = triton::gpu::getContigPerThread(tensorTy)[order[0]];
+  if (auto *axisInfo = axisAnalysisPass.getAxisInfo(ptr))
+    contiguity =
+        std::min<unsigned>(contiguity, axisInfo->getContiguity(order[0]));
+  unsigned pointeeBitWidth = triton::getPointeeBitWidth(tensorTy);
+  unsigned vec = std::min<unsigned>(128 / pointeeBitWidth,
+                                    std::max<unsigned>(contiguity, 1));
+  return clampVecSizeForNpot(vec, tensorTy);
+}
+
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass) {
   auto contiguity = getContiguity(ptr, offset, axisAnalysisPass);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -97,6 +97,12 @@ unsigned getContiguity(Value ptr, Value offset,
 // Determine the vector size of a tensor of pointers
 unsigned getVectorSize(Value ptr, ModuleAxisInfoAnalysis &axisAnalysisPass);
 
+// Determine the vector size from per-thread and analyzed contiguity without
+// requiring the pointer base to have the vector's natural alignment.
+unsigned
+getVectorSizeIgnoringAlignment(Value ptr,
+                               ModuleAxisInfoAnalysis &axisAnalysisPass);
+
 // Given a scalar pointer and a tensor of offsets, determine the vector size
 unsigned getVectorSize(Value ptr, Value offset,
                        ModuleAxisInfoAnalysis &axisAnalysisPass);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -28,6 +28,7 @@
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 using ::mlir::LLVM::AMD::getVectorSize;
+using ::mlir::LLVM::AMD::getVectorSizeIgnoringAlignment;
 using mlir::triton::amdgpu::TargetFeatures;
 
 namespace ttg = mlir::triton::gpu;
@@ -504,10 +505,12 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
       mlir::MLIRContext *context,
       DenseMap<Value, SetVector<Operation *>> &assumptions,
       ModuleAxisInfoAnalysis &axisAnalysisPass,
-      std::shared_ptr<DataFlowSolver> solver, bool analyzeSmallTensorOfst_)
+      std::shared_ptr<DataFlowSolver> solver, bool analyzeSmallTensorOfst_,
+      StringRef targetArch_)
       : mlir::OpRewritePattern<SourceOp>(context), assumptions(assumptions),
         axisAnalysisPass(axisAnalysisPass), solver(std::move(solver)),
-        analyzeSmallTensorOfst(analyzeSmallTensorOfst_) {}
+        analyzeSmallTensorOfst(analyzeSmallTensorOfst_),
+        targetArch(targetArch_) {}
   mlir::LogicalResult
   matchAndRewrite(SourceOp op, PatternRewriter &rewriter) const override {
     LDBG("Try to convert: " << op);
@@ -534,9 +537,19 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
       auto bufferLoadOp = [&]() {
         if constexpr (std::is_same_v<SourceOp, triton::LoadOp>) {
           unsigned contig = getVectorSize(ptr, axisAnalysisPass);
-          if (maybeMask)
+          if (canUseUnalignedVectorizedLoad(op, targetArch)) {
+            contig = std::max(
+                contig, getVectorSizeIgnoringAlignment(ptr, axisAnalysisPass));
+            if (maybeMask) {
+              auto ptrTy = cast<RankedTensorType>(ptr.getType());
+              contig = std::min<unsigned>(
+                  contig, axisAnalysisPass.getMaskAlignment(
+                              maybeMask, ttg::getOrder(ptrTy)[0]));
+            }
+          } else if (maybeMask) {
             contig = std::min<unsigned>(
                 contig, axisAnalysisPass.getMaskAlignment(maybeMask));
+          }
           return triton::amdgpu::BufferLoadOp::create(
               rewriter, op->getLoc(), op.getType(), basePtr, tensorOffset,
               blockStride, op.getCache(), maybeMask, maybeOther, contig);
@@ -569,6 +582,7 @@ private:
   ModuleAxisInfoAnalysis &axisAnalysisPass;
   std::shared_ptr<DataFlowSolver> solver;
   bool analyzeSmallTensorOfst;
+  std::string targetArch;
 };
 
 struct ConvertTritonStoreToBufferStore
@@ -638,7 +652,10 @@ struct TritonAMDGPUConvertToBufferOpsPass
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     ModuleOp mod = getOperation();
-    TargetFeatures targetFeatures{llvm::StringRef(gfxArch)};
+    StringRef targetArch = gfxArch;
+    if (auto moduleArch = getAMDArch(mod))
+      targetArch = moduleArch->split(':').first;
+    TargetFeatures targetFeatures{targetArch};
 
     // Collect assumptions in the function
     DenseMap<Value, SetVector<Operation *>> assumptions =
@@ -653,15 +670,17 @@ struct TritonAMDGPUConvertToBufferOpsPass
       return signalPassFailure();
 
     AMD::ModuleAxisInfoAnalysis axisInfoAnalysis(mod);
-    patterns.add<ConvertTritonLoadToBufferLoad<tt::LoadOp>,
-                 ConvertTritonStoreToBufferStore>(context, assumptions,
+    patterns.add<ConvertTritonLoadToBufferLoad<tt::LoadOp>>(
+        context, assumptions, axisInfoAnalysis, solver,
+        this->analyzeSmallTensorOfst, targetArch);
+    patterns.add<ConvertTritonStoreToBufferStore>(context, assumptions,
                                                   axisInfoAnalysis, solver,
                                                   this->analyzeSmallTensorOfst);
     if (targetFeatures.supportsBufferLoadToLocal()) {
       patterns
           .add<ConvertTritonLoadToBufferLoad<ttg::AsyncCopyGlobalToLocalOp>>(
               context, assumptions, axisInfoAnalysis, solver,
-              this->analyzeSmallTensorOfst);
+              this->analyzeSmallTensorOfst, targetArch);
     }
 
     if (this->allowBufferAtomics && targetFeatures.supportsBufferAtomicRMW())


### PR DESCRIPTION
Summary:

gfx950 supports unaligned global vector accesses in hardware, and LLVM already models this capability through FeatureUnalignedBufferAccess and unaligned-access-mode. Triton, however, selects the distributed load layout before LLVM lowering and conservatively limits its vector width using the base-pointer alignment. The AMD lowering therefore never sees the wider transaction that the hardware can execute.

This change centralizes the eligibility decision in a shared, target-aware predicate. On gfx950, a non-volatile `tt.load` may retain the vector width proven by AxisInfo contiguity even when the base address has weaker natural alignment. Only the base-alignment clamp is relaxed: logical tensor extent, non-power-of-two width clamping, and the existing 128-bit per-thread limit remain unchanged.

Masked loads are supported when the mask is sufficiently aligned. Their final width is `min(pointer contiguity, mask alignment, hardware width cap)`, so every element in one vector transaction shares a predicate. An arbitrary or fine-grained mask therefore remains scalar, while a mask constant across a dwordx2/dwordx4 group can use that width safely. The AMD buffer-op conversion applies the same rule when selecting the physical transaction width.

Conversion still requires the existing buffer-safety proof: a splatted base and either i32 offsets or range-proven i64 offsets that are non-negative and remain inside the 2 GiB resource descriptor. Stores, atomics, volatile loads, and direct global-to-LDS accesses keep their conservative alignment rules. The capability is intentionally restricted to gfx950 even though LLVM models support on additional AMD targets; future architectures should be enabled only after equivalent compiler and hardware validation. This replaces the kernel-specific opt-in without weakening alignment handling for unrelated memory operations.

Performance was measured on gfx950 with a temporary, uncommitted compiler flag that disables only this relaxation. Each result is the average of two run medians; each run used 30 warmups followed by 7 samples of 100 launches with an independent Triton cache. The wider loads do not imply fewer underlying memory transactions, but they materially reduce issued load instructions and instruction/scheduling pressure in these BMMs.

| B | MxNxK | Feature disabled | Feature enabled | Latency reduction | Static `buffer_load_*` instructions |
| ---: | --- | ---: | ---: | ---: | ---: |
| 1024 | 40x256x1956 | 187.04 us | 180.77 us | 3.4% | 34 -> 22 |
| 1024 | 262x256x294 | 141.40 us | 101.23 us | 28.4% | 64 -> 31 |
| 3072 | 448x160x931 | 1191.69 us | 771.39 us | 35.3% | 93 -> 51 |
| 1024 | 1195x256x2309 | 2543.08 us | 1991.56 us | 21.7% | 216 -> 104 |

Reviewed By: htyu

Differential Revision: D116569328


