### PR TITLE
[triton][tlx] Dump TTGIR-to-TLX from the AMD backend

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -423,6 +423,9 @@ class compilation_knobs(base_knobs):
     override: env_bool = env_bool("TRITON_KERNEL_OVERRIDE")
     dump_ir: env_bool = env_bool("TRITON_KERNEL_DUMP")
     dump_ir_extract_di_local_variables: env_bool = env_bool("LLVM_EXTRACT_DI_LOCAL_VARIABLES")
+    # Dump the final TTGIR of each kernel as equivalent TLX Python
+    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
+    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     store_binary_only: env_bool = env_bool("TRITON_STORE_BINARY_ONLY")
     always_compile: env_bool = env_bool("TRITON_ALWAYS_COMPILE")
     # TODO: Use enum to constrain / 'typecheck' the values
@@ -633,8 +636,6 @@ class nvidia_knobs(base_knobs):
     # it (knobs.nvidia.scope()) instead of leaking global env state.
     modulo_strict_error: env_bool = env_bool("TRITON_MODULO_STRICT_ERROR")
     disable_wsbarrier_reorder: env_bool = env_bool("TRITON_DISABLE_WSBARRIER_REORDER")
-    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
-    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     # Default ON; opt out with TRITON_USE_C_DISPATCHER=0.
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER", True)

