### PR TITLE
[TLX][Inductor] Prototype generic cross-phase LDS retention (#3447)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -1,18 +1,33 @@
 # Owner(s): ["module: inductor"]
+import contextlib
 import unittest
 from unittest import mock
 
+import sympy
 import torch
 from torch._inductor import config
+from torch._inductor.codegen.simd_kernel_features import (
+    DisableReduction,
+    EnableReduction,
+)
+from torch._inductor.dependencies import MemoryDep, ReadWrites
+from torch._inductor import ir
+from torch._inductor.scheduler import SchedulerNode
+from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import run_and_get_code
+from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE
+from torch.utils._ordered_set import OrderedSet
 from torch.utils._triton import has_datacenter_blackwell_tma_device
 from triton.language.extra.tlx.inductor import tlx_config
+from triton.language.extra.tlx.inductor.local_buffer_retention_gfx950 import (
+    LocalBufferRetention,
+)
 from triton.language.extra.tlx.hw.target import current_target
 
 
@@ -73,6 +88,314 @@ TEMPLATE_TEST_SHAPES = [
     # Covered by benchmarks instead.
 ]
 
+
+class TestLocalBufferRetention(TestCase):
+    @contextlib.contextmanager
+    def _on_gfx950(self):
+        """Make the legality envelope's hardware gate pass off-gfx950.
+
+        Without this a rejection test passes for the wrong reason: _is_enabled
+        returns False on any other device and every plan comes back None.
+        """
+        with mock.patch.object(torch.version, "hip", "6.0"), mock.patch.object(
+            torch.cuda,
+            "get_device_properties",
+            return_value=mock.Mock(gcnArchName="gfx950:sramecc+:xnack-"),
+        ):
+            yield
+
+    def _graph_mock(self):
+        # _is_enabled reads the compilation target off the graph, so every graph
+        # stand-in needs a real device rather than a Mock attribute.
+        graph = mock.Mock(sizevars=SizeVarAllocator(), scheduler=mock.Mock())
+        graph.get_current_device_or_throw.return_value = torch.device("cuda")
+        return graph
+
+    def _scheduler_node(
+        self,
+        name,
+        *,
+        is_reduction=False,
+        reduction_type="welford_reduce",
+        ancestors=(),
+        rnumel=4096,
+        reads=(),
+        writes=(),
+    ):
+        snode = object.__new__(SchedulerNode)
+        snode.node = object.__new__(ir.ComputedBuffer)
+        snode.node.get_reduction_type = mock.Mock(
+            return_value=reduction_type if is_reduction else None
+        )
+        snode.group = (torch.device("cuda"), (1024, rnumel if is_reduction else 1))
+        snode.is_reduction = mock.Mock(return_value=is_reduction)
+        snode.has_strict_reduction = mock.Mock(return_value=False)
+        snode.get_device = mock.Mock(return_value=torch.device("cuda"))
+        snode.get_operation_names = mock.Mock(return_value=OrderedSet([name]))
+        snode.ancestors = OrderedSet(ancestors)
+        snode.read_writes = ReadWrites(
+            OrderedSet(reads), OrderedSet(writes), OrderedSet()
+        )
+        return snode
+
+    def test_enablement_requires_allow_and_gfx950(self):
+        with V.set_graph_handler(self._graph_mock()), mock.patch.object(
+            torch.version, "hip", "6.0"
+        ):
+            with mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=mock.Mock(gcnArchName="gfx950:sramecc+:xnack-"),
+            ):
+                with config.patch({"triton.tlx_mode": "allow"}):
+                    self.assertTrue(LocalBufferRetention._is_enabled())
+                with config.patch({"triton.tlx_mode": "force"}):
+                    self.assertFalse(LocalBufferRetention._is_enabled())
+
+            with mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=mock.Mock(gcnArchName="gfx942:sramecc+:xnack-"),
+            ):
+                with config.patch({"triton.tlx_mode": "allow"}):
+                    self.assertFalse(LocalBufferRetention._is_enabled())
+
+    def test_enablement_follows_the_compilation_target(self):
+        # gfx950 properties are available, but the graph is compiling for a
+        # different device, so retention must stay off.
+        cpu_graph = self._graph_mock()
+        cpu_graph.get_current_device_or_throw.return_value = torch.device("cpu")
+        with V.set_graph_handler(cpu_graph), mock.patch.object(
+            torch.version, "hip", "6.0"
+        ), mock.patch.object(
+            torch.cuda,
+            "get_device_properties",
+            return_value=mock.Mock(gcnArchName="gfx950:sramecc+:xnack-"),
+        ):
+            with config.patch({"triton.tlx_mode": "allow"}):
+                self.assertFalse(LocalBufferRetention._is_enabled())
+
+    def test_finds_cross_phase_buffer(self):
+        i, r = sympy.symbols("i r", integer=True)
+        dynamic_rows = sympy.Symbol("dynamic_rows", integer=True, positive=True)
+        access = MemoryDep("workspace", 4096 * i + r, (i, r), (128, 4096))
+        first_reduction = self._scheduler_node(
+            "first_reduction", is_reduction=True, reduction_type="sum"
+        )
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, writes=(access,)
+        )
+        consumer = self._scheduler_node(
+            "consumer", is_reduction=True, reads=(access,), writes=(access,)
+        )
+        node_schedule = [
+            first_reduction,  # phase 0
+            DisableReduction,
+            EnableReduction,
+            producer,  # phase 2: stores `workspace`
+            DisableReduction,
+            EnableReduction,
+            consumer,  # phase 4: loads `workspace`
+        ]
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float16
+        graph.get_numel.return_value = dynamic_rows * 4096
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": None}):
+                self.assertIsNone(LocalBufferRetention.plan_for(node_schedule))
+            with config.patch({"triton.tlx_mode": "force"}):
+                self.assertIsNone(LocalBufferRetention.plan_for(node_schedule))
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(node_schedule)
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.reduction_numel, 4096)
+        self.assertEqual(plan.reduction_block, 2048)
+        self.assertEqual(plan.num_warps, 4)
+        self.assertEqual(plan.waves_per_eu, 4)
+        self.assertEqual(plan.total_bytes, 8192)
+        self.assertEqual(len(plan.buffers), 1)
+        self.assertEqual(plan.buffers[0].name, "workspace")
+        self.assertEqual(plan.buffers[0].store_phase, 2)
+        self.assertEqual(plan.buffers[0].load_phases, (4,))
+
+    def test_rejects_unproven_buffer_multiple(self):
+        i, r = sympy.symbols("i r", integer=True)
+        dynamic_rows = sympy.Symbol("dynamic_rows", integer=True, positive=True)
+        access = MemoryDep("workspace", 4096 * i + r, (i, r), (128, 4096))
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, writes=(access,)
+        )
+        consumer = self._scheduler_node(
+            "consumer", is_reduction=True, reads=(access,), writes=(access,)
+        )
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float16
+        graph.get_numel.return_value = dynamic_rows * 4096 + 1
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(
+                    [producer, DisableReduction, EnableReduction, consumer]
+                )
+
+        self.assertIsNone(plan)
+
+    def test_rejects_read_left_on_the_global_path(self):
+        # The pointwise reader sits in an odd (reduction-disabled) phase, so it
+        # cannot be redirected to LDS.  Eliding the global store would leave it
+        # reading memory the kernel never writes.
+        i, r = sympy.symbols("i r", integer=True)
+        access = MemoryDep("workspace", 4096 * i + r, (i, r), (128, 4096))
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, writes=(access,)
+        )
+        pointwise_reader = self._scheduler_node("pointwise_reader", reads=(access,))
+        consumer = self._scheduler_node(
+            "consumer", is_reduction=True, reads=(access,), writes=(access,)
+        )
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float16
+        graph.get_numel.return_value = 128 * 4096
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(
+                    [
+                        producer,
+                        DisableReduction,
+                        pointwise_reader,
+                        EnableReduction,
+                        consumer,
+                    ]
+                )
+
+        self.assertIsNone(plan)
+
+    def test_rejects_rewrite_before_read_in_same_phase(self):
+        # Two separate nodes share the load phase and the rewriter runs first,
+        # so the reader must observe the rewrite rather than the retained value.
+        i, r = sympy.symbols("i r", integer=True)
+        access = MemoryDep("workspace", 4096 * i + r, (i, r), (128, 4096))
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, writes=(access,)
+        )
+        rewriter = self._scheduler_node(
+            "rewriter", is_reduction=True, writes=(access,)
+        )
+        reader = self._scheduler_node("reader", is_reduction=True, reads=(access,))
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float16
+        graph.get_numel.return_value = 128 * 4096
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(
+                    [
+                        producer,
+                        DisableReduction,
+                        EnableReduction,
+                        rewriter,
+                        reader,
+                    ]
+                )
+
+        self.assertIsNone(plan)
+
+    def test_rejects_local_buffer_overflow(self):
+        i, r = sympy.symbols("i r", integer=True)
+        dynamic_rows = sympy.Symbol("dynamic_rows", integer=True, positive=True)
+        access = MemoryDep("workspace", 16384 * i + r, (i, r), (128, 16384))
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, rnumel=16384, writes=(access,)
+        )
+        consumer = self._scheduler_node(
+            "consumer",
+            is_reduction=True,
+            rnumel=16384,
+            reads=(access,),
+            writes=(access,),
+        )
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float32
+        graph.get_numel.return_value = dynamic_rows * 16384
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(
+                    [producer, DisableReduction, EnableReduction, consumer]
+                )
+
+        self.assertIsNone(plan)
+
+    def test_rejects_nonmatching_access(self):
+        i, r = sympy.symbols("i r", integer=True)
+        store = MemoryDep("workspace", 4096 * i + r, (i, r), (128, 4096))
+        transposed_load = MemoryDep("workspace", i + 128 * r, (i, r), (128, 4096))
+        producer = self._scheduler_node(
+            "producer", is_reduction=True, writes=(store,)
+        )
+        consumer = self._scheduler_node(
+            "consumer",
+            is_reduction=True,
+            reads=(transposed_load,),
+            writes=(store,),
+        )
+        graph = self._graph_mock()
+        graph.get_dtype.return_value = torch.float16
+        graph.get_numel.return_value = 128 * 4096
+
+        with V.set_graph_handler(graph), self._on_gfx950():
+            with config.patch({"triton.tlx_mode": "allow"}):
+                plan = LocalBufferRetention.plan_for(
+                    [producer, DisableReduction, EnableReduction, consumer]
+                )
+
+        self.assertIsNone(plan)
+
+    @unittest.skipIf(not is_gfx950(), "Need AMD MI350X (gfx950)")
+    def test_inductor_codegen(self):
+        n = 6144
+
+        def double_layernorm_silu(x, residual, weight1, bias1, weight2, bias2):
+            z = residual + torch.nn.functional.layer_norm(
+                x, (n,), weight1, bias1, 1.0e-5
+            )
+            return z * torch.sigmoid(
+                torch.nn.functional.layer_norm(z, (n,), weight2, bias2, 1.0e-5)
+            )
+
+        # Citrine C3: create test inputs directly on the target GPU.
+        inputs = (
+            torch.randn((2, n), device=GPU_TYPE, dtype=torch.float16),
+            torch.randn((2, n), device=GPU_TYPE, dtype=torch.float16),
+            *(torch.randn((n,), device=GPU_TYPE, dtype=torch.float16) for _ in range(4)),
+        )
+        # The retained kernel is offered as a MultiKernel choice, and
+        # triton.multi_kernel defaults to 0, so it must be enabled explicitly.
+        with config.patch(
+            {
+                "triton.tlx_mode": "allow",
+                "triton.multi_kernel": 1,
+                "force_disable_caches": True,
+            }
+        ):
+            actual, code = run_and_get_code(
+                torch.compile(double_layernorm_silu, fullgraph=True), *inputs
+            )
+
+        expected = double_layernorm_silu(*inputs)
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        generated_code = "\n".join(code)
+        self.assertIn("tlx.local_alloc", generated_code)
+        self.assertIn("tlx.local_store", generated_code)
+        self.assertIn("tlx.local_load", generated_code)
+        self.assertIn("tl.debug_barrier()", generated_code)
+        self.assertIn("tl.static_range", generated_code)
+        self.assertNotIn(
+            "tl.store(out_ptr1", generated_code
+        )  # retained buffer not written to HBM
 
 @instantiate_parametrized_tests
 class TestTLXTemplates(TestCase):

