### PR TITLE
[triton][3.8] Remove InterleaveTMem rollback, gate at one load (#3449)

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -5,7 +5,6 @@
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
 #include "triton/Tools/Sys/GetEnv.h"
 #include "llvm/ADT/AddressRanges.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
 #include <cstdlib>
 
@@ -73,25 +72,38 @@ struct AccessRange {
 
 std::pair<Value, AccessRange> findBufferAccess(Value a);
 
+// Resolve the subview's per-dimension start offsets. An empty entry means the
+// offset is not a compile-time constant, so the whole dimension may be
+// accessed.
+//
+// This must not build IR. It runs as alias analysis underneath `sinkOps`,
+// which re-queries it while walking the very block it is deciding how to
+// reorder; materializing an `arith.constant` here inserts an op into that
+// block and breaks the caller's contiguity check, so the sinking loop never
+// reaches a fixed point.
 std::pair<Value, AccessRange>
 findBufferAccessMemdescSubview(Operation *subview) {
-  OpBuilder builder(subview);
-  Location loc = subview->getLoc();
   TypedValue<ttg::MemDescType> src;
   SmallVector<int64_t> shape;
-  SmallVector<Value> offsets;
+  SmallVector<std::optional<int64_t>> offsets;
   if (auto indexOp = dyn_cast<ttg::MemDescIndexOp>(subview)) {
     src = indexOp.getSrc();
     shape = to_vector(indexOp.getType().getShape());
-    offsets = {indexOp.getIndex()};
+    APInt index;
+    offsets.push_back(matchPattern(indexOp.getIndex(), m_ConstantInt(&index))
+                          ? std::optional<int64_t>(index.getSExtValue())
+                          : std::nullopt);
+    // An index view selects one slice of the outermost dim; the dims it keeps
+    // all start at 0.
     for (int i = 0, e = std::max<int>(0, shape.size() - 1); i < e; ++i)
-      offsets.push_back(arith::ConstantIntOp::create(builder, loc, 0, 32));
+      offsets.push_back(0);
   } else {
     auto subsliceOp = cast<ttg::MemDescSubsliceOp>(subview);
     src = subsliceOp.getSrc();
     shape = to_vector(subsliceOp.getType().getShape());
+    // Subslice offsets are static attributes.
     for (auto offset : subsliceOp.getOffsets())
-      offsets.push_back(arith::ConstantIntOp::create(builder, loc, offset, 32));
+      offsets.push_back(offset);
   }
   auto [alloc, parentAccess] = findBufferAccess(src);
   if (!alloc)
@@ -113,13 +125,12 @@ findBufferAccessMemdescSubview(Operation *subview) {
     }
 
     // If the offset is not known, then the entire dim may be accessed.
-    APInt value;
-    if (!matchPattern(offset, m_ConstantInt(&value))) {
+    if (!offset) {
       childAccess.ranges.push_back({});
       continue;
     }
 
-    uint64_t accessStart = parentRange->start() + value.getSExtValue();
+    uint64_t accessStart = parentRange->start() + *offset;
     uint64_t accessSize = 1;
     if (i >= childAccess.rankOffset)
       accessSize = shape[i - childAccess.rankOffset];
@@ -204,9 +215,115 @@ bool tmemMayAlias(Value a, Value b) {
   return true;
 }
 
+// Trace SMEM memdesc views to a stable root, looking through
+// `ttg.warp_specialize` explicit captures the same way findBufferAccess does.
+// Resolving captures matters for aliasing: a partition that captures one buffer
+// twice presents it as two distinct block arguments, which must not be mistaken
+// for two distinct buffers. Only distinct local allocations are known not to
+// alias; every other root, including a block argument that does not resolve to
+// a capture, is treated conservatively by smemMayAlias below.
+Value findSMemBase(Value value) {
+  while (true) {
+    if (Operation *def = value.getDefiningOp()) {
+      if (!isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+               ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+               ttg::MemDescReshapeOp>(def))
+        break;
+      value = def->getOperand(0);
+      continue;
+    }
+    auto arg = dyn_cast<BlockArgument>(value);
+    if (!arg)
+      break;
+    auto wsOp = dyn_cast_or_null<ttg::WarpSpecializePartitionsOp>(
+        arg.getOwner()->getParentOp());
+    if (!wsOp)
+      break;
+    value = wsOp.getExplicitCaptures()[arg.getArgNumber()];
+  }
+  return value;
+}
+
+bool isKnownSMemBase(Value value) {
+  return value.getDefiningOp<ttg::LocalAllocOp>() != nullptr;
+}
+
+bool smemMayAlias(Value a, Value b) {
+  Value aBase = findSMemBase(a);
+  Value bBase = findSMemBase(b);
+  if (aBase == bBase)
+    return true;
+  return !(isKnownSMemBase(aBase) && isKnownSMemBase(bBase));
+}
+
+bool mayWriteOrFreeSMem(Operation *op, Value buffer) {
+  SmallVector<MemoryEffects::EffectInstance> effects;
+  collectEffects(op, effects);
+  for (const auto &effect : effects) {
+    if (!isa<MemoryEffects::Write, MemoryEffects::Free>(effect.getEffect()))
+      continue;
+    if (isa<SideEffects::DefaultResource>(effect.getResource()))
+      return true;
+    if (effect.getResource() == ttg::SharedMemory::get() &&
+        (!effect.getValue() || smemMayAlias(effect.getValue(), buffer)))
+      return true;
+  }
+  return false;
+}
+
+// A token wait is "plain" when it carries no barrier operands, i.e. it only
+// waits for the TMA store queue to drain past its own token. "Plain" is about
+// barriers specifically: a wait that also gates an mbarrier publishes a signal
+// other partitions observe, so it is not free to move.
 bool isPlainTMAStoreTokenWait(Operation *op) {
   auto wait = dyn_cast<TMAStoreTokenWaitOp>(op);
   return wait && wait.getBarriers().empty();
+}
+
+bool isTMAStoreLike(Operation *op);
+
+// Sink each barrier-free TMA store token wait as late as the staging buffer
+// allows: down to just before the first following store that may clobber the
+// buffer the store is still reading. Nothing between the store and that point
+// needs the transfer to have completed, so delaying the wait lets the TMEM
+// load and layout conversion for the next subtile overlap the in-flight TMA
+// store instead of stalling behind it. The walk stops early at another async
+// reader or at any operation whose memory effects cannot be proven independent
+// of the staging buffer.
+void delayPlainTMAStoreTokenWaits(Block &block) {
+  SmallVector<TMAStoreTokenWaitOp> waits;
+  for (Operation &op : block)
+    if (isPlainTMAStoreTokenWait(&op))
+      waits.push_back(cast<TMAStoreTokenWaitOp>(&op));
+
+  for (TMAStoreTokenWaitOp wait : waits) {
+    Operation *tmaStore = wait.getToken().getDefiningOp();
+    if (!tmaStore ||
+        !isa<AsyncTMACopyLocalToGlobalOp, AsyncTMAReduceOp>(tmaStore) ||
+        tmaStore->getBlock() != &block)
+      continue;
+    Value staging;
+    if (auto copy = dyn_cast<AsyncTMACopyLocalToGlobalOp>(tmaStore))
+      staging = copy.getSrc();
+    else
+      staging = cast<AsyncTMAReduceOp>(tmaStore).getSrc();
+    for (auto it = std::next(wait->getIterator()); it != block.end(); ++it) {
+      auto localStore = dyn_cast<ttg::LocalStoreOp>(&*it);
+      if (localStore) {
+        if (!smemMayAlias(localStore.getDst(), staging))
+          continue;
+        wait->moveBefore(localStore);
+        break;
+      }
+
+      // Do not make this queue-wide wait cover another async reader, or cross
+      // an operation whose memory effects we cannot prove independent.
+      if (isa<ttg::LocalAllocOp>(&*it))
+        continue;
+      if (isTMAStoreLike(&*it) || mayWriteOrFreeSMem(&*it, staging))
+        break;
+    }
+  }
 }
 
 // Check whether a movable chain can sink past `next`. When opConstraints is
@@ -224,8 +341,25 @@ bool canSinkUseChainPast(Value buffer, ArrayRef<Operation *> useChain,
       break;
     }
   }
-  if (isWSBarrierReorderEnabled()) {
-    if (!canAdvanceWSBarrier(opConstraints, next))
+  // A TMEM epilogue load can carry the constraints from its own arrive
+  // barrier. Use those constraints even when the global barrier-reorder
+  // knob is disabled: this moves only the load/use chain (and its matching
+  // arrive), rather than globally raising and sinking every WS barrier in the
+  // block.
+  if (opConstraints || isWSBarrierReorderEnabled()) {
+    // Once the load chain has picked up its own arrive, it may pass another
+    // WS arrive: both operations only delay signals. This mirrors
+    // sinkWSArrives, but is deliberately limited to the one epilogue chain.
+    // Both arrives must carry WS barrier constraints; an unconstrained arrive
+    // has no channel to prove independence against, so it stays subject to
+    // canAdvanceWSBarrier.
+    auto chainArrive = dyn_cast<ArriveBarrierOp>(useChain.back());
+    auto nextArrive = dyn_cast<ArriveBarrierOp>(next);
+    bool arrivesCanSwap =
+        chainArrive && nextArrive &&
+        hasWSBarrierConstraints(chainArrive.getConstraints()) &&
+        hasWSBarrierConstraints(nextArrive.getConstraints());
+    if (!arrivesCanSwap && !canAdvanceWSBarrier(opConstraints, next))
       return false;
   } else {
     // Legacy safe behavior: don't sink past barrier signals, since they may
@@ -254,21 +388,53 @@ bool canSinkUseChainPast(Value buffer, ArrayRef<Operation *> useChain,
   return !dep;
 }
 
-void moveUseChainAfter(ArrayRef<Operation *> useChain, Operation *op) {
-  Operation *insertBefore = op->getNextNode();
-  assert(insertBefore && "expected op before block terminator");
-  for (Operation *chainOp : useChain)
-    chainOp->moveBefore(insertBefore);
+// An arrive that releases the buffer this chain is reading must stay behind
+// the chain, so it cannot be sunk past. Absorbing it instead lets both move
+// together: the load keeps its position ahead of the release it signals, and
+// the release is only ever delayed. Matching the chain's own constraints is
+// what identifies the arrive as belonging to this channel; an arrive from
+// another channel stays subject to canSinkUseChainPast.
+bool isAbsorbableArrive(Operation *op,
+                        std::optional<DictionaryAttr> opConstraints) {
+  if (!opConstraints)
+    return false;
+  auto arrive = dyn_cast<ArriveBarrierOp>(op);
+  if (!arrive)
+    return false;
+  auto constraints = arrive.getConstraints();
+  return constraints && *constraints == *opConstraints;
+}
+
+// True when the chain already sits contiguously just before `insertBefore`,
+// i.e. moving it would be a no-op. Absorbing an arrive can leave the chain
+// non-contiguous even when its last op is already in place, so contiguity has
+// to be checked rather than just the final position.
+bool isChainInPlace(ArrayRef<Operation *> useChain, Operation *insertBefore) {
+  for (auto [op, nextOp] :
+       llvm::zip(useChain.drop_back(), useChain.drop_front()))
+    if (op->getNextNode() != nextOp)
+      return false;
+  return useChain.back()->getNextNode() == insertBefore;
 }
 
 // Sink ops as close to their use as possible to reduce register pressure.
 // When opConstraints is provided, uses canAdvanceWSBarrier to decide whether
 // the op can sink past barriers from independent channels.
-bool sinkOps(Value buffer, ArrayRef<Operation *> useChain,
+bool sinkOps(Value buffer, SmallVectorImpl<Operation *> &useChain,
              std::optional<DictionaryAttr> opConstraints) {
   Operation *insertBefore = nullptr;
   Operation *next = useChain.back()->getNextNode();
   while (next && !next->hasTrait<OpTrait::IsTerminator>()) {
+    // The walk starts after the chain, so only an arrive that already follows
+    // the load is ever a candidate; one that precedes it is never visited.
+    if (isAbsorbableArrive(next, opConstraints)) {
+      useChain.push_back(next);
+      // Any insertion point found before the arrive is now stale: reusing it
+      // would hoist the arrive above ops it currently follows.
+      insertBefore = nullptr;
+      next = next->getNextNode();
+      continue;
+    }
     insertBefore = next;
     bool dep = false;
     if (!canSinkUseChainPast(buffer, useChain, next, opConstraints))
@@ -277,12 +443,13 @@ bool sinkOps(Value buffer, ArrayRef<Operation *> useChain,
       break;
     next = next->getNextNode();
   }
-  if (insertBefore && insertBefore != useChain.back()->getNextNode()) {
-    for (Operation *op : useChain)
-      op->moveBefore(insertBefore);
-    return true;
-  }
-  return false;
+  if (!insertBefore)
+    insertBefore = useChain.back()->getNextNode();
+  if (!insertBefore || isChainInPlace(useChain, insertBefore))
+    return false;
+  for (Operation *op : useChain)
+    op->moveBefore(insertBefore);
+  return true;
 }
 
 SmallVector<Operation *> getMovableUseChain(Operation *op) {
@@ -302,112 +469,13 @@ bool trySinkOp(Operation *op, Value buffer,
   return sinkOps(buffer, useChain, opConstraints);
 }
 
-struct TMemLoadGroup {
-  DictionaryAttr constraints;
-  Value alloc;
-  SmallVector<Operation *> loads;
-};
-
-DenseMap<Operation *, unsigned> getBlockOpPositions(Block &block) {
-  DenseMap<Operation *, unsigned> opToPosition;
-  unsigned position = 0;
-  for (Operation &op : block)
-    opToPosition[&op] = position++;
-  return opToPosition;
-}
-
-Operation *
-getTMemLoadLiveRangeEnd(Operation *load,
-                        const DenseMap<Operation *, unsigned> &opToPosition) {
-  SmallVector<Operation *> useChain = getMovableUseChain(load);
-  Operation *tail = useChain.back();
-  Operation *end = tail;
-  unsigned endPos = opToPosition.lookup(tail);
-
-  for (Value result : tail->getResults()) {
-    for (Operation *user : result.getUsers()) {
-      auto userIt = opToPosition.find(user);
-      if (userIt != opToPosition.end() && userIt->second > endPos) {
-        end = user;
-        endPos = userIt->second;
-      }
-    }
-  }
-  return end;
-}
-
-bool isAfter(Operation *op, Operation *boundary,
-             const DenseMap<Operation *, unsigned> &opToPosition) {
-  auto opIt = opToPosition.find(op);
-  auto boundaryIt = opToPosition.find(boundary);
-  if (opIt == opToPosition.end() || boundaryIt == opToPosition.end())
-    return false;
-  return opIt->second > boundaryIt->second;
-}
-
-bool sinkTMemLoadAfter(Operation *load, Operation *boundary, Value buffer,
-                       std::optional<DictionaryAttr> opConstraints) {
-  bool changed = false;
-  while (true) {
-    DenseMap<Operation *, unsigned> opToPosition =
-        getBlockOpPositions(*load->getBlock());
-    if (isAfter(load, boundary, opToPosition))
-      return changed;
-
-    SmallVector<Operation *> useChain = getMovableUseChain(load);
-    std::optional<DictionaryAttr> effectiveConstraints = opConstraints;
-    Operation *next = useChain.back()->getNextNode();
-    auto arrive = dyn_cast_or_null<ArriveBarrierOp>(next);
-    if (arrive && arrive.getConstraints()) {
-      DictionaryAttr arriveConstraints = *arrive.getConstraints();
-      if (!effectiveConstraints || arriveConstraints == *effectiveConstraints) {
-        useChain.push_back(next);
-        effectiveConstraints = arriveConstraints;
-      }
-    }
-    next = useChain.back()->getNextNode();
-    if (!next || next->hasTrait<OpTrait::IsTerminator>())
-      return changed;
-    if (!canSinkUseChainPast(buffer, useChain, next, effectiveConstraints))
-      return changed;
-
-    moveUseChainAfter(useChain, next);
-    changed = true;
-  }
-}
-
-bool sinkTMemLoadsToFreshLiveRanges(
-    const TMemLoadGroup &group,
-    const DenseMap<Operation *, DictionaryAttr> &memOpConstraints) {
-  bool changed = false;
-  Operation *previousLoad = group.loads.front();
-  for (Operation *load : llvm::drop_begin(group.loads)) {
-    DenseMap<Operation *, unsigned> opToPosition =
-        getBlockOpPositions(*load->getBlock());
-    Operation *previousEnd =
-        getTMemLoadLiveRangeEnd(previousLoad, opToPosition);
-    auto loadOp = cast<TMEMLoadOp>(load);
-    auto it = memOpConstraints.find(load);
-    std::optional<DictionaryAttr> constraints =
-        it != memOpConstraints.end() ? std::optional<DictionaryAttr>(it->second)
-                                     : std::nullopt;
-    changed |=
-        sinkTMemLoadAfter(load, previousEnd, loadOp.getSrc(), constraints);
-    previousLoad = load;
-  }
-  return changed;
+bool isTMAStoreLike(Operation *op) {
+  return isa<AsyncTMACopyLocalToGlobalOp, AsyncTMAReduceOp>(op);
 }
 
 struct BlockInterleaveInfo {
   Block *block;
-  unsigned tmemLoadCount = 0;
-  SmallVector<Operation *> tmemLoads;
   SmallVector<std::pair<Operation *, Value>> opsToSink;
-};
-
-struct OverlapLiveness {
-  SmallVector<unsigned> numLiveTMEMLoads;
-  SmallVector<unsigned> overlapProfile;
 };
 
 BlockInterleaveInfo collectBlockInterleaveInfo(Block *block) {
@@ -415,168 +483,12 @@ BlockInterleaveInfo collectBlockInterleaveInfo(Block *block) {
   info.block = block;
   for (Operation &op : *block) {
     if (auto load = dyn_cast<TMEMLoadOp>(&op)) {
-      info.tmemLoadCount++;
-      info.tmemLoads.push_back(load);
       info.opsToSink.emplace_back(load, load.getSrc());
     } else if (auto alloc = dyn_cast<TMEMAllocOp>(&op)) {
       info.opsToSink.emplace_back(alloc, alloc.getResult());
     }
   }
   return info;
-}
-
-SmallVector<TMemLoadGroup> buildTMemLoadGroups(
-    ArrayRef<Operation *> tmemLoads,
-    const DenseMap<Operation *, DictionaryAttr> &memOpConstraints) {
-  SmallVector<TMemLoadGroup> groups;
-  for (Operation *op : tmemLoads) {
-    auto load = cast<TMEMLoadOp>(op);
-    DictionaryAttr constraints;
-    if (auto it = memOpConstraints.find(op); it != memOpConstraints.end())
-      constraints = it->second;
-    Value alloc = findBufferAccess(load.getSrc()).first;
-
-    auto groupIt = llvm::find_if(groups, [&](const TMemLoadGroup &group) {
-      return group.constraints == constraints && group.alloc == alloc;
-    });
-    if (groupIt == groups.end()) {
-      groups.push_back({constraints, alloc, {}});
-      groupIt = std::prev(groups.end());
-    }
-    groupIt->loads.push_back(op);
-  }
-
-  llvm::erase_if(groups, [](const TMemLoadGroup &group) {
-    return group.loads.size() < 2;
-  });
-  return groups;
-}
-
-SmallVector<Operation *> getBlockOpOrder(Block &block) {
-  SmallVector<Operation *> order;
-  for (Operation &op : block) {
-    if (!op.hasTrait<OpTrait::IsTerminator>())
-      order.push_back(&op);
-  }
-  return order;
-}
-
-void restoreBlockOpOrder(Block &block, ArrayRef<Operation *> order) {
-  llvm::SmallPtrSet<Operation *, 32> originalOps(order.begin(), order.end());
-  SmallVector<Operation *> addedOps;
-  for (Operation &op : block) {
-    if (!op.hasTrait<OpTrait::IsTerminator>() && !originalOps.contains(&op))
-      addedOps.push_back(&op);
-  }
-  for (Operation *op : addedOps) {
-    if (op->use_empty() && isMemoryEffectFree(op))
-      op->erase();
-  }
-
-  Operation *insertPt = block.getTerminator();
-  for (Operation *op : llvm::reverse(order)) {
-    if (op->getBlock() != &block)
-      continue;
-    op->moveBefore(insertPt);
-    insertPt = op;
-  }
-}
-
-// Computes the live range (start and end positions) for each TMEM load
-// operation within a block's operation order.
-DenseMap<Operation *, std::pair<unsigned, unsigned>>
-computeLoadLiveRanges(ArrayRef<Operation *> order,
-                      ArrayRef<Operation *> tmemLoads) {
-  DenseMap<Operation *, unsigned> opToPosition;
-  unsigned position = 0;
-  for (Operation *op : order)
-    opToPosition[op] = position++;
-
-  DenseMap<Operation *, std::pair<unsigned, unsigned>> liveRanges;
-  for (Operation *load : tmemLoads) {
-    auto startIt = opToPosition.find(load);
-    if (startIt == opToPosition.end())
-      continue;
-
-    SmallVector<Operation *> useChain = getMovableUseChain(load);
-    Operation *tail = useChain.back();
-    auto tailIt = opToPosition.find(tail);
-    unsigned end =
-        tailIt != opToPosition.end() ? tailIt->second : startIt->second;
-
-    for (Value result : tail->getResults()) {
-      for (Operation *user : result.getUsers()) {
-        auto userIt = opToPosition.find(user);
-        if (userIt != opToPosition.end())
-          end = std::max(end, userIt->second);
-      }
-    }
-    liveRanges[load] = {startIt->second, end};
-  }
-
-  return liveRanges;
-}
-
-// Computes overlapping liveness occupancy across the given TMEM loads. Walks
-// the union of their live ranges and records, for each contiguous span, how
-// many of the candidate loads are simultaneously live. The resulting
-// `overlapProfile` (counts > 1, sorted descending) is the rollback acceptance
-// key: a transformation is kept only when this profile improves.
-OverlapLiveness computeOverlapLiveness(
-    const DenseMap<Operation *, std::pair<unsigned, unsigned>> &liveRanges,
-    ArrayRef<Operation *> tmemLoads) {
-  OverlapLiveness liveness;
-  SmallVector<std::pair<unsigned, unsigned>> groupLiveRanges;
-  for (Operation *load : tmemLoads) {
-    auto it = liveRanges.find(load);
-    if (it != liveRanges.end())
-      groupLiveRanges.push_back(it->second);
-  }
-  if (groupLiveRanges.empty())
-    return liveness;
-
-  unsigned minStart = groupLiveRanges.front().first;
-  unsigned maxEnd = groupLiveRanges.front().second;
-  for (auto [start, end] : groupLiveRanges) {
-    minStart = std::min(minStart, start);
-    maxEnd = std::max(maxEnd, end);
-  }
-
-  unsigned lastCount = 0;
-  for (unsigned pos = minStart; pos <= maxEnd; ++pos) {
-    unsigned count = 0;
-    for (auto [start, end] : groupLiveRanges) {
-      if (start <= pos && pos <= end)
-        count++;
-    }
-    if (count == 0) {
-      lastCount = 0;
-      continue;
-    }
-    if (count == lastCount)
-      continue;
-    liveness.numLiveTMEMLoads.push_back(count);
-    lastCount = count;
-  }
-
-  for (unsigned count : liveness.numLiveTMEMLoads) {
-    if (count > 1)
-      liveness.overlapProfile.push_back(count);
-  }
-  llvm::sort(liveness.overlapProfile,
-             [](unsigned lhs, unsigned rhs) { return lhs > rhs; });
-  return liveness;
-}
-
-bool isOverlapProfileImproved(ArrayRef<unsigned> before,
-                              ArrayRef<unsigned> after) {
-  for (auto [beforeCount, afterCount] : llvm::zip(before, after)) {
-    if (afterCount < beforeCount)
-      return true;
-    if (afterCount > beforeCount)
-      return false;
-  }
-  return after.size() < before.size();
 }
 
 DenseMap<Operation *, DictionaryAttr> buildTMemLoadConstraints(Block &block) {
@@ -608,11 +520,6 @@ DenseMap<Operation *, DictionaryAttr> buildTMemLoadConstraints(Block &block) {
 
 void processBlock(BlockInterleaveInfo &info) {
   Block &block = *info.block;
-  SmallVector<Operation *> originalOrder = getBlockOpOrder(block);
-  SmallVector<Operation *> originalLivenessOrder = originalOrder;
-  originalLivenessOrder.push_back(block.getTerminator());
-  auto beforeLiveRanges =
-      computeLoadLiveRanges(originalLivenessOrder, info.tmemLoads);
   bool reorderWSBarriers = isWSBarrierReorderEnabled();
 
   // Step 1: Record which memory op each WS barrier guards.
@@ -627,53 +534,35 @@ void processBlock(BlockInterleaveInfo &info) {
     raiseWSWaits(block);
   }
 
-  // Step 3: Move TMEM allocs close to their uses, then sink tmem_loads only
-  // far enough to start after the previous load's live range.
-  DenseMap<Operation *, DictionaryAttr> memOpConstraints;
-  if (reorderWSBarriers)
-    memOpConstraints = buildTMemLoadConstraints(block);
-  SmallVector<TMemLoadGroup> loadGroups =
-      buildTMemLoadGroups(info.tmemLoads, memOpConstraints);
-  for (auto [op, buffer] : info.opsToSink) {
-    if (isa<TMEMLoadOp>(op))
-      continue;
+  // Step 3: Move TMEM allocs close to their uses, then sink tmem_loads as far
+  // as legality allows.
+  // Constraint-guided TMEM epilogue sinking is safe independently of the
+  // global WS-barrier normalization. Build the mapping unconditionally so a
+  // load can carry its own arrive across barriers from independent channels.
+  DenseMap<Operation *, DictionaryAttr> memOpConstraints =
+      buildTMemLoadConstraints(block);
+  auto sinkGreedily = [&](Operation *op, Value buffer) {
     auto it = memOpConstraints.find(op);
     std::optional<DictionaryAttr> constraints =
         it != memOpConstraints.end() ? std::optional<DictionaryAttr>(it->second)
                                      : std::nullopt;
     while (trySinkOp(op, buffer, constraints)) {
     }
-  }
-  for (const TMemLoadGroup &group : loadGroups)
-    sinkTMemLoadsToFreshLiveRanges(group, memOpConstraints);
+  };
+  for (auto [op, buffer] : info.opsToSink)
+    if (!isa<TMEMLoadOp>(op))
+      sinkGreedily(op, buffer);
+  for (auto [op, buffer] : info.opsToSink)
+    if (isa<TMEMLoadOp>(op))
+      sinkGreedily(op, buffer);
 
   // Step 4: Restore barriers to optimal positions near their memory ops.
   if (reorderWSBarriers)
     optimizeWSBarrierLocations(barrierMap);
-
-  SmallVector<Operation *> currentLivenessOrder = getBlockOpOrder(block);
-  currentLivenessOrder.push_back(block.getTerminator());
-  auto afterLiveRanges =
-      computeLoadLiveRanges(currentLivenessOrder, info.tmemLoads);
-  bool hasOverlappingGroup = false;
-  bool allOverlappingGroupsImproved = true;
-  for (const TMemLoadGroup &group : loadGroups) {
-    OverlapLiveness before =
-        computeOverlapLiveness(beforeLiveRanges, group.loads);
-    if (before.overlapProfile.empty())
-      continue;
-    hasOverlappingGroup = true;
-    OverlapLiveness after =
-        computeOverlapLiveness(afterLiveRanges, group.loads);
-    if (!isOverlapProfileImproved(before.overlapProfile,
-                                  after.overlapProfile)) {
-      allOverlappingGroupsImproved = false;
-      break;
-    }
-  }
-
-  if (!hasOverlappingGroup || !allOverlappingGroupsImproved)
-    restoreBlockOpOrder(block, originalOrder);
+  // Barrier restoration and TMEM-load sinking may move a load across a token
+  // wait that was already positioned before staging reuse. Re-establish that
+  // canonical placement so the load/conversion overlaps the prior TMA store.
+  delayPlainTMAStoreTokenWaits(block);
 }
 
 } // anonymous namespace
@@ -690,7 +579,12 @@ struct TritonNvidiaGPUInterleaveTMemPass
     SmallVector<BlockInterleaveInfo> blocksToProcess;
     m.walk([&](Block *block) {
       BlockInterleaveInfo info = collectBlockInterleaveInfo(block);
-      if (info.tmemLoadCount < 2)
+      // One movable op is enough: distancing a single load from its producing
+      // MMA is worthwhile on its own, and alloc sinking does not depend on
+      // loads at all. The gate stays because processBlock's barrier steps are
+      // block-scoped rather than driven by opsToSink, so an empty worklist
+      // would still reorder every WS barrier and TMA store token wait here.
+      if (info.opsToSink.empty())
         return;
       blocksToProcess.push_back(std::move(info));
     });

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s
+// RUN: env TRITON_DISABLE_WSBARRIER_REORDER=1 triton-opt %s --triton-nvidia-interleave-tmem --allow-unregistered-dialect | FileCheck %s --check-prefix=TARGETED
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 2], order = [1, 0]}>
 #linear64 = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 32]], block = []}>
@@ -17,8 +18,6 @@ tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_m
                           %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>)
                           -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
 
-  // CHECK: ttng.tmem_load
-  // CHECK-NEXT: ttg.convert_layout
   %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
   %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
   %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
@@ -27,9 +26,11 @@ tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_m
   %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
 
   // CHECK: ttg.local_alloc
-  // CHECK-NEXT: arith.truncf
-  // CHECK-NEXT: ttng.tmem_load
-  // CHECK-NEXT: ttg.convert_layout
+  // CHECK: [[LHS:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[LHS_LAYOUT:%.+]] = ttg.convert_layout [[LHS]]
+  // CHECK-NEXT: arith.truncf [[LHS_LAYOUT]]
+  // CHECK-NEXT: [[RHS:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[RHS_LAYOUT:%.+]] = ttg.convert_layout [[RHS]]
   %4 = ttg.local_alloc %arg1 : (tensor<128x128xf16, #blocked>) -> !ttg.memdesc<128x128xf16, #shared, #smem>
   %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
 
@@ -39,7 +40,7 @@ tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_m
   %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
 
   // CHECK: ttng.tmem_store
-  // CHECK-NEXT: arith.truncf
+  // CHECK-NEXT: arith.truncf [[RHS_LAYOUT]]
   // CHECK: ttng.tmem_load
   // CHECK-NEXT: ttg.convert_layout
   // CHECK-NEXT: "unknow_may_side_effect"() : () -> ()
@@ -53,8 +54,8 @@ tt.func public @sink_load(%arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_m
   tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
 }
 
-// CHECK-LABEL: @sink_loads_to_fresh_ranges
-tt.func public @sink_loads_to_fresh_ranges(%arg0: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>)
+// CHECK-LABEL: @sink_split_loads_greedily
+tt.func public @sink_split_loads_greedily(%arg0: !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable>)
     -> (tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>, tensor<128x64xf32, #blocked>) {
   %bias0_h = arith.constant dense<1.0> : tensor<128x1xf16, #blocked>
   %bias1_h = arith.constant dense<2.0> : tensor<128x1xf16, #blocked>
@@ -65,8 +66,6 @@ tt.func public @sink_loads_to_fresh_ranges(%arg0: !ttg.memdesc<128x256xf32, #tme
   %slice2 = ttng.tmem_subslice %arg0 {N = 128 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
   %slice3 = ttng.tmem_subslice %arg0 {N = 192 : i32} : !ttg.memdesc<128x256xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256>
 
-  // CHECK: [[L0:%.+]] = ttng.tmem_load
-  // CHECK-NEXT: [[V0:%.+]] = ttg.convert_layout [[L0]]
   %load0 = ttng.tmem_load %slice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256> -> tensor<128x64xf32, #linear64>
   %val0 = ttg.convert_layout %load0 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
   %load1 = ttng.tmem_load %slice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256> -> tensor<128x64xf32, #linear64>
@@ -76,35 +75,37 @@ tt.func public @sink_loads_to_fresh_ranges(%arg0: !ttg.memdesc<128x256xf32, #tme
   %load3 = ttng.tmem_load %slice3 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x256> -> tensor<128x64xf32, #linear64>
   %val3 = ttg.convert_layout %load3 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
 
-  // CHECK-NEXT: [[B0F:%.+]] = arith.extf
+  // CHECK: [[B0F:%.+]] = arith.extf
   // CHECK-NEXT: [[B0:%.+]] = tt.broadcast [[B0F]]
-  // CHECK-NEXT: [[O0:%.+]] = arith.addf [[V0]], [[B0]]
   %bias0_f = arith.extf %bias0_h : tensor<128x1xf16, #blocked> to tensor<128x1xf32, #blocked>
   %bias0 = tt.broadcast %bias0_f : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
   %out0 = arith.addf %val0, %bias0 : tensor<128x64xf32, #blocked>
 
-  // CHECK-NEXT: [[L1:%.+]] = ttng.tmem_load
-  // CHECK-NEXT: [[V1:%.+]] = ttg.convert_layout [[L1]]
   // CHECK-NEXT: [[B1F:%.+]] = arith.extf
   // CHECK-NEXT: [[B1:%.+]] = tt.broadcast [[B1F]]
-  // CHECK-NEXT: [[O1:%.+]] = arith.addf [[V1]], [[B1]]
   %bias1_f = arith.extf %bias1_h : tensor<128x1xf16, #blocked> to tensor<128x1xf32, #blocked>
   %bias1 = tt.broadcast %bias1_f : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
   %out1 = arith.addf %val1, %bias1 : tensor<128x64xf32, #blocked>
 
-  // CHECK-NEXT: [[L2:%.+]] = ttng.tmem_load
-  // CHECK-NEXT: [[V2:%.+]] = ttg.convert_layout [[L2]]
   // CHECK-NEXT: [[B2F:%.+]] = arith.extf
   // CHECK-NEXT: [[B2:%.+]] = tt.broadcast [[B2F]]
-  // CHECK-NEXT: [[O2:%.+]] = arith.addf [[V2]], [[B2]]
   %bias2_f = arith.extf %bias2_h : tensor<128x1xf16, #blocked> to tensor<128x1xf32, #blocked>
   %bias2 = tt.broadcast %bias2_f : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
   %out2 = arith.addf %val2, %bias2 : tensor<128x64xf32, #blocked>
 
-  // CHECK-NEXT: [[L3:%.+]] = ttng.tmem_load
-  // CHECK-NEXT: [[V3:%.+]] = ttg.convert_layout [[L3]]
   // CHECK-NEXT: [[B3F:%.+]] = arith.extf
   // CHECK-NEXT: [[B3:%.+]] = tt.broadcast [[B3F]]
+  // CHECK-NEXT: [[L0:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[V0:%.+]] = ttg.convert_layout [[L0]]
+  // CHECK-NEXT: [[O0:%.+]] = arith.addf [[V0]], [[B0]]
+  // CHECK-NEXT: [[L1:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[V1:%.+]] = ttg.convert_layout [[L1]]
+  // CHECK-NEXT: [[O1:%.+]] = arith.addf [[V1]], [[B1]]
+  // CHECK-NEXT: [[L2:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[V2:%.+]] = ttg.convert_layout [[L2]]
+  // CHECK-NEXT: [[O2:%.+]] = arith.addf [[V2]], [[B2]]
+  // CHECK-NEXT: [[L3:%.+]] = ttng.tmem_load
+  // CHECK-NEXT: [[V3:%.+]] = ttg.convert_layout [[L3]]
   // CHECK-NEXT: [[O3:%.+]] = arith.addf [[V3]], [[B3]]
   %bias3_f = arith.extf %bias3_h : tensor<128x1xf16, #blocked> to tensor<128x1xf32, #blocked>
   %bias3 = tt.broadcast %bias3_f : tensor<128x1xf32, #blocked> -> tensor<128x64xf32, #blocked>
@@ -134,9 +135,9 @@ tt.func @interleave_load_store_ws() {
       %cur_acc = ttg.memdesc_index %arg0[%i] : !ttg.memdesc<2x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
 
       // CHECK-NEXT: [[S0:%.+]] = ttng.tmem_subslice %{{.+}} {N = 0 : i32}
+      // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
       // CHECK-NEXT: [[L0:%.+]] = ttng.tmem_load [[S0]]
       // CHECK-NEXT: [[M0:%.+]] = arith.mulf [[L0]]
-      // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.+}} {N = 64 : i32}
       // CHECK-NEXT: ttng.tmem_store [[M0]], [[S0]]
       %slice0 = ttng.tmem_subslice %cur_acc {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
       %val0 = ttng.tmem_load %slice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
@@ -166,8 +167,10 @@ tt.func @arrive_barrier(%arg0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutab
   // CHECK-COUNT-2: ttng.tmem_alloc
   %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   %noalias_alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-  // CHECK-NEXT: tmem_load
+  // The load sinks past the store because the two allocations do not alias, but
+  // stops at the unconstrained arrive.
   // CHECK-NEXT: tmem_store
+  // CHECK-NEXT: tmem_load
   %0 = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
   ttng.tmem_store %cst, %noalias_alloc, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   // CHECK-NEXT: arrive_barrier
@@ -183,15 +186,18 @@ tt.func @arrive_restore_after_operand_defs(
   %c0 = arith.constant 0 : i32
   %cst = arith.constant dense<0.0> : tensor<128x128xf32, #linear128>
   %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // The load cannot sink past a store to the same allocation.
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: ttng.tmem_store
   %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
-  // CHECK: ttng.tmem_store
   ttng.tmem_store %cst, %alloc, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // The restored arrive must still land after the def of its barrier operand.
   // CHECK-NEXT: [[BAR:%.+]] = ttg.memdesc_index
   %bar = ttg.memdesc_index %arg0[%c0] : !ttg.memdesc<1x1xi64, #barrier_shared, #smem, mutable> -> !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   %use0 = arith.addi %c0, %c0 : i32
-  // CHECK-NEXT: arith.addi
   // CHECK-NEXT: ttng.arrive_barrier [[BAR]], 1
   ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  // CHECK-NEXT: arith.addi
   // CHECK-NEXT: arith.addi
   %use1 = arith.addi %use0, %c0 : i32
   "user"(%unused, %use1) : (tensor<128x128xf32, #linear128>, i32) -> ()
@@ -199,21 +205,24 @@ tt.func @arrive_restore_after_operand_defs(
 }
 
 // CHECK-LABEL: @sink_alloc_op
+// The block holds allocs and no load, so the worklist gate admits it on the
+// allocs alone. Each alloc/subview pair sinks to just before the store that
+// consumes it, which reverses the two pairs relative to program order.
 tt.func @sink_alloc_op(%arg0: tensor<128x128xf32, #linear128>) {
   %c0 = arith.constant 0 : i32
   %true = arith.constant true
 
-  // CHECK: [[ALLOC0:%.+]] = ttng.tmem_alloc
-  %alloc0 = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-  // CHECK-NEXT: [[SUBVIEW0:%.+]] = ttg.memdesc_index [[ALLOC0]]
-  %subview0 = ttg.memdesc_index %alloc0[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-  // CHECK-NEXT: [[ALLOC1:%.+]] = ttng.tmem_alloc
-  %alloc1 = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK: [[ALLOC1:%.+]] = ttng.tmem_alloc
   // CHECK-NEXT: [[SUBVIEW1:%.+]] = ttg.memdesc_index [[ALLOC1]]
-  %subview1 = ttg.memdesc_index %alloc1[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   // CHECK-NEXT: tmem_store %arg0, [[SUBVIEW1]]
-  ttng.tmem_store %arg0, %subview1, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  // CHECK-NEXT: [[ALLOC0:%.+]] = ttng.tmem_alloc
+  // CHECK-NEXT: [[SUBVIEW0:%.+]] = ttg.memdesc_index [[ALLOC0]]
   // CHECK-NEXT: tmem_store %arg0, [[SUBVIEW0]]
+  %alloc0 = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %subview0 = ttg.memdesc_index %alloc0[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %alloc1 = ttng.tmem_alloc : () -> !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %subview1 = ttg.memdesc_index %alloc1[%c0] : !ttg.memdesc<1x128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.tmem_store %arg0, %subview1, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   ttng.tmem_store %arg0, %subview0, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   tt.return
 }
@@ -227,10 +236,19 @@ tt.func @sink_arrive_past_wait_disjoint(
     %phase: i32) {
   %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
   %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
-  // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
-  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
-  // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: 1>
-  // CHECK: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1>
+  // The cg2 arrive sinks past the disjoint cg1 wait, and the cg1 wait rises past
+  // the disjoint cg2 arrive, leaving both waits ahead of both arrives.
+  //
+  // The two arrives are intentionally left unordered. Both scan back to the
+  // same tmem_load when barrier restoration builds its barrier-to-memory-op
+  // map, and that map is a DenseMap, so whichever arrive restoration visits
+  // second is the one that ends up adjacent to the load. CHECK-NEXT here would
+  // pin an order that varies with DenseMap iteration.
+  // CHECK:      ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 1>
+  // CHECK:      ttng.tmem_load
+  // CHECK-DAG:  ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK-DAG:  ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1>
   ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.arrive_barrier %bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   ttng.wait_barrier %bar2, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 1>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
@@ -358,10 +376,11 @@ tt.func @plain_tma_store_token_wait_does_not_block_tmem_load(
   %s1 = ttng.tmem_subslice %alloc {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
   %v1 = ttng.tmem_load %s1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
   // CHECK:      ttng.async_tma_copy_local_to_global
-  // CHECK-NEXT: ttng.async_tma_store_token_wait
-  // CHECK-NEXT: arith.truncf
   // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: arith.truncf
+  // CHECK-NEXT: ttng.async_tma_store_token_wait
   // CHECK-NEXT: ttg.local_store
+  // CHECK-NEXT: ttng.tmem_load
   // CHECK-NEXT: arith.truncf
   // CHECK-NEXT: ttg.local_store
   %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %smem_buf : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
@@ -370,6 +389,35 @@ tt.func @plain_tma_store_token_wait_does_not_block_tmem_load(
   ttg.local_store %u0, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   %u1 = arith.truncf %v1 : tensor<128x64xf32, #linear64> to tensor<128x64xf16, #linear64>
   ttg.local_store %u1, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  tt.return
+}
+
+// A queue-wide token wait must not be delayed across a later TMA launch. That
+// would make the wait cover an additional async reader and change its pending
+// count before the first staging buffer is reused.
+// CHECK-LABEL: @plain_wait_does_not_cross_next_tma_launch
+// CHECK: %[[TOK0:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttng.async_tma_store_token_wait %[[TOK0]]
+// CHECK-NEXT: %[[TOK1:.*]] = ttng.async_tma_copy_local_to_global
+// CHECK-NEXT: ttg.local_store
+tt.func @plain_wait_does_not_cross_next_tma_launch(
+    %desc: !tt.tensordesc<128x64xf16, #shared>,
+    %src: tensor<128x64xf16, #linear64>,
+    %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>) {
+  %c0 = arith.constant 0 : i32
+  %tok0 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttng.async_tma_store_token_wait %tok0 : !ttg.async.token
+  %tok1 = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf1 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttg.local_store %src, %buf0 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  ttng.async_tma_store_token_wait %tok1 : !ttg.async.token
+  // The worklist gate admits a block only if it holds a TMEM load or alloc, so
+  // without these the pass would skip the block and never run token-wait
+  // delaying at all. They sit after the stores so they cannot perturb the
+  // sequence above: the alloc is pinned by its use and the load has nowhere
+  // left to sink.
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
   tt.return
 }
 
@@ -486,6 +534,7 @@ tt.func @tmem_load_does_not_sink_with_later_wait_region(
 // All split tmem_loads should inherit the channelGraph from their arrive
 // barrier and sink past store-channel barriers independently.
 // CHECK-LABEL: @split_tmem_loads_all_sink
+// TARGETED-LABEL: @split_tmem_loads_all_sink
 tt.func @split_tmem_loads_all_sink(
     %tmem_wait_bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
     %store_bar0: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
@@ -517,29 +566,73 @@ tt.func @split_tmem_loads_all_sink(
   ttg.local_store %t1, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
   ttng.arrive_barrier %store_bar1, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
 
-  // Expected: the tmem_loads stay before their same-channel arrive when the
-  // final order cannot improve their fresh live ranges.
+  // Expected: the second load sinks past the first load's consumer, so the two
+  // subtile values are no longer live at the same time.
   //
   // CHECK:      ttng.wait_barrier %{{.*}}, %{{.*}} :
   // CHECK-NEXT: ttng.tmem_load
-  // CHECK-NEXT: ttng.tmem_load
-  // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
-  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: arith.truncf
+  // CHECK-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
   // CHECK-NEXT: ttg.local_store
   // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
+  // CHECK-NEXT: arith.truncf
+  // With global barrier normalization disabled, each load carries its own
+  // arrive across the independent store-channel wait, so each subtile reaches
+  // its own consumer and the two are never live at once. The arrive ends up
+  // behind both loads, which is what keeps the release correct. This covers
+  // the targeted epilogue path used by FA backward.
+  // TARGETED:      ttng.wait_barrier %{{.*}}, %{{.*}} :
+  // TARGETED-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // TARGETED-NEXT: ttng.tmem_load
+  // TARGETED-NEXT: arith.truncf
+  // TARGETED-NEXT: ttg.local_store
+  // TARGETED-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 2>
+  // TARGETED-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // TARGETED-NEXT: ttng.tmem_load
+  // TARGETED-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
+  // TARGETED-NEXT: arith.truncf
   tt.return
 }
 
-// When the final order does not reduce overlapping tmem_load liveness, restore
-// the original block order.
-// CHECK-LABEL: @rollback_when_overlap_profile_unchanged
-tt.func @rollback_when_overlap_profile_unchanged() {
+// Only an arrive that already follows the load is absorbed. The leading
+// same-channel arrive is never visited by the forward walk, so it stays put
+// while the trailing one is carried across the store-channel wait.
+// CHECK-LABEL: @arrive_before_load_not_absorbed
+// TARGETED-LABEL: @arrive_before_load_not_absorbed
+tt.func @arrive_before_load_not_absorbed(
+    %bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %store_bar: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %smem_buf: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %s0 = ttng.tmem_subslice %alloc {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+
+  // TARGETED:      ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
+  // TARGETED-NEXT: ttng.wait_barrier {{.*}}channelGraph = array<i32: 2>
+  // TARGETED-NEXT: ttng.tmem_load
+  // TARGETED-NEXT: ttng.arrive_barrier {{.*}}channelGraph = array<i32: 1, 3>
+  // TARGETED-NEXT: arith.truncf
+  // TARGETED-NEXT: ttg.local_store
+  ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %v0 = ttng.tmem_load %s0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
+  ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %store_bar, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  %t0 = arith.truncf %v0 : tensor<128x64xf32, #linear64> to tensor<128x64xf16, #linear64>
+  ttg.local_store %t0, %smem_buf : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  tt.return
+}
+
+// An op with unknown side effects blocks sinking. Both loads move up to that
+// boundary but do not cross it.
+// CHECK-LABEL: @unknown_side_effect_blocks_sinking
+tt.func @unknown_side_effect_blocks_sinking() {
   %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
 
   // CHECK:      [[S0:%.+]] = ttng.tmem_subslice %{{.*}} {N = 0 : i32}
-  // CHECK-NEXT: [[V0:%.+]] = ttng.tmem_load [[S0]]
   // CHECK-NEXT: [[S1:%.+]] = ttng.tmem_subslice %{{.*}} {N = 64 : i32}
+  // CHECK-NEXT: [[V0:%.+]] = ttng.tmem_load [[S0]]
   // CHECK-NEXT: [[V1:%.+]] = ttng.tmem_load [[S1]]
   // CHECK-NEXT: "unknown_may_side_effect"
   // CHECK-NEXT: "user"([[V0]])
@@ -575,7 +668,10 @@ tt.func @restore_ws_arrive_stops_at_named_barrier(
   %out0 = arith.addf %v0, %bias0 : tensor<128x64xf32, #linear64>
   %out1 = arith.addf %v1, %bias1 : tensor<128x64xf32, #linear64>
 
-  // CHECK: ttng.tmem_store
+  // CHECK: ttng.tmem_load
+  // CHECK-NEXT: arith.addf
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: arith.addf
   // CHECK-NEXT: ttng.wait_barrier_named
   // CHECK-NEXT: ttng.arrive_barrier
   // CHECK-SAME: channelGraph = array<i32: 4>
@@ -583,6 +679,48 @@ tt.func @restore_ws_arrive_stops_at_named_barrier(
   ttng.wait_barrier_named %c9, %c128 : i32, i32
   ttng.arrive_barrier %bar, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 4>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
   tt.return %out0, %out1 : tensor<128x64xf32, #linear64>, tensor<128x64xf32, #linear64>
+}
+
+// Two shared-memory block arguments cannot be proven distinct: a warp
+// specialization capture list, or a caller, can bind both to the same buffer.
+// The TMA store token wait must therefore stop at the first store through
+// either argument rather than sinking past one that may clobber the staging
+// buffer while the store is still in flight.
+// CHECK-LABEL: @wait_stops_at_possibly_aliasing_arg
+// CHECK: = ttng.async_tma_copy_local_to_global {{.*}} %[[BUF0:[0-9a-zA-Z_]+]] :
+// CHECK-NEXT: ttng.async_tma_store_token_wait
+// CHECK-NEXT: ttg.local_store
+// CHECK-NEXT: ttg.local_store %{{.*}}, %[[BUF0]] :
+tt.func public @wait_stops_at_possibly_aliasing_arg(
+    %arg0: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %arg2: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+    %desc: !tt.tensordesc<128x64xf16, #shared>,
+    %buf0: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %buf1: !ttg.memdesc<128x64xf16, #shared, #smem, mutable>,
+    %v: tensor<128x64xf16, #linear64>) -> (tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>) {
+  %c0 = arith.constant 0 : i32
+  %subslice0 = ttng.tmem_subslice %arg0 {N = 0 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subtile0 = ttng.tmem_load %subslice0 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
+  %outLHS = ttg.convert_layout %subtile0 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
+  %subslice1 = ttng.tmem_subslice %arg0 {N = 64 : i32} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128>
+  %subtile1 = ttng.tmem_load %subslice1 : !ttg.memdesc<128x64xf32, #tmem, #ttng.tensor_memory, mutable, 128x128> -> tensor<128x64xf32, #linear64>
+  %outRHS = ttg.convert_layout %subtile1 : tensor<128x64xf32, #linear64> -> tensor<128x64xf32, #blocked>
+
+  %tok = ttng.async_tma_copy_local_to_global %desc[%c0, %c0] %buf0 : !tt.tensordesc<128x64xf16, #shared>, !ttg.memdesc<128x64xf16, #shared, #smem, mutable> -> !ttg.async.token
+  ttng.async_tma_store_token_wait %tok : !ttg.async.token
+  ttg.local_store %v, %buf1 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+  ttg.local_store %v, %buf0 : tensor<128x64xf16, #linear64> -> !ttg.memdesc<128x64xf16, #shared, #smem, mutable>
+
+  %5 = arith.truncf %outLHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  %true = arith.constant true
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #linear128>
+  ttng.tmem_store %cst, %arg2, %true : tensor<128x128xf32, #linear128> -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %6 = arith.truncf %outRHS : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+  %7 = ttng.tmem_load %arg2 : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  %8 = ttg.convert_layout %7 : tensor<128x128xf32, #linear128> -> tensor<128x128xf32, #blocked>
+  "unknow_may_side_effect"() : () -> ()
+  %9 = arith.truncf %8 : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
+  tt.return %5, %6, %9 : tensor<128x64xf16, #blocked>, tensor<128x64xf16, #blocked>, tensor<128x128xf16, #blocked>
 }
 
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
@@ -1,22 +1,41 @@
 # TMEM Interleave
 
-`triton-nvidia-interleave-tmem` tries to reduce overlapping liveness between
-`ttng.tmem_load` values. It does this by moving TMEM loads and their pure
-single-use chains closer to their consumers, while also moving warp-specialized
-barriers when those barriers are known to protect independent channels.
+`triton-nvidia-interleave-tmem` moves `ttng.tmem_load` values and TMEM
+allocation ops later in their block, and moves warp-specialized barriers when
+those barriers are known to protect independent channels.
+
+The pass has one objective: **distance a load from its producer.**
+`ttng.tc_gen5_mma` is asynchronous, so the consuming `ttng.tmem_load` cannot
+retire until the MMA completes. The gap between them is exactly the amount of
+independent work available to cover that latency. When producer and consumer
+sit in the same partition there is no other warpgroup to hide behind, so that
+gap has to come from instruction scheduling. This applies to every load,
+whether or not the accumulator is split.
+
+Sinking also shortens the load's own register live range, and when an
+accumulator is read as several subtiles it tends to keep the subtiles from
+being live at once. That is a useful side effect, not a guarantee, and it is
+not what the pass optimizes for. A chain grows through adjacent pure users, so
+a sinking load absorbs its consumer and carries it along; that isolates the
+subtile value but drags the consumer's *other* operands into a longer live
+range. Peak register pressure can come out unchanged even when every subtile
+value is separated. Treat subtile liveness as a property to observe, not one
+the pass establishes — the measurements that justify this pass are latency
+measurements.
 
 The pass is scheduled as a module pass, but its algorithm is block-local:
 
-1. Build a worklist of blocks with at least two direct `ttng.tmem_load` ops.
+1. Build a worklist of blocks holding at least one direct `ttng.tmem_load` or
+   `ttng.tmem_alloc` op.
 2. For each block, collect the TMEM loads and TMEM allocation ops that may move.
 3. Reorder WS barriers within that block to unblock legal movement.
 4. Sink eligible TMEM loads and allocation ops within that block.
 5. Restore WS barriers near the memory operations they guard.
-6. Run rollback analysis for that block before processing the next block.
 
-Blocks with fewer than two direct `ttng.tmem_load` ops are skipped. They cannot
-benefit from the pass objective because there is no in-block TMEM load overlap
-to isolate.
+A block holding neither op is skipped. The skip is not just an optimization:
+steps 3 and 5 walk the whole block rather than the collected worklist, so
+without it a block with no TMEM at all would still have its WS barriers and its
+plain TMA store token waits repositioned for no benefit.
 
 ## Barrier Movement
 
@@ -37,98 +56,76 @@ For each candidate load, the pass forms a movable chain starting at the
 chain can sink as a unit as long as the move remains legal for the underlying
 TMEM buffer and for the channel constraints associated with the load.
 
-The load-sinking target is the first legal position where the load starts after
-the previous comparable TMEM load's value live range. The pass does not sink a
-load all the way to its consumer once that fresh-range target has been reached.
-This keeps independent operand-preparation work, such as bias cast/broadcast
-chains feeding the eventual add, close to that consumer when the extra sinking
-is not needed to isolate TMEM values.
+Every load sinks greedily, as far as legality allows. Split loads are processed
+in program order, so each one can move next to its own consumer without making
+later subtile values live early. The first load is not kept as an anchor: it is
+subject to the same legality checks and movement as every later load.
 
 Split TMEM loads can inherit the `channelGraph` constraints from the guarding
 arrive barrier. This lets loads from the same TMEM allocation, but different
 subtiles, sink independently around store-channel waits when the channels are
 disjoint.
 
+A chain cannot sink past the arrive that releases the buffer it is reading,
+because that would let the release fire before the read. Instead the chain
+absorbs that arrive and the two move together, which delays the release rather
+than reordering it against the load. Only an arrive that already follows the
+load is a candidate: the chain walk starts after the chain, so a preceding
+arrive is never visited. An arrive whose constraints differ belongs to another
+channel and stays subject to the ordinary legality checks. Once a chain has
+picked up its own arrive it may also pass a second constrained arrive, since
+two arrives only delay signals.
+
 Plain `ttng.async_tma_store_token_wait` ops do not block TMEM load sinking by
 themselves. They wait for a TMA store to finish reading SMEM, but do not carry
 WS barrier semantics unless they include attached barrier operands. Barrier-
 bearing token waits still block movement like other arrive-like operations.
 
-## Rollback
+## No Rollback
 
-The pass keeps a block transformation only when finalized lowering improves the
-overlapping liveness of comparable TMEM loads. The decision is made after final
-barrier restoration, because the final barrier positions can affect load
-liveness.
+The pass applies its transformation unconditionally. It does not snapshot the
+block, score the result, and restore the original order on a bad score.
 
-Rollback uses overlapping liveness occupancy, not total live-range length:
+A previous version did, keyed on an overlapping-liveness profile. That metric
+only ever measured how many candidate load values were simultaneously live, so
+it was structurally unable to see producer-to-consumer distance — the thing the
+pass exists to widen. A rewrite that opened that gap and shortened a live range
+scored as "unchanged" and was discarded. The metric also could not fire at all
+on a block with no multi-load group, and the rollback treated that absence of
+evidence as grounds to reject, undoing the alloc sinking that had already
+happened.
 
-```cpp
-struct OverlapLiveness {
-  // One entry per contiguous block-order span where at least one candidate
-  // tmem_load value is live.
-  SmallVector<unsigned> numLiveTMEMLoads;
-  // Entries from numLiveTMEMLoads greater than 1, sorted descending. This is
-  // the comparison key.
-  SmallVector<unsigned> overlapProfile;
-};
-```
+If a scoring heuristic is reintroduced, it has to see distance and not just
+overlap. A peak simultaneous count captures multiplicative register pressure
+and is blind to the durational pressure and latency exposure this pass targets;
+an integral over the liveness curve would subsume the old metric rather than
+trade against it.
 
-The implementation may compute temporary start/end positions for each load, but
-those ranges are not the acceptance metric. `numLiveTMEMLoads` records only
-spans where at least one candidate load is live. If two TMEM loads are back to
-back and both values are live after the second load, the important value is `2`;
-the brief prefix where only one load is live is ignored for the pass objective.
+## Out of Scope: Reshaping Barriers for Codegen
 
-`overlapProfile` is built by dropping all `1` entries from
-`numLiveTMEMLoads` and sorting the remaining counts descending. A group is
-improved when the final profile is lexicographically smaller than the original
-profile.
+The barrier movement described above is in scope. It exists to unblock legal
+TMEM movement, and every barrier still ends up near the memory operation it
+guards.
 
-Examples:
-
-- `[4, 2] -> [4, 1, 1]` succeeds because the profiles are `[4, 2] -> [4]`.
-- `[4, 2] -> [3, 3]` succeeds because the maximum overlap decreases.
-- `[4, 2] -> [4, 3]` fails.
-- `[2, 2, 2, 2] -> [4]` fails because the maximum overlap got worse.
-
-Do not treat a shorter non-overlapping tail, earlier last use, or smaller total
-live range as sufficient on its own. The pass goal is specifically to isolate
-TMEM load values that were live at the same time.
-
-### Candidate Groups
-
-Rollback compares loads in block-local candidate groups. The current grouping
-uses:
-
-1. The derived `memOpConstraints` / `channelGraph` dictionary for the load.
-2. The root TMEM allocation returned by `findBufferAccess(load.getSrc())`.
-
-Groups with fewer than two loads are ignored. Groups whose original
-`overlapProfile` is empty are also ignored because there was no overlap to
-improve.
-
-### Restore Behavior
-
-Before mutating a block, the pass records the original order of non-terminator
-ops. If no candidate group had initial overlap, or if any initially-overlapping
-group fails to improve, the pass restores that block by moving the same
-operations back into the recorded order.
-
-Rollback is intentionally block-level. The pass moves both memory ops and
-barriers inside a block, and a load's final liveness often depends on their
-coupled placement. Per-load rollback is possible as a future refinement, but it
-must preserve shared barrier placement and avoid making another load group's
-overlap profile worse.
+What is out of scope is reshaping barrier placement to unlock a downstream
+codegen optimization. The motivating example is hoisting several
+`ttng.wait_barrier` ops to a common program point so that a value broadcast to
+their consumers becomes optimizable in PTX. That is driven by codegen quality
+rather than by TMEM liveness or MMA latency, and on a given block the two
+objectives can pull in opposite directions: the placement that best exposes a
+broadcast is not generally the placement that best distances a load from its
+producer. Handle it in future work on barrier placement rather than adding
+cases here.
 
 ## Testing
 
 Coverage lives in `test/TritonNvidiaGPU/interleave_tmem.mlir` and should
 include:
 
-- single-load blocks staying unchanged
-- split-load cases where overlap improves and the transformation is kept
-- rollback cases where the final overlap profile does not improve
+- single-load blocks, where the load sinks away from its producing MMA
+- split-load cases where each load reaches its own consumer independently
+- loads whose sinking is blocked by aliasing or barrier constraints, which must
+  stay put
 
 After changing the C++ implementation, rebuild before testing:
 


### PR DESCRIPTION
Summary:

Port D117364688 to the Triton 3.8 snapshot. Sink each TMEM load greedily as far as barrier and memory-effect legality permits, remove the overlap-profile rollback, and run the pass for blocks containing a single load. Adapt the token-wait ordering expectation to the 3.8 implementation.

Authored with Claude.

Reviewed By: fengxizhou

Differential Revision: D117484320