--- a/test/TLX/print-ttgir-to-tlx-clc.mlir
+++ b/test/TLX/print-ttgir-to-tlx-clc.mlir
@@ -1,0 +1,59 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that Cluster Launch Control ops round-trip to their TLX spellings.
+//
+// A persistent CLC kernel issues a cancel request into a response buffer,
+// waits on an mbarrier, then decodes the stolen tile out of the response.
+// None of those ops have a generic mapping: the response buffer's ui128
+// element type is unnameable in TLX, and the issue and query ops take
+// different operand orders and result counts than the printer's default.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The ui128 response buffer gets its own allocator rather than a local_alloc
+  // of an element type TLX cannot name.
+  // CHECK-LABEL: def clc_response_alloc(
+  // CHECK: tlx._alloc_clc_responses(1)
+  // CHECK-NOT: tlx.local_alloc(
+  tt.func public @clc_response_alloc() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The issue op takes (mbarrier, response) in TTGIR but (response, barrier)
+  // in TLX, so the operands are swapped rather than printed in order.
+  // Binding each name where it is defined is what makes the swap observable:
+  // the barrier is allocated first, so a call emitted in source order would
+  // read _clc_issue([[BAR]], [[RESP]]) and fail here.
+  // CHECK-LABEL: def clc_issue(
+  // CHECK: [[BAR:[a-zA-Z_0-9]+]] = tlx.alloc_barriers(1)
+  // CHECK: [[RESP:[a-zA-Z_0-9]+]] = tlx._alloc_clc_responses(1)
+  // CHECK: tlx._clc_issue([[RESP]], [[BAR]])
+  tt.func public @clc_issue() attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.async_clc_try_cancel %bar, %resp : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // The query decodes three results, which are bound as one tuple.
+  // CHECK-LABEL: def clc_query(
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = tlx._clc_query(
+  tt.func public @clc_query() attributes {noinline = false} {
+    %resp = ttg.local_alloc : () -> !ttg.memdesc<1xui128, #shared, #smem, mutable>
+    %x, %y, %z = ttng.clc_query_cancel %resp : (!ttg.memdesc<1xui128, #shared, #smem, mutable>) -> (i32, i32, i32)
+    tt.return
+  }
+
+  // The CLC lowering replaces tl.program_id(0) with the cluster id; emitting
+  // program_id back re-derives the same value on recompile.
+  // CHECK-LABEL: def cluster_id(
+  // CHECK: tl.program_id(axis=0)
+  tt.func public @cluster_id() attributes {noinline = false} {
+    %cid = "nvg.cluster_id"() : () -> i32
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-predicates.mlir
+++ b/test/TLX/print-ttgir-to-tlx-predicates.mlir
@@ -1,0 +1,158 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx -split-input-file %s | FileCheck %s
+
+// Test that the predicates the software pipeliner puts on its prefetched ops
+// round-trip, and that a constant-true one is left implicit.
+//
+// The pipeliner predicates the prefetched wait and dot with `k < k_tiles - 1`
+// so the drain iteration neither waits on a buffer that is never filled nor
+// runs a dot on unloaded operands. A constant-true predicate is the default
+// and carries no information, so only a real one is emitted.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // A real predicate guards whether the wait executes, so it must survive.
+  // CHECK-LABEL: def wait_with_predicate(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.barrier_wait({{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, pred=[[PRED]])
+  tt.func public @wait_with_predicate(%k: i32, %k_tiles: i32, %phase: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %pred : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A constant-true predicate is the default, so it is left implicit.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_constant_true(
+  // CHECK: tlx.barrier_wait(
+  // CHECK-NOT: pred=
+  tt.func public @wait_with_constant_true(%phase: i32) attributes {noinline = false} {
+    %true = arith.constant true
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %true : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The same holds for the dot: dropping its predicate would let the drain
+// iteration accumulate garbage into the tmem accumulator.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def dot_with_predicate(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.async_dot({{.*}}pred=[[PRED]]{{.*}})
+  tt.func public @dot_with_predicate(%k: i32, %k_tiles: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %pred, %bar[%true] {is_async} : !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// A constant-true dot predicate is likewise left implicit. This is the half of
+// the dot change that is observable: a real predicate was already emitted
+// before, a constant-true one was emitted too and should not be.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def dot_with_constant_true(
+  // CHECK: tlx.async_dot(
+  // CHECK-NOT: pred=
+  tt.func public @dot_with_constant_true() attributes {noinline = false} {
+    %false = arith.constant false
+    %true = arith.constant true
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.tc_gen5_mma %a, %b, %acc, %false, %true, %bar[%true] {is_async} : !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared2, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// The predicate is found by skipping the variadic memdesc dependency buffers,
+// which are a scheduling hint rather than something the wait's behavior
+// depends on, so they are not emitted.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_predicate_and_deps(
+  // CHECK: [[PRED:[a-zA-Z_0-9]+]] = {{.*}} < {{.*}}
+  // CHECK: tlx.barrier_wait({{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}}, pred=[[PRED]])
+  tt.func public @wait_with_predicate_and_deps(%k: i32, %k_tiles: i32, %phase: i32) attributes {noinline = false} {
+    %c1_i32 = arith.constant 1 : i32
+    %last = arith.subi %k_tiles, %c1_i32 : i32
+    %pred = arith.cmpi slt, %k, %last : i32
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase, %pred deps %a : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// Deps with no predicate: nothing is emitted for either.
+
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def wait_with_deps_only(
+  // CHECK: tlx.barrier_wait(
+  // CHECK-NOT: pred=
+  tt.func public @wait_with_deps_only(%phase: i32) attributes {noinline = false} {
+    %bar = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    ttng.wait_barrier %bar, %phase deps %a : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -26,7 +26,8 @@
 
 // Verify MMA operations are replaced
 // CHECK-DAG: tlx.async_dot(
-// CHECK-DAG: use_acc=False, pred=True, mBarriers=[{{[^]]+}}], two_ctas=True, force_async=True
+// A constant-true predicate is the default and is elided.
+// CHECK-DAG: use_acc=False, mBarriers=[{{[^]]+}}], two_ctas=True, force_async=True
 // CHECK-DAG: tlx.tcgen05_commit({{[^,)]+}}, two_ctas=True)
 
 // Verify TMA operations are replaced

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -484,6 +484,16 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
+        # Print TTGIR to TLX mapping before final emission (for debugging/analysis)
+        tlx_dump_dir = None
+        tlx_saved_fd = None
+        tlx_capture_file = None
+        if knobs.compilation.dump_tlx_benchmark:
+            from triton.tools.tlx_benchmark_gen import setup_tlx_dump
+
+            tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
+        elif knobs.compilation.dump_ttgir_to_tlx:
+            tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         amd.passes.ttgpuir.add_warp_pipeline_conversion(pm, options.arch)
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
@@ -533,7 +543,15 @@ class HIPBackend(BaseBackend):
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, options.arch, __HIP_FTZ)
         passes.convert.add_reconcile_unrealized_casts(pm)
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
+
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1192,11 +1192,11 @@ class CUDABackend(BaseBackend):
         tlx_dump_dir = None
         tlx_saved_fd = None
         tlx_capture_file = None
-        if knobs.nvidia.dump_tlx_benchmark:
+        if knobs.compilation.dump_tlx_benchmark:
             from triton.tools.tlx_benchmark_gen import setup_tlx_dump
 
             tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
-        elif knobs.nvidia.dump_ttgir_to_tlx:
+        elif knobs.compilation.dump_ttgir_to_tlx:
             tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if CUDABackend.instrumentation:
@@ -1238,13 +1238,15 @@ class CUDABackend(BaseBackend):
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("llvmir_to_llvm", pm, mod.context)
 
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
 
-        # After pm.run(), restore stdout and generate TLX benchmark artifacts
-        if tlx_dump_dir is not None:
-            from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
-
-            finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -370,6 +370,17 @@ StringRef getCmpFOperator(int64_t predicate) {
   }
 }
 
+// True if `v` is a constant-true i1. Such a predicate is the default, so it is
+// elided rather than emitted.
+bool isConstantTrue(Value v) {
+  Operation *def = v.getDefiningOp();
+  if (!def || def->getName().getStringRef() != "arith.constant")
+    return false;
+  if (auto intAttr = def->getAttrOfType<IntegerAttr>("value"))
+    return intAttr.getValue().isOne();
+  return false;
+}
+
 // Build a lookup map for fast operation name lookup
 llvm::StringMap<StringRef> buildOpNameMap() {
   llvm::StringMap<StringRef> map;
@@ -1590,11 +1601,25 @@ void printSimplifiedOp(
     return;
   }
 
-  // ttng.wait_barrier: emit barrier_wait(bar, phase) without pred
+  // ttng.wait_barrier: emit barrier_wait(bar, phase[, pred=...]).
   if (opName == "ttng.wait_barrier" && op->getNumOperands() >= 2) {
     os << "tlx.barrier_wait("
        << getValueName(op->getOperand(0), argSubstitutionMap) << ", "
-       << getValueName(op->getOperand(1), argSubstitutionMap) << ")";
+       << getValueName(op->getOperand(1), argSubstitutionMap);
+    // After (alloc, phase) come an optional i1 predicate and variadic memdesc
+    // dependency buffers. Only the predicate changes whether the wait executes,
+    // so emit that and skip the deps.
+    Value pred;
+    for (unsigned i = 2; i < op->getNumOperands(); ++i) {
+      Value v = op->getOperand(i);
+      if (!isa<ttg::MemDescType>(v.getType())) {
+        pred = v;
+        break;
+      }
+    }
+    if (pred && !isConstantTrue(pred))
+      os << ", pred=" << getValueName(pred, argSubstitutionMap);
+    os << ")";
     printLocComment(op, os);
     return;
   }
@@ -1762,9 +1787,12 @@ void printSimplifiedOp(
       int idx = 3 + sizes[3]; // skip a,b,d,acc_dep
       os << ", use_acc="
          << getValueName(op->getOperand(idx), argSubstitutionMap);
-      ++idx;
-      os << ", pred=" << getValueName(op->getOperand(idx), argSubstitutionMap);
-      ++idx;
+      // The predicate operand follows useD, and guards whether the dot runs
+      // at all.
+      Value mmaPred = op->getOperand(idx + 1);
+      idx += 2; // skip useD, pred
+      if (!isConstantTrue(mmaPred))
+        os << ", pred=" << getValueName(mmaPred, argSubstitutionMap);
       int numBarriers = sizes[6];
       if (numBarriers > 0) {
         os << ", mBarriers=[";

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1392,6 +1392,20 @@ void printSimplifiedOp(
 
   // Special handling for local_alloc
   if (opName == "ttg.local_alloc") {
+    // A ui128 buffer is a CLC response allocation; that element type has no
+    // TLX spelling, so emit the dedicated allocator.
+    if (auto memDescType =
+            dyn_cast<ttg::MemDescType>(op->getResult(0).getType())) {
+      if (memDescType.getElementType().isUnsignedInteger(128)) {
+        os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+        int64_t num = 1;
+        for (int64_t dim : memDescType.getShape())
+          num *= dim;
+        os << "tlx._alloc_clc_responses(" << num << ")";
+        printLocComment(op, os);
+        return;
+      }
+    }
     auto it = allocInfoMap.find(op);
     if (it != allocInfoMap.end()) {
       const LocalAllocInfo &info = it->second;
@@ -1900,6 +1914,40 @@ void printSimplifiedOp(
     if (op->getNumOperands() >= 2)
       os << ", pred=" << getValueName(op->getOperand(1), argSubstitutionMap);
     os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // nvg.cluster_id: the CLC-persistent lowering replaces the source's
+  // tl.program_id(0) with the cluster id, identical for single-CTA clusters.
+  if (opName == "nvg.cluster_id") {
+    if (op->getNumResults() > 0)
+      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+    os << "tl.program_id(axis=0)";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.async_clc_try_cancel(mbar, response): TLX takes (response, barrier).
+  if (opName == "ttng.async_clc_try_cancel") {
+    os << "tlx._clc_issue("
+       << getValueName(op->getOperand(1), argSubstitutionMap) << ", "
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // ttng.clc_query_cancel(response): decodes the stolen tile's 3D CTA id,
+  // or (-1, -1, -1) when no work was claimed.
+  if (opName == "ttng.clc_query_cancel") {
+    unsigned nres = op->getNumResults();
+    for (unsigned i = 0; i < nres; ++i)
+      os << (i ? ", " : "")
+         << getValueName(op->getResult(i), argSubstitutionMap);
+    if (nres > 0)
+      os << " = ";
+    os << "tlx._clc_query("
+       << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
     printLocComment(op, os);
     return;
   }

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -493,7 +493,9 @@ def async_dot(
         handles = [t.handle for t in mBarriers]
         is_async = force_async or len(handles) > 0
         use_acc_handle = _get_use_acc_handle(use_acc, _semantic.builder)
-        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred,
+        # The builder wants an ir.value or None, so unwrap a tl.tensor pred.
+        pred_handle = pred.handle if isinstance(pred, tl.tensor) else pred
+        output = _semantic.builder.create_tcgen5_dot(A_handle, B_handle, acc_handle, use_acc_handle, pred_handle,
                                                      bool(two_ctas), handles, bool(is_async))
         return tl.tensor(output, tl.void)
     else:
@@ -658,6 +660,8 @@ def async_dot_scaled(
     bar_handles = [t.handle for t in mBarriers]
     is_async = force_async or len(bar_handles) > 0
     use_acc_handle = _get_use_acc_handle(use_acc, _semantic.builder)
+    # The builder wants an ir.value or None, so unwrap a tl.tensor pred.
+    pred_handle = pred.handle if isinstance(pred, tl.tensor) else pred
     output = _semantic.builder.create_tcgen5_dot_scaled(
         A_handle,
         B_handle,
@@ -667,7 +671,7 @@ def async_dot_scaled(
         A_type,
         B_type,
         use_acc_handle,
-        pred,
+        pred_handle,
         bool(two_ctas),
         bar_handles,
         bool(is_async),


### PR DESCRIPTION
Summary:
The TTGIR-to-TLX printer was only reachable from the NVIDIA backend, so
`TRITON_DUMP_TTGIR_TO_TLX=1` was silently a no-op on AMD. Nothing about the pass
is NVIDIA-specific -- its op table is keyed by op name, and the AMD backend
already loads the TLX dialect -- so this adds the missing call, identical to the
NVIDIA one.

Placement is the part worth reviewing. NVIDIA prints late in `make_llir`, which
does not transfer: AMD runs `add_scf_to_cf` third, flattening the loops the
printer renders as Python control flow, and `add_warp_pipeline_conversion` just
before it, consuming the `tlx.warp_pipeline_stage` markers. The hook goes at the
top of `make_llir` instead, after `add_update_async_wait_count`.

Since a second backend now reads them, the two dump knobs move from
`nvidia_knobs` to `compilation_knobs`. The environment variables are unchanged.

`finalize_tlx_dump` moves into a `finally`. It restores the stdout fd that
`setup_tlx_dump` redirects, so a compilation failure previously left stdout
pointing at the capture file for the rest of the process. Both backends get it,
so the two blocks stay identical.

This diff only makes the printer run. The TLX it emits for an AMD kernel is not
yet recompilable; later diffs in the stack finish that.

Authored with Claude.

Reviewed By: stashuk-olek

Differential Revision: D118285975