--- a/third_party/tlx/language/tlx/inductor/choices.py
+++ b/third_party/tlx/language/tlx/inductor/choices.py
@@ -21,6 +21,8 @@ from . import tlx_config
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
+    from torch._inductor.codegen.triton import TritonKernel
     from torch._inductor.codegen.common import KernelTemplate
     from torch._inductor.ir import ChoiceCaller
     from torch._inductor.kernel_inputs import KernelInputs
@@ -64,6 +66,19 @@ class TLXInductorChoices(InductorChoices):
         from .fusion import maybe_add_tlx_prefix
 
         return maybe_add_tlx_prefix(fused_name, src_code)
+
+    def get_extra_triton_kernel_choices(
+        self,
+        kernel_cls: type[TritonKernel],
+        features: SIMDKernelFeatures,
+        kernel_args: list[Any],
+        kernel_kwargs: dict[str, Any],
+    ) -> list[TritonKernel]:
+        from .local_buffer_retention_gfx950 import get_extra_kernel_choices
+
+        return get_extra_kernel_choices(
+            kernel_cls, features, kernel_args, kernel_kwargs
+        )
 
     def override_best_choice(
         self,

--- a/third_party/tlx/language/tlx/inductor/local_buffer_retention_gfx950.py
+++ b/third_party/tlx/language/tlx/inductor/local_buffer_retention_gfx950.py
@@ -1,0 +1,564 @@
+"""gfx950 TLX local-buffer retention integration for TorchInductor."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+from collections import defaultdict
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import sympy
+import torch
+from torch._inductor import config
+from torch._inductor.codegen.common import CSEVariable, StoreMode
+from torch._inductor.codegen.simd_kernel_features import (
+    DisableReduction,
+    EnableReduction,
+    NodeScheduleMarker,
+    SIMDKernelFeatures,
+)
+from torch._inductor.codegen.triton import (
+    FixedTritonConfig,
+    TritonCSEVariable,
+    TritonKernel,
+    triton_type,
+)
+from torch._inductor.dependencies import MemoryDep
+from torch._inductor.ir import ComputedBuffer
+from torch._inductor.scheduler import BaseSchedulerNode, SchedulerNode
+from torch._inductor.utils import get_dtype_size, IndentedBuffer
+from torch._inductor.virtualized import V
+from torch.utils._ordered_set import OrderedSet
+
+
+@dataclasses.dataclass(frozen=True)
+class LocalBufferRetentionSpec:
+    """One global buffer access interval that can be backed by CTA-local LDS."""
+
+    name: str
+    dtype: torch.dtype
+    element_count: int
+    padded_element_count: int
+    store_phase: int
+    load_phases: tuple[int, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class LocalBufferRetentionPlan:
+    """Structured scheduler-to-codegen contract for local buffer retention."""
+
+    buffers: tuple[LocalBufferRetentionSpec, ...]
+    reduction_numel: int
+    reduction_block: int
+    num_warps: int
+    waves_per_eu: int
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(
+            spec.padded_element_count * get_dtype_size(spec.dtype)
+            for spec in self.buffers
+        )
+
+
+class LocalBufferRetention:
+    """Find cross-phase values that can stay in LDS instead of round-tripping HBM."""
+
+    _MAX_LOCAL_BYTES = 32 * 1024
+
+    @staticmethod
+    def _is_enabled() -> bool:
+        if config.triton.tlx_mode != "allow" or torch.version.hip is None:
+            return False
+        try:
+            # Gate on the device being compiled for rather than device 0: a
+            # multi-GPU host can mix architectures.  Pass the device itself --
+            # its index is None for a bare "cuda", which resolves to the
+            # current device, whereas int(None) would not.
+            device = V.graph.get_current_device_or_throw()
+            if device.type != "cuda":
+                return False
+            properties = torch.cuda.get_device_properties(device)
+        except (AssertionError, RuntimeError):
+            return False
+        return "gfx950" in getattr(properties, "gcnArchName", "")
+
+    @staticmethod
+    def _next_power_of_2(value: int) -> int:
+        return 1 << (value - 1).bit_length()
+
+    @staticmethod
+    def _phase_accesses(
+        node_schedule: Sequence[object],
+    ) -> tuple[
+        dict[str, dict[int, list[MemoryDep]]],
+        dict[str, dict[int, list[MemoryDep]]],
+        dict[tuple[str, int], int],
+        dict[tuple[str, int], int],
+    ]:
+        reads: dict[str, dict[int, list[MemoryDep]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        writes: dict[str, dict[int, list[MemoryDep]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        # A phase can hold several nodes, so phase numbers alone cannot order
+        # a write against a read of the same buffer.  Keep node positions too.
+        last_read_pos: dict[tuple[str, int], int] = {}
+        first_write_pos: dict[tuple[str, int], int] = {}
+        phase = 0
+        for position, item in enumerate(node_schedule):
+            if item is DisableReduction or item is EnableReduction:
+                phase += 1
+                continue
+            if not isinstance(item, BaseSchedulerNode):
+                continue
+            for dep in item.read_writes.reads:
+                if isinstance(dep, MemoryDep):
+                    reads[dep.name][phase].append(dep.simplify_with_ranges())
+                    last_read_pos[dep.name, phase] = position
+            for dep in item.read_writes.writes:
+                if isinstance(dep, MemoryDep) and dep.mode is None:
+                    writes[dep.name][phase].append(dep.simplify_with_ranges())
+                    first_write_pos.setdefault((dep.name, phase), position)
+        return reads, writes, last_read_pos, first_write_pos
+
+    @staticmethod
+    def _matching_contiguous_accesses(
+        stores: Sequence[MemoryDep], loads: Sequence[MemoryDep]
+    ) -> bool:
+        if not stores or not loads:
+            return False
+        normalized_stores = [dep.normalize() for dep in stores]
+        normalized_loads = [dep.normalize() for dep in loads]
+        reference = normalized_stores[0]
+        return all(
+            dep.mode is None
+            and dep.is_contiguous()
+            and dep.index == reference.index
+            and dep.size == reference.size
+            for dep in (*normalized_stores, *normalized_loads)
+        )
+
+    @staticmethod
+    def _can_elide_global_store(
+        name: str,
+        store_phase: int,
+        load_phases: Sequence[int],
+        writes: dict[str, dict[int, list[MemoryDep]]],
+        fused_node_names: OrderedSet[str],
+    ) -> bool:
+        if any(
+            phase >= max(load_phases) for phase in writes[name] if phase > store_phase
+        ):
+            return True
+
+        scheduler = V.graph.scheduler
+        return bool(
+            scheduler
+            and scheduler.can_buffer_be_removed_through_fusion(name, fused_node_names)
+        )
+
+    @classmethod
+    def plan_for(
+        cls, node_schedule: Sequence[object]
+    ) -> LocalBufferRetentionPlan | None:
+        if not cls._is_enabled():
+            return None
+
+        scheduled_nodes = list(NodeScheduleMarker.only_nodes(node_schedule))
+        if not scheduled_nodes or DisableReduction not in node_schedule:
+            return None
+        if any(
+            node.get_device() is None or node.get_device().type != "cuda"
+            for node in scheduled_nodes
+        ):
+            return None
+
+        reductions: list[SchedulerNode] = []
+        for scheduled_node in scheduled_nodes:
+            for node in scheduled_node.get_nodes():
+                if not node.is_reduction():
+                    continue
+                if not isinstance(node, SchedulerNode) or not isinstance(
+                    node.node, ComputedBuffer
+                ):
+                    return None
+                if node.has_strict_reduction():
+                    return None
+                reductions.append(node)
+
+        if not reductions:
+            return None
+
+        first_numel, first_rnumel = reductions[0].group[1]
+        for reduction in reductions[1:]:
+            _, (numel, rnumel) = reduction.group
+            if not (
+                V.graph.sizevars.statically_known_equals(first_numel, numel)
+                and V.graph.sizevars.statically_known_equals(first_rnumel, rnumel)
+            ):
+                return None
+
+        reduction_numel = V.graph.sizevars.simplify(first_rnumel)
+        if not isinstance(reduction_numel, (int, sympy.Integer)):
+            return None
+        reduction_numel = int(reduction_numel)
+        if reduction_numel <= 1:
+            return None
+
+        reads, writes, last_read_pos, first_write_pos = cls._phase_accesses(
+            node_schedule
+        )
+        fused_node_names = OrderedSet(
+            name for node in scheduled_nodes for name in node.get_operation_names()
+        )
+        padded_numel = cls._next_power_of_2(reduction_numel)
+        specs: list[LocalBufferRetentionSpec] = []
+        used_bytes = 0
+
+        for name in sorted(writes.keys() & reads.keys()):
+            write_phases = sorted(writes[name])
+            read_phases = sorted(reads[name])
+            for store_phase in write_phases:
+                if store_phase % 2 != 0:
+                    continue
+                later_reads = tuple(
+                    phase for phase in read_phases if phase > store_phase
+                )
+                if not later_reads:
+                    continue
+                next_store = next(
+                    (phase for phase in write_phases if phase > store_phase), None
+                )
+                load_phases = tuple(
+                    phase
+                    for phase in later_reads
+                    if phase % 2 == 0
+                    and (next_store is None or phase <= next_store)
+                    # A read in a phase that also rewrites the buffer is only
+                    # safe ahead of that rewrite.  One node reads before it
+                    # stores, so equal positions are fine.
+                    and (
+                        (name, phase) not in first_write_pos
+                        or last_read_pos[name, phase] <= first_write_pos[name, phase]
+                    )
+                )
+                # Every later read has to come out of LDS.  The global store is
+                # about to be elided, so a read left on the global path would
+                # observe memory this kernel never writes.
+                if set(load_phases) != set(later_reads):
+                    continue
+                if not cls._matching_contiguous_accesses(
+                    writes[name][store_phase],
+                    [dep for phase in load_phases for dep in reads[name][phase]],
+                ):
+                    continue
+                if not cls._can_elide_global_store(
+                    name,
+                    store_phase,
+                    load_phases,
+                    writes,
+                    fused_node_names,
+                ):
+                    continue
+
+                try:
+                    dtype = V.graph.get_dtype(name)
+                    buffer_numel = V.graph.sizevars.simplify(V.graph.get_numel(name))
+                except (KeyError, NotImplementedError, RuntimeError):
+                    continue
+                if dtype not in (torch.float16, torch.bfloat16, torch.float32):
+                    continue
+                if not V.graph.sizevars.statically_known_multiple_of(
+                    buffer_numel, reduction_numel
+                ):
+                    continue
+
+                spec_bytes = padded_numel * get_dtype_size(dtype)
+                if used_bytes + spec_bytes > cls._MAX_LOCAL_BYTES:
+                    continue
+                specs.append(
+                    LocalBufferRetentionSpec(
+                        name=name,
+                        dtype=dtype,
+                        element_count=reduction_numel,
+                        padded_element_count=padded_numel,
+                        store_phase=store_phase,
+                        load_phases=load_phases,
+                    )
+                )
+                used_bytes += spec_bytes
+                break
+
+        if not specs:
+            return None
+
+        return LocalBufferRetentionPlan(
+            buffers=tuple(specs),
+            reduction_numel=reduction_numel,
+            reduction_block=min(2048, 1 << (reduction_numel.bit_length() - 1)),
+            num_warps=4,
+            waves_per_eu=4,
+        )
+
+
+class LocalBufferRetentionKernel(TritonKernel):
+    """Triton kernel candidate that retains cross-phase values in TLX LDS."""
+
+    def __init__(
+        self,
+        *args: Any,
+        local_buffer_retention_plan: LocalBufferRetentionPlan,
+        **kwargs: Any,
+    ) -> None:
+        self.local_buffer_retention_plan = local_buffer_retention_plan
+        self.local_buffer_retention_phase = 0
+        self.local_buffer_retention_emitting = False
+        self.local_buffer_retention_barriers: set[int] = set()
+        self.local_buffer_retention_stored: set[str] = set()
+        self.local_buffer_retention_loaded: set[str] = set()
+        self.local_buffer_retention_names = {
+            spec.name: f"tlx_local_{index}"
+            for index, spec in enumerate(local_buffer_retention_plan.buffers)
+        }
+        super().__init__(*args, **kwargs)
+
+    def _local_buffer_spec(self, name: str) -> LocalBufferRetentionSpec | None:
+        return next(
+            (
+                spec
+                for spec in self.local_buffer_retention_plan.buffers
+                if spec.name == name
+            ),
+            None,
+        )
+
+    def is_buffer_retained_locally(self, name: str, *, store: bool) -> bool:
+        spec = self._local_buffer_spec(name)
+        if spec is None:
+            return False
+        if store:
+            return self.local_buffer_retention_phase == spec.store_phase
+        return self.local_buffer_retention_phase in spec.load_phases
+
+    def finalize_indexing(self, indices: Sequence[sympy.Expr]) -> None:
+        # The scheduler walks the node schedule twice, once to collect indexing
+        # and once to emit, and calls this exactly between the two.  Both walks
+        # drive disable_reduction(), so reset here and only start writing to the
+        # body afterwards -- otherwise the indexing walk emits a stray barrier.
+        super().finalize_indexing(indices)
+        self.local_buffer_retention_phase = 0
+        self.local_buffer_retention_emitting = True
+        self.local_buffer_retention_barriers.clear()
+        self.local_buffer_retention_stored.clear()
+        self.local_buffer_retention_loaded.clear()
+
+    def disable_reduction(self) -> contextlib.AbstractContextManager[None]:
+        # This context manager straddles both markers: the scheduler enters it
+        # on DisableReduction and closes it on EnableReduction, so overriding it
+        # observes every phase transition without a scheduler-side counter.
+        # Advance inside the base context on entry and after it on exit, so a
+        # barrier is written only once the pending reduction loop is flushed.
+        inner = super().disable_reduction()
+
+        @contextlib.contextmanager
+        def ctx() -> Iterator[None]:
+            with inner:
+                self._advance_local_buffer_retention_phase()
+                yield
+            self._advance_local_buffer_retention_phase()
+
+        return ctx()
+
+    def _advance_local_buffer_retention_phase(self) -> None:
+        self.local_buffer_retention_phase += 1
+        phase = self.local_buffer_retention_phase
+        if not self.local_buffer_retention_emitting:
+            return
+        if phase in self.local_buffer_retention_barriers:
+            return
+        if any(
+            phase in spec.load_phases
+            for spec in self.local_buffer_retention_plan.buffers
+        ):
+            self.body.writeline("tl.debug_barrier()")
+            self.local_buffer_retention_barriers.add(phase)
+
+    def _local_buffer_shape_and_slice(self, name: str) -> tuple[str, str]:
+        spec = self._local_buffer_spec(name)
+        if spec is None:
+            raise AssertionError(f"no local-buffer retention spec for {name}")
+        reduction_trees = [tree for tree in self.range_trees if tree.is_reduction]
+        if len(reduction_trees) != 1:
+            raise AssertionError("local-buffer retention requires one reduction axis")
+        reduction_tree = reduction_trees[0]
+        if reduction_tree.tensor_dim is None:
+            raise AssertionError("local-buffer retention requires a tensor dimension")
+
+        allocation_shape = ["1"] * self.triton_tensor_ndim()
+        allocation_shape[reduction_tree.tensor_dim] = str(spec.padded_element_count)
+        offsets = ["0"] * self.triton_tensor_ndim()
+        offsets[reduction_tree.tensor_dim] = self.index_to_str(
+            reduction_tree.block_offset()
+        )
+        access_shape = ["1"] * self.triton_tensor_ndim()
+        access_shape[reduction_tree.tensor_dim] = reduction_tree.block_size_str()
+        return (
+            f"({', '.join(allocation_shape)},)",
+            f"tlx.local_slice({self.local_buffer_retention_names[name]}, "
+            f"[{', '.join(offsets)}], "
+            f"[{', '.join(access_shape)}])",
+        )
+
+    def _load_from_local_buffer(
+        self, name: str, index: sympy.Expr
+    ) -> TritonCSEVariable:
+        spec = self._local_buffer_spec(name)
+        if spec is None:
+            raise AssertionError(f"no local-buffer retention spec for {name}")
+        # The global buffer stays in the signature so this kernel keeps the same
+        # arguments as its sibling multi-kernel choices, which do use it.
+        self.args.input(name)
+        self.must_keep_buffers.add(name)
+        self.local_buffer_retention_loaded.add(name)
+        _, local_slice = self._local_buffer_shape_and_slice(name)
+        line = f"tlx.local_load({local_slice}, relaxed=True)"
+        dtype = spec.dtype
+        if (
+            dtype in (torch.float16, torch.bfloat16)
+            and config.triton.codegen_upcast_to_fp32
+        ):
+            line += ".to(tl.float32)"
+            dtype = torch.float32
+        result = self.cse.generate(
+            self.loads,
+            line,
+            dtype=dtype,
+            shape=tuple(self.dense_size_list()),
+        )
+        if not isinstance(result, TritonCSEVariable):
+            raise AssertionError(f"expected TritonCSEVariable, got {type(result)}")
+        return result
+
+    def _store_to_local_buffer(
+        self, name: str, value: CSEVariable, mode: StoreMode
+    ) -> None:
+        if mode is not None:
+            raise AssertionError("local-buffer retention only supports plain stores")
+        spec = self._local_buffer_spec(name)
+        if spec is None:
+            raise AssertionError(f"no local-buffer retention spec for {name}")
+        # See _load_from_local_buffer: kept for multi-kernel argument parity.
+        self.args.output(name)
+        self.must_keep_buffers.add(name)
+        self.local_buffer_retention_stored.add(name)
+        _, local_slice = self._local_buffer_shape_and_slice(name)
+        self.stores.writeline(
+            f"tlx.local_store({local_slice}, {value}.to({triton_type(spec.dtype)}))"
+        )
+
+    def load(self, name: str, index: sympy.Expr):
+        if self.is_buffer_retained_locally(name, store=False):
+            return self._load_from_local_buffer(name, index)
+        return super().load(name, index)
+
+    def store(
+        self,
+        name: str,
+        index: sympy.Expr,
+        value: CSEVariable,
+        mode: StoreMode = None,
+    ) -> None:
+        if self.is_buffer_retained_locally(name, store=True):
+            self._store_to_local_buffer(name, value, mode)
+            return
+        super().store(name, index, value, mode)
+
+    def reduction_loop_range(
+        self, prefix: str, loop_start: str, loop_end: str
+    ) -> str:
+        if self.cooperative_reduction:
+            raise AssertionError(
+                "local-buffer retention does not support cooperative reduction"
+            )
+        return (
+            f"tl.static_range(0, {self.local_buffer_retention_plan.reduction_numel}, "
+            f"{prefix.upper()}BLOCK)"
+        )
+
+    def codegen_static_numels(self, code: IndentedBuffer) -> None:
+        super().codegen_static_numels(code)
+        code.writeline("tl.static_assert(XBLOCK == 1)")
+        for spec in self.local_buffer_retention_plan.buffers:
+            allocation_shape, _ = self._local_buffer_shape_and_slice(spec.name)
+            local_name = self.local_buffer_retention_names[spec.name]
+            code.writeline(
+                f"{local_name}_storage = tlx.local_alloc("
+                f"{allocation_shape}, {triton_type(spec.dtype)}, 1)"
+            )
+            code.writeline(f"{local_name} = tlx.local_view({local_name}_storage, 0)")
+
+    def codegen_kernel(self, *args: Any, **kwargs: Any) -> str:
+        # The plan is derived from SIMDKernelFeatures.node_schedule, but phases
+        # are counted over whatever schedule the scheduler actually emits.  If
+        # those disagree the redirection silently lands on the wrong accesses,
+        # so refuse to emit a kernel whose plan was not fully applied.
+        for spec in self.local_buffer_retention_plan.buffers:
+            if (
+                spec.name not in self.local_buffer_retention_stored
+                or spec.name not in self.local_buffer_retention_loaded
+            ):
+                raise AssertionError(
+                    f"local-buffer retention plan for {spec.name} was not applied: "
+                    "the global store is elided only when both the store and at "
+                    "least one load are redirected to LDS"
+                )
+            if self.local_buffer_retention_barriers.isdisjoint(spec.load_phases):
+                raise AssertionError(
+                    f"local-buffer retention for {spec.name} emitted no barrier "
+                    "between the LDS store and its first load"
+                )
+        return super().codegen_kernel(*args, **kwargs)
+
+    def inductor_meta_per_kernel(self) -> dict[str, Any]:
+        metadata = super().inductor_meta_per_kernel()
+        metadata["tlx_local_buffer_retention"] = {
+            "buffers": tuple(
+                spec.name for spec in self.local_buffer_retention_plan.buffers
+            ),
+            "bytes": self.local_buffer_retention_plan.total_bytes,
+        }
+        return metadata
+
+
+def get_extra_kernel_choices(
+    kernel_cls: type[TritonKernel],
+    features: SIMDKernelFeatures,
+    kernel_args: list[Any],
+    kernel_kwargs: dict[str, Any],
+) -> list[TritonKernel]:
+    """Return the opt-in retained-LDS candidate for a compatible schedule."""
+    if kernel_cls is not TritonKernel or "fixed_config" in kernel_kwargs:
+        return []
+    plan = LocalBufferRetention.plan_for(features.node_schedule)
+    if plan is None:
+        return []
+
+    retained_kwargs = {
+        **kernel_kwargs,
+        "local_buffer_retention_plan": plan,
+        "override_persistent_reduction": False,
+        "override_cooperative_reduction": False,
+        "fixed_config": FixedTritonConfig(
+            {
+                "XBLOCK": 1,
+                "R0_BLOCK": plan.reduction_block,
+                "num_warps": plan.num_warps,
+                "num_stages": 1,
+                "waves_per_eu": plan.waves_per_eu,
+            }
+        ),
+    }
+    return [LocalBufferRetentionKernel(*kernel_args, **retained_kwargs)]


### PR DESCRIPTION
Summary:

This is a tentative diff for review, more improvements & tests in progress.

Add an opt-in scheduler/codegen prototype that retains materialized values in TLX local memory across reduction phases on AMD. Candidate discovery is dataflow-based: it finds a direct contiguous store followed by a matching later load owned by the same program.

The scheduler sends a structured buffer/phase/storage plan to Triton codegen. Codegen allocates LDS, redirects only the selected store/load interval, preserves the original storage-dtype rounding, emits the required barrier, and statically unrolls the retained reduction tiles. The ordinary Triton kernel remains a sibling MultiKernel choice so runtime benchmarking can reject an unprofitable LDS candidate.

The initial legality envelope is intentionally conservative: AMD with Triton beta, one reduction dimension, one row per CTA, static contiguous access, fp16/bf16/fp32 storage, and at most 32 KiB of retained data per CTA. This covers the production double-LayerNorm case while defining a reusable mechanism for other non-templated reduction pipelines.

The diff retains the hand-written double-LayerNorm kernel as a performance-ceiling reference and adds an Inductor A/B benchmark with configurable hidden width.

Reviewed By: dshi7, htyu

Differential Revision: D117433340


