### PR TITLE
[triton][beta] Fix SleefNameGenerator ulp buffer truncation

### DIFF
--- a/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
+++ b/third_party/cpu/lib/TritonCPUToLLVM/MathToVecLib.cpp
@@ -240,8 +240,8 @@ public:
     if (ulp == 0) {
       ulpSuffix = "";
     } else {
-      char buf[5]; // 4 char suffix + '\0' added by snprintf
-      snprintf(buf, 5, "_u%02u", ulp);
+      char buf[13]; // "_u" + 10 unsigned digits + '\0'
+      snprintf(buf, sizeof(buf), "_u%02u", ulp);
       ulpSuffix = buf;
     }
   }


### PR DESCRIPTION
Summary: The 5-byte buffer with snprintf(buf, 5, ...) truncates the _u suffix for large ulp values, since %02u is a minimum width, not a maximum. Size the buffer for the full unsigned range ("_u" + 10 digits + NUL) and pass sizeof(buf).

Differential Revision: D118556033


