### PR TITLE
[TLX][FA] Eliminate causal rescaling and masked diagonal work (#3440)

### DIFF
--- a/third_party/tlx/tutorials/amd_addmm_gfx950.py
+++ b/third_party/tlx/tutorials/amd_addmm_gfx950.py
@@ -48,6 +48,7 @@ def _path_key(
     a: torch.Tensor,
     b: torch.Tensor,
     split_k,
+    config,
 ) -> tuple[object, ...]:
     return (
         a.device.type,
@@ -59,6 +60,7 @@ def _path_key(
         a.stride(),
         b.stride(),
         split_k,
+        tuple(sorted(config.items())) if config is not None else None,
     )
 
 
@@ -153,6 +155,8 @@ def available_paths(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor) -> tup
 
 
 def _dispatch(path: str, bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, split_k, config=None):
+    if config is not None and path != "register":
+        raise ValueError("config is only supported by the register path")
     if path == "inter_wave":
         return _launch(a, b, bias=bias, SPLIT_K=split_k)
     if path == "inter_wave_tail":
@@ -167,13 +171,17 @@ def _autotune_path(
     a: torch.Tensor,
     b: torch.Tensor,
     split_k,
+    config=None,
 ) -> str:
-    key = _path_key(bias, a, b, split_k)
+    key = _path_key(bias, a, b, split_k, config)
     cached = _PATH_CACHE.get(key)
     if cached is not None:
         return cached
 
-    register = lambda: _launch_register(a, b, bias=bias)
+    register = lambda: _launch_register(a, b, bias=bias, config=config)
+    if config is not None:
+        _PATH_CACHE[key] = "register"
+        return "register"
     register_output = register()
     candidates = {"register": register}
     if _can_use_inter_wave(a):
@@ -206,9 +214,8 @@ def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None, pa
 
     ``path`` pins one of `available_paths`; the default (None) times the valid
     paths against each other and keeps the winner per shape. ``config`` pins
-    the register path's kernel config, bypassing its autotuner. Correctness
-    tests should pass both: neither the path race nor the config sweep tells
-    them anything, and together they dominate the suite's wall clock.
+    both the register path and its kernel config, bypassing both autotuners.
+    Supplying ``config`` with an explicit non-register path is an error.
     """
     if a.ndim != 2 or b.ndim != 2:
         raise ValueError("addmm expects two-dimensional matrix operands")
@@ -230,10 +237,19 @@ def addmm(bias: torch.Tensor, a: torch.Tensor, b: torch.Tensor, SPLIT_K=None, pa
             raise ValueError("SPLIT_K is only supported by the inter-wave kernel")
         if path not in (None, "inter_wave"):
             raise ValueError(f"SPLIT_K > 1 requires the inter_wave path, got {path!r}")
+        if config is not None:
+            raise ValueError("config is only supported by the register path, but SPLIT_K > 1 requires inter_wave")
         return _launch(a, b, bias=bias_2d, SPLIT_K=SPLIT_K)
     if path is not None:
         valid = available_paths(bias_2d, a, b)
         if path not in valid:
             raise ValueError(f"Path {path!r} is not valid for this shape; valid paths are {valid}")
         return _dispatch(path, bias_2d, a, b, SPLIT_K, config=config)
-    return _dispatch(_autotune_path(bias_2d, a, b, SPLIT_K), bias_2d, a, b, SPLIT_K, config=config)
+    return _dispatch(
+        _autotune_path(bias_2d, a, b, SPLIT_K, config=config),
+        bias_2d,
+        a,
+        b,
+        SPLIT_K,
+        config=config,
+    )

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -150,7 +150,15 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
     return pruned
 
 
-_S2_F16_GAUGE = tl.constexpr(0.055517269)
+_RCP_LN2 = tl.constexpr(1.4426950408889634)
+_ROUNDING_GAUGE = tl.constexpr(0.055517269)
+_BF16_FIXED_GAUGE = tl.constexpr(4.055517269)
+_CAUSAL_FIXED_GAUGE_HEADROOM = tl.constexpr(64.0)
+_EXP2_MAGIC = tl.constexpr(12582912.0)
+_EXP2_BF16_SCALE = tl.constexpr(128.0)
+_EXP2_BF16_BIAS = tl.constexpr(126.0)
+_EXP2_F16_SCALE = tl.constexpr(1024.0)
+_EXP2_F16_BIAS = tl.constexpr(14.0)
 
 
 @core.builtin
@@ -190,19 +198,17 @@ def _s2_exp2_bf16(x, a2, b2m, _semantic=None):
         """
         {
             .reg .b64 ra, rb, rc, rd;
-            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
+            .reg .b32 v0, v1, pk, uu, mk, c0;
             mov.b64 ra, { $1, $2 };
             mov.b64 rb, { $3, $4 };
             mov.b64 rc, { $5, $6 };
             fma.rn.f32x2 rd, ra, rb, rc;
             mov.b64 { v0, v1 }, rd;
             prmt.b32 pk, v0, v1, 0x5410;
-            mov.b32 zz, 0;
             mov.b32 mk, 0x00400040;
             add.s16x2 uu, pk, mk;
             mov.b32 c0, 0x3f3b3f3b;
-            fma.rn.bf16x2 pk, uu, c0, pk;
-            max.bf16x2 pk, pk, zz;
+            fma.rn.relu.bf16x2 pk, uu, c0, pk;
             mov.b32 $0, pk;
         }
         """,
@@ -385,7 +391,7 @@ def _fwd_softmax_tile_1cta(
                         col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
                         qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
                     m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-                m_i = tl.ceil(m_i) + _S2_F16_GAUGE
+                m_i = tl.ceil(m_i) + _ROUNDING_GAUGE
             l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
             p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
             for fragment_id in tl.static_range(0, 4):
@@ -400,8 +406,8 @@ def _fwd_softmax_tile_1cta(
                 if FAST_BF16:
                     p_h = _s2_exp2_bf16(
                         qk_fragment,
-                        qk_scale * 128.0,
-                        12582912.0 + 128.0 * (126.0 - m_i[:, None]),
+                        qk_scale * _EXP2_BF16_SCALE,
+                        _EXP2_MAGIC + _EXP2_BF16_SCALE * (_EXP2_BF16_BIAS - m_i[:, None]),
                     )
                 elif STAGE == 2:
                     p_i = tl.math.exp2(_fma_f32x2(qk_fragment, qk_scale, -m_i[:, None]))
@@ -409,8 +415,8 @@ def _fwd_softmax_tile_1cta(
                 else:
                     p_h = _s2_exp2_f16(
                         qk_fragment,
-                        qk_scale * 1024.0,
-                        12582912.0 + 1024.0 * (14.0 - m_i[:, None]),
+                        qk_scale * _EXP2_F16_SCALE,
+                        _EXP2_MAGIC + _EXP2_F16_SCALE * (_EXP2_F16_BIAS - m_i[:, None]),
                     )
                 if (FAST_BF16 or FAST_F16) and fragment_id % 2 == 0:
                     p_pending = p_h
@@ -538,15 +544,6 @@ def _fwd_softmax_tile_2cta(
     for start_n in tl.range(lo, hi, BLOCK_N):
         _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
         tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
-        if gauge_cnt == 0:
-            for fragment_id in tl.static_range(0, 4):
-                qk_fragment = tlx.local_load(tlx.subslice(
-                    tlx.local_view(qk_tiles, cid),
-                    fragment_id * 32,
-                    32,
-                ))
-                m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-            m_i = tl.ceil(m_i) + 0.055517269
         l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
         p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
         for fragment_id in tl.static_range(0, 4):
@@ -557,8 +554,8 @@ def _fwd_softmax_tile_2cta(
             ))
             p_h = _s2_exp2_bf16(
                 qk_fragment,
-                qk_scale * 128.0,
-                12582912.0 + 128.0 * (126.0 - m_i[:, None]),
+                qk_scale * _EXP2_BF16_SCALE,
+                _EXP2_MAGIC + _EXP2_BF16_SCALE * (_EXP2_BF16_BIAS - _BF16_FIXED_GAUGE),
             )
             if fragment_id < 2:
                 p_fragment = tlx.local_slice(
@@ -585,6 +582,10 @@ def _fwd_softmax_tile_2cta(
                     remote_cta_rank=0,
                 )
             l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
+            if gauge_cnt == 0:
+                m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
+        if gauge_cnt == 0:
+            m_i = tl.ceil(m_i)
         l_i += l_ij
         accum_cnt_qk += 1
         gauge_cnt += 1
@@ -792,6 +793,129 @@ def _fwd_softmax_tile(
 
 
 @triton.jit
+def _fwd_fixed_2cta_control_tile(
+    tile_id,
+    tile_count,
+    accum_cnt_qk,
+    gauge_cnt,
+    sm_scale,
+    M,
+    H,
+    num_pid_n,
+    num_pid_in_group,
+    N_CTX,
+    desc_v,
+    desc_o,
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    acc_empties,
+    acc_tiles,
+    qk_empties,
+    o_empties,
+    o_fulls,
+    o_tiles,
+    cluster_cta_rank,
+    BLOCK_M: tl.constexpr,
+    BLOCK_M_SPLIT: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    EFFECTIVE_BLOCK_M: tl.constexpr,
+    GROUP_SIZE_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    start_m, off_hz, lo, hi, _, _ = _compute_offsets(
+        tile_id,
+        H,
+        num_pid_n,
+        num_pid_in_group,
+        N_CTX,
+        EFFECTIVE_BLOCK_M,
+        STAGE,
+        GROUP_SIZE_N,
+    )
+    m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32)
+    qk_scale = sm_scale * _RCP_LN2
+    gauge_cnt -= gauge_cnt
+    cid = 0
+    offs_m = (start_m * EFFECTIVE_BLOCK_M) + (cluster_cta_rank * BLOCK_M_SPLIT +
+                                                 tl.arange(0, BLOCK_M_SPLIT))
+    if STAGE & 1:
+        m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile_2cta(
+            qk_fulls,
+            qk_tiles,
+            p_fulls,
+            p_tiles,
+            cid,
+            accum_cnt_qk,
+            gauge_cnt,
+            qk_scale,
+            m_i,
+            l_i,
+            start_m,
+            N_CTX,
+            tlx.dtype_of(desc_v),
+            BLOCK_M,
+            BLOCK_N,
+            NUM_MMA_SLICES,
+            STAGE=4 - STAGE,
+        )
+    if STAGE & 2:
+        m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile_2cta(
+            qk_fulls,
+            qk_tiles,
+            p_fulls,
+            p_tiles,
+            cid,
+            accum_cnt_qk,
+            gauge_cnt,
+            qk_scale,
+            m_i,
+            l_i,
+            start_m,
+            N_CTX,
+            tlx.dtype_of(desc_v),
+            BLOCK_M,
+            BLOCK_N,
+            NUM_MMA_SLICES,
+            STAGE=2,
+        )
+
+    tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
+    m_out = m_i * qk_scale if RESCALE_OPT else m_i
+    l_bits = l_i.to(tl.int32, bitcast=True)
+    l_bits += (4 - m_out.to(tl.int32)) << 23
+    l_for_m = l_bits.to(tl.float32, bitcast=True)
+    m_out += _ROUNDING_GAUGE
+    tl.store(M + off_hz * N_CTX + offs_m, tl.math.log2(l_for_m) + m_out)
+    _, phase = get_bufidx_phase(tile_count, 1)
+    tlx.barrier_wait(acc_empties[cid], phase)
+    tlx.barrier_wait(o_empties[cid], phase ^ 1)
+    scale = (1 / l_i)[:, None]
+    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+        subslice = tlx.subslice(
+            acc_tiles[cid],
+            HEAD_DIM * slice_id // NUM_MMA_SLICES,
+            HEAD_DIM // NUM_MMA_SLICES,
+        )
+        acc = _mul_f32x2(tlx.local_load(subslice), scale)
+        acc = acc.to(tlx.dtype_of(desc_o))
+        subslice_o = tlx.local_slice(
+            o_tiles[cid],
+            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
+            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
+        )
+        tlx.local_store(subslice_o, acc)
+    tlx.fence("async_shared")
+    tlx.barrier_arrive(o_fulls[cid])
+    return accum_cnt_qk, gauge_cnt
+
+
+@triton.jit
 def _fwd_control_tile(
     tile_id,
     tile_count,
@@ -907,7 +1031,7 @@ def _fwd_control_tile(
         else:
             tlx.barrier_arrive(qk_empties[cid])
         if RESCALE_OPT:
-            m = m * sm_scale * 1.44269504
+            m = m * sm_scale * _RCP_LN2
         m += tl.math.log2(l)
         offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
         m_ptrs = M + off_hz * N_CTX + offs_m
@@ -945,6 +1069,37 @@ def _fwd_control_tile(
 
 
 @triton.jit
+def _fwd_load_first_k_tile(
+    accum_cnt_k,
+    lo,
+    hi,
+    kv_offset_y,
+    desc_k,
+    k_tiles,
+    k_fulls,
+    k_empties,
+    K_BYTES_PER_ELEM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    cluster_cta_rank,
+    NUM_CTAS: tl.constexpr,
+):
+    buf, phase = get_bufidx_phase(accum_cnt_k, NUM_BUFFERS_KV)
+    tlx.barrier_wait(k_empties[buf], phase ^ 1)
+    if cluster_cta_rank == 0:
+        tlx.barrier_expect_bytes(k_fulls[buf], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+    tlx.async_descriptor_load(
+        desc_k,
+        k_tiles[buf],
+        [kv_offset_y + cluster_cta_rank * (BLOCK_N // NUM_CTAS), 0],
+        k_fulls[buf],
+        two_ctas=True,
+    )
+    return accum_cnt_k + (hi - lo) // BLOCK_N
+
+
+@triton.jit
 def _fwd_load_tile(
     tile_count,
     accum_cnt_kv,
@@ -975,6 +1130,7 @@ def _fwd_load_tile(
     v_empties=None,
     NUM_GROUPS_PER_CTA: tl.constexpr = 2,
     NUM_CTAS: tl.constexpr = 1,
+    SKIP_FIRST_K: tl.constexpr = False,
 ):
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
     # load q0
@@ -992,7 +1148,23 @@ def _fwd_load_tile(
                 q_fulls[q_id],
                 two_ctas=True,
             )
-        for _ in tl.range(lo, hi, BLOCK_N):
+        if SKIP_FIRST_K:
+            buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+            tlx.barrier_wait(v_empties[buf], phase ^ 1)
+            if cluster_cta_rank == 0:
+                tlx.barrier_expect_bytes(v_fulls[buf], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+            tlx.async_descriptor_load(
+                desc_v,
+                v_tiles[buf],
+                [kv_offset_y, cluster_cta_rank * (HEAD_DIM // NUM_CTAS)],
+                v_fulls[buf],
+                two_ctas=True,
+            )
+            kv_offset_y += BLOCK_N
+            accum_cnt_kv += 1
+
+        loop_start = lo + BLOCK_N if SKIP_FIRST_K else lo
+        for _ in tl.range(loop_start, hi, BLOCK_N):
             buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
             tlx.barrier_wait(kv_empties[buf], phase ^ 1)
             tlx.barrier_wait(v_empties[buf], phase ^ 1)
@@ -1146,6 +1318,8 @@ def _fwd_mma_tile(
         mBarriers=[qk_fulls[0]],
         two_ctas=USE_2CTA,
     )
+    if USE_2CTA and SKIP_RESCALE and lo + BLOCK_N >= hi:
+        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
 
     # -- compute q1 @ k ----
     tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
@@ -1158,6 +1332,8 @@ def _fwd_mma_tile(
         mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
         two_ctas=USE_2CTA,
     )
+    if USE_2CTA and SKIP_RESCALE and lo + BLOCK_N >= hi:
+        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
 
     _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
 
@@ -1225,6 +1401,8 @@ def _fwd_mma_tile(
             mBarriers=[qk_fulls[0]],
             two_ctas=USE_2CTA,
         )
+        if USE_2CTA and SKIP_RESCALE and i + BLOCK_N >= hi:
+            tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
 
         # -- compute p1 @ v from the previous iteration----
         if USE_2CTA:
@@ -1277,6 +1455,8 @@ def _fwd_mma_tile(
             mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
             two_ctas=USE_2CTA,
         )
+        if USE_2CTA and SKIP_RESCALE and i + BLOCK_N >= hi:
+            tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
 
         # -- compute p0 @ v ----
         # wait for the V buffer to be populated by the producer
@@ -1318,8 +1498,9 @@ def _fwd_mma_tile(
                     two_ctas=USE_2CTA,
                 )
 
-    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
-    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
+    if not SKIP_RESCALE or not USE_2CTA:
+        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
+        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
     tlx.tcgen05_commit(acc_empties[0], two_ctas=USE_2CTA)
 
     # -- compute p1 @ v ----
@@ -1444,8 +1625,13 @@ def _attn_fwd_ws_kernel(
     tl.static_assert(not USE_2CTA or BLOCK_M == 256)
     FAST_F16_CAPABLE: tl.constexpr = (tlx.dtype_of(desc_v) == tl.float16 and NUM_MMA_SLICES == 4 and not RESCALE_OPT
                                       and not USE_2CTA)
-    # BF16 fixed-gauge row sums are too imprecise for the softmax metadata reused by backward.
-    USE_FAST_FIXED: tl.constexpr = FAST_FIXED and FAST_F16_CAPABLE
+    FAST_2CTA_CAPABLE: tl.constexpr = (
+        USE_2CTA
+        and tlx.dtype_of(desc_v) == tl.bfloat16
+        and NUM_MMA_SLICES == 2
+        and not RESCALE_OPT
+    )
+    USE_FAST_FIXED: tl.constexpr = FAST_FIXED and (FAST_F16_CAPABLE or FAST_2CTA_CAPABLE)
     USE_FAST_F16: tl.constexpr = USE_FAST_FIXED and FAST_F16_CAPABLE
     FUSE_EPILOG: tl.constexpr = USE_FAST_FIXED and not USE_2CTA
     DIRECT_SCHED: tl.constexpr = USE_2CTA or USE_FAST_F16
@@ -1607,13 +1793,50 @@ def _attn_fwd_ws_kernel(
         # correction group
         with tlx.async_task("default"):
             accum_cnt = 0
+            accum_cnt_qk = 0
+            gauge_cnt = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_producer = 1
             clc_phase_consumer = 0
             while tile_id != -1:
                 # Publish this persistent tile, then finalize its M and O outputs.
-                if not USE_2CTA:
+                if USE_2CTA and USE_FAST_FIXED:
+                    accum_cnt_qk, gauge_cnt = _fwd_fixed_2cta_control_tile(
+                        tile_id,
+                        tile_count,
+                        accum_cnt_qk,
+                        gauge_cnt,
+                        sm_scale,
+                        M,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        N_CTX,
+                        desc_v,
+                        desc_o,
+                        qk_fulls,
+                        qk_tiles,
+                        p_fulls,
+                        p_tiles,
+                        acc_empties,
+                        acc_tiles,
+                        qk_empties,
+                        o_empties,
+                        o_fulls,
+                        o_tiles,
+                        cluster_cta_rank,
+                        BLOCK_M,
+                        BLOCK_M_SPLIT,
+                        BLOCK_N,
+                        EFFECTIVE_BLOCK_M,
+                        GROUP_SIZE_N,
+                        HEAD_DIM,
+                        NUM_MMA_SLICES,
+                        RESCALE_OPT,
+                        STAGE,
+                    )
+                elif not USE_2CTA:
                     if not DIRECT_SCHED:
                         tlx.clc_producer(clc_context, clc_phase_producer)
                         clc_phase_producer ^= 1
@@ -1667,7 +1890,8 @@ def _attn_fwd_ws_kernel(
                     clc_phase_consumer ^= 1
 
         # softmax groups
-        with tlx.async_task(num_warps=4, registers=DENSE_REGS if USE_2CTA else 168, replicate=NUM_GROUPS_PER_CTA):
+        with tlx.async_task(num_warps=4, registers=DENSE_REGS if USE_2CTA else 168,
+                            replicate=1 if USE_2CTA and USE_FAST_FIXED else NUM_GROUPS_PER_CTA):
             accum_cnt_qk = 0
             gauge_cnt = 0
             tile_count = 0
@@ -1694,15 +1918,15 @@ def _attn_fwd_ws_kernel(
                 if not USE_FAST_FIXED:
                     l_i += 1.0
                 qk_scale = sm_scale
-                qk_scale *= 1.44269504  # 1/log(2)
+                qk_scale *= _RCP_LN2
                 p_dtype = tlx.dtype_of(desc_v)
 
-                if USE_2CTA:
-                    cid = tlx.async_task_replica_id()
+                if USE_2CTA and USE_FAST_FIXED:
+                    cid = 1
                     group_id = cid * NUM_CTAS + cluster_cta_rank
                 else:
                     cid = tlx.async_task_replica_id()
-                    group_id = cid
+                    group_id = cid * NUM_CTAS + cluster_cta_rank if USE_2CTA else cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
                     m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
@@ -1770,9 +1994,16 @@ def _attn_fwd_ws_kernel(
                 if USE_2CTA:
                     tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
                     m_out = m_i * qk_scale if RESCALE_OPT else m_i
+                    if USE_FAST_FIXED:
+                        l_bits = l_i.to(tl.int32, bitcast=True)
+                        l_bits += (4 - m_out.to(tl.int32)) << 23
+                        l_for_m = l_bits.to(tl.float32, bitcast=True)
+                        m_out += _ROUNDING_GAUGE
+                    else:
+                        l_for_m = l_i
                     tl.store(
                         M + off_hz * N_CTX + offs_m,
-                        tl.math.log2(l_i) + m_out,
+                        tl.math.log2(l_for_m) + m_out,
                         mask=offs_m < N_CTX,
                     )
                     _, phase = get_bufidx_phase(tile_count, 1)
@@ -1796,7 +2027,6 @@ def _attn_fwd_ws_kernel(
                     tlx.fence("async_shared")
                     tlx.barrier_arrive(o_fulls[cid])
                 else:
-                    # prepare l_i for the epilog
                     tlx.local_store(l_tiles[cid], tl.join(l_i, l_i) if SCALAR_N == 2 else l_i[:, None])
                     tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
                     tlx.barrier_arrive(l_fulls[cid])
@@ -1900,6 +2130,41 @@ def _attn_fwd_ws_kernel(
                     tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
+        if USE_2CTA and USE_FAST_FIXED:
+            with tlx.async_task(num_warps=1, registers=24):
+                accum_cnt_k = 0
+                tile_id = start_pid
+                while tile_id != -1:
+                    _, _, lo, hi, _, kv_offset_y = _compute_offsets(
+                        tile_id,
+                        H,
+                        num_pid_n,
+                        num_pid_in_group,
+                        N_CTX,
+                        EFFECTIVE_BLOCK_M,
+                        STAGE,
+                        GROUP_SIZE_N,
+                    )
+                    accum_cnt_k = _fwd_load_first_k_tile(
+                        accum_cnt_k,
+                        lo,
+                        hi,
+                        kv_offset_y,
+                        desc_k,
+                        k_tiles,
+                        k_fulls,
+                        k_empties,
+                        K_BYTES_PER_ELEM,
+                        BLOCK_N,
+                        HEAD_DIM,
+                        NUM_BUFFERS_KV,
+                        cluster_cta_rank,
+                        NUM_CTAS,
+                    )
+                    tlx.named_barrier_wait(15, 64)
+                    next_tile_id = tile_id + persistent_stride
+                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
+
         # Q/K/V loader role; output publication remains in the epilog task.
         with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
@@ -1948,7 +2213,10 @@ def _attn_fwd_ws_kernel(
                         v_empties,
                         NUM_GROUPS_PER_CTA,
                         NUM_CTAS,
+                        SKIP_FIRST_K=USE_FAST_FIXED,
                     )
+                    if USE_FAST_FIXED:
+                        tlx.named_barrier_arrive(15, 64)
                 else:
                     accum_cnt_kv = _fwd_load_tile(
                         tile_count,
@@ -2004,13 +2272,24 @@ def _attn_fwd_ws_kernel(
                         GROUP_SIZE_N,
                     )
                     _, phase = get_bufidx_phase(tile_count, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        group_id = cid * NUM_CTAS + cluster_cta_rank
-                        tlx.barrier_wait(o_fulls[cid], phase)
-                        qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                        tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                    if USE_FAST_FIXED and NUM_GROUPS_PER_CTA == 2:
+                        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                            group_id = cid * NUM_CTAS + cluster_cta_rank
+                            tlx.barrier_wait(o_fulls[cid], phase)
+                            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                        tlx.async_descriptor_store_wait(1)
+                        tlx.barrier_arrive(o_empties[0])
                         tlx.async_descriptor_store_wait(0)
-                        tlx.barrier_arrive(o_empties[cid])
+                        tlx.barrier_arrive(o_empties[1])
+                    else:
+                        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                            group_id = cid * NUM_CTAS + cluster_cta_rank
+                            tlx.barrier_wait(o_fulls[cid], phase)
+                            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                            tlx.async_descriptor_store_wait(0)
+                            tlx.barrier_arrive(o_empties[cid])
 
                     tile_count += 1
                     if DIRECT_SCHED:
@@ -3273,7 +3552,7 @@ def _attn_bwd_ws(
     DIRECT_DQ_OUTPUT: tl.constexpr = SCALE_QK_IN_KERNEL
     DQ_READ_DONE_BAR: tl.constexpr = 12
     NUM_REDUCE_THREADS: tl.constexpr = 4 * 32
-    qk_scale = sm_scale * 1.4426950408889634
+    qk_scale = sm_scale * _RCP_LN2
 
     # Compute bytes per element for each tensor type
     Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
@@ -4167,7 +4446,7 @@ def _select_forward_plan(q, k, v, causal):
         pipelined=pipelined,
         policy=policy,
         num_ctas=(2 if head_dim == 128 and q.dtype == torch.bfloat16 and not causal and q.shape == k.shape
-                  and q.shape == v.shape and (n_ctx == 1024 or n_ctx >= 4096) else 1),
+                  and q.shape == v.shape and n_ctx >= 1024 else 1),
     )
 
 
@@ -4189,7 +4468,7 @@ class _attention(torch.autograd.Function):
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
-        use_s1_2cta = plan.num_ctas == 2
+        use_2cta = plan.num_ctas == 2
         dummy_block = [128, HEAD_DIM_K] if plan.pipelined else [1, 1]
         desc_q = TensorDescriptor(
             q,
@@ -4201,13 +4480,13 @@ class _attention(torch.autograd.Function):
             v,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=[128, 64] if use_s1_2cta else dummy_block,
+            block_shape=[128, 64] if use_2cta else dummy_block,
         )
         desc_k = TensorDescriptor(
             k,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=[64, 128] if use_s1_2cta else dummy_block,
+            block_shape=[64, 128] if use_2cta else dummy_block,
         )
         desc_o = TensorDescriptor(
             o,
@@ -4224,8 +4503,15 @@ class _attention(torch.autograd.Function):
         if plan.pipelined:
             work_ctas = (triton.cdiv(q.shape[2], FWD_BLOCK_M.value * plan.num_ctas) * q.shape[0] * q.shape[1] *
                          plan.num_ctas)
-            grid = (min(torch.cuda.get_device_properties(q.device).multi_processor_count, work_ctas)
-                    if use_s1_2cta else work_ctas, )
+            if use_2cta:
+                full_ctas = min(torch.cuda.get_device_properties(q.device).multi_processor_count, work_ctas)
+                full_clusters = full_ctas // plan.num_ctas
+                work_clusters = work_ctas // plan.num_ctas
+                persistent_waves = triton.cdiv(work_clusters, full_clusters)
+                packed_clusters = triton.cdiv(work_clusters, persistent_waves)
+                grid = (packed_clusters * plan.num_ctas, )
+            else:
+                grid = (work_ctas, )
             _attn_fwd_ws.fn[grid](
                 sm_scale,
                 M,  #
@@ -4252,11 +4538,11 @@ class _attention(torch.autograd.Function):
                 NUM_CTAS=plan.num_ctas,
                 PIPELINED=True,
                 POLICY=plan.policy,
-                DENSE_REGS=176 if use_s1_2cta else 168,
+                DENSE_REGS=176 if use_2cta else 168,
                 FAST_FIXED=True,
                 num_stages=1,
                 num_warps=4,
-                **({"ctas_per_cga": (2, 1, 1)} if use_s1_2cta else {}),
+                **({"ctas_per_cga": (2, 1, 1)} if use_2cta else {}),
                 **extra_kern_args,
             )
         else:
@@ -4316,8 +4602,7 @@ class _attention(torch.autograd.Function):
             dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
         PRE_BLOCK = 128
         BLK_SLICE_FACTOR = 2
-        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
-        arg_k = k if direct_dq_output else k * (ctx.sm_scale * RCP_LN2)
+        arg_k = k if direct_dq_output else k * (ctx.sm_scale * _RCP_LN2.value)
         assert N_CTX % PRE_BLOCK == 0
         pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
         delta = torch.empty_like(M)

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -171,7 +171,6 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
 _RCP_LN2 = tl.constexpr(1.4426950408889634)
 _ROUNDING_GAUGE = tl.constexpr(0.055517269)
 _BF16_FIXED_GAUGE = tl.constexpr(4.055517269)
-_CAUSAL_FIXED_GAUGE_HEADROOM = tl.constexpr(64.0)
 _EXP2_MAGIC = tl.constexpr(12582912.0)
 _EXP2_BF16_SCALE = tl.constexpr(128.0)
 _EXP2_BF16_BIAS = tl.constexpr(126.0)
@@ -440,6 +439,7 @@ def _fwd_softmax_tile_1cta(
     RESCALE_OPT: tl.constexpr,
     SCALAR_N: tl.constexpr,
     FAST_FIXED: tl.constexpr,
+    SKIP_CAUSAL_DIAG: tl.constexpr,
 ):
     FAST_BF16: tl.constexpr = FAST_FIXED and out_dtype == tl.bfloat16
     FAST_F16: tl.constexpr = FAST_FIXED and out_dtype == tl.float16
@@ -449,7 +449,26 @@ def _fwd_softmax_tile_1cta(
         for start_n in tl.range(lo, hi, BLOCK_N):
             _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
             tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
-            if gauge_cnt == 0:
+            skip_q0 = SKIP_CAUSAL_DIAG and STAGE == 2 and cid == 0 and start_n + BLOCK_N >= hi
+            if skip_q0:
+                for slice_id in tl.static_range(0, NUM_P_SLICES):
+                    p_bufIdx = cid * NUM_P_SLICES + slice_id
+                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+            else:
+                if gauge_cnt == 0:
+                    for fragment_id in tl.static_range(0, 4):
+                        qk_fragment = tlx.local_load(tlx.subslice(
+                            tlx.local_view(qk_tiles, cid),
+                            fragment_id * 32,
+                            32,
+                        ))
+                        if STAGE == 2:
+                            col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
+                            qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
+                        m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
+                    m_i = tl.ceil(m_i) + _ROUNDING_GAUGE
+                l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
+                p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
                 for fragment_id in tl.static_range(0, 4):
                     qk_fragment = tlx.local_load(tlx.subslice(
                         tlx.local_view(qk_tiles, cid),
@@ -459,47 +478,34 @@ def _fwd_softmax_tile_1cta(
                     if STAGE == 2:
                         col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
                         qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
-                    m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-                m_i = tl.ceil(m_i) + _ROUNDING_GAUGE
-            l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
-            p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
-            for fragment_id in tl.static_range(0, 4):
-                qk_fragment = tlx.local_load(tlx.subslice(
-                    tlx.local_view(qk_tiles, cid),
-                    fragment_id * 32,
-                    32,
-                ))
-                if STAGE == 2:
-                    col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
-                    qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
-                if FAST_BF16:
-                    p_h = _s2_exp2_bf16(
-                        qk_fragment,
-                        qk_scale * _EXP2_BF16_SCALE,
-                        _EXP2_MAGIC + _EXP2_BF16_SCALE * (_EXP2_BF16_BIAS - m_i[:, None]),
-                    )
-                elif STAGE == 2:
-                    p_i = tl.math.exp2(_fma_f32x2(qk_fragment, qk_scale, -m_i[:, None]))
-                    p_h = p_i.to(out_dtype)
-                else:
-                    p_h = _s2_exp2_f16(
-                        qk_fragment,
-                        qk_scale * _EXP2_F16_SCALE,
-                        _EXP2_MAGIC + _EXP2_F16_SCALE * (_EXP2_F16_BIAS - m_i[:, None]),
-                    )
-                if (FAST_BF16 or FAST_F16) and fragment_id % 2 == 0:
-                    p_pending = p_h
-                elif FAST_BF16 or FAST_F16:
-                    p_bufIdx = cid * 2 + fragment_id // 2
-                    tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), _join_n_2D([p_pending, p_h]))
-                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-                if FAST_BF16:
-                    l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
-                elif STAGE == 2:
-                    l_ij += tl.sum(p_i, 1)
-                else:
-                    l_ij += tl.sum(p_h, 1).to(tl.float32)
-            l_i += l_ij
+                    if FAST_BF16:
+                        p_h = _s2_exp2_bf16(
+                            qk_fragment,
+                            qk_scale * _EXP2_BF16_SCALE,
+                            _EXP2_MAGIC + _EXP2_BF16_SCALE * (_EXP2_BF16_BIAS - m_i[:, None]),
+                        )
+                    elif STAGE == 2:
+                        p_i = tl.math.exp2(_fma_f32x2(qk_fragment, qk_scale, -m_i[:, None]))
+                        p_h = p_i.to(out_dtype)
+                    else:
+                        p_h = _s2_exp2_f16(
+                            qk_fragment,
+                            qk_scale * _EXP2_F16_SCALE,
+                            _EXP2_MAGIC + _EXP2_F16_SCALE * (_EXP2_F16_BIAS - m_i[:, None]),
+                        )
+                    if (FAST_BF16 or FAST_F16) and fragment_id % 2 == 0:
+                        p_pending = p_h
+                    elif FAST_BF16 or FAST_F16:
+                        p_bufIdx = cid * 2 + fragment_id // 2
+                        tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), _join_n_2D([p_pending, p_h]))
+                        tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+                    if FAST_BF16:
+                        l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
+                    elif STAGE == 2:
+                        l_ij += tl.sum(p_i, 1)
+                    else:
+                        l_ij += tl.sum(p_h, 1).to(tl.float32)
+                l_i += l_ij
             accum_cnt_qk += 1
             gauge_cnt += 1
         return m_i, l_i, accum_cnt_qk, gauge_cnt
@@ -510,80 +516,75 @@ def _fwd_softmax_tile_1cta(
         qk_buf_phase = accum_cnt_qk & 1
         alpha_phase = accum_cnt_qk & 1
         tlx.barrier_wait(tlx.local_view(qk_fulls, qk_buf), qk_buf_phase)
-        qk = tlx.local_load(tlx.local_view(qk_tiles, qk_buf))
-
-        if STAGE == 2:
-            col_limit_right = (offs_m - start_n + 1)[:, None]
-            qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
-
-        # compute m_i, p in registers
-        # update_row_max: row_max_new = _compute_row_max(qk, row_max[0])
-        # -> FA4 handles one row per thread (32 threads per warp * 4)
-        # -> use fmax_reduce(one row of qk, m_i[0])
-        # -> m_i|m_ij = row_max[0] * scale
-        if RESCALE_OPT:
-            m_ij = tl.maximum(m_i, tl.max(qk, 1))
-        else:
-            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
-
-        # -- compute correction factor
-        # update_row_max: acc_scale_ = (row_max[0] - row_max_new) * scale
-        # -> acc_scale = exp2(acc_scale_)
-        # -> if (acc_scale_ >= -8.0):
-        # ->   row_max_new = row_max[0]; acc_scale = 1.0
-        # -> row_max[0] = row_max_new
-        if RESCALE_OPT:
-            alpha_ = (m_i - m_ij) * qk_scale  # alpha_ is 1D distributed over the warp group
-            alpha = tl.math.exp2(alpha_)
-            rescale_mask = alpha_ >= -8.0
-            alpha = tl.where(rescale_mask, 1.0, alpha)
-            m_ij = tl.where(rescale_mask, m_i, m_ij)
-        else:
-            alpha = tl.math.exp2(m_i - m_ij)
-        tlx.barrier_wait(tlx.local_view(alpha_empties, cid), alpha_phase ^ 1)
-        tlx.local_store(tlx.local_view(alpha_tiles, cid), tl.join(alpha, alpha) if SCALAR_N == 2 else alpha[:, None])
-        tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
-        # Shorten alpha's lifetime: consume immediately, add l_ij later
-        l_i *= alpha
-
-        # scale_subtract_rowmax:
-        # -> row_max_scaled = row_max_new * scale
-        # -> s[i], s[i+1] = fma_packed_f32x2((s[i], s[i+1]), (scale, scale), (-row_max_scaled, -row_max_scaled))
-        if RESCALE_OPT:
-            m_scaled = m_ij * qk_scale
-            qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
-        else:
-            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
-        # apply_epx2_convert in FA4:
-        # 128 elements per row is divided into 4 fragments, first fragment covers [0] to [31]
-        # for last fragment, always use SFU, for first 3 fragments, elements 0 to 11 use SFU,
-        # elements 12 to 15 use emulation, elements 16 to 27 use SFU, elements 28 to 31 use emulation
-        # the loop is unrolled twice likely for vectorization
-        qks = _split_n_2D(qk, NUM_MMA_SLICES)
-        l_ij = tl.zeros_like(l_i)
-        p_pending = tl.zeros([BLOCK_M // 2, BLOCK_N // NUM_MMA_SLICES], dtype=out_dtype)
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            # prepare p for the v dot
-            p_i = tl.math.exp2(qks[slice_id])
-            p_h = p_i.to(out_dtype)
-            if FAST_F16:
-                if slice_id % 2 == 0:
-                    p_pending = p_h
-                else:
-                    p_bufIdx = qk_buf * NUM_P_SLICES + slice_id // 2
-                    tlx.local_store(
-                        tlx.local_view(p_tiles, p_bufIdx),
-                        _join_n_2D([p_pending, p_h]),
-                    )
-                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-            else:
+        skip_q0 = SKIP_CAUSAL_DIAG and STAGE == 2 and cid == 0 and start_n + BLOCK_N >= hi
+        if skip_q0:
+            alpha = tl.full([BLOCK_M // 2], 1.0, tl.float32)
+            tlx.barrier_wait(tlx.local_view(alpha_empties, cid), alpha_phase ^ 1)
+            tlx.local_store(
+                tlx.local_view(alpha_tiles, cid),
+                tl.join(alpha, alpha) if SCALAR_N == 2 else alpha[:, None],
+            )
+            tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
+            for slice_id in tl.static_range(0, NUM_P_SLICES):
                 p_bufIdx = qk_buf * NUM_P_SLICES + slice_id
-                tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
                 tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-            l_ij += tl.sum(p_i, 1)
+        else:
+            qk = tlx.local_load(tlx.local_view(qk_tiles, qk_buf))
 
-        l_i += l_ij
-        m_i = m_ij
+            if STAGE == 2:
+                col_limit_right = (offs_m - start_n + 1)[:, None]
+                qk = _apply_causal_mask(qk, col_limit_right, BLOCK_N)
+
+            if RESCALE_OPT:
+                m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            else:
+                m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+
+            if RESCALE_OPT:
+                alpha_ = (m_i - m_ij) * qk_scale
+                alpha = tl.math.exp2(alpha_)
+                rescale_mask = alpha_ >= -8.0
+                alpha = tl.where(rescale_mask, 1.0, alpha)
+                m_ij = tl.where(rescale_mask, m_i, m_ij)
+            else:
+                alpha = tl.math.exp2(m_i - m_ij)
+            tlx.barrier_wait(tlx.local_view(alpha_empties, cid), alpha_phase ^ 1)
+            tlx.local_store(
+                tlx.local_view(alpha_tiles, cid),
+                tl.join(alpha, alpha) if SCALAR_N == 2 else alpha[:, None],
+            )
+            tlx.barrier_arrive(tlx.local_view(alpha_fulls, cid))
+            l_i *= alpha
+
+            if RESCALE_OPT:
+                m_scaled = m_ij * qk_scale
+                qk = _fma_f32x2(qk, qk_scale, -m_scaled[:, None])
+            else:
+                qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
+            qks = _split_n_2D(qk, NUM_MMA_SLICES)
+            l_ij = tl.zeros_like(l_i)
+            p_pending = tl.zeros([BLOCK_M // 2, BLOCK_N // NUM_MMA_SLICES], dtype=out_dtype)
+            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                p_i = tl.math.exp2(qks[slice_id])
+                p_h = p_i.to(out_dtype)
+                if FAST_F16:
+                    if slice_id % 2 == 0:
+                        p_pending = p_h
+                    else:
+                        p_bufIdx = qk_buf * NUM_P_SLICES + slice_id // 2
+                        tlx.local_store(
+                            tlx.local_view(p_tiles, p_bufIdx),
+                            _join_n_2D([p_pending, p_h]),
+                        )
+                        tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+                else:
+                    p_bufIdx = qk_buf * NUM_P_SLICES + slice_id
+                    tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
+                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+                l_ij += tl.sum(p_i, 1)
+
+            l_i += l_ij
+            m_i = m_ij
         accum_cnt_qk += 1
     return m_i, l_i, accum_cnt_qk, gauge_cnt
 
@@ -788,6 +789,7 @@ def _fwd_softmax_tile(
     SCALAR_N: tl.constexpr,
     USE_2CTA: tl.constexpr,
     FAST_FIXED: tl.constexpr,
+    SKIP_CAUSAL_DIAG: tl.constexpr,
 ):
     if USE_2CTA:
         if FAST_FIXED:
@@ -858,6 +860,7 @@ def _fwd_softmax_tile(
         RESCALE_OPT,
         SCALAR_N,
         FAST_FIXED,
+        SKIP_CAUSAL_DIAG,
     )
 
 
@@ -986,6 +989,74 @@ def _fwd_fixed_2cta_control_tile(
     tlx.fence("async_shared")
     tlx.barrier_arrive(o_fulls[cid])
     return accum_cnt_qk, gauge_cnt
+
+
+@triton.jit
+def _fwd_softmax_stages(
+    qk_fulls,
+    qk_tiles,
+    p_fulls,
+    p_tiles,
+    alpha_empties,
+    alpha_fulls,
+    alpha_tiles,
+    acc_fulls,
+    acc_tiles,
+    cid,
+    accum_cnt_qk,
+    gauge_cnt,
+    qk_scale,
+    offs_m,
+    m_i,
+    l_i,
+    start_m,
+    N_CTX,
+    out_dtype,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_MMA_SLICES: tl.constexpr,
+    STAGE: tl.constexpr,
+    RESCALE_OPT: tl.constexpr,
+    SCALAR_N: tl.constexpr,
+    USE_2CTA: tl.constexpr,
+    FAST_FIXED: tl.constexpr,
+    SKIP_CAUSAL_DIAG: tl.constexpr,
+):
+    for stage_bit in tl.static_range(1, 3):
+        if STAGE & stage_bit:
+            m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
+                qk_fulls,
+                qk_tiles,
+                p_fulls,
+                p_tiles,
+                alpha_empties,
+                alpha_fulls,
+                alpha_tiles,
+                acc_fulls,
+                acc_tiles,
+                cid,
+                accum_cnt_qk,
+                gauge_cnt,
+                qk_scale,
+                offs_m,
+                m_i,
+                l_i,
+                start_m,
+                N_CTX,
+                out_dtype,
+                BLOCK_M,
+                BLOCK_N,
+                HEAD_DIM,
+                NUM_MMA_SLICES,
+                STAGE=4 - STAGE if stage_bit == 1 else 2,
+                RESCALE_OPT=RESCALE_OPT,
+                SCALAR_N=SCALAR_N,
+                USE_2CTA=USE_2CTA,
+                FAST_FIXED=FAST_FIXED,
+                SKIP_CAUSAL_DIAG=SKIP_CAUSAL_DIAG,
+            )
+    return m_i, l_i, accum_cnt_qk, gauge_cnt
 
 
 @triton.jit
@@ -1370,6 +1441,7 @@ def _fwd_mma_tile(
     v_empties=None,
     USE_2CTA: tl.constexpr = False,
     SKIP_RESCALE: tl.constexpr = False,
+    SKIP_CAUSAL_Q0_LAST: tl.constexpr = False,
 ):
     v_tiles = v_tiles if USE_2CTA else kv_tiles
     v_fulls = v_fulls if USE_2CTA else kv_fulls
@@ -1470,14 +1542,18 @@ def _fwd_mma_tile(
         k_tile = tlx.local_trans(kv_tiles[k_bufIdx])
         _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
 
-        tlx.async_dot(
-            q_tiles[0],
-            k_tile,
-            qk_tiles[0],
-            use_acc=False,
-            mBarriers=[qk_fulls[0]],
-            two_ctas=USE_2CTA,
-        )
+        skip_q0 = SKIP_CAUSAL_Q0_LAST and i + BLOCK_N >= hi
+        if skip_q0:
+            tlx.tcgen05_commit(qk_fulls[0], two_ctas=USE_2CTA)
+        else:
+            tlx.async_dot(
+                q_tiles[0],
+                k_tile,
+                qk_tiles[0],
+                use_acc=False,
+                mBarriers=[qk_fulls[0]],
+                two_ctas=USE_2CTA,
+            )
         if USE_2CTA and SKIP_RESCALE and i + BLOCK_N >= hi:
             tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
 
@@ -1566,14 +1642,15 @@ def _fwd_mma_tile(
                     [BLOCK_N * slice_id // NUM_P_SLICES, 0],
                     [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
                 )
-                tlx.async_dot(
-                    p_tiles[p_bufIdx],
-                    kv_slice,
-                    acc_tiles[0],
-                    use_acc=True,
-                    force_async=True,
-                    two_ctas=USE_2CTA,
-                )
+                if not skip_q0:
+                    tlx.async_dot(
+                        p_tiles[p_bufIdx],
+                        kv_slice,
+                        acc_tiles[0],
+                        use_acc=True,
+                        force_async=True,
+                        two_ctas=USE_2CTA,
+                    )
 
     if not SKIP_RESCALE or not USE_2CTA:
         tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
@@ -1717,6 +1794,11 @@ def _attn_fwd_ws_kernel(
     )
     USE_FAST_FIXED: tl.constexpr = FAST_FIXED and (FAST_F16_CAPABLE or FAST_2CTA_CAPABLE)
     USE_FAST_F16: tl.constexpr = USE_FAST_FIXED and FAST_F16_CAPABLE
+    SKIP_CAUSAL_DIAG: tl.constexpr = (
+        STAGE == 3
+        and NUM_PID_M_STATIC <= 16
+        and BLOCK_N * 2 <= BLOCK_M
+    )
     FUSE_EPILOG: tl.constexpr = USE_FAST_FIXED and not USE_2CTA
     DIRECT_SCHED: tl.constexpr = USE_2CTA or USE_FAST_F16
     USE_GRID_LPT: tl.constexpr = (
@@ -2045,68 +2127,37 @@ def _attn_fwd_ws_kernel(
                     cid = tlx.async_task_replica_id()
                     group_id = cid * NUM_CTAS + cluster_cta_rank if USE_2CTA else cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
-                if STAGE & 1:
-                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
-                        qk_fulls,
-                        qk_tiles,
-                        p_fulls,
-                        p_tiles,
-                        alpha_empties,
-                        alpha_fulls,
-                        alpha_tiles,
-                        acc_fulls,
-                        acc_tiles,
-                        cid,
-                        accum_cnt_qk,
-                        gauge_cnt,
-                        qk_scale,
-                        offs_m,
-                        m_i,
-                        l_i,
-                        start_m,
-                        N_CTX,
-                        p_dtype,
-                        BLOCK_M,
-                        BLOCK_N,
-                        HEAD_DIM,
-                        NUM_MMA_SLICES,
-                        STAGE=4 - STAGE,
-                        RESCALE_OPT=RESCALE_OPT,
-                        SCALAR_N=SCALAR_N,
-                        USE_2CTA=USE_2CTA,
-                        FAST_FIXED=USE_FAST_FIXED,
-                    )
-                if STAGE & 2:
-                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
-                        qk_fulls,
-                        qk_tiles,
-                        p_fulls,
-                        p_tiles,
-                        alpha_empties,
-                        alpha_fulls,
-                        alpha_tiles,
-                        acc_fulls,
-                        acc_tiles,
-                        cid,
-                        accum_cnt_qk,
-                        gauge_cnt,
-                        qk_scale,
-                        offs_m,
-                        m_i,
-                        l_i,
-                        start_m,
-                        N_CTX,
-                        p_dtype,
-                        BLOCK_M,
-                        BLOCK_N,
-                        HEAD_DIM,
-                        NUM_MMA_SLICES,
-                        STAGE=2,
-                        RESCALE_OPT=RESCALE_OPT,
-                        SCALAR_N=SCALAR_N,
-                        USE_2CTA=USE_2CTA,
-                        FAST_FIXED=USE_FAST_FIXED,
-                    )
+                m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_stages(
+                    qk_fulls,
+                    qk_tiles,
+                    p_fulls,
+                    p_tiles,
+                    alpha_empties,
+                    alpha_fulls,
+                    alpha_tiles,
+                    acc_fulls,
+                    acc_tiles,
+                    cid,
+                    accum_cnt_qk,
+                    gauge_cnt,
+                    qk_scale,
+                    offs_m,
+                    m_i,
+                    l_i,
+                    start_m,
+                    N_CTX,
+                    p_dtype,
+                    BLOCK_M,
+                    BLOCK_N,
+                    HEAD_DIM,
+                    NUM_MMA_SLICES,
+                    STAGE,
+                    RESCALE_OPT,
+                    SCALAR_N,
+                    USE_2CTA,
+                    USE_FAST_FIXED,
+                    SKIP_CAUSAL_DIAG,
+                )
 
                 if USE_2CTA:
                     tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
@@ -2250,6 +2301,7 @@ def _attn_fwd_ws_kernel(
                         None,
                         False,
                         SKIP_RESCALE=USE_FAST_FIXED,
+                        SKIP_CAUSAL_Q0_LAST=SKIP_CAUSAL_DIAG,
                     )
                 tile_count += 1
                 if DIRECT_SCHED:

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -68,6 +68,7 @@ configs = [
             "USE_WHERE": where,  # used when RESCALE_OPT is True
             "USE_WARP_BARRIER": uwb,
             "FAST_FIXED": fast_fixed,
+            "COMPACT_CLC": compact_clc,
         },
         num_stages=1,
         num_warps=4,
@@ -78,6 +79,7 @@ configs = [
         (True, False, False),
         (True, True, False),
     ] for uwb in [False, True]
+    for compact_clc in ([False, True] if grp_n > 4 and uwb and not fast_fixed else [False])
 ] + [
     triton.Config(
         {
@@ -94,6 +96,7 @@ configs = [
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
             "FAST_FIXED": fast_fixed,
+            "COMPACT_CLC": False,
         },
         num_stages=1,
         num_warps=4,
@@ -303,20 +306,57 @@ def _compute_offsets(
     BLOCK_M: tl.constexpr,
     STAGE: tl.constexpr,
     GROUP_SIZE_N: tl.constexpr,
+    NUM_PID_M_STATIC: tl.constexpr,
+    GRID_X_STATIC: tl.constexpr,
 ):
     if STAGE == 3 and GROUP_SIZE_N > 4:
-        num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
-        tiles_per_batch = num_pid_m * H
-        off_z = tile_idx // tiles_per_batch
-        tile_in_batch = tile_idx % tiles_per_batch
-        section_id = tile_in_batch // (num_pid_m * GROUP_SIZE_N)
-        first_head = section_id * GROUP_SIZE_N
-        group_size_n = min(H - first_head, GROUP_SIZE_N)
-        tile_in_section = tile_in_batch - section_id * num_pid_m * GROUP_SIZE_N
-        start_m = tile_in_section // group_size_n
-        off_h = first_head + tile_in_section % group_size_n
-        start_m = num_pid_m - 1 - start_m
-        off_hz = off_z * H + off_h
+        if GRID_X_STATIC > 0:
+            head_lane = tile_idx % GRID_X_STATIC
+            grid_row = tile_idx // GRID_X_STATIC
+            head_chunks = H // GRID_X_STATIC
+            rows_per_batch: tl.constexpr = NUM_PID_M_STATIC * head_chunks
+            off_z = grid_row // rows_per_batch
+            row_in_batch = grid_row % rows_per_batch
+            if H <= GROUP_SIZE_N:
+                m_in_section = row_in_batch // head_chunks
+                head_chunk = row_in_batch % head_chunks
+                off_h = head_chunk * GRID_X_STATIC + head_lane
+            else:
+                chunks_per_full_section: tl.constexpr = GROUP_SIZE_N // GRID_X_STATIC
+                rows_per_full_section: tl.constexpr = NUM_PID_M_STATIC * chunks_per_full_section
+                full_sections: tl.constexpr = H // GROUP_SIZE_N
+                tail_heads: tl.constexpr = H % GROUP_SIZE_N
+                if tail_heads == 0:
+                    section_id = row_in_batch // rows_per_full_section
+                    row_in_section = row_in_batch % rows_per_full_section
+                    m_in_section = row_in_section // chunks_per_full_section
+                    head_chunk = row_in_section % chunks_per_full_section
+                else:
+                    full_rows: tl.constexpr = full_sections * rows_per_full_section
+                    in_tail = row_in_batch >= full_rows
+                    full_row = row_in_batch % rows_per_full_section
+                    tail_chunks: tl.constexpr = tail_heads // GRID_X_STATIC
+                    tail_row = row_in_batch - full_rows
+                    section_id = tl.where(in_tail, full_sections, row_in_batch // rows_per_full_section)
+                    m_in_section = tl.where(in_tail, tail_row // tail_chunks,
+                                            full_row // chunks_per_full_section)
+                    head_chunk = tl.where(in_tail, tail_row % tail_chunks, full_row % chunks_per_full_section)
+                off_h = section_id * GROUP_SIZE_N + head_chunk * GRID_X_STATIC + head_lane
+            start_m = NUM_PID_M_STATIC - 1 - m_in_section
+            off_hz = off_z * H + off_h
+        else:
+            num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+            tiles_per_batch = num_pid_m * H
+            off_z = tile_idx // tiles_per_batch
+            tile_in_batch = tile_idx % tiles_per_batch
+            section_id = tile_in_batch // (num_pid_m * GROUP_SIZE_N)
+            first_head = section_id * GROUP_SIZE_N
+            group_size_n = min(H - first_head, GROUP_SIZE_N)
+            tile_in_section = tile_in_batch - section_id * num_pid_m * GROUP_SIZE_N
+            start_m = tile_in_section // group_size_n
+            off_h = first_head + tile_in_section % group_size_n
+            start_m = num_pid_m - 1 - start_m
+            off_hz = off_z * H + off_h
     else:
         group_id = tile_idx // num_pid_in_group
         first_pid_n = group_id * GROUP_SIZE_N
@@ -851,6 +891,8 @@ def _fwd_fixed_2cta_control_tile(
     BLOCK_N: tl.constexpr,
     EFFECTIVE_BLOCK_M: tl.constexpr,
     GROUP_SIZE_N: tl.constexpr,
+    NUM_PID_M_STATIC: tl.constexpr,
+    GRID_X_STATIC: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     NUM_MMA_SLICES: tl.constexpr,
     RESCALE_OPT: tl.constexpr,
@@ -865,6 +907,8 @@ def _fwd_fixed_2cta_control_tile(
         EFFECTIVE_BLOCK_M,
         STAGE,
         GROUP_SIZE_N,
+        NUM_PID_M_STATIC,
+        GRID_X_STATIC,
     )
     m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
     l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32)
@@ -974,6 +1018,8 @@ def _fwd_control_tile(
     BLOCK_N: tl.constexpr,
     EFFECTIVE_BLOCK_M: tl.constexpr,
     GROUP_SIZE_N: tl.constexpr,
+    NUM_PID_M_STATIC: tl.constexpr,
+    GRID_X_STATIC: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     NUM_CTAS: tl.constexpr,
     NUM_GROUPS_PER_CTA: tl.constexpr,
@@ -995,6 +1041,8 @@ def _fwd_control_tile(
         EFFECTIVE_BLOCK_M,
         STAGE,
         GROUP_SIZE_N,
+        NUM_PID_M_STATIC,
+        GRID_X_STATIC,
     )
     control_lo = hi if SKIP_RESCALE else lo
     # Rescale the live output accumulator when the online-softmax gauge changes.
@@ -1086,10 +1134,10 @@ def _fwd_control_tile(
                 [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
             )
             tlx.local_store(subslice_o, acc)
-        tlx.fence("async_shared")
         if FUSE_EPILOG:
             qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+            tlx.async_descriptor_store(
+                desc_o, o_tiles[cid], [qo_offset_y_split, 0], eviction_policy="evict_first")
             tlx.async_descriptor_store_wait(0)
             tlx.barrier_arrive(o_empties[cid])
         else:
@@ -1585,8 +1633,8 @@ def _fwd_mma_tile(
 def _attn_fwd_ws(
     sm_scale,
     M,  #
-    Z,
-    H,
+    Z: tl.constexpr,
+    H: tl.constexpr,
     desc_q,
     desc_k,
     desc_v,
@@ -1610,18 +1658,22 @@ def _attn_fwd_ws(
     POLICY: tl.constexpr = POLICY_DENSE,
     DENSE_REGS: tl.constexpr = 200,
     FAST_FIXED: tl.constexpr = True,
+    NUM_PID_M_STATIC: tl.constexpr = 1,
+    GRID_X_STATIC: tl.constexpr = 1,
+    COMPACT_CLC: tl.constexpr = False,
 ):
     _attn_fwd_ws_kernel(sm_scale, M, Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX, HEAD_DIM, BLOCK_M, BLOCK_N, STAGE,
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_BUFFERS_QK, NUM_MMA_GROUPS, NUM_MMA_SLICES, GROUP_SIZE_N,
-                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS, FAST_FIXED)
+                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS, FAST_FIXED,
+                        NUM_PID_M_STATIC, GRID_X_STATIC, COMPACT_CLC)
 
 
 @triton.jit
 def _attn_fwd_ws_kernel(
     sm_scale,
     M,  #
-    Z,
-    H,
+    Z: tl.constexpr,
+    H: tl.constexpr,
     desc_q,
     desc_k,
     desc_v,
@@ -1645,6 +1697,9 @@ def _attn_fwd_ws_kernel(
     POLICY: tl.constexpr = POLICY_DENSE,
     DENSE_REGS: tl.constexpr = 200,
     FAST_FIXED: tl.constexpr = True,
+    NUM_PID_M_STATIC: tl.constexpr = 1,
+    GRID_X_STATIC: tl.constexpr = 1,
+    COMPACT_CLC: tl.constexpr = False,
 ):
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
@@ -1664,6 +1719,19 @@ def _attn_fwd_ws_kernel(
     USE_FAST_F16: tl.constexpr = USE_FAST_FIXED and FAST_F16_CAPABLE
     FUSE_EPILOG: tl.constexpr = USE_FAST_FIXED and not USE_2CTA
     DIRECT_SCHED: tl.constexpr = USE_2CTA or USE_FAST_F16
+    USE_GRID_LPT: tl.constexpr = (
+        STAGE == 3
+        and COMPACT_CLC
+        and GROUP_SIZE_N > 4
+    )
+    LPT_GRID_X: tl.constexpr = (
+        GRID_X_STATIC
+        if USE_GRID_LPT and GRID_X_STATIC <= GROUP_SIZE_N
+        else min(GROUP_SIZE_N, GRID_X_STATIC & -GRID_X_STATIC)
+        if USE_GRID_LPT
+        else 1
+    )
+    OFFSET_GRID_X: tl.constexpr = LPT_GRID_X if USE_GRID_LPT else 0
     cluster_cta_rank = tlx.cluster_cta_rank() if USE_2CTA else 0
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
@@ -1685,12 +1753,16 @@ def _attn_fwd_ws_kernel(
     # original grid
     #   triton.cdiv(q.shape[2], META["BLOCK_M"]),
     #   q.shape[0] * q.shape[1],
-    start_pid = tl.program_id(0) // NUM_CTAS
     num_pid_m = tl.cdiv(N_CTX, EFFECTIVE_BLOCK_M)
     num_pid_n = Z * H
     num_pid_in_group = num_pid_m * GROUP_SIZE_N
     num_tiles = num_pid_m * num_pid_n
-    persistent_stride = tl.num_programs(0) // NUM_CTAS
+    if USE_GRID_LPT:
+        start_pid = tl.program_id(0) + LPT_GRID_X * tl.program_id(1)
+        persistent_stride = tl.num_programs(0) * tl.num_programs(1)
+    else:
+        start_pid = tl.program_id(0) // NUM_CTAS
+        persistent_stride = tl.num_programs(0) // NUM_CTAS
 
     # allocate SMEM buffers and barriers
     NUM_Q_BUFS: tl.constexpr = NUM_GROUPS_PER_CTA * NUM_BUFFERS_Q
@@ -1860,6 +1932,8 @@ def _attn_fwd_ws_kernel(
                         BLOCK_N,
                         EFFECTIVE_BLOCK_M,
                         GROUP_SIZE_N,
+                        NUM_PID_M_STATIC,
+                        OFFSET_GRID_X,
                         HEAD_DIM,
                         NUM_MMA_SLICES,
                         RESCALE_OPT,
@@ -1898,6 +1972,8 @@ def _attn_fwd_ws_kernel(
                         BLOCK_N,
                         EFFECTIVE_BLOCK_M,
                         GROUP_SIZE_N,
+                        NUM_PID_M_STATIC,
+                        OFFSET_GRID_X,
                         HEAD_DIM,
                         NUM_CTAS,
                         NUM_GROUPS_PER_CTA,
@@ -1915,7 +1991,17 @@ def _attn_fwd_ws_kernel(
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    if USE_GRID_LPT:
+                        cta_x, cta_y, cta_z = tlx.clc_consumer(
+                            clc_context, clc_phase_consumer, return_3d=True
+                        )
+                        tile_id = tl.where(
+                            cta_x >= 0,
+                            cta_x + LPT_GRID_X * (cta_y + tl.num_programs(1) * cta_z),
+                            -1,
+                        )
+                    else:
+                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
         # softmax groups
@@ -1938,6 +2024,8 @@ def _attn_fwd_ws_kernel(
                     EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
+                    NUM_PID_M_STATIC,
+                    OFFSET_GRID_X,
                 )
                 # initialize pointer to m and l
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
@@ -2064,7 +2152,17 @@ def _attn_fwd_ws_kernel(
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    if USE_GRID_LPT:
+                        cta_x, cta_y, cta_z = tlx.clc_consumer(
+                            clc_context, clc_phase_consumer, return_3d=True
+                        )
+                        tile_id = tl.where(
+                            cta_x >= 0,
+                            cta_x + LPT_GRID_X * (cta_y + tl.num_programs(1) * cta_z),
+                            -1,
+                        )
+                    else:
+                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
         # mma group
@@ -2085,6 +2183,8 @@ def _attn_fwd_ws_kernel(
                     EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
+                    NUM_PID_M_STATIC,
+                    OFFSET_GRID_X,
                 )
                 if USE_2CTA:
                     if is_leader:
@@ -2156,7 +2256,17 @@ def _attn_fwd_ws_kernel(
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    if USE_GRID_LPT:
+                        cta_x, cta_y, cta_z = tlx.clc_consumer(
+                            clc_context, clc_phase_consumer, return_3d=True
+                        )
+                        tile_id = tl.where(
+                            cta_x >= 0,
+                            cta_x + LPT_GRID_X * (cta_y + tl.num_programs(1) * cta_z),
+                            -1,
+                        )
+                    else:
+                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
         if USE_2CTA and USE_FAST_FIXED:
@@ -2173,6 +2283,8 @@ def _attn_fwd_ws_kernel(
                         EFFECTIVE_BLOCK_M,
                         STAGE,
                         GROUP_SIZE_N,
+                        NUM_PID_M_STATIC,
+                        OFFSET_GRID_X,
                     )
                     accum_cnt_k = _fwd_load_first_k_tile(
                         accum_cnt_k,
@@ -2210,6 +2322,8 @@ def _attn_fwd_ws_kernel(
                     EFFECTIVE_BLOCK_M,
                     STAGE,
                     GROUP_SIZE_N,
+                    NUM_PID_M_STATIC,
+                    OFFSET_GRID_X,
                 )
                 if USE_2CTA:
                     accum_cnt_kv = _fwd_load_tile(
@@ -2278,7 +2392,17 @@ def _attn_fwd_ws_kernel(
                     next_tile_id = tile_id + persistent_stride
                     tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                 else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                    if USE_GRID_LPT:
+                        cta_x, cta_y, cta_z = tlx.clc_consumer(
+                            clc_context, clc_phase_consumer, return_3d=True
+                        )
+                        tile_id = tl.where(
+                            cta_x >= 0,
+                            cta_x + LPT_GRID_X * (cta_y + tl.num_programs(1) * cta_z),
+                            -1,
+                        )
+                    else:
+                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                     clc_phase_consumer ^= 1
 
         # epilog group
@@ -2299,6 +2423,8 @@ def _attn_fwd_ws_kernel(
                         EFFECTIVE_BLOCK_M,
                         STAGE,
                         GROUP_SIZE_N,
+                        NUM_PID_M_STATIC,
+                        OFFSET_GRID_X,
                     )
                     _, phase = get_bufidx_phase(tile_count, 1)
                     if USE_FAST_FIXED and NUM_GROUPS_PER_CTA == 2:
@@ -2306,7 +2432,8 @@ def _attn_fwd_ws_kernel(
                             group_id = cid * NUM_CTAS + cluster_cta_rank
                             tlx.barrier_wait(o_fulls[cid], phase)
                             qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                            tlx.async_descriptor_store(
+                                desc_o, o_tiles[cid], [qo_offset_y_split, 0], eviction_policy="evict_first")
                         tlx.async_descriptor_store_wait(1)
                         tlx.barrier_arrive(o_empties[0])
                         tlx.async_descriptor_store_wait(0)
@@ -2316,8 +2443,10 @@ def _attn_fwd_ws_kernel(
                             group_id = cid * NUM_CTAS + cluster_cta_rank
                             tlx.barrier_wait(o_fulls[cid], phase)
                             qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
-                            tlx.async_descriptor_store_wait(0)
+                            tlx.async_descriptor_store(
+                                desc_o, o_tiles[cid], [qo_offset_y_split, 0], eviction_policy="evict_first")
+                        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                            tlx.async_descriptor_store_wait(NUM_GROUPS_PER_CTA - 1 - cid)
                             tlx.barrier_arrive(o_empties[cid])
 
                     tile_count += 1
@@ -2325,7 +2454,17 @@ def _attn_fwd_ws_kernel(
                         next_tile_id = tile_id + persistent_stride
                         tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
                     else:
-                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
+                        if USE_GRID_LPT:
+                            cta_x, cta_y, cta_z = tlx.clc_consumer(
+                                clc_context, clc_phase_consumer, return_3d=True
+                            )
+                            tile_id = tl.where(
+                                cta_x >= 0,
+                                cta_x + LPT_GRID_X * (cta_y + tl.num_programs(1) * cta_z),
+                                -1,
+                            )
+                        else:
+                            tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
                         clc_phase_consumer ^= 1
 
 
@@ -4479,6 +4618,11 @@ def _select_forward_plan(q, k, v, causal):
     )
 
 
+def _compact_clc_grid(heads, group, num_pid_m, batches):
+    grid_x = heads if heads <= group else min(group, heads & -heads)
+    return grid_x, num_pid_m * (heads // grid_x) * batches
+
+
 class _attention(torch.autograd.Function):
 
     @staticmethod
@@ -4569,6 +4713,9 @@ class _attention(torch.autograd.Function):
                 POLICY=plan.policy,
                 DENSE_REGS=176 if use_2cta else 168,
                 FAST_FIXED=True,
+                NUM_PID_M_STATIC=triton.cdiv(q.shape[2], 256 * plan.num_ctas),
+                GRID_X_STATIC=q.shape[1],
+                COMPACT_CLC=False,
                 num_stages=1,
                 num_warps=4,
                 **({"ctas_per_cga": (2, 1, 1)} if use_2cta else {}),
@@ -4578,7 +4725,18 @@ class _attention(torch.autograd.Function):
 
             def grid(META):
                 num_ctas = META.get("NUM_CTAS") or 1
-                n_clusters = triton.cdiv(q.shape[2], META["BLOCK_M"] * num_ctas) * q.shape[0] * q.shape[1]
+                num_pid_m = triton.cdiv(q.shape[2], META["BLOCK_M"] * num_ctas)
+                group = META["GROUP_SIZE_N"]
+                if (
+                    causal
+                    and group > 4
+                    and META.get("COMPACT_CLC", False)
+                    and num_ctas == 1
+                ):
+                    grid_x = min(group, q.shape[1])
+                    sections = triton.cdiv(q.shape[1], group)
+                    return (grid_x, num_pid_m * sections * q.shape[0])
+                n_clusters = num_pid_m * q.shape[0] * q.shape[1]
                 return (n_clusters * num_ctas, )
 
             _attn_fwd_ws[grid](
@@ -4596,6 +4754,8 @@ class _attention(torch.autograd.Function):
                 PIPELINED=False,
                 POLICY=plan.policy,
                 DENSE_REGS=168,
+                NUM_PID_M_STATIC=triton.cdiv(q.shape[2], 256),
+                GRID_X_STATIC=q.shape[1],
                 **extra_kern_args,
             )
         ctx.grid = grid
@@ -4792,8 +4952,17 @@ def attention(q, k, v, sm_scale, causal, config=None):
 
     num_ctas = config.get("NUM_CTAS", 1)
     assert q.shape[2] % (config["BLOCK_M"] * num_ctas) == 0 or num_ctas == 1
-    grid0 = (triton.cdiv(q.shape[2], config["BLOCK_M"] * num_ctas) * q.shape[0] * q.shape[1] * num_ctas)
-    grid = (grid0, 1, 1)
+    num_pid_m = triton.cdiv(q.shape[2], config["BLOCK_M"] * num_ctas)
+    if (
+        causal
+        and config["GROUP_SIZE_N"] > 4
+        and config.get("COMPACT_CLC", False)
+        and num_ctas == 1
+    ):
+        grid = _compact_clc_grid(q.shape[1], config["GROUP_SIZE_N"], num_pid_m, q.shape[0])
+    else:
+        grid0 = num_pid_m * q.shape[0] * q.shape[1] * num_ctas
+        grid = (grid0, 1, 1)
     launch_kwargs = {}
     if num_ctas > 1:
         launch_kwargs["ctas_per_cga"] = (num_ctas, 1, 1)
@@ -4809,6 +4978,8 @@ def attention(q, k, v, sm_scale, causal, config=None):
         N_CTX=q.shape[2],
         HEAD_DIM=HEAD_DIM_K,
         STAGE=stage,
+        NUM_PID_M_STATIC=num_pid_m,
+        GRID_X_STATIC=q.shape[1],
         num_stages=1,
         **launch_kwargs,
         **config,

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -72,7 +72,7 @@ configs = [
         num_stages=1,
         num_warps=4,
         pre_hook=_host_descriptor_pre_hook,
-    ) for kv in [3, 6] for grp_n in [1, 4] for (rescale_opt, where, fast_fixed) in [
+    ) for kv in [3, 6] for grp_n in [1, 2, 4, 8, 16, 32, 64] for (rescale_opt, where, fast_fixed) in [
         (False, False, True),
         (False, False, False),
         (True, False, False),
@@ -129,13 +129,28 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
     N_CTX = kwargs["N_CTX"]
     STAGE = kwargs["STAGE"]
     target_kv_buffers = 6 if HEAD_DIM == 64 else 3
-    target_group_size_n = 4 if STAGE == 3 else 1
+    if STAGE == 3:
+        h = int(named_args["H"])
+        # Size a Q/K section against the usable L2 budget. This kernel supports
+        # fp16 and bf16 inputs, so every Q/K element is two bytes.
+        bytes_per_element = 2
+        l2_budget_bytes = 50 * 1024 * 1024
+        bytes_per_head = 2 * N_CTX * HEAD_DIM * bytes_per_element
+        capacity_heads = max(1, l2_budget_bytes // bytes_per_head)
+        if capacity_heads >= h:
+            l2_group_size_n = 1 << (h - 1).bit_length()
+        else:
+            l2_group_size_n = 1 << (capacity_heads.bit_length() - 1)
+        l2_group_size_n = min(64, l2_group_size_n)
+        target_group_sizes = ((4, l2_group_size_n) if l2_group_size_n > 4 else (4,))
+    else:
+        target_group_sizes = (1,)
     pruned = []
     for conf in configs:
         kv = conf.kwargs.get("NUM_BUFFERS_KV", 0)
         grp_n = conf.kwargs.get("GROUP_SIZE_N", 0)
         is_2cta = conf.kwargs.get("NUM_CTAS", 1) > 1
-        if grp_n != target_group_size_n:
+        if grp_n not in target_group_sizes:
             continue
         if is_2cta:
             num_ctas = conf.kwargs["NUM_CTAS"]
@@ -289,13 +304,27 @@ def _compute_offsets(
     STAGE: tl.constexpr,
     GROUP_SIZE_N: tl.constexpr,
 ):
-    group_id = tile_idx // num_pid_in_group
-    first_pid_n = group_id * GROUP_SIZE_N
-    group_size_n = min(num_pid_n - first_pid_n, GROUP_SIZE_N)
-    start_m = (tile_idx % num_pid_in_group) // group_size_n
-    off_hz = first_pid_n + (tile_idx % group_size_n)
-    off_z = off_hz // H
-    off_h = off_hz % H
+    if STAGE == 3 and GROUP_SIZE_N > 4:
+        num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+        tiles_per_batch = num_pid_m * H
+        off_z = tile_idx // tiles_per_batch
+        tile_in_batch = tile_idx % tiles_per_batch
+        section_id = tile_in_batch // (num_pid_m * GROUP_SIZE_N)
+        first_head = section_id * GROUP_SIZE_N
+        group_size_n = min(H - first_head, GROUP_SIZE_N)
+        tile_in_section = tile_in_batch - section_id * num_pid_m * GROUP_SIZE_N
+        start_m = tile_in_section // group_size_n
+        off_h = first_head + tile_in_section % group_size_n
+        start_m = num_pid_m - 1 - start_m
+        off_hz = off_z * H + off_h
+    else:
+        group_id = tile_idx // num_pid_in_group
+        first_pid_n = group_id * GROUP_SIZE_N
+        group_size_n = min(num_pid_n - first_pid_n, GROUP_SIZE_N)
+        start_m = (tile_idx % num_pid_in_group) // group_size_n
+        off_hz = first_pid_n + (tile_idx % group_size_n)
+        off_z = off_hz // H
+        off_h = off_hz % H
     offset_y = off_z * (N_CTX * H) + off_h * N_CTX
     qo_offset_y = offset_y + start_m * BLOCK_M
     lo, hi = _get_fused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
@@ -1549,7 +1578,7 @@ def _fwd_mma_tile(
 
 @triton.autotune(
     configs=configs,
-    key=["N_CTX", "HEAD_DIM", "STAGE"],
+    key=["N_CTX", "HEAD_DIM", "H", "STAGE"],
     prune_configs_by={"early_config_prune": prune_configs_by_hdim},
 )
 @triton.jit

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -919,6 +919,11 @@ def _make_attention_numeric_inputs(shape, dtype, distribution):
         return tuple(torch.empty(shape, device=DEVICE, dtype=dtype).uniform_(-0.5, 0.5) for _ in range(3))
     if distribution == "normal_random":
         return tuple(torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5) for _ in range(3))
+    if distribution in ("positive_shift", "negative_shift"):
+        q = torch.full(shape, 1.5, device=DEVICE, dtype=dtype)
+        k = torch.full(shape, 1.5 if distribution == "positive_shift" else -1.5, device=DEVICE, dtype=dtype)
+        v = torch.empty(shape, device=DEVICE, dtype=dtype).normal_(mean=0.0, std=0.5)
+        return q, k, v
     q = torch.ones(shape, device=DEVICE, dtype=dtype)
     q[:, :, shape[2] // 2:, :] = -1
     amplitude = 0.625 if shape[3] == 128 else 0.2
@@ -957,7 +962,8 @@ def test_blackwell_fa_ws_pipelined_persistent_fast_fixed_bf16_numerics(distribut
 
 
 @pytest.mark.parametrize("rescale_opt", [False, True])
-@pytest.mark.parametrize("distribution", ["uniform_random", "normal_random", "far_apart"])
+@pytest.mark.parametrize("distribution",
+                         ["uniform_random", "normal_random", "far_apart", "positive_shift", "negative_shift"])
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
 def test_blackwell_fa_ws_pipelined_persistent_2cta_non_fast_fixed_numerics(distribution, rescale_opt):
     Z, H, N_CTX, HEAD_DIM = 4, 48, 1024, 128

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -2372,11 +2372,21 @@ def test_amd_gemm_large_output_offsets():
     torch.testing.assert_close(out[-1], torch.full_like(out[-1], K))
 
 
+def test_amd_addmm_rejects_register_config_for_inter_wave():
+    a = torch.empty((256, 2048), device="meta", dtype=torch.float16)
+    b = torch.empty((256, 2048), device="meta", dtype=torch.float16).T
+    bias = torch.empty(256, device="meta", dtype=torch.float16)
+
+    with pytest.raises(ValueError, match="config is only supported by the register path"):
+        _amd_addmm(bias, a, b, path="inter_wave", config={})
+
+
 def _check_addmm_all_paths(bias, a, b, split_k=None):
     ref = torch.addmm(bias, a, b)
     config = Gemm.CONFIGS["amd_standalone_addmm_register"]
     for path in _amd_addmm_paths(bias, a, b):
-        out = _amd_addmm(bias, a, b, SPLIT_K=split_k, path=path, config=config)
+        path_config = config if path == "register" else None
+        out = _amd_addmm(bias, a, b, SPLIT_K=split_k, path=path, config=path_config)
         torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2, msg=lambda m, path=path: f"path={path}\n{m}")
 
 


### PR DESCRIPTION
Summary:

This one changes the algorithm and finds one exploit. For the K tile, during the masked read, most of the token would be masked out. So then  entire QK block is masked and its' PV contribution is just zero. We can just skip QK/KV portion for that directly.

Reviewed By: htyu

Differential Revision: D117757889


