### PR TITLE
[TLX] Expose NVMMA tiled shared layout API (#3451)

### DIFF
--- a/python/test/unit/language/test_tlx_layout.py
+++ b/python/test/unit/language/test_tlx_layout.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 import triton
 import triton.language as tl
-from triton._internal_testing import is_blackwell, is_cuda, is_hip_cdna4
+from triton._internal_testing import is_blackwell, is_cuda, is_hip_cdna4, is_hopper
 import triton.language.extra.tlx as tlx
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -803,6 +803,52 @@ def test_shared_linear_layout_lowers_on_cdna4():
 
     ttgir = kernel.warmup(layout, grid=(1, ), num_warps=4).asm["ttgir"]
     assert "#ttg.shared_linear" in ttgir
+
+
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+def test_nv_mma_tiled_shared_linear_reinterpret_pin_false_on_hopper():
+    """A non-pinned shared-linear view does not retag its NVMMA backing buffer."""
+    score_layout = tlx.nv_mma_shared_layout_encoding(
+        (64, 64),
+        [1, 0],
+        tl.bfloat16,
+        [1, 1],
+        [1, 1],
+        [1, 0],
+        False,
+        True,
+    ).tile_to_shape((64, 128))
+
+    @triton.jit
+    def kernel(LAYOUT: tl.constexpr):
+        backing = tlx.local_alloc((64, 128), tl.bfloat16, 1)
+        view = tlx.local_reinterpret(backing[0], tl.bfloat16, [64, 128], layout=LAYOUT, pin=False)
+        subview = tlx.local_slice(view, [0, 0], [64, 64])
+        values = tl.full((64, 64), 1.0, tl.bfloat16)
+        tlx.local_store(subview, values)
+
+    compiled = kernel.warmup(score_layout, grid=(1, ), num_warps=4)
+    ttgir = compiled.asm["ttgir"]
+    assert "ttg.memdesc_reinterpret" in ttgir
+    assert "#ttg.shared_linear" in ttgir
+    assert "#tlx.user_layout" not in ttgir
+
+
+def test_nv_mma_tile_to_shape_builds_shared_linear():
+    """`tile_to_shape` exposes CuTe's atom-layout tiled-to-shape spelling."""
+    layout = tlx.nv_mma_shared_layout_encoding(
+        (64, 64),
+        [1, 0],
+        tl.bfloat16,
+        [1, 1],
+        [1, 1],
+        [1, 0],
+        False,
+        True,
+    ).tile_to_shape((64, 128))
+
+    assert isinstance(layout, tlx.shared_linear_layout_encoding)
+    assert layout.tile_shape == [64, 128]
 
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Need gfx950 (CDNA4)")

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -10,6 +10,7 @@
 #include "tlx/dialect/include/Transforms/Passes.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LayoutUtils.h"
@@ -571,6 +572,42 @@ void init_triton_tlx_ir(py::module_ &m) {
                    context, /*swizzlingByteWidth=*/0, transposed,
                    elemType.getIntOrFloatBitWidth(), fp4Padded, CTALayout));
              }
+           })
+      .def("make_nv_mma_tiled_shared_linear_encoding_attr",
+           [](TritonOpBuilder &self, std::vector<int64_t> atomShape,
+              std::vector<unsigned> order, Type &elemType,
+              std::vector<unsigned> CTAsPerCGA,
+              std::vector<unsigned> CTASplitNum, std::vector<unsigned> CTAOrder,
+              bool fp4Padded, bool swizzled,
+              std::vector<int64_t> tileShape, unsigned alignment) {
+             assert(atomShape.size() == order.size());
+             assert(order.size() == CTAsPerCGA.size());
+             assert(CTAsPerCGA.size() == CTASplitNum.size());
+             assert(CTASplitNum.size() == CTAOrder.size());
+             assert(tileShape.size() == atomShape.size());
+
+             auto context = self.getBuilder().getContext();
+             auto CTALayout =
+                 makeCGALayout(context, CTAsPerCGA, CTASplitNum, CTAOrder);
+             ttg::NVMMASharedEncodingAttr atomLayout;
+             // swizzlingByteWidth is not passed through: for the swizzled
+             // path the (shape, order) builder overload derives it (0/32/64/128)
+             // from the contiguous dim size in bytes, so it is implied by
+             // atomShape; the explicit-width overload is only needed for the
+             // unswizzled path where width is definitionally 0.
+             if (swizzled) {
+               atomLayout = ttg::NVMMASharedEncodingAttr::get(
+                   context, atomShape, order, CTALayout, elemType, fp4Padded);
+             } else {
+               bool transposed = order.size() > 1 ? (order[0] == 0) : false;
+               atomLayout = ttg::NVMMASharedEncodingAttr::get(
+                   context, /*swizzlingByteWidth=*/0, transposed,
+                   elemType.getIntOrFloatBitWidth(), fp4Padded, CTALayout);
+             }
+             auto linearLayout = ttg::nvmmaSharedToLinearLayout(
+                 tileShape, atomLayout, ttg::TMAMode::Tiled);
+             return mlir::cast<Attribute>(ttg::SharedLinearEncodingAttr::get(
+                 context, std::move(linearLayout), alignment));
            })
       .def("make_nv_mma_encoding_attr",
            [](TritonOpBuilder &self, Value opndA, Value opndAcc,

--- a/third_party/tlx/language/tlx/mem_ops.py
+++ b/third_party/tlx/language/tlx/mem_ops.py
@@ -1323,18 +1323,23 @@ def local_reinterpret(
     dtype: tl.dtype,
     shape: list[tl.constexpr] = None,
     layout: tl.constexpr = None,
+    pin: tl.constexpr = True,
     _semantic=None,
 ) -> tlx.buffered_tensor:
     """
     Reinterpret the dtype and shape of a buffered tensor.
 
     When ``layout`` is supplied, the descriptor is also viewed through that
-    explicit shared-memory layout.  This is a zero-copy descriptor change used
+    explicit shared-memory layout. This is a zero-copy descriptor change used
     by the Gluon CDNA4 transpose-read path: a row-major rank-3 physical image
     is loaded by direct-to-LDS and then reinterpreted as a bank-aware rank-2 K
-    tile.  Without ``layout`` the source layout is preserved for compatibility.
+    tile. With ``pin=False``, the view remains optimizer-flexible instead of
+    becoming a hard ``#tlx.user_layout`` anchor. Without ``layout`` the source
+    layout is preserved for compatibility.
     """
     layout = tl._unwrap_if_constexpr(layout)
+    pin = tl._unwrap_if_constexpr(pin)
+    assert isinstance(pin, bool), f"pin must be a constexpr bool, got {type(pin).__name__}"
     if shape is None:
         shape = src.type.shape
     else:
@@ -1351,7 +1356,7 @@ def local_reinterpret(
         # reinterpret view as inferred, and padded sources then fail the
         # MemDescReinterpret verifier before placeholder layouts are
         # finalized (user-wrapped padded source versus raw padded result).
-        if not getattr(layout, "_tlx_default", False):
+        if pin and not getattr(layout, "_tlx_default", False):
             layout._tlx_user_pinned = True
             encoding = _semantic.builder.make_user_layout_attr(encoding)
     reinterpreted_value_handle = _semantic.builder.create_memdesc_reinterpret(src.handle,

--- a/third_party/tlx/language/tlx/types.py
+++ b/third_party/tlx/language/tlx/types.py
@@ -317,9 +317,9 @@ class shared_linear_layout_encoding(shared_layout_encoding):
     """Explicit linear shared-memory mapping used by Gluon K-tile paths.
 
     Unlike :class:`padded_shared_layout_encoding`, this encoding has no
-    implicit interval padding.  Each offset basis maps one shared-memory bit
-    to a tensor dimension, which lets CDNA4 transpose reads consume a physical
-    row-major 16x16 tile image without an intermediate register permutation.
+    implicit interval padding. Each offset basis maps one shared-memory bit
+    to a tensor dimension. NVMMA layouts can also defer materializing these
+    bases until an IR builder is available.
     """
 
     def __init__(self, offset_bases, block_bases=None, alignment=16):
@@ -327,20 +327,53 @@ class shared_linear_layout_encoding(shared_layout_encoding):
         self.offset_bases = [list(map(int, basis)) for basis in offset_bases]
         self.block_bases = [list(map(int, basis)) for basis in (block_bases or [])]
         self.alignment = int(alignment)
+        self._nv_mma_atom = None
         assert self.offset_bases and len(self.offset_bases[0]) > 0
         rank = len(self.offset_bases[0])
         assert all(len(basis) == rank for basis in self.offset_bases)
         assert all(len(basis) == rank for basis in self.block_bases)
         assert self.alignment > 0 and (self.alignment & (self.alignment - 1)) == 0
 
+    @classmethod
+    def from_nv_mma(cls, atom_layout, tile_shape, alignment=1024):
+        result = cls.__new__(cls)
+        shared_layout_encoding.__init__(result)
+        result.offset_bases = []
+        result.block_bases = []
+        result.alignment = int(alignment)
+        result._nv_mma_atom = atom_layout
+        result.tile_shape = list(map(int, tile_shape))
+        assert len(result.tile_shape) == len(atom_layout.shape)
+        assert result.alignment > 0 and (result.alignment & (result.alignment - 1)) == 0
+        return result
+
     def make_permute(self, dims):
+        if self._nv_mma_atom is not None:
+            return shared_linear_layout_encoding.from_nv_mma(
+                self._nv_mma_atom.make_permute(dims),
+                [self.tile_shape[d] for d in dims],
+                self.alignment,
+            )
         # SharedLinear is used as a physical image; preserve the bit bases and
         # let the consumer's memdesc_trans describe the logical permutation.
-        del dims
         return self
 
     def to_ir(self, builder: ir.builder) -> None:
-        return builder.make_shared_linear_encoding_attr(self.offset_bases, self.block_bases, self.alignment)
+        if self._nv_mma_atom is None:
+            return builder.make_shared_linear_encoding_attr(self.offset_bases, self.block_bases, self.alignment)
+        atom = self._nv_mma_atom
+        return builder.make_nv_mma_tiled_shared_linear_encoding_attr(
+            [int(tl._unwrap_if_constexpr(x)) for x in atom.shape],
+            [int(tl._unwrap_if_constexpr(x)) for x in atom.order],
+            atom.elemType.to_ir(builder),
+            [int(tl._unwrap_if_constexpr(x)) for x in atom.numCTAsPerCGA],
+            [int(tl._unwrap_if_constexpr(x)) for x in atom.numCTASplit],
+            [int(tl._unwrap_if_constexpr(x)) for x in atom.numCTAOrder],
+            bool(tl._unwrap_if_constexpr(atom.fp4Padded)),
+            bool(tl._unwrap_if_constexpr(atom.swizzled)),
+            self.tile_shape,
+            self.alignment,
+        )
 
 
 class amd_mfma_layout(layout_encoding):
@@ -546,15 +579,21 @@ class nv_mma_shared_layout_encoding(shared_layout_encoding):
 
     def to_ir(self, builder: ir.builder) -> None:
         return builder.make_nv_mma_shared_encoding_attr(
-            [int(x) for x in self.shape],
-            self.order,
+            [int(tl._unwrap_if_constexpr(x)) for x in self.shape],
+            [int(tl._unwrap_if_constexpr(x)) for x in self.order],
             self.elemType.to_ir(builder),
-            self.numCTAsPerCGA,
-            self.numCTASplit,
-            self.numCTAOrder,
-            self.fp4Padded,
-            self.swizzled,
+            [int(tl._unwrap_if_constexpr(x)) for x in self.numCTAsPerCGA],
+            [int(tl._unwrap_if_constexpr(x)) for x in self.numCTASplit],
+            [int(tl._unwrap_if_constexpr(x)) for x in self.numCTAOrder],
+            bool(tl._unwrap_if_constexpr(self.fp4Padded)),
+            bool(tl._unwrap_if_constexpr(self.swizzled)),
         )
+
+    def tile_to_shape(self, tile_shape, alignment=1024):
+        return shared_linear_layout_encoding.from_nv_mma(self, tile_shape, alignment)
+
+    def make_shared_linear(self, alignment=1024, tile_shape=None):
+        return self.tile_to_shape(tile_shape or self.shape, alignment)
 
     def __str__(self) -> str:
         return f"nv_mma_shared_layout_encoding<{self.shape}, {self.order}, {self.elemType}, {self.numCTAsPerCGA}, {self.numCTASplit}, {self.numCTAOrder}, {self.fp4Padded}, {self.swizzled}>"


### PR DESCRIPTION
Summary:

Expose a `tile_to_shape` spelling on `nv_mma_shared_layout_encoding` so TLX kernels can describe the same atom-layout-tiled-to-full-shape intent used by FA3/CuTe shared operands.

This keeps the existing shared-linear lowering path while providing a public TLX API for constructing an NVMMA shared layout from an atom layout tiled to the full tensor shape.

Differential Revision: D118422138


