### PR TITLE
[TLX][Agent] Improve autonomous kernel optimization

### DIFF
--- a/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/SKILL.md
+++ b/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: trx-kernel-optimization-agent
+name: tlx-kernel-optimization-agent
 description: >
   Execute the TLX Kernel Optimization Agent CLI on a Triton or TLX kernel.
   Use this skill whenever the user says "use the TLX agent", "use the kernel
@@ -11,9 +11,8 @@ description: >
 # Run The TLX Kernel Optimization Agent
 
 The executable is `third_party/tlx/tools/agents/kernel_optimization/cli.py`.
-Use the user-facing name "TLX kernel optimization agent"; the on-disk skill
-name is compatibility-only. Follow the layers below in order. Target-specific
-profiling rules supplement, but never replace, the generic workflow.
+Follow the layers below in order. Target-specific profiling rules supplement,
+but never replace, the generic workflow.
 
 ## Layer 0: Invocation And Safety
 
@@ -33,6 +32,9 @@ profiling rules supplement, but never replace, the generic workflow.
    Submission remains a separate explicit action.
 6. If the live kernel changes concurrently, do not overwrite it. Preserve the
    winner artifact and report the conflict.
+7. When continuing a completed optimization, pass `--prior-run <output-dir>`.
+   This imports prior evidence and source hashes for cross-run deduplication but
+   never adopts the old winner or replaces validation of the current kernel.
 
 Reading agent implementation is allowed only after the CLI reports an internal
 failure that requires diagnosis. The first attempt must use the public contract.
@@ -78,6 +80,17 @@ Read `references/input-contract.md` for the complete construction and
 validation checklist. Do not start the optimization loop until the bundle is
 validated.
 
+Candidate generation automatically receives trusted source-optimization skills
+owned by `third_party/tlx/tools/agents/kernel_optimization/skills/`: every target
+receives layout-conversion efficiency guidance, CUDA/NVIDIA targets additionally
+receive async TMA output publication guidance, and Blackwell targets additionally
+receive persistent CLC scheduling and persistent pipeline efficiency guidance.
+Canonical profiling workflow documentation lives under
+`third_party/tlx/tools/agents/kernel_optimization/docs/profiling/` and is not
+injected as source guidance. Keep workload-specific
+invariants and exclusions in `target.json.optimization_guidance`; they are applied
+after the built-in target skills.
+
 For every candidate, the standard loop is:
 
 ```text
@@ -118,11 +131,13 @@ mapping, and command files as artifacts, and reference them with absolute paths.
 
 Profiling has three distinct layers:
 
-- Proton wrapper/launch attribution: read `references/proton-profiling.md` and
+- Proton wrapper/launch attribution: read
+  `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/proton.md` and
   collect for every correctness-passing candidate.
 - Target summary/deep profiling: request `native_profiler`; each target harness
   maps it to its platform tool. For CUDA/NVIDIA, this is NCU and the harness
-  should follow `targets/nvidia/ncu-profiling.md`.
+  should follow
+  `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md`.
 - Diagnostic-only Proton intra-kernel instrumentation: use only for attribution
   questions that cannot be answered from wrapper timelines or target counters.
 
@@ -148,7 +163,8 @@ promoted, committed, or used as speedup evidence.
 
 Select target profiling guidance from `target.json`:
 
-- CUDA/NVIDIA: read `targets/nvidia/ncu-profiling.md`.
+- CUDA/NVIDIA: read
+  `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md`.
 - Other backends: use a sibling target guide when present; otherwise use the
   vendor-neutral `profile()` contract without inventing NVIDIA requirements.
 
@@ -215,6 +231,7 @@ PYTHONPATH=<repo-root> python -m third_party.tlx.tools.agents.kernel_optimizatio
   --cases <absolute-cases.json> \
   --target <absolute-target.json> \
   --output-dir <absolute-output-dir> \
+  --prior-run <optional-previous-output-dir> \
   --provider codex \
   --max-rounds 5 \
   --candidates-per-round 2 \

--- a/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/references/input-contract.md
+++ b/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/references/input-contract.md
@@ -173,11 +173,27 @@ include `.hatchet`, `.chrome_trace`, target profiler reports, CSV exports,
 async-task or warp mapping files, and the exact commands that generated them.
 Large payloads are spilled into the agent artifact directory automatically.
 
-Generic Proton guidance lives in `references/proton-profiling.md`. Target-specific
-tools and metric mappings live under `targets/<vendor>/`. CUDA/NVIDIA bundles
-must follow `targets/nvidia/ncu-profiling.md`. Other targets must not fabricate
+Generic Proton guidance lives in
+`third_party/tlx/tools/agents/kernel_optimization/docs/profiling/proton.md`.
+CUDA/NVIDIA bundles must follow
+`third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md`.
+Other targets must not fabricate
 NVIDIA fields. Unsupported counters are omitted or represented as `null` with
 diagnostics, never silently converted to zero.
+
+Before freezing a CUDA bundle, its profile implementation must satisfy these
+integration checks:
+
+- pass the target's exact main-kernel scope to
+  `parse_proton_launch_attribution(..., main_scope=...)` and verify the expected
+  main launch has nonzero attributed time;
+- collect NCU with an exported `.ncu-rep`, then call
+  `export_ncu_report_details()` to run `ncu --import ... --page details --csv`;
+- never parse NCU collection stdout as metric CSV when `--export` is enabled,
+  because that stream contains profiler status lines rather than metric rows;
+- retain the report, import command, details CSV, and stderr as absolute artifact
+  paths, and verify at least normalized NCU duration is non-null when NCU is
+  available.
 
 A compact profile response should look like:
 

--- a/third_party/tlx/tools/agents/kernel_optimization/README.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/README.md
@@ -58,6 +58,12 @@ python -m third_party.tlx.tools.agents.kernel_optimization.cli \
   --max-rounds 5 \
   --provider codex --arch blackwell
 
+# Continue from a completed run without adopting its winner:
+python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel my_kernel.py --output-dir /tmp/tlx-kernel-agent-next \
+  --prior-run /tmp/tlx-kernel-agent-run \
+  --provider codex --arch blackwell
+
 # A revalidated winner is committed by default:
 python -m third_party.tlx.tools.agents.kernel_optimization.cli \
   --kernel my_kernel.py --output-dir /tmp/tlx-kernel-agent-run \
@@ -67,20 +73,29 @@ python -m third_party.tlx.tools.agents.kernel_optimization.cli \
 
 `--arch` selects `harnesses/<arch>/targets/<kernel>`; `harness`/`cases`/`target` can also be passed explicitly.
 
+`--prior-run` accepts a completed output directory or its `experiments.json`. It
+imports recomputed source hashes for exact cross-run deduplication and bounded,
+sanitized experiment evidence for candidate prompts. It never mutates prior
+artifacts or adopts the prior winner; the current kernel is always rebuilt and
+validated as the new baseline.
+
 `--reference-kernel` is optional: a trusted oracle kernel. When provided it is persisted to `reference_kernel.py` in the output dir, exposed to harness workers via `TLX_REFERENCE_KERNEL_PATH`, and shown (truncated) to Codex in the prompt as comparison context. `verify` may load it to compare candidate vs reference.
 
 `--provider` is `codex` (default, shells `codex exec`) or `mock` (deterministic stub for
 CI that replays canned candidates or echoes the current source). When `codex` is not
 installed the provider fails fast with a clear error suggesting `--provider mock`.
 
-Winner commits are enabled by default and run only after successful final revalidation.
-Use `--no-commit-winner` for artifact-only runs. The CLI
+Promotion checkpoint commits are enabled by default. Every candidate that passes the
+promotion gates is committed immediately before the next candidate is generated. Use
+`--no-commit-winner` for artifact-only runs. The CLI
 finds the repository from the absolute kernel path and supports `--vcs auto|git|hg` without
-using `sl`. Every generated commit includes the body line `TLX agent authored`. Existing
-unrelated staged and dirty work is preserved. If the target was already dirty, only the
-baseline-to-winner delta is committed and the original target edits remain unstaged/dirty;
-overlapping edits fail safely. Exit code `3` means optimization succeeded but commit failed,
-and `best_kernel.py` remains available. Commit metadata is written to `auto_commit.json`.
+using `sl`. Every promoted-candidate commit includes the body line `TLX agent authored`.
+Existing unrelated staged and dirty work is preserved. If the target was already dirty, only
+the Agent delta is committed and the original target edits remain unstaged/dirty; overlapping
+edits fail safely. If final revalidation fails after promotions, the Agent creates a forward
+rollback commit without the winner attribution and keeps the checkpoint commits in history.
+Exit code `3` means a promotion or rollback commit failed. Ordered commit metadata is written
+to `promotion_commits.json`; the compatibility summary remains in `auto_commit.json`.
 
 The optimizer reports baseline, every candidate, and final revalidation performance
 to stderr as soon as each evaluation completes. Each line includes status, aggregate
@@ -112,11 +127,20 @@ auto_commit.json             # present when --commit-winner reaches finalization
 artifacts/profile_traces/   # spilled large profile payloads
 experiments/
   baseline/{kernel.py, result.json, profile.json}
-  r001-c000/{kernel.py, result.json, profile.json}
+  r001-c000/{kernel.py, incremental.patch, cumulative.patch, result.json, profile.json}
   r001-c001/...
 ```
 
-`--harness-mode` is retained for compatibility and currently always uses subprocess
+Every returned candidate source is cached before deduplication, compilation, correctness,
+or performance evaluation. `incremental.patch` compares against the exact current-best
+parent used to generate that action; `cumulative.patch` compares against the original run
+baseline. The live log records the absolute artifact paths and prints the complete incremental
+patch between `incremental-diff-begin` and `incremental-diff-end` markers before evaluation.
+Failed, duplicate, and rejected candidates keep these artifacts and log entries. If the
+provider fails before returning source, the experiment has no patch paths because no candidate
+exists to diff.
+
+`--harness-mode` is retained for compatibility
 isolation in the CLI path; `StandaloneHarness` is available via the Python API.
 
 ## TLX GEMM example
@@ -130,17 +154,25 @@ requests or NCU collection.
 
 ### Target-supplied profiling
 
+Canonical workflow guidance lives in `docs/profiling/proton.md` for Proton and
+`docs/profiling/nvidia-ncu.md` for NVIDIA NCU. These documents guide harness and
+run orchestration; they are not injected into candidate source prompts.
+
 A target harness may implement `profile(build_artifact, case, request)` to honor structured
 profile requests. Missing tools, unsupported metrics, and profiler failures should be returned
-as diagnostics so correctness and benchmark results remain usable.
+as diagnostics so correctness and benchmark results remain usable. Before freezing a CUDA
+bundle, smoke-test that an expected Proton main launch has nonzero time and NCU duration is
+non-null when those tools are available.
 
 - **Triton Proton launch attribution:** handle `tools=["proton_launch"]` with an absolute
   `artifacts_dir`. A supporting harness should warm up, synchronize, collect one
-  launch-attribution-only Proton tree, save raw artifacts, and return normalized totals.
+  launch-attribution-only Proton tree, save raw artifacts, and call
+  `parse_proton_launch_attribution()` with the target's exact `main_scope`.
 - **Native profiler:** handle `tools=["native_profiler"]` by mapping this portable name to the
-  target platform profiler. NVIDIA requests are resolved to NCU, and a supporting harness may
-  collect summary or deep metrics and save command/query/CSV/stderr artifacts. Explicit `ncu`
-  remains a compatible NVIDIA-only request.
+  target platform profiler. NVIDIA requests are resolved to NCU. Collect into an `.ncu-rep`,
+  then call `export_ncu_report_details()` to persist and parse the details CSV; collection
+  stdout contains status messages rather than metric rows when `--export` is used. Explicit
+  `ncu` remains a compatible NVIDIA-only request.
 - **Diagnostic instrumentation:** `proton_intra_kernel` requires a target-supplied instrumented
   replay. Instrumented source and timing must never be benchmarked, promoted, or committed.
 

--- a/third_party/tlx/tools/agents/kernel_optimization/artifacts.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/artifacts.py
@@ -1,13 +1,102 @@
 from __future__ import annotations
 
 import json
+import math
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
-from .models import JsonValue, to_json_value
+from .models import PriorExperimentEvidence, PriorRunEvidence, JsonValue, to_json_value
+from .source import source_digest, source_diff
 
 _INLINE_PROFILE_LIMIT_BYTES = 1_000_000
+_MAX_PRIOR_JSON_BYTES = 8 * 1024 * 1024
+_MAX_PRIOR_SOURCE_BYTES = 4 * 1024 * 1024
+_MAX_PRIOR_EXPERIMENTS = 1000
+_MAX_PRIOR_PROMPT_EXPERIMENTS = 12
+_SAFE_EXPERIMENT_ID = re.compile(r"^[A-Za-z0-9_.-]{1,80}$")
+
+
+def _bounded_text(value: object, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.replace("\x00", " ").split())[:limit]
+
+
+def load_prior_run_evidence(path: Path) -> PriorRunEvidence:
+    resolved = path.resolve()
+    experiments_path = resolved / "experiments.json" if resolved.is_dir() else resolved
+    run_path = experiments_path.parent
+    if not experiments_path.is_file():
+        raise ValueError(f"experiments.json not found at {experiments_path}")
+    if experiments_path.stat().st_size > _MAX_PRIOR_JSON_BYTES:
+        raise ValueError("experiments.json exceeds the prior-run size limit")
+    try:
+        payload = json.loads(experiments_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"unable to read experiments.json: {error}") from error
+    if not isinstance(payload, list):
+        raise ValueError("experiments.json must contain a list")
+    if len(payload) > _MAX_PRIOR_EXPERIMENTS:
+        raise ValueError("experiments.json exceeds the experiment count limit")
+
+    hashes: list[str] = []
+    evidence: list[PriorExperimentEvidence] = []
+    warnings: list[str] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise ValueError(f"experiment {index} must be an object")
+        experiment_id = item.get("experiment_id")
+        if not isinstance(experiment_id, str) or not _SAFE_EXPERIMENT_ID.fullmatch(experiment_id):
+            raise ValueError(f"experiment {index} has an unsafe experiment_id")
+        source_path = (run_path / "experiments" / experiment_id / "kernel.py").resolve()
+        try:
+            source_path.relative_to(run_path)
+        except ValueError as error:
+            raise ValueError(f"experiment {experiment_id} escapes the prior run") from error
+        if source_path.is_file():
+            if source_path.stat().st_size > _MAX_PRIOR_SOURCE_BYTES:
+                raise ValueError(f"source for {experiment_id} exceeds the size limit")
+            try:
+                source = source_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError) as error:
+                raise ValueError(f"unable to read source for {experiment_id}: {error}") from error
+            if source.strip():
+                hashes.append(source_digest(source))
+        elif experiment_id != "baseline":
+            warnings.append(f"source unavailable for {experiment_id}")
+
+        if experiment_id == "baseline" or len(evidence) >= _MAX_PRIOR_PROMPT_EXPERIMENTS:
+            continue
+        performance = item.get("performance")
+        speedup = performance.get("aggregate_speedup") if isinstance(performance, dict) else None
+        if not isinstance(speedup, (int, float)) or not math.isfinite(float(speedup)):
+            speedup = None
+        evidence.append(
+            PriorExperimentEvidence(
+                experiment_id=experiment_id,
+                status=_bounded_text(item.get("status"), 40) or "unknown",
+                hypothesis=_bounded_text(item.get("hypothesis"), 240),
+                change=_bounded_text(item.get("mutation_summary"), 240),
+                aggregate_speedup=float(speedup) if speedup is not None else None,
+                diagnostics=_bounded_text(item.get("diagnostics"), 500),
+            )
+        )
+    return PriorRunEvidence(
+        run_path=run_path,
+        experiments_path=experiments_path,
+        source_hashes=tuple(dict.fromkeys(hashes)),
+        experiments=tuple(evidence),
+        warnings=tuple(warnings[:20]),
+    )
+
+
+@dataclass(frozen=True)
+class CandidateArtifactPaths:
+    source_path: Path
+    incremental_patch_path: Path
+    cumulative_patch_path: Path
 
 
 @dataclass(frozen=True)
@@ -23,6 +112,41 @@ class ArtifactStore:
         source_path = experiment_dir / "kernel.py"
         source_path.write_text(source)
         return source_path
+
+    def write_candidate_artifacts(
+        self,
+        experiment_id: str,
+        *,
+        source: str,
+        parent_source: str,
+        parent_id: str,
+        baseline_source: str,
+    ) -> CandidateArtifactPaths:
+        experiment_dir = self.root / "experiments" / experiment_id
+        source_path = self.write_source(experiment_id, source)
+        incremental_patch_path = experiment_dir / "incremental.patch"
+        incremental_patch_path.write_text(
+            source_diff(
+                parent_source,
+                source,
+                fromfile=f"experiments/{parent_id}/kernel.py",
+                tofile=f"experiments/{experiment_id}/kernel.py",
+            )
+        )
+        cumulative_patch_path = experiment_dir / "cumulative.patch"
+        cumulative_patch_path.write_text(
+            source_diff(
+                baseline_source,
+                source,
+                fromfile="experiments/baseline/kernel.py",
+                tofile=f"experiments/{experiment_id}/kernel.py",
+            )
+        )
+        return CandidateArtifactPaths(
+            source_path=source_path,
+            incremental_patch_path=incremental_patch_path,
+            cumulative_patch_path=cumulative_patch_path,
+        )
 
     def write_json(self, relative_path: str, value: JsonValue | object) -> Path:
         path = self.root / relative_path

--- a/third_party/tlx/tools/agents/kernel_optimization/cli.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/cli.py
@@ -8,19 +8,29 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
+from .artifacts import load_prior_run_evidence
 from .harness import HarnessExecutionError, SubprocessHarness
 from .models import (
+    AutoCommitResult,
+    ExperimentSummary,
     InputCase,
     KernelOptimizationRequest,
     KernelOptimizationResult,
     KernelTarget,
     OptimizationBudget,
+    PerformanceSummary,
     passes_protected_cases,
     to_json_value,
 )
 from .optimizer import KernelOptimizer
 from .providers import CodexCandidateProvider, MockLLMProvider
-from .vcs import commit_winner, failed_auto_commit, prepare_auto_commit
+from .vcs import (
+    AutoCommitSession,
+    commit_promotion,
+    commit_rollback,
+    failed_auto_commit,
+    prepare_auto_commit,
+)
 
 
 def _load_json(path: Path) -> Any:
@@ -43,6 +53,16 @@ def _parse_args(arguments: list[str] | None = None) -> argparse.Namespace:
         help="Target arch under harnesses/<arch>/targets/<kernel> (e.g. blackwell, hopper, host). Defaults to first available.",
     )
     parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--prior-run",
+        type=Path,
+        default=None,
+        help=(
+            "Read-only path to a prior TLX Agent output directory or its "
+            "experiments.json; imports evidence and source hashes without "
+            "adopting the prior winner."
+        ),
+    )
     parser.add_argument("--max-rounds", type=int, default=5)
     parser.add_argument("--candidates-per-round", type=int, default=2)
     parser.add_argument("--max-candidate-seconds", type=float, default=600.0)
@@ -225,10 +245,16 @@ def _validate_host_matches_target(
         )
 
 
-def _commit_body(result: KernelOptimizationResult) -> str:
-    baseline_by_id = {case.case_id: case for case in result.baseline.cases}
+def _performance_commit_body(
+    baseline_summary: PerformanceSummary,
+    comparison: PerformanceSummary,
+    experiment_id: str,
+    commit_summary: str,
+    heading: str,
+) -> str:
+    baseline_by_id = {case.case_id: case for case in baseline_summary.cases}
     rows: list[tuple[str, str, str, str, str, str, str]] = []
-    for winner in result.final.cases:
+    for winner in comparison.cases:
         baseline = baseline_by_id.get(winner.case_id)
         baseline_timing = baseline.timing if baseline else None
         winner_timing = winner.timing
@@ -266,12 +292,110 @@ def _commit_body(result: KernelOptimizationResult) -> str:
     table.extend(format_row(row) for row in rows)
     validation = (
         "Performance:\n"
-        f"Final revalidation for {result.winner_experiment_id}:\n"
+        f"{heading} for {experiment_id}:\n"
         + "\n".join(table)
-        + f"\nWeighted aggregate speedup: {result.final.aggregate_speedup:.4f}x."
+        + f"\nWeighted aggregate speedup: {comparison.aggregate_speedup:.4f}x."
     )
-    summary = result.winner_commit_summary.strip()
+    summary = commit_summary.strip()
     return f"{summary}\n\n{validation}" if summary else validation
+
+
+def _commit_body(result: KernelOptimizationResult) -> str:
+    return _performance_commit_body(
+        result.baseline,
+        result.final,
+        result.winner_experiment_id,
+        result.winner_commit_summary,
+        "Final revalidation",
+    )
+
+
+class _PromotionAutoCommitter:
+    def __init__(
+        self,
+        session: AutoCommitSession,
+        harness_path: Path,
+        cases: tuple[InputCase, ...],
+        target: KernelTarget,
+        budget: OptimizationBudget,
+        output_dir: Path,
+        fallback_subject: str,
+        override_subject: str | None,
+    ) -> None:
+        self._session = session
+        self._harness_path = harness_path
+        self._cases = cases
+        self._target = target
+        self._budget = budget
+        self._output_dir = output_dir
+        self._fallback_subject = fallback_subject
+        self._override_subject = override_subject
+
+    def _validate(self, committed_source: str, experiment_id: str) -> None:
+        validation = SubprocessHarness(
+            self._harness_path, self._budget.max_candidate_seconds
+        ).evaluate(
+            committed_source,
+            self._cases,
+            self._target,
+            self._budget.benchmark_repetitions,
+        )
+        self._output_dir.joinpath(
+            "experiments", experiment_id, "commit_revalidation.json"
+        ).write_text(json.dumps(to_json_value(validation), indent=2, sort_keys=True) + "\n")
+        if not passes_protected_cases(validation, self._cases):
+            raise HarnessExecutionError(
+                "merged promotion source failed one or more protected correctness cases"
+            )
+
+    def commit_promotion(
+        self,
+        experiment: ExperimentSummary,
+        source: str,
+        baseline: PerformanceSummary,
+        performance: PerformanceSummary,
+    ) -> AutoCommitResult:
+        subject = self._override_subject or experiment.commit_title or self._fallback_subject
+        try:
+            result = commit_promotion(
+                self._session,
+                source,
+                subject,
+                _performance_commit_body(
+                    baseline,
+                    performance,
+                    experiment.experiment_id,
+                    experiment.commit_summary,
+                    "Promotion evaluation",
+                ),
+                validate_committed_source=lambda committed: self._validate(
+                    committed, experiment.experiment_id
+                ),
+            )
+        except Exception as error:  # noqa: BLE001
+            result = failed_auto_commit(self._session.snapshot, subject, error)
+        _report_commit(result)
+        self._output_dir.joinpath("promotion_commits.json").write_text(
+            json.dumps(
+                to_json_value(tuple(self._session.promotion_commits)),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
+        return result
+
+    def rollback_to_baseline(self, diagnostics: str) -> AutoCommitResult:
+        subject = f"Revert TLX agent promotions after failed final revalidation"
+        try:
+            result = commit_rollback(self._session, subject, diagnostics)
+        except Exception as error:  # noqa: BLE001
+            result = failed_auto_commit(self._session.snapshot, subject, error)
+        _report_commit(result)
+        self._output_dir.joinpath("rollback_commit.json").write_text(
+            json.dumps(to_json_value(result), indent=2, sort_keys=True) + "\n"
+        )
+        return result
 
 
 def _report_commit(commit_result: object) -> None:
@@ -351,6 +475,27 @@ def main() -> int:
             print(json.dumps(to_json_value(commit_result), indent=2, sort_keys=True))
             return 3
     reference_source = args.reference_kernel.read_text() if args.reference_kernel else None
+    prior_run_evidence = None
+    if args.prior_run is not None:
+        try:
+            prior_run_evidence = load_prior_run_evidence(args.prior_run)
+        except ValueError as error:
+            raise SystemExit(f"--prior-run is invalid: {error}") from error
+        print(
+            "[tlx-agent] prior-run "
+            f"path={json.dumps(str(prior_run_evidence.run_path))} "
+            f"experiments={len(prior_run_evidence.experiments)} "
+            f"source_hashes={len(prior_run_evidence.source_hashes)} "
+            f"warnings={len(prior_run_evidence.warnings)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        for warning in prior_run_evidence.warnings:
+            print(
+                f"[tlx-agent] prior-run warning={json.dumps(warning)}",
+                file=sys.stderr,
+                flush=True,
+            )
     request = KernelOptimizationRequest(
         kernel_source=kernel_source,
         reference_kernel_source=reference_source,
@@ -360,52 +505,28 @@ def main() -> int:
         budget=budget,
         output_dir=args.output_dir,
         diagnostic_proton_intra_kernel=args.diagnostic_proton_intra_kernel,
+        prior_run_evidence=prior_run_evidence,
     )
-    result = KernelOptimizer(provider).optimize(request)
+    promotion_committer = None
+    if commit_snapshot is not None:
+        promotion_committer = _PromotionAutoCommitter(
+            AutoCommitSession.create(commit_snapshot),
+            harness_path,
+            cases,
+            target,
+            budget,
+            args.output_dir,
+            fallback_commit_subject,
+            args.commit_message,
+        )
+    result = KernelOptimizer(provider).optimize(request, promotion_committer)
     exit_code = 0 if result.success else 2
-    if args.commit_winner and result.success:
-        assert commit_snapshot is not None
-        commit_subject = (
-            args.commit_message
-            or result.winner_commit_title
-            or fallback_commit_subject
-        )
-
-        def validate_committed_source(committed_source: str) -> None:
-            harness = SubprocessHarness(harness_path, budget.max_candidate_seconds)
-            validation = harness.evaluate(
-                committed_source,
-                cases,
-                target,
-                budget.benchmark_repetitions,
-            )
-            args.output_dir.joinpath("commit_revalidation.json").write_text(
-                json.dumps(to_json_value(validation), indent=2, sort_keys=True) + "\n"
-            )
-            if not passes_protected_cases(validation, cases):
-                raise HarnessExecutionError(
-                    "merged commit source failed one or more protected correctness cases"
-                )
-
-        try:
-            commit_result = commit_winner(
-                commit_snapshot,
-                result.best_kernel,
-                commit_subject,
-                body=_commit_body(result),
-                validate_committed_source=validate_committed_source,
-            )
-        except Exception as error:  # noqa: BLE001
-            commit_result = failed_auto_commit(commit_snapshot, commit_subject, error)
-            exit_code = 3
-        result = replace(result, auto_commit=commit_result)
-        _report_commit(commit_result)
+    if result.auto_commit is not None:
         args.output_dir.joinpath("auto_commit.json").write_text(
-            json.dumps(to_json_value(commit_result), indent=2, sort_keys=True) + "\n"
+            json.dumps(to_json_value(result.auto_commit), indent=2, sort_keys=True) + "\n"
         )
-        args.output_dir.joinpath("result.json").write_text(
-            json.dumps(to_json_value(result), indent=2, sort_keys=True) + "\n"
-        )
+    if result.stopping_reason in {"promotion_commit_failed", "rollback_commit_failed"}:
+        exit_code = 3
     print(json.dumps(to_json_value(result), indent=2, sort_keys=True))
     return exit_code
 

--- a/third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md
@@ -2,8 +2,8 @@
 
 Use this guide only when `target.json.backend` is CUDA/NVIDIA. It supplements
 the generic TLX optimization workflow with NVIDIA NCU requirements. Proton
-wrapper/launch attribution and diagnostic instrumentation live in
-`references/proton-profiling.md`.
+wrapper/launch attribution and diagnostic instrumentation live in the sibling
+`proton.md` guide.
 
 ## Metric Discovery
 
@@ -30,6 +30,33 @@ Resolve metrics for these groups when supported:
 
 Persist the raw NCU report, CSV exports, metric mapping, and exact commands as
 absolute artifact paths.
+
+## Report Export
+
+When collection uses `--export`, NCU writes metrics into the `.ncu-rep`; the
+collection process stdout contains `==PROF==` status messages, not metric CSV.
+After a successful collection, every harness must export and normalize the
+report through the shared helper:
+
+```python
+exported = export_ncu_report_details(
+    report_path,
+    artifacts_dir=ncu_artifacts_dir,
+    level=profile_request.level,
+    ncu_binary=ncu_path,
+)
+```
+
+The helper runs `ncu --import REPORT --page details --csv`, persists the exact
+import command, details CSV, and stderr, and returns normalized `ncu` data plus
+diagnostics. Merge those fields into the harness profile response. Do not parse
+collection stdout, synthesize zero for missing fields, or discard correctness
+and benchmark results when report import fails.
+
+Before freezing a CUDA harness, collect one real report and verify that the
+normalized duration is non-null. When the selected metric set includes them,
+also check throughput, occupancy, stalls, cache, and byte counters and confirm
+that units such as `Gbyte` were normalized to bytes.
 
 ## Summary Profile
 

--- a/third_party/tlx/tools/agents/kernel_optimization/docs/profiling/proton.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/docs/profiling/proton.md
@@ -2,8 +2,8 @@
 
 Use Proton for vendor-neutral attribution around the benchmark wrapper, launch
 path, and optional diagnostic source instrumentation. Keep target-specific
-counters in `targets/<vendor>/`; this file only describes Proton usage and
-artifact expectations.
+counter requirements in sibling vendor guides such as `nvidia-ncu.md`; this file
+only describes Proton usage and artifact expectations.
 
 ## Wrapper And Launch Attribution
 
@@ -13,9 +13,23 @@ wrapper, setup/teardown, launch path, synchronization, or the profiled kernel
 window.
 
 An ordinary Proton timeline using `hook='triton'` can show the wrapper and one
-compiled Triton kernel launch. That timeline does not show TLX async-task
-overlap inside the kernel. Do not treat a single kernel region as evidence that
-producer, consumer, TMA, MMA, or store tasks overlapped.
+compiled Triton kernel launch. The target harness must identify that launch with
+its exact scope rather than a name heuristic:
+
+```python
+attribution = parse_proton_launch_attribution(
+    tree,
+    main_scope=main_kernel_scope,
+)
+```
+
+The scope is target knowledge and should not be added to the generic profile
+request. Before freezing the harness, verify that the expected main launch has
+nonzero `main_kernel_us` and helper CUDA launches are attributed as non-main.
+
+This timeline does not show TLX async-task overlap inside the kernel. Do not
+treat a single kernel region as evidence that producer, consumer, TMA, MMA, or
+store tasks overlapped.
 
 Return compact normalized JSON inline and keep raw files in the requested
 `artifacts_dir`:

--- a/third_party/tlx/tools/agents/kernel_optimization/models.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/models.py
@@ -58,6 +58,25 @@ class OptimizationBudget:
 
 
 @dataclass(frozen=True)
+class PriorExperimentEvidence:
+    experiment_id: str
+    status: str
+    hypothesis: str = ""
+    change: str = ""
+    aggregate_speedup: float | None = None
+    diagnostics: str = ""
+
+
+@dataclass(frozen=True)
+class PriorRunEvidence:
+    run_path: Path
+    experiments_path: Path
+    source_hashes: tuple[str, ...] = ()
+    experiments: tuple[PriorExperimentEvidence, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class KernelOptimizationRequest:
     kernel_source: str
     harness_path: Path
@@ -68,6 +87,7 @@ class KernelOptimizationRequest:
     reference_kernel_source: str | None = None
     output_dir: Path | None = None
     diagnostic_proton_intra_kernel: bool = False
+    prior_run_evidence: PriorRunEvidence | None = None
 
     def __post_init__(self) -> None:
         if not self.kernel_source.strip():
@@ -169,6 +189,8 @@ class ExperimentSummary:
     parent_id: str | None
     status: str
     source_path: Path
+    incremental_patch_path: Path | None = None
+    cumulative_patch_path: Path | None = None
     performance: PerformanceSummary | None = None
     diagnostics: str = ""
     mutation_summary: str = ""
@@ -179,6 +201,7 @@ class ExperimentSummary:
     commit_title: str = ""
     commit_summary: str = ""
     profile_path: Path | None = None
+    auto_commit: AutoCommitResult | None = None
 
 
 @dataclass(frozen=True)
@@ -209,6 +232,8 @@ class KernelOptimizationResult:
     winner_experiment_id: str = "baseline"
     winner_commit_title: str = ""
     winner_commit_summary: str = ""
+    promotion_commits: tuple[AutoCommitResult, ...] = ()
+    rollback_commit: AutoCommitResult | None = None
     auto_commit: AutoCommitResult | None = None
 
 

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -6,11 +6,12 @@ import time
 from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
-from .artifacts import ArtifactStore
+from .artifacts import ArtifactStore, CandidateArtifactPaths
 from .harness import HarnessExecutionError, SubprocessHarness
 from .models import (
+    AutoCommitResult,
     ExperimentSummary,
     InputCase,
     KernelOptimizationRequest,
@@ -34,6 +35,18 @@ _PROFILE_TOOLS = ("proton_launch", "native_profiler")
 _DIAGNOSTIC_PROFILE_TOOLS = ("proton_intra_kernel",)
 _DIAGNOSTIC_PROFILE_KEY = "diagnostic_proton_intra_kernel"
 _NEAR_THRESHOLD_WINDOW = 0.01
+
+
+class PromotionCommitter(Protocol):
+    def commit_promotion(
+        self,
+        experiment: ExperimentSummary,
+        source: str,
+        baseline: PerformanceSummary,
+        performance: PerformanceSummary,
+    ) -> AutoCommitResult: ...
+
+    def rollback_to_baseline(self, diagnostics: str) -> AutoCommitResult: ...
 
 
 def _profile_request(
@@ -369,11 +382,48 @@ def _ncu_regression_diagnostics(
     return "; ".join(diagnostics)
 
 
+def _report_candidate_artifacts(
+    experiment_id: str, artifacts: CandidateArtifactPaths
+) -> None:
+    print(
+        " ".join(
+            [
+                f"[tlx-agent] {experiment_id} status=artifacts",
+                f"source={str(artifacts.source_path.resolve())!r}",
+                f"incremental_patch={str(artifacts.incremental_patch_path.resolve())!r}",
+                f"cumulative_patch={str(artifacts.cumulative_patch_path.resolve())!r}",
+            ]
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    print(
+        f"[tlx-agent] {experiment_id} incremental-diff-begin",
+        file=sys.stderr,
+    )
+    patch = artifacts.incremental_patch_path.read_text()
+    if patch:
+        sys.stderr.write(patch)
+        if not patch.endswith("\n"):
+            sys.stderr.write("\n")
+    else:
+        print("(no source changes)", file=sys.stderr)
+    print(
+        f"[tlx-agent] {experiment_id} incremental-diff-end",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 class KernelOptimizer:
     def __init__(self, provider: CandidateProvider | None = None) -> None:
         self._provider = provider or CodexCandidateProvider()
 
-    def optimize(self, request: KernelOptimizationRequest) -> KernelOptimizationResult:
+    def optimize(
+        self,
+        request: KernelOptimizationRequest,
+        promotion_committer: PromotionCommitter | None = None,
+    ) -> KernelOptimizationResult:
         artifacts_dir = request.output_dir or Path(
             tempfile.mkdtemp(prefix="tlx-kernel-agent-")
         )
@@ -441,7 +491,15 @@ class KernelOptimizer:
         best_commit_summary = ""
         best_profiles = baseline_profiles
         diagnostics: list[str] = []
-        seen_sources = {source_digest(request.kernel_source)}
+        promotion_commits: list[AutoCommitResult] = []
+        rollback_commit: AutoCommitResult | None = None
+        last_auto_commit: AutoCommitResult | None = None
+        prior_source_hashes = set(
+            request.prior_run_evidence.source_hashes
+            if request.prior_run_evidence is not None
+            else ()
+        )
+        seen_sources = {source_digest(request.kernel_source), *prior_source_hashes}
         stopping_reason = "round_budget_exhausted"
         exhausted = False
 
@@ -456,7 +514,10 @@ class KernelOptimizer:
                     exhausted = True
                     break
                 experiment_id = f"r{round_index:03d}-c{candidate_index:03d}"
+                parent_id = best_experiment_id
+                parent_source = best_source
                 proposal = None
+                candidate_artifacts = None
                 try:
                     _report_performance(experiment_id, "generating", None)
                     proposal = self._provider.propose(
@@ -464,17 +525,29 @@ class KernelOptimizer:
                         CandidateContext(
                             round_index=round_index,
                             candidate_index=candidate_index,
-                            current_source=best_source,
+                            current_source=parent_source,
                             current_performance=best_performance,
                             previous_diagnostics=tuple(diagnostics),
                         ),
                     )
                     _report_candidate_summary(experiment_id, proposal)
+                    candidate_artifacts = store.write_candidate_artifacts(
+                        experiment_id,
+                        source=proposal.source,
+                        parent_source=parent_source,
+                        parent_id=parent_id,
+                        baseline_source=request.kernel_source,
+                    )
+                    _report_candidate_artifacts(experiment_id, candidate_artifacts)
                     digest = source_digest(proposal.source)
                     if digest in seen_sources:
-                        raise ValueError("candidate source duplicates an earlier experiment")
+                        origin = (
+                            "a prior run experiment"
+                            if digest in prior_source_hashes
+                            else "an earlier experiment"
+                        )
+                        raise ValueError(f"candidate source duplicates {origin}")
                     seen_sources.add(digest)
-                    source_path = store.write_source(experiment_id, proposal.source)
                     _report_performance(experiment_id, "evaluating", None)
                     performance = harness.evaluate(
                         proposal.source,
@@ -535,9 +608,11 @@ class KernelOptimizer:
                     experiment = ExperimentSummary(
                         experiment_id=experiment_id,
                         round_index=round_index,
-                        parent_id=best_experiment_id,
+                        parent_id=parent_id,
                         status=status,
-                        source_path=source_path,
+                        source_path=candidate_artifacts.source_path,
+                        incremental_patch_path=candidate_artifacts.incremental_patch_path,
+                        cumulative_patch_path=candidate_artifacts.cumulative_patch_path,
                         performance=performance,
                         mutation_summary=proposal.summary,
                         hypothesis=proposal.hypothesis,
@@ -580,7 +655,26 @@ class KernelOptimizer:
                         cases=request.cases,
                         diagnostics=f"decision={decision}",
                     )
-                    if status == "promoted":
+                    if status == "promoted" and promotion_committer is not None:
+                        commit_result = promotion_committer.commit_promotion(
+                            experiment,
+                            proposal.source,
+                            baseline,
+                            performance,
+                        )
+                        experiment = replace(experiment, auto_commit=commit_result)
+                        last_auto_commit = commit_result
+                        if commit_result.success:
+                            promotion_commits.append(commit_result)
+                        else:
+                            experiment = replace(
+                                experiment,
+                                status="failed",
+                                diagnostics=commit_result.diagnostics,
+                            )
+                            stopping_reason = "promotion_commit_failed"
+                            exhausted = True
+                    if status == "promoted" and not exhausted:
                         best_source = proposal.source
                         best_performance = performance
                         best_experiment_id = experiment_id
@@ -591,15 +685,27 @@ class KernelOptimizer:
                 except Exception as error:  # noqa: BLE001
                     message = f"{experiment_id}: {type(error).__name__}: {error}"
                     diagnostics.append(message)
-                    source_path = store.write_source(
-                        experiment_id, proposal.source if proposal is not None else ""
+                    source_path = (
+                        candidate_artifacts.source_path
+                        if candidate_artifacts is not None
+                        else store.write_source(experiment_id, "")
                     )
                     experiment = ExperimentSummary(
                         experiment_id=experiment_id,
                         round_index=round_index,
-                        parent_id=best_experiment_id,
+                        parent_id=parent_id,
                         status="failed",
                         source_path=source_path,
+                        incremental_patch_path=(
+                            candidate_artifacts.incremental_patch_path
+                            if candidate_artifacts is not None
+                            else None
+                        ),
+                        cumulative_patch_path=(
+                            candidate_artifacts.cumulative_patch_path
+                            if candidate_artifacts is not None
+                            else None
+                        ),
                         diagnostics=message,
                     )
                     _report_performance(
@@ -650,6 +756,13 @@ class KernelOptimizer:
             best_commit_title = ""
             best_commit_summary = ""
             stopping_reason = "finalist_revalidation_failed"
+            if promotion_committer is not None and promotion_commits:
+                rollback_commit = promotion_committer.rollback_to_baseline(
+                    "; ".join(diagnostics) or "final revalidation failed"
+                )
+                last_auto_commit = rollback_commit
+                if not rollback_commit.success:
+                    stopping_reason = "rollback_commit_failed"
         elif best_experiment_id != "baseline":
             if request.diagnostic_proton_intra_kernel:
                 final_diagnostics = _collect_diagnostic_profiles(
@@ -692,6 +805,9 @@ class KernelOptimizer:
             winner_experiment_id=best_experiment_id,
             winner_commit_title=best_commit_title,
             winner_commit_summary=best_commit_summary,
+            promotion_commits=tuple(promotion_commits),
+            rollback_commit=rollback_commit,
+            auto_commit=last_auto_commit,
         )
         store.write_json("result.json", result)
         return result

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -6,6 +6,7 @@ import inspect
 import io
 import json
 import re
+import subprocess
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -33,47 +34,77 @@ SUMMARY_NCU_METRIC_ALIASES: Mapping[str, tuple[str, ...]] = {
         "duration_us",
         "gpu__time_duration.sum",
         "gpu__time_duration.avg",
+        "gpu__time_duration",
+        "gpu__time_duration_measured_user",
+        "gpu__time_duration_measured_wallclock",
         "Duration",
     ),
     "sm_throughput_pct": (
         "sm_throughput_pct",
         "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+        "sm__throughput",
     ),
     "dram_throughput_pct": (
         "dram_throughput_pct",
         "dram__throughput.avg.pct_of_peak_sustained_elapsed",
+        "dram__throughput",
+        "gpu__dram_throughput",
     ),
 }
 
 DEEP_NCU_METRIC_ALIASES: Mapping[str, tuple[str, ...]] = {
     **SUMMARY_NCU_METRIC_ALIASES,
-    "barrier_pct": ("smsp__warp_issue_stalled_barrier_per_warp_active.pct",),
-    "async_wait_pct": ("smsp__warp_issue_stalled_wait_per_warp_active.pct",),
+    "barrier_pct": (
+        "smsp__warp_issue_stalled_barrier_per_warp_active.pct",
+        "smsp__warp_issue_stalled_barrier_per_warp_active",
+    ),
+    "async_wait_pct": (
+        "smsp__warp_issue_stalled_wait_per_warp_active.pct",
+        "smsp__warp_issue_stalled_wait_per_warp_active",
+    ),
     "long_scoreboard_pct": (
         "smsp__warp_issue_stalled_long_scoreboard_per_warp_active.pct",
+        "smsp__warp_issue_stalled_long_scoreboard_per_warp_active",
     ),
     "short_scoreboard_pct": (
         "smsp__warp_issue_stalled_short_scoreboard_per_warp_active.pct",
+        "smsp__warp_issue_stalled_short_scoreboard_per_warp_active",
     ),
     "mio_throttle_pct": (
         "smsp__warp_issue_stalled_mio_throttle_per_warp_active.pct",
+        "smsp__warp_issue_stalled_mio_throttle_per_warp_active",
     ),
-    "dependency_pct": ("smsp__warp_issue_stalled_math_pipe_throttle_per_warp_active.pct",),
+    "dependency_pct": (
+        "smsp__warp_issue_stalled_math_pipe_throttle_per_warp_active.pct",
+        "smsp__warp_issue_stalled_math_pipe_throttle_per_warp_active",
+    ),
     "registers_per_thread": ("launch__registers_per_thread",),
     "achieved_occupancy_pct": ("sm__warps_active.avg.pct_of_peak_sustained_active",),
     "theoretical_occupancy_pct": ("launch__occupancy_limit_registers",),
-    "local_load_bytes": ("l1tex__t_bytes_pipe_lsu_mem_local_op_ld.sum",),
-    "local_store_bytes": ("l1tex__t_bytes_pipe_lsu_mem_local_op_st.sum",),
+    "local_load_bytes": (
+        "l1tex__t_bytes_pipe_lsu_mem_local_op_ld.sum",
+        "l1tex__t_bytes_pipe_lsu_mem_local_op_ld",
+    ),
+    "local_store_bytes": (
+        "l1tex__t_bytes_pipe_lsu_mem_local_op_st.sum",
+        "l1tex__t_bytes_pipe_lsu_mem_local_op_st",
+    ),
     "spill_loads": ("launch__sass_reg_spill_loads",),
     "spill_stores": ("launch__sass_reg_spill_stores",),
-    "l1_bytes": ("l1tex__t_bytes.sum",),
-    "l1_hit_rate_pct": ("l1tex__t_sector_hit_rate.pct",),
-    "shared_bank_conflicts": ("l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum",),
+    "l1_bytes": ("l1tex__t_bytes.sum", "l1tex__t_bytes"),
+    "l1_hit_rate_pct": (
+        "l1tex__t_sector_hit_rate.pct",
+        "l1tex__t_sector_hit_rate",
+    ),
+    "shared_bank_conflicts": (
+        "l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum",
+        "l1tex__data_bank_conflicts_pipe_lsu_mem_shared",
+    ),
     "l2_read_bytes": ("lts__t_bytes_op_read.sum",),
     "l2_write_bytes": ("lts__t_bytes_op_write.sum",),
     "l2_hit_rate_pct": ("lts__t_sector_hit_rate.pct",),
-    "dram_read_bytes": ("dram__bytes_read.sum",),
-    "dram_write_bytes": ("dram__bytes_write.sum",),
+    "dram_read_bytes": ("dram__bytes_read.sum", "dram__bytes_read"),
+    "dram_write_bytes": ("dram__bytes_write.sum", "dram__bytes_write"),
     "tensor_activity_pct": ("sm__pipe_tensor_active.avg.pct_of_peak_sustained_active",),
     "issue_active_pct": ("smsp__issue_active.avg.pct_of_peak_sustained_active",),
     "eligible_warps_per_cycle": ("smsp__warps_eligible.avg.per_cycle_active",),
@@ -299,8 +330,11 @@ def compact_profile_output(
     }
 
 
-def parse_proton_launch_attribution(payload: Any) -> dict[str, Any]:
+def parse_proton_launch_attribution(
+    payload: Any, *, main_scope: str | None = None
+) -> dict[str, Any]:
     leaves: list[dict[str, Any]] = []
+    leaf_kinds: list[str] = []
     for node in _iter_nodes(payload):
         children = _node_children(node)
         if children:
@@ -311,6 +345,7 @@ def parse_proton_launch_attribution(payload: Any) -> dict[str, Any]:
         name = _node_name(node)
         count = _node_count(node)
         leaves.append({"name": name, "time_us": time_us, "count": count})
+        leaf_kinds.append(_leaf_kind(name, node=node, main_scope=main_scope))
 
     totals = {
         "wrapper_us": 0.0,
@@ -319,11 +354,10 @@ def parse_proton_launch_attribution(payload: Any) -> dict[str, Any]:
         "leaf_time_us": 0.0,
         "count": 0,
     }
-    for leaf in leaves:
+    for leaf, kind in zip(leaves, leaf_kinds):
         time_us = float(leaf["time_us"] or 0.0)
         totals["leaf_time_us"] += time_us
         totals["count"] += int(leaf["count"] or 0)
-        kind = _leaf_kind(leaf["name"])
         if kind == "main_kernel":
             totals["main_kernel_us"] += time_us
         elif kind == "non_main_kernel":
@@ -358,10 +392,114 @@ def parse_ncu_csv(csv_text: str) -> dict[str, dict[str, Any]]:
     return metrics
 
 
+def export_ncu_report_details(
+    report_path: str | Path,
+    *,
+    artifacts_dir: str | Path,
+    level: str = "summary",
+    ncu_binary: str = "ncu",
+    timeout_s: float | None = 120.0,
+) -> dict[str, Any]:
+    _ncu_aliases_for_level(level)
+    report = Path(report_path)
+    output_dir = Path(artifacts_dir)
+    if not report.is_absolute():
+        raise ValueError("NCU report path must be absolute")
+    if not output_dir.is_absolute():
+        raise ValueError("NCU artifacts directory must be absolute")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command_path = output_dir / "import_command.json"
+    csv_path = output_dir / "details.csv"
+    stderr_path = output_dir / "import_stderr.txt"
+    command = [
+        ncu_binary,
+        "--import",
+        str(report),
+        "--page",
+        "details",
+        "--csv",
+    ]
+    command_path.write_text(json.dumps(command, indent=2) + "\n")
+    csv_path.write_text("")
+    stderr_path.write_text("")
+    artifacts = {
+        "ncu_report": str(report),
+        "ncu_import_command": str(command_path),
+        "ncu_details_csv": str(csv_path),
+        "ncu_import_stderr": str(stderr_path),
+    }
+    diagnostics: list[str] = []
+    stdout = ""
+    stderr = ""
+    return_code: int | None = None
+
+    if not report.is_file():
+        diagnostics.append(f"NCU report does not exist: {report}")
+    else:
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=timeout_s,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+            return_code = completed.returncode
+            if return_code != 0:
+                diagnostics.append(
+                    f"NCU report import failed with exit code {return_code}"
+                )
+        except subprocess.TimeoutExpired as error:
+            stdout = _subprocess_output_text(error.stdout)
+            stderr = _subprocess_output_text(error.stderr)
+            diagnostics.append(
+                f"NCU report import timed out after {timeout_s} seconds"
+            )
+        except OSError as error:
+            diagnostics.append(
+                f"NCU report import failed: {type(error).__name__}: {error}"
+            )
+
+    csv_path.write_text(stdout)
+    stderr_path.write_text(stderr)
+    raw_metrics = parse_ncu_csv(stdout)
+    if return_code == 0 and not raw_metrics:
+        diagnostics.append("NCU report import produced no metric rows")
+    normalized = normalize_ncu_metrics(raw_metrics, level)
+    return {
+        "success": return_code == 0 and bool(raw_metrics),
+        "ncu": normalized,
+        "artifacts": artifacts,
+        "diagnostics": diagnostics + list(normalized["diagnostics"]),
+    }
+
+
 def parse_ncu_query_metrics(query_text: str) -> set[str]:
-    reader = csv.DictReader(io.StringIO(query_text))
-    if reader.fieldnames is not None:
-        headers = {_normalize_header(header): header for header in reader.fieldnames}
+    lines = query_text.splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip() or line.lstrip().startswith("$"):
+            continue
+        header_reader = csv.reader((line,))
+        header = next(header_reader, ())
+        normalized = {_normalize_header(column) for column in header}
+        name_headers = {
+            "metric_name",
+            "name",
+            "metric",
+            "identifier",
+            "metric_identifier",
+        }
+        if not normalized.intersection(name_headers):
+            continue
+        reader = csv.DictReader(io.StringIO("\n".join(lines[index:])))
+        if reader.fieldnames is None:
+            break
+        headers = {
+            _normalize_header(column): column for column in reader.fieldnames
+        }
         name_key = _first_header(
             headers,
             ("metric_name", "name", "metric", "identifier", "metric_identifier"),
@@ -374,8 +512,9 @@ def parse_ncu_query_metrics(query_text: str) -> set[str]:
             }
             if metrics:
                 return metrics
+        break
     metrics: set[str] = set()
-    for line in query_text.splitlines():
+    for line in lines:
         token = line.strip().split(",", 1)[0].strip().strip('"')
         if token and "__" in token:
             metrics.add(token)
@@ -387,10 +526,27 @@ def select_ncu_metric_names(
 ) -> dict[str, Any]:
     aliases = _ncu_aliases_for_level(level)
     supported = {str(name) for name in supported_names}
+    canonical_supported: dict[str, list[str]] = {}
+    supported_base_metrics: set[str] = set()
+    for name in sorted(supported, key=lambda value: ("." in value, value)):
+        canonical = _canonical_ncu_metric_name(name)
+        canonical_supported.setdefault(canonical, []).append(name)
+        if canonical == _ncu_metric_family(canonical):
+            supported_base_metrics.add(canonical)
     selected: dict[str, str | None] = {}
     diagnostics: list[str] = []
     for semantic_name, candidates in aliases.items():
-        match = next((candidate for candidate in candidates if candidate in supported), None)
+        match = _select_ncu_metric(candidates, supported, canonical_supported)
+        if match is None:
+            match = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if "__" in candidate
+                    and _ncu_metric_family(candidate) in supported_base_metrics
+                ),
+                None,
+            )
         selected[semantic_name] = match
         if match is None:
             diagnostics.append(f"missing NCU metric for {semantic_name}")
@@ -414,12 +570,23 @@ def normalize_ncu_metrics(raw_metrics: Mapping[str, Any], level: str = "summary"
         if metric_name is None:
             result[group][semantic_name] = None
             continue
-        record = raw_metrics[metric_name]
+        raw_metric_name = _find_raw_ncu_metric_name(raw_metrics, metric_name)
+        if raw_metric_name is None:
+            result[group][semantic_name] = None
+            result["diagnostics"].append(
+                "missing collected NCU metric for "
+                f"{semantic_name}: {metric_name}"
+            )
+            continue
+        record = raw_metrics[raw_metric_name]
         value = _metric_record_value(record)
+        unit = _metric_record_unit(record)
         if semantic_name == "duration_us":
-            value = _duration_to_us(value, _metric_record_unit(record))
+            value = _duration_to_us(value, unit)
+        elif semantic_name.endswith("_bytes"):
+            value = _bytes_to_bytes(value, unit)
         result[group][semantic_name] = value
-        result["raw_metrics"][metric_name] = record
+        result["raw_metrics"][raw_metric_name] = record
     return result
 
 
@@ -519,6 +686,13 @@ def _node_name(node: Mapping[str, Any]) -> str:
         value = node.get(key)
         if value:
             return str(value)
+    frame = node.get("frame")
+    if isinstance(frame, Mapping):
+        value = frame.get("name")
+        if value:
+            return str(value)
+    elif frame:
+        return str(frame)
     return "unknown"
 
 
@@ -534,7 +708,7 @@ def _node_time_us(node: Mapping[str, Any]) -> float | None:
         ("time", 1.0),
         ("duration", 1.0),
     ):
-        value = _coerce_float(node.get(key))
+        value = _coerce_float(_mapping_value(node, key))
         if value is not None:
             return value * multiplier
     metrics = node.get("metrics")
@@ -545,19 +719,114 @@ def _node_time_us(node: Mapping[str, Any]) -> float | None:
 
 def _node_count(node: Mapping[str, Any]) -> int:
     for key in ("count", "calls", "num_calls", "instances"):
-        value = _coerce_float(node.get(key))
+        value = _coerce_float(_mapping_value(node, key))
         if value is not None:
             return int(value)
+    metrics = node.get("metrics")
+    if isinstance(metrics, Mapping):
+        return _node_count(metrics)
     return 1
 
 
-def _leaf_kind(name: object) -> str:
+def _leaf_kind(
+    name: object,
+    *,
+    node: Mapping[str, Any] | None = None,
+    main_scope: str | None = None,
+) -> str:
+    if main_scope is not None:
+        if str(name).strip() == main_scope.strip():
+            return "main_kernel"
+        metrics = node.get("metrics") if node is not None else None
+        if isinstance(metrics, Mapping):
+            device_type = _mapping_value(metrics, "device_type")
+            if str(device_type or "").strip().lower() in {"cuda", "gpu"}:
+                return "non_main_kernel"
+        return "wrapper"
     lowered = str(name).lower()
     if "main" in lowered and "kernel" in lowered:
         return "main_kernel"
     if "kernel" in lowered or "launch" in lowered:
         return "non_main_kernel"
     return "wrapper"
+
+
+def _mapping_value(mapping: Mapping[str, Any], key: str) -> Any:
+    if key in mapping:
+        return mapping[key]
+    normalized_key = _normalize_header(key)
+    for candidate, value in mapping.items():
+        if _normalize_header(str(candidate)) == normalized_key:
+            return value
+    return None
+
+
+def _canonical_ncu_metric_name(name: str) -> str:
+    parts = name.split(".")
+    for index, part in enumerate(parts):
+        if "__" in part:
+            return ".".join(parts[index:])
+    return name
+
+
+def _ncu_metric_family(name: str) -> str:
+    return _canonical_ncu_metric_name(name).split(".", 1)[0]
+
+
+def _select_ncu_metric(
+    candidates: tuple[str, ...],
+    supported: set[str],
+    canonical_supported: Mapping[str, list[str]],
+) -> str | None:
+    for candidate in candidates:
+        if candidate in supported:
+            if "__" in candidate and "." not in candidate:
+                return _preferred_derived_ncu_metric(candidates, candidate)
+            return candidate
+    for candidate in candidates:
+        canonical = _canonical_ncu_metric_name(candidate)
+        matches = canonical_supported.get(canonical, ())
+        if matches:
+            match = matches[0]
+            if "." not in _canonical_ncu_metric_name(match):
+                return _preferred_derived_ncu_metric(candidates, match)
+            return match
+    return None
+
+
+def _preferred_derived_ncu_metric(
+    candidates: tuple[str, ...], base_name: str
+) -> str:
+    family = _ncu_metric_family(base_name)
+    return next(
+        (
+            candidate
+            for candidate in candidates
+            if _ncu_metric_family(candidate) == family
+            and "." in _canonical_ncu_metric_name(candidate)
+        ),
+        base_name,
+    )
+
+
+def _find_raw_ncu_metric_name(
+    raw_metrics: Mapping[str, Any], requested_name: str
+) -> str | None:
+    if requested_name in raw_metrics:
+        return requested_name
+    requested_canonical = _canonical_ncu_metric_name(requested_name)
+    for name in raw_metrics:
+        if _canonical_ncu_metric_name(name) == requested_canonical:
+            return name
+    requested_family = _ncu_metric_family(requested_name)
+    base_matches = [
+        name
+        for name in raw_metrics
+        if _canonical_ncu_metric_name(name) == requested_family
+    ]
+    if len(base_matches) == 1:
+        return base_matches[0]
+    return None
 
 
 def _normalize_header(header: str) -> str:
@@ -574,6 +843,14 @@ def _first_header(headers: Mapping[str, str], candidates: tuple[str, ...]) -> st
 def _parse_metric_value(value: str) -> float | str | None:
     parsed = _coerce_float(value)
     return parsed if parsed is not None else value or None
+
+
+def _subprocess_output_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -618,6 +895,21 @@ def _duration_to_us(value: float | str | None, unit: str) -> float | None:
     if normalized in {"s", "sec", "second", "seconds"}:
         return duration * 1_000_000.0
     return duration
+
+
+def _bytes_to_bytes(value: float | str | None, unit: str) -> float | None:
+    byte_count = _coerce_float(value)
+    if byte_count is None:
+        return None
+    multiplier = {
+        "byte": 1.0,
+        "bytes": 1.0,
+        "kbyte": 1_000.0,
+        "mbyte": 1_000_000.0,
+        "gbyte": 1_000_000_000.0,
+        "tbyte": 1_000_000_000_000.0,
+    }.get(unit.strip().lower(), 1.0)
+    return byte_count * multiplier
 
 
 def _compact_value(value: Any) -> Any:

--- a/third_party/tlx/tools/agents/kernel_optimization/providers.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/providers.py
@@ -4,12 +4,26 @@ import json
 import subprocess
 import tempfile
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
 
-from .models import KernelOptimizationRequest, PerformanceSummary
+from .models import KernelOptimizationRequest, KernelTarget, PerformanceSummary
 from .profiling import compact_profile_summary
 from .source import validate_replacement_source
+
+_SKILLS_ROOT = Path(__file__).resolve().parent / "skills"
+_LAYOUT_CONVERSION_SKILL = _SKILLS_ROOT / "common/layout-conversion-efficiency.md"
+_NVIDIA_TARGET_SKILLS = _SKILLS_ROOT / "targets/nvidia"
+_ASYNC_TMA_OUTPUT_SKILL = _NVIDIA_TARGET_SKILLS / "async-tma-output-publication.md"
+_BLACKWELL_CLC_SKILL = _NVIDIA_TARGET_SKILLS / "blackwell-persistent-clc-scheduling.md"
+_BLACKWELL_PIPELINE_SKILL = (
+    _NVIDIA_TARGET_SKILLS / "blackwell-persistent-pipeline-efficiency.md"
+)
+_BLACKWELL_ARCHITECTURES = frozenset(
+    {"blackwell", "sm100", "sm_100", "b200", "b200a", "gb200", "gb300"}
+)
+
 
 TLX_PROMPT_PREAMBLE = """You are optimizing one Triton or TLX kernel against an external deterministic harness.
 The candidate is a complete replacement source file. Preserve every public entry point,
@@ -263,6 +277,57 @@ class CodexCandidateProvider:
         )
 
 
+@lru_cache(maxsize=None)
+def _read_target_skill(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as error:
+        raise RuntimeError(f"unable to read built-in target skill {path}: {error}") from error
+
+
+def _target_skill_paths(target: KernelTarget) -> tuple[Path, ...]:
+    skills = [_LAYOUT_CONVERSION_SKILL]
+    backend = target.backend.strip().lower()
+    if backend not in {"cuda", "nvidia"}:
+        return tuple(skills)
+    architecture = target.architecture.strip().lower()
+    skills.append(_ASYNC_TMA_OUTPUT_SKILL)
+    if architecture in _BLACKWELL_ARCHITECTURES:
+        skills.extend((_BLACKWELL_CLC_SKILL, _BLACKWELL_PIPELINE_SKILL))
+    return tuple(skills)
+
+
+def _target_skill_guidance(target: KernelTarget) -> str:
+    return "\n\n".join(_read_target_skill(path) for path in _target_skill_paths(target))
+
+
+def _prior_run_prompt_block(request: KernelOptimizationRequest) -> str:
+    prior = request.prior_run_evidence
+    if prior is None or not prior.experiments:
+        return ""
+    lines = []
+    for experiment in prior.experiments:
+        speedup = (
+            f"{experiment.aggregate_speedup:.4f}x"
+            if experiment.aggregate_speedup is not None
+            else "unavailable"
+        )
+        lines.append(
+            f"- {experiment.experiment_id}: status={experiment.status}, "
+            f"speedup={speedup}, hypothesis={json.dumps(experiment.hypothesis)}, "
+            f"change={json.dumps(experiment.change)}, "
+            f"diagnostics={json.dumps(experiment.diagnostics)}"
+        )
+    evidence = "\n".join(lines)
+    return (
+        "\nPrior run evidence, read-only:\n"
+        "Do not automatically adopt a prior winner. Do not repeat exact prior "
+        "candidates or semantically equivalent rejected changes; use these "
+        "results only to choose a new evidence-backed hypothesis.\n"
+        f"{evidence[:8000]}\n"
+    )
+
+
 def _build_prompt(
     request: KernelOptimizationRequest,
     context: CandidateContext,
@@ -283,13 +348,20 @@ def _build_prompt(
     reference_block = ""
     if getattr(request, "reference_kernel_source", None):
         reference_block = f"\nReference kernel (oracle, do not copy verbatim — use for correctness/performance comparison):\n```python\n{request.reference_kernel_source[:4000]}\n```\n"
+    target_skills = _target_skill_guidance(request.target)
+    target_skills_block = (
+        f"\nTrusted built-in target optimization skills:\n{target_skills}\n"
+        if target_skills
+        else ""
+    )
     guidance = request.target.optimization_guidance.strip()
     guidance_block = (
         f"\nFrozen target-specific optimization guidance:\n{guidance}\n"
         if guidance
         else ""
     )
-    return f"""{TLX_PROMPT_PREAMBLE}{guidance_block}{reference_block}
+    prior_run_block = _prior_run_prompt_block(request)
+    return f"""{TLX_PROMPT_PREAMBLE}{target_skills_block}{guidance_block}{reference_block}{prior_run_block}
 You are proposing one candidate for the closed loop `build -> verify -> benchmark -> profile -> propose -> repeat`.
 Edit `candidate.py` directly. Do not return source or a diff, and do not claim correctness
 or performance; an external deterministic harness reads the file and decides both.

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/common/layout-conversion-efficiency.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/common/layout-conversion-efficiency.md
@@ -1,0 +1,79 @@
+# TLX Layout Conversion Efficiency
+
+Apply this guidance to Triton and TLX kernels on every target. Layout changes can be free metadata rewrites, register permutations, lane shuffles, or shared-memory round trips. Optimize only conversions whose material cost is demonstrated in the compiled pipeline.
+
+## Inspect The Final Layout Flow
+
+Do not infer cost from source-level `require_layout`, `release_layout`, transpose, reshape, or conversion counts. Compare early TTGIR with TTGIR after layout propagation and the final remove-layout-conversions pass. A conversion that disappears before lowering is not a runtime cost.
+
+For each conversion that survives final TTGIR, record its shape, source and destination encodings, execution frequency, and producer-consumer path. Classify the expected lowering:
+
+- equivalent layouts or metadata-only views: no physical movement;
+- within-thread register reorder: usually low cost;
+- cross-lane permutation or shuffle: potentially material;
+- cross-warp, cross-block, or shared-memory redistribution: high priority because it may require stores, synchronization, and reloads.
+
+Confirm the classification in lowered IR or generated code when possible. Do not estimate shared-memory capacity or prune configurations for scratch that the final compiler pipeline does not allocate.
+
+## Trace Layout Anchors
+
+Find why both sides require different layouts before changing either side. Common anchors include:
+
+- global or descriptor loads and stores with coalescing or TMA geometry requirements;
+- `local_load`, `local_store`, and explicitly laid-out local allocations;
+- dot operands, accumulators, reductions, and epilogues;
+- TMEM loads, stores, and subslices;
+- warp-specialization captures and region-carried values;
+- user-pinned `require_layout` boundaries.
+
+Trace through elementwise operations, casts, broadcast, expand-dims, reshape, transpose, join, split, and loop-carried values. Prefer changing a flexible chain over forcing a fixed hardware-facing anchor into an incompatible layout.
+
+## Choose Layouts At The Data Boundary
+
+When a consumer needs a transposed or specialized layout, prefer expressing it at the memory-descriptor or load boundary rather than materializing data and converting it later. Consider:
+
+- a metadata-only local transpose or reshape before `local_load`;
+- a consumer-compatible register layout on `local_load` when the API and target support it;
+- a shared-memory layout compatible with both the producer access and the dominant consumer;
+- preserving a native dot-accumulator layout until narrowing or epilogue storage;
+- relocating casts or elementwise work so they do not block packed conversion or layout propagation.
+
+Keep layout selection aligned with vectorization, bank-conflict avoidance, descriptor legality, and tensor-core operand requirements. A conversion-free path that introduces uncoalesced traffic, bank conflicts, extra registers, or spills is not an improvement.
+
+## Use Layout Constraints Deliberately
+
+Treat layout constraints according to their semantics:
+
+- use an unpinned requirement only when the layout is a preference the compiler may propagate or reconcile;
+- use `release_layout` when downstream consumers should regain layout freedom;
+- use a pinned requirement only for a proven correctness or performance boundary;
+- never remove or bypass a pinned layout merely to reduce the visible conversion count.
+
+Over-pinning can prevent propagation and create conversions on both sides of a boundary. Under-constraining can let an epilogue or store layout propagate backward into a hot accumulator or producer. Compare both directions and place the boundary where it minimizes total material movement.
+
+## Preserve Memory And Task Contracts
+
+Layout changes can alter thread ownership, vector width, local-memory addressing, and the point where data becomes visible. Before changing a layout across asynchronous or warp-specialized code, prove that:
+
+- every producer and consumer agrees on tile shape and element ownership;
+- descriptor and TMA block geometry remains legal;
+- shared-memory and TMEM aliases retain their intended physical footprint;
+- barriers, fences, arrival counts, and phase reuse still protect the same bytes;
+- region-carried and cross-task values retain compatible layouts;
+- boundary tiles and fallback paths remain valid.
+
+Do not replace a physical transpose with a metadata-only view unless the resulting memory encoding and consumer interpretation are equivalent.
+
+## Validate Material Savings
+
+For every proposed layout change, retain evidence from before and after:
+
+- final surviving conversion count and lowering category;
+- allocated shared-memory or LDS scratch;
+- register count, spills, occupancy, and code size;
+- shared-memory or LDS transactions, bank conflicts, barriers, and dependency stalls;
+- generated shuffle, load/store, and conversion instructions;
+- correctness across shapes, dtypes, boundary cases, topology variants, and repeated launches;
+- stable end-to-end benchmark latency.
+
+Use conversion removal as a hypothesis, not the promotion criterion. Accept the change only when the intended physical movement or resource cost decreases and protected end-to-end performance improves without weakening numerical or synchronization contracts.

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/async-tma-output-publication.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/async-tma-output-publication.md
@@ -1,0 +1,31 @@
+# NVIDIA Async TMA Output Publication
+
+Use this guidance only for NVIDIA kernels that publish output through asynchronous descriptor stores. Consult `.claude/skills/tlx-api-reference/SKILL.md` for TLX APIs and `.claude/skills/proxy-fence-insertion/SKILL.md` for proxy-fence correctness.
+
+## Look For Serialized Publication
+
+Inspect output paths for independent `tlx.async_descriptor_store` operations that are immediately followed by `tlx.async_descriptor_store_wait(0)`. When output tiles and buffers are independent, consider issuing multiple stores before waiting so publication can overlap.
+
+Use the wait argument as an in-flight-store contract, not as a generic synchronization hint. Before releasing or reusing each local output buffer, prove that the store reading that buffer has completed.
+
+## Preserve Visibility And Lifetime
+
+Prove the complete chain:
+
+1. the producing task finishes writing the local output tile;
+2. required async-proxy visibility is established;
+3. the descriptor store is issued with valid coordinates and shape;
+4. completion is observed before the local buffer is overwritten;
+5. producer/consumer barriers are signaled in the correct phase.
+
+Do not remove `tlx.fence("async_shared")` merely because a nearby kernel omits it. Remove a fence only when the producing operation or API contract already provides equivalent visibility, and verify that claim against the generated IR or architecture documentation.
+
+## Batch Stores Conservatively
+
+For multiple output buffers, issue independent stores first and then wait in an order consistent with the permitted outstanding-store count and buffer reuse order. Avoid converting a pipelined output path into an unbounded queue or releasing all buffers after only one store completes.
+
+For write-once output tiles, `eviction_policy="evict_first"` may reduce cache pollution. Treat it as an evidence-driven hint, not a correctness mechanism, and verify performance across protected paths.
+
+## Validate Failure-Prone Cases
+
+Test invalid/dead tiles, boundary coordinates, multiple output slices, persistent-loop reuse, and multi-CTA ownership. If publication changes synchronization or store ordering, require a producer/consumer lifetime proof and reject the candidate on any nondeterministic correctness failure.

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/blackwell-persistent-clc-scheduling.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/blackwell-persistent-clc-scheduling.md
@@ -1,0 +1,33 @@
+# Blackwell Persistent CLC Scheduling
+
+Use this guidance only for NVIDIA Blackwell kernels that use persistent scheduling or Cluster Launch Control (CLC). Consult `.claude/skills/tlx-api-reference/SKILL.md`, `docs/design/triton-clc-tile-scheduler.md`, and `third_party/tlx/language/tlx/dynamic_launch.py` for API and protocol details.
+
+## Find Runtime Scheduling Overhead
+
+Inspect persistent loops for repeated integer division, modulo, `cdiv`, section lookup, head lookup, and flattened tile-ID decoding. These operations are especially costly when repeated for every tile by every async task.
+
+When batch size, head count, group size, tile count, or launch geometry are compile-time or launch-time metadata, prefer encoding their stable structure in `tl.constexpr` values and the launch grid. Do not specialize runtime numerical parameters such as `sm_scale`.
+
+## Preserve Structured CLC Coordinates
+
+Prefer a 2D or 3D launch grid when its axes can directly represent head lanes, head chunks, sections, batches, or tile rows. When appropriate, consume CLC responses with `return_3d=True` and preserve the structured coordinates instead of flattening them and immediately decoding them with runtime div/mod.
+
+If a logical tile ID is still required, reconstruct it with compile-time strides derived from the launch grid. All warp-specialized tasks must derive the same logical work item and advance the CLC phase exactly once per consumed response.
+
+## Handle Groups And Tails Explicitly
+
+Prove the mapping for all of these cases:
+
+- `H <= GROUP_SIZE_N`;
+- full head groups where `H % GROUP_SIZE_N == 0`;
+- a tail group where `H % GROUP_SIZE_N != 0`;
+- single-CTA and multi-CTA launch modes;
+- invalid or exhausted CLC responses.
+
+Compute full-section counts, rows per section, and chunks per section at compile time where possible. Ensure the tail path cannot divide by zero or produce an out-of-range head. Preserve the kernel's original causal tile order.
+
+## Gate And Measure The Optimization
+
+Introduce a separate `tl.constexpr` or autotune flag for compact scheduling and retain the original scheduler as a fallback. Enable it only for validated combinations of stage, group size, grid geometry, CTA count, and synchronization mode.
+
+Validate the target causal path and protect dense, backward, alternate head counts, and tail-group cases from regressions. Treat fewer scheduling instructions as a hypothesis; promotion still requires stable end-to-end latency improvement with passing correctness.

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/blackwell-persistent-pipeline-efficiency.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/blackwell-persistent-pipeline-efficiency.md
@@ -1,0 +1,62 @@
+# Blackwell Persistent Pipeline Efficiency
+
+Apply this guidance to NVIDIA Blackwell kernels with persistent workers, preprocessing launches, asynchronous task pipelines, or staged output publication. Preserve the kernel's numerical and synchronization contracts; optimize data movement and scheduling without assuming a particular algorithm.
+
+## Amortize Launch And Scheduling Overhead
+
+When the logical work grid contains many small work groups, consider persistent workers that process multiple groups. Prefer native multidimensional program coordinates for direct launches and a compact task counter for persistent launches. All warp-specialized tasks must decode the same logical work item and use one shared outer-task/ring phase convention.
+
+Select the persistent grid from measured occupancy and available CTAs rather than launching one worker for every logical task. Protect small workloads where persistent scheduling or multi-CTA coordination costs more than the launch overhead it removes.
+
+## Fuse Compatible Preprocessing
+
+If a preprocessing pass already traverses an input/output domain, consider fusing other bandwidth-compatible elementwise work into that pass:
+
+- applying a normalization or scale needed by the main kernel;
+- materializing a transformed input that removes repeated work from the main loop;
+- initializing an accumulation destination required by reduce-add publication.
+
+Only fuse operations with compatible traversal and lifetime. Prove the transformed representation preserves the required rounding and numerical contract. Repeated launches and autotune warmups must initialize accumulation destinations deterministically and exactly once.
+
+## Remove Redundant Main-Kernel State
+
+When preprocessing makes a main-kernel input or transformation redundant, remove its load, shared-memory allocation, barriers, and repeated arithmetic together. Keep the original path behind a compile-time fallback until the transformed contract is validated across all protected cases.
+
+Packed native arithmetic can reduce conversions and instruction count when operand layout and dtype permit it. Use it only when its rounding behavior satisfies the protected tolerance; preserve a wider-precision fallback for unsupported dtypes or stricter numerical requirements.
+
+## Schedule By True Data Readiness
+
+Order pipeline stages by producer/consumer readiness rather than source order. Defer a load or barrier wait until immediately before first use when doing so creates useful overlap, but never move it past a dependency.
+
+TMEM and SMEM reuse require explicit lifetime proofs. Before aliasing storage:
+
+- prove every compute operation and local load completed its final read;
+- prove every asynchronous store drained before its staging slot is overwritten;
+- include reuse across persistent outer-loop iterations, not only one logical item;
+- add an explicit barrier when different warps can overwrite storage still being read.
+
+## Parameterize Publication Rings Consistently
+
+For sliced output publication, give each outstanding store a distinct staging or ring slot. Use pending-store waits only when same-slot reuse distance matches the ring depth, then drain stores before releasing aliased source storage.
+
+Represent ring depth with one compile-time contract shared by:
+
+- storage and barrier allocation;
+- slot indexing and phase calculation;
+- producer publication and consumer acquisition;
+- asynchronous store wait depth;
+- host configuration and pruning.
+
+Deeper rings may improve overlap on long workloads but regress short workloads through resource pressure. Select ring depth and persistent worker count by measured workload class, independently from numerical changes.
+
+## Keep One Authoritative Topology Policy
+
+Use one host-side selection path for descriptor geometry, CTA topology, persistence, ring depth, and fallbacks. Prune unsupported or predictably unprofitable configurations before autotuning.
+
+Gate specialized paths by the actual requirements they depend on, such as dtype, shape, alignment, storage capacity, and CTA topology. Preserve fallback routes for boundary tiles, alternate dtypes, small workloads, and configurations that cannot satisfy the optimized lifetime proof.
+
+## Validate The Pipeline
+
+Test short and long workloads, boundary shapes, supported dtypes, one-CTA and multi-CTA modes, persistent and direct launches, repeated executions, and every selected ring depth. Require finite, repeatable outputs and reference correctness before performance promotion.
+
+Use profiling to distinguish launch overhead, dependency stalls, barrier waits, local-memory traffic, spill pressure, and publication serialization. Treat lower instruction count or deeper buffering as hypotheses; promotion still requires stable end-to-end latency improvement.

--- a/third_party/tlx/tools/agents/kernel_optimization/source.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/source.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import difflib
 import hashlib
 import re
 import subprocess
@@ -110,6 +111,23 @@ def validate_replacement_source(candidate: str, current: str) -> None:
 
 def canonicalize_source(source: str) -> str:
     return source.strip() + "\n"
+
+
+def source_diff(
+    before: str,
+    after: str,
+    *,
+    fromfile: str,
+    tofile: str,
+) -> str:
+    return "".join(
+        difflib.unified_diff(
+            canonicalize_source(before).splitlines(keepends=True),
+            canonicalize_source(after).splitlines(keepends=True),
+            fromfile=fromfile,
+            tofile=tofile,
+        )
+    )
 
 
 def source_digest(source: str) -> str:

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from . import optimizer as optimizer_module
+from .artifacts import load_prior_run_evidence
 from .cli import (
     _commit_body,
     _parse_args,
@@ -17,12 +18,15 @@ from .cli import (
 )
 from .harness import StandaloneHarness, SubprocessHarness
 from .models import (
+    AutoCommitResult,
     CaseEvaluation,
     InputCase,
     KernelOptimizationRequest,
     KernelTarget,
     OptimizationBudget,
     PerformanceSummary,
+    PriorExperimentEvidence,
+    PriorRunEvidence,
     TimingSamples,
     VerificationResult,
     is_promotable,
@@ -155,6 +159,124 @@ class ScoringTest(unittest.TestCase):
         self.assertIn("Performance:", prompt)
         self.assertIn("external harness adds", prompt)
         self.assertIn("expected_effect", prompt)
+        self.assertIn("Trusted built-in target optimization skills", prompt)
+        self.assertIn("# TLX Layout Conversion Efficiency", prompt)
+        self.assertIn("# NVIDIA Async TMA Output Publication", prompt)
+        self.assertIn("# Blackwell Persistent CLC Scheduling", prompt)
+        self.assertIn("# Blackwell Persistent Pipeline Efficiency", prompt)
+        self.assertIn("optimize data movement and scheduling", prompt)
+        self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
+        self.assertLess(
+            prompt.index("# TLX Layout Conversion Efficiency"),
+            prompt.index("# NVIDIA Async TMA Output Publication"),
+        )
+        self.assertLess(
+            prompt.index("Trusted built-in target optimization skills"),
+            prompt.index("Frozen target-specific optimization guidance"),
+        )
+
+    def test_codex_prompt_selects_nvidia_non_blackwell_skill(self) -> None:
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("target", {}),),
+            target=KernelTarget("nvidia", "hopper"),
+            output_dir=Path("/tmp/tlx-agent-test"),
+        )
+        prompt = _build_prompt(
+            request,
+            CandidateContext(
+                1,
+                0,
+                request.kernel_source,
+                _performance(("target", 100.0)),
+                (),
+            ),
+        )
+        self.assertIn("# TLX Layout Conversion Efficiency", prompt)
+        self.assertIn("# NVIDIA Async TMA Output Publication", prompt)
+        self.assertLess(
+            prompt.index("# TLX Layout Conversion Efficiency"),
+            prompt.index("# NVIDIA Async TMA Output Publication"),
+        )
+        self.assertNotIn("# Blackwell Persistent CLC Scheduling", prompt)
+        self.assertNotIn("# Blackwell Persistent Pipeline Efficiency", prompt)
+        self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
+
+    def test_codex_prompt_selects_common_skill_only_for_amd(self) -> None:
+        guidance = "Preserve runtime scale behavior."
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("target", {}),),
+            target=KernelTarget(
+                "amd",
+                "gfx950",
+                optimization_guidance=guidance,
+            ),
+            output_dir=Path("/tmp/tlx-agent-test"),
+        )
+        prompt = _build_prompt(
+            request,
+            CandidateContext(
+                1,
+                0,
+                request.kernel_source,
+                _performance(("target", 100.0)),
+                (),
+            ),
+        )
+        self.assertIn(guidance, prompt)
+        self.assertIn("Trusted built-in target optimization skills", prompt)
+        self.assertIn("# TLX Layout Conversion Efficiency", prompt)
+        self.assertNotIn("# NVIDIA Async TMA Output Publication", prompt)
+        self.assertNotIn("# Blackwell Persistent CLC Scheduling", prompt)
+        self.assertNotIn("# Blackwell Persistent Pipeline Efficiency", prompt)
+        self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
+        self.assertLess(
+            prompt.index("# TLX Layout Conversion Efficiency"),
+            prompt.index("Frozen target-specific optimization guidance"),
+        )
+
+    def test_prompt_includes_prior_run_evidence_without_source(self) -> None:
+        prior_source = "SECRET_PRIOR_SOURCE = 1\n"
+        request = KernelOptimizationRequest(
+            kernel_source="VALUE = 1\n",
+            harness_path=Path(__file__),
+            cases=(InputCase("target", {}),),
+            target=KernelTarget("amd", "gfx950"),
+            output_dir=Path("/tmp/tlx-agent-test"),
+            prior_run_evidence=PriorRunEvidence(
+                run_path=Path("/tmp/prior"),
+                experiments_path=Path("/tmp/prior/experiments.json"),
+                source_hashes=(source_digest(prior_source),),
+                experiments=(
+                    PriorExperimentEvidence(
+                        experiment_id="r001-c000",
+                        status="rejected",
+                        hypothesis="wider tiles improve reuse",
+                        change="double the tile width",
+                        aggregate_speedup=0.95,
+                        diagnostics="speedup below threshold",
+                    ),
+                ),
+            ),
+        )
+        prompt = _build_prompt(
+            request,
+            CandidateContext(
+                1,
+                0,
+                request.kernel_source,
+                _performance(("target", 100.0)),
+                (),
+            ),
+        )
+        self.assertIn("Prior run evidence, read-only", prompt)
+        self.assertIn("Do not automatically adopt a prior winner", prompt)
+        self.assertIn("wider tiles improve reuse", prompt)
+        self.assertIn("speedup=0.9500x", prompt)
+        self.assertNotIn(prior_source.strip(), prompt)
 
     def test_candidate_metadata_reads_summary_and_builds_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -317,10 +439,70 @@ class ScoringTest(unittest.TestCase):
         self.assertEqual(source_digest("VALUE = 1\n"), source_digest("VALUE = 1\n  \n"))
 
 
+class PriorRunEvidenceTest(unittest.TestCase):
+    def test_loads_sources_and_sanitized_evidence_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = "VALUE = 2\nCORRECT = True\n"
+            source_path = root / "experiments" / "r001-c000" / "kernel.py"
+            source_path.parent.mkdir(parents=True)
+            source_path.write_text(source)
+            payload = [
+                {
+                    "experiment_id": "r001-c000",
+                    "status": "rejected",
+                    "source_path": "/etc/passwd",
+                    "hypothesis": "  remove   a conversion  ",
+                    "mutation_summary": "pin consumer layout",
+                    "performance": {"aggregate_speedup": 0.99},
+                    "diagnostics": "below threshold",
+                }
+            ]
+            (root / "experiments.json").write_text(json.dumps(payload))
+            before = sorted(path.relative_to(root) for path in root.rglob("*"))
+
+            prior = load_prior_run_evidence(root)
+
+            after = sorted(path.relative_to(root) for path in root.rglob("*"))
+            self.assertEqual(before, after)
+            self.assertEqual(prior.source_hashes, (source_digest(source),))
+            self.assertEqual(prior.experiments[0].hypothesis, "remove a conversion")
+            self.assertEqual(prior.experiments[0].aggregate_speedup, 0.99)
+
+    def test_rejects_unsafe_experiment_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "experiments.json").write_text(
+                json.dumps([{"experiment_id": "../escape", "status": "failed"}])
+            )
+            with self.assertRaisesRegex(ValueError, "unsafe experiment_id"):
+                load_prior_run_evidence(root)
+
+    def test_rejects_non_list_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "experiments.json"
+            path.write_text("{}")
+            with self.assertRaisesRegex(ValueError, "must contain a list"):
+                load_prior_run_evidence(path)
+
+
 class CliTest(unittest.TestCase):
     def test_commit_winner_is_enabled_by_default(self) -> None:
         args = _parse_args(["--kernel", "kernel.py", "--output-dir", "/tmp/out"])
         self.assertTrue(args.commit_winner)
+
+    def test_prior_run_arg_parses(self) -> None:
+        args = _parse_args(
+            [
+                "--kernel",
+                "kernel.py",
+                "--output-dir",
+                "/tmp/out",
+                "--prior-run",
+                "/tmp/prior",
+            ]
+        )
+        self.assertEqual(args.prior_run, Path("/tmp/prior"))
 
     def test_commit_winner_can_be_disabled(self) -> None:
         args = _parse_args(
@@ -628,6 +810,145 @@ class CommitBodyTest(unittest.TestCase):
 
 
 class KernelOptimizerTest(unittest.TestCase):
+    def test_prior_source_is_rejected_without_adopting_prior_winner(self) -> None:
+        baseline_source = "LATENCY_US = 100\nCORRECT = True\n"
+        prior_source = "LATENCY_US = 80\nCORRECT = True\n"
+        provider = FixedCandidateProvider([CandidateProposal(prior_source, "duplicate")])
+        prior = PriorRunEvidence(
+            run_path=Path("/tmp/prior"),
+            experiments_path=Path("/tmp/prior/experiments.json"),
+            source_hashes=(source_digest(prior_source),),
+            experiments=(
+                PriorExperimentEvidence(
+                    experiment_id="r001-c000",
+                    status="promoted",
+                    change="prior winner",
+                    aggregate_speedup=1.25,
+                ),
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source=baseline_source,
+                    harness_path=Path(__file__).with_name("testdata")
+                    / "fake_harness.py",
+                    cases=(InputCase("a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(directory),
+                    prior_run_evidence=prior,
+                )
+            )
+            experiment = result.experiments[-1]
+            cached_source = experiment.source_path.read_text()
+            incremental_patch_exists = experiment.incremental_patch_path.is_file()
+            cumulative_patch_exists = experiment.cumulative_patch_path.is_file()
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.winner_experiment_id, "baseline")
+        self.assertEqual(result.best_kernel, baseline_source)
+        self.assertEqual(experiment.status, "failed")
+        self.assertIn(
+            "candidate source duplicates a prior run experiment",
+            experiment.diagnostics,
+        )
+        self.assertEqual(cached_source, prior_source)
+        self.assertTrue(incremental_patch_exists)
+        self.assertTrue(cumulative_patch_exists)
+
+    def test_candidate_patches_track_promoted_parent_and_baseline(self) -> None:
+        baseline_source = "LATENCY_US = 100\nCORRECT = True\n"
+        first_source = "LATENCY_US = 80\nCORRECT = True\n"
+        second_source = "LATENCY_US = 60\nCORRECT = True\n"
+        provider = FixedCandidateProvider(
+            [
+                CandidateProposal(first_source, "first promotion"),
+                CandidateProposal(second_source, "second promotion"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source=baseline_source,
+                    harness_path=Path(__file__).with_name("testdata")
+                    / "fake_harness.py",
+                    cases=(InputCase("a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=2,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(directory),
+                )
+            )
+
+            first, second = result.experiments[1:]
+            self.assertEqual(second.parent_id, first.experiment_id)
+            incremental = second.incremental_patch_path.read_text()
+            cumulative = second.cumulative_patch_path.read_text()
+            self.assertIn("-LATENCY_US = 80", incremental)
+            self.assertIn("+LATENCY_US = 60", incremental)
+            self.assertIn("-LATENCY_US = 100", cumulative)
+            self.assertIn("+LATENCY_US = 60", cumulative)
+
+    def test_failed_promotion_commit_does_not_advance_best(self) -> None:
+        class FailingCommitter:
+            def commit_promotion(self, experiment, source, baseline, performance):
+                del experiment, source, baseline, performance
+                return AutoCommitResult(
+                    requested=True,
+                    success=False,
+                    diagnostics="checkpoint failed",
+                )
+
+            def rollback_to_baseline(self, diagnostics):
+                raise AssertionError(f"unexpected rollback: {diagnostics}")
+
+        baseline_source = "LATENCY_US = 100\nCORRECT = True\n"
+        candidate_source = "LATENCY_US = 80\nCORRECT = True\n"
+        with tempfile.TemporaryDirectory() as directory:
+            result = KernelOptimizer(
+                FixedCandidateProvider(
+                    [CandidateProposal(candidate_source, "faster")]
+                )
+            ).optimize(
+                KernelOptimizationRequest(
+                    kernel_source=baseline_source,
+                    harness_path=Path(__file__).with_name("testdata")
+                    / "fake_harness.py",
+                    cases=(InputCase("a", {"scale": 1.0}),),
+                    target=KernelTarget("fake", "fake"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(directory),
+                ),
+                FailingCommitter(),
+            )
+            experiment = result.experiments[-1]
+            self.assertTrue(experiment.source_path.is_file())
+            self.assertTrue(experiment.incremental_patch_path.is_file())
+            self.assertTrue(experiment.cumulative_patch_path.is_file())
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.best_kernel, baseline_source)
+        self.assertEqual(result.stopping_reason, "promotion_commit_failed")
+        self.assertEqual(result.promotion_commits, ())
+        self.assertIsNone(result.rollback_commit)
+        self.assertFalse(result.auto_commit.success)
+        self.assertEqual(experiment.status, "failed")
+
     def test_reports_performance_after_each_evaluation(self) -> None:
         provider = FixedCandidateProvider(
             [
@@ -666,6 +987,13 @@ class KernelOptimizerTest(unittest.TestCase):
             output = stderr.getvalue()
             self.assertIn("[tlx-agent] baseline status=baseline", output)
             self.assertIn("median=100.000us", output)
+            self.assertIn("[tlx-agent] r001-c000 status=artifacts", output)
+            self.assertIn("incremental_patch=", output)
+            self.assertIn("cumulative_patch=", output)
+            self.assertIn("[tlx-agent] r001-c000 incremental-diff-begin", output)
+            self.assertIn("-LATENCY_US = 100", output)
+            self.assertIn("+LATENCY_US = 120", output)
+            self.assertIn("[tlx-agent] r001-c000 incremental-diff-end", output)
             self.assertIn("[tlx-agent] r001-c000 status=rejected", output)
             self.assertIn("speedup=0.8333x", output)
             self.assertIn("[tlx-agent] r001-c001 change='faster'", output)
@@ -678,6 +1006,39 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertEqual(result.winner_commit_title, "Use faster latency path")
             self.assertIn("Use the faster path.", result.winner_commit_summary)
             self.assertTrue(result.success)
+
+    def test_duplicate_candidate_patch_is_logged_before_rejection(self) -> None:
+        source = "LATENCY_US = 100\nCORRECT = True\n"
+        with tempfile.TemporaryDirectory() as directory:
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = KernelOptimizer(
+                    FixedCandidateProvider([CandidateProposal(source, "duplicate")])
+                ).optimize(
+                    KernelOptimizationRequest(
+                        kernel_source=source,
+                        harness_path=Path(__file__).with_name("testdata")
+                        / "fake_harness.py",
+                        cases=(InputCase("a", {"scale": 1.0}),),
+                        target=KernelTarget("fake", "fake"),
+                        budget=OptimizationBudget(
+                            max_rounds=1,
+                            candidates_per_round=1,
+                            min_speedup=1.01,
+                            benchmark_repetitions=2,
+                        ),
+                        output_dir=Path(directory),
+                    )
+                )
+
+            output = stderr.getvalue()
+            artifacts_at = output.index("r001-c000 status=artifacts")
+            failed_at = output.index("r001-c000 status=failed")
+            self.assertLess(artifacts_at, failed_at)
+            self.assertIn("r001-c000 incremental-diff-begin", output)
+            self.assertIn("(no source changes)", output)
+            self.assertIn("r001-c000 incremental-diff-end", output)
+            self.assertEqual(result.experiments[-1].status, "failed")
 
     def test_rejected_candidate_evidence_reaches_next_proposal(self) -> None:
         contexts: list[CandidateContext] = []

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from .profiling import (
     ProfileRequest,
     compact_profile_summary,
+    export_ncu_report_details,
     extract_ncu_duration_us,
     ncu_regression_diagnostic,
     normalize_ncu_metrics,
@@ -130,6 +133,65 @@ class ProfileParsingTest(unittest.TestCase):
         self.assertAlmostEqual(totals["non_main_kernel_us"], 3.0)
         self.assertEqual(totals["count"], 5)
 
+    def test_parse_proton_hatchet_tree_with_explicit_main_scope(self) -> None:
+        proton = [
+            {
+                "children": [
+                    {
+                        "children": [],
+                        "frame": {
+                            "name": "_attn_bwd_preprocess",
+                            "type": "function",
+                        },
+                        "metrics": {
+                            "count": 2,
+                            "device_id": "0",
+                            "device_type": "CUDA",
+                            "time (ns)": 160448,
+                        },
+                    },
+                    {
+                        "children": [],
+                        "frame": {
+                            "name": "_attn_bwd_mxf8_ws",
+                            "type": "function",
+                        },
+                        "metrics": {
+                            "count": 3,
+                            "device_id": "0",
+                            "device_type": "CUDA",
+                            "time (ns)": 9322456,
+                        },
+                    },
+                ],
+                "frame": {"name": "ROOT", "type": "function"},
+                "metrics": {"count": 0, "time (ns)": 0},
+            },
+            {"CUDA": {"0": {"arch": "100"}}},
+        ]
+
+        summary = parse_proton_launch_attribution(
+            proton, main_scope="_attn_bwd_mxf8_ws"
+        )
+
+        self.assertEqual(
+            summary["leaves"],
+            [
+                {
+                    "name": "_attn_bwd_preprocess",
+                    "time_us": 160.448,
+                    "count": 2,
+                },
+                {"name": "_attn_bwd_mxf8_ws", "time_us": 9322.456, "count": 3},
+            ],
+        )
+        totals = summary["totals"]
+        self.assertAlmostEqual(totals["leaf_time_us"], 9482.904)
+        self.assertAlmostEqual(totals["main_kernel_us"], 9322.456)
+        self.assertAlmostEqual(totals["non_main_kernel_us"], 160.448)
+        self.assertEqual(totals["wrapper_us"], 0.0)
+        self.assertEqual(totals["count"], 5)
+
     def test_parse_ncu_csv_and_metric_selection(self) -> None:
         csv_text = (
             'ID,Metric Name,Metric Unit,Metric Value\n'
@@ -159,6 +221,136 @@ class ProfileParsingTest(unittest.TestCase):
         )
         self.assertEqual(normalized["registers"]["local_load_bytes"], 4096.0)
 
+    def test_exports_and_normalizes_ncu_report_details(self) -> None:
+        details_csv = (
+            'ID,Metric Name,Metric Unit,Metric Value\n'
+            '0,gpu__time_duration.sum,ms,17.18\n'
+            '0,sm__throughput.avg.pct_of_peak_sustained_elapsed,%,39.83\n'
+            '0,dram__bytes_read.sum,Gbyte,1.52\n'
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "profile.ncu-rep"
+            report.write_bytes(b"report")
+            artifacts_dir = root / "export"
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=details_csv, stderr="warning\n"
+            )
+            with mock.patch("subprocess.run", return_value=completed) as run:
+                result = export_ncu_report_details(
+                    report,
+                    artifacts_dir=artifacts_dir,
+                    level="deep",
+                    ncu_binary="/opt/ncu",
+                )
+
+            run.assert_called_once_with(
+                [
+                    "/opt/ncu",
+                    "--import",
+                    str(report),
+                    "--page",
+                    "details",
+                    "--csv",
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=120.0,
+            )
+            self.assertTrue(result["success"])
+            self.assertEqual(result["ncu"]["summary"]["duration_us"], 17180.0)
+            self.assertEqual(
+                result["ncu"]["summary"]["sm_throughput_pct"], 39.83
+            )
+            self.assertEqual(
+                result["ncu"]["memory"]["dram_read_bytes"],
+                1_520_000_000.0,
+            )
+            artifacts = result["artifacts"]
+            self.assertTrue(all(Path(path).is_absolute() for path in artifacts.values()))
+            self.assertEqual(Path(artifacts["ncu_details_csv"]).read_text(), details_csv)
+            self.assertEqual(
+                Path(artifacts["ncu_import_stderr"]).read_text(), "warning\n"
+            )
+
+    def test_preserves_failed_ncu_report_import_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "profile.ncu-rep"
+            report.write_bytes(b"report")
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=2, stdout="status\n", stderr="bad metric\n"
+            )
+            with mock.patch("subprocess.run", return_value=completed):
+                result = export_ncu_report_details(
+                    report,
+                    artifacts_dir=root / "export",
+                )
+
+            self.assertFalse(result["success"])
+            self.assertTrue(
+                any("exit code 2" in item for item in result["diagnostics"])
+            )
+            self.assertEqual(
+                Path(result["artifacts"]["ncu_details_csv"]).read_text(),
+                "status\n",
+            )
+            self.assertEqual(
+                Path(result["artifacts"]["ncu_import_stderr"]).read_text(),
+                "bad metric\n",
+            )
+            self.assertIsNone(result["ncu"]["summary"]["duration_us"])
+
+    def test_handles_missing_and_timed_out_ncu_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            missing = root / "missing.ncu-rep"
+            with mock.patch("subprocess.run") as run:
+                result = export_ncu_report_details(
+                    missing,
+                    artifacts_dir=root / "missing-export",
+                )
+            run.assert_not_called()
+            self.assertFalse(result["success"])
+            self.assertTrue(
+                any("does not exist" in item for item in result["diagnostics"])
+            )
+
+            report = root / "profile.ncu-rep"
+            report.write_bytes(b"report")
+            timeout = subprocess.TimeoutExpired(
+                cmd=["ncu"], timeout=0.1, output=b"partial", stderr=b"timeout"
+            )
+            with mock.patch("subprocess.run", side_effect=timeout):
+                result = export_ncu_report_details(
+                    report,
+                    artifacts_dir=root / "timeout-export",
+                    timeout_s=0.1,
+                )
+            self.assertFalse(result["success"])
+            self.assertTrue(
+                any("timed out" in item for item in result["diagnostics"])
+            )
+            self.assertEqual(
+                Path(result["artifacts"]["ncu_details_csv"]).read_text(),
+                "partial",
+            )
+            self.assertEqual(
+                Path(result["artifacts"]["ncu_import_stderr"]).read_text(),
+                "timeout",
+            )
+
+    def test_rejects_relative_ncu_export_paths(self) -> None:
+        with self.assertRaisesRegex(ValueError, "report path must be absolute"):
+            export_ncu_report_details(
+                "profile.ncu-rep", artifacts_dir="/tmp/ncu-export"
+            )
+        with self.assertRaisesRegex(ValueError, "artifacts directory must be absolute"):
+            export_ncu_report_details(
+                "/tmp/profile.ncu-rep", artifacts_dir="relative"
+            )
+
     def test_parse_ncu_query_metrics_accepts_csv_and_plain_text(self) -> None:
         csv_metrics = parse_ncu_query_metrics(
             "Metric Name,Description\n"
@@ -171,6 +363,106 @@ class ProfileParsingTest(unittest.TestCase):
             "sm__throughput.avg.pct_of_peak_sustained_elapsed some description\n"
         )
         self.assertIn("gpu__time_duration.sum", text_metrics)
+
+    def test_parse_ncu_query_metrics_skips_command_preamble(self) -> None:
+        metrics = parse_ncu_query_metrics(
+            "$ /usr/local/cuda-12.8/bin/ncu --query-metrics --csv\n"
+            "\n"
+            '"Metric name","Metric type","Metric unit",'
+            '"Metric description","NVIDIA B200"\n'
+            '"gpu__time_duration","Counter","ns","Duration","1"\n'
+            '"sm__throughput","Throughput","%","SM throughput","1"\n'
+        )
+
+        self.assertEqual(metrics, {"gpu__time_duration", "sm__throughput"})
+
+    def test_selects_b200_base_and_scoped_metric_names(self) -> None:
+        supported = {
+            "gpu__time_duration",
+            "sm__throughput",
+            "TriageCompute.sm__throughput",
+            "FBSP.TriageCompute.dram__throughput",
+            "smsp__warp_issue_stalled_barrier_per_warp_active",
+            "l1tex__t_bytes_pipe_lsu_mem_local_op_ld",
+            "dram__bytes_read",
+        }
+
+        selected = select_ncu_metric_names(supported, "deep")
+
+        self.assertEqual(
+            selected["metrics"]["duration_us"], "gpu__time_duration.sum"
+        )
+        self.assertEqual(
+            selected["metrics"]["sm_throughput_pct"],
+            "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+        )
+        self.assertEqual(
+            selected["metrics"]["dram_throughput_pct"],
+            "dram__throughput.avg.pct_of_peak_sustained_elapsed",
+        )
+        self.assertEqual(
+            selected["metrics"]["barrier_pct"],
+            "smsp__warp_issue_stalled_barrier_per_warp_active.pct",
+        )
+        self.assertEqual(
+            selected["metrics"]["local_load_bytes"],
+            "l1tex__t_bytes_pipe_lsu_mem_local_op_ld.sum",
+        )
+        self.assertEqual(
+            selected["metrics"]["dram_read_bytes"], "dram__bytes_read.sum"
+        )
+        self.assertIsNone(selected["metrics"]["registers_per_thread"])
+        self.assertIsNone(selected["metrics"]["tensor_activity_pct"])
+
+    def test_normalizes_b200_base_metrics(self) -> None:
+        normalized = normalize_ncu_metrics(
+            {
+                "gpu__time_duration": {"value": 125000.0, "unit": "ns"},
+                "sm__throughput": {"value": 75.0, "unit": "%"},
+                "dram__throughput": {"value": 50.0, "unit": "%"},
+                "dram__bytes_read": {"value": 1.52, "unit": "Gbyte"},
+                "smsp__warp_issue_stalled_wait_per_warp_active": {
+                    "value": 12.5,
+                    "unit": "%",
+                },
+            },
+            "deep",
+        )
+
+        self.assertEqual(normalized["summary"]["duration_us"], 125.0)
+        self.assertEqual(normalized["summary"]["sm_throughput_pct"], 75.0)
+        self.assertEqual(normalized["summary"]["dram_throughput_pct"], 50.0)
+        self.assertEqual(
+            normalized["memory"]["dram_read_bytes"], 1_520_000_000.0
+        )
+        self.assertEqual(normalized["stalls"]["async_wait_pct"], 12.5)
+        self.assertIsNone(normalized["compute"]["tensor_activity_pct"])
+
+    def test_does_not_match_ncu_sibling_derivatives(self) -> None:
+        selected = select_ncu_metric_names(
+            {
+                "sm__throughput.avg.pct_of_peak_sustained_active",
+                "dram__bytes_read.avg",
+            },
+            "deep",
+        )
+        self.assertIsNone(selected["metrics"]["sm_throughput_pct"])
+        self.assertIsNone(selected["metrics"]["dram_read_bytes"])
+
+        normalized = normalize_ncu_metrics(
+            {
+                "gpu__time_duration.max": {"value": 250000.0, "unit": "ns"},
+                "gpu__time_duration.min": {"value": 125000.0, "unit": "ns"},
+            },
+            "summary",
+        )
+        self.assertIsNone(normalized["summary"]["duration_us"])
+        self.assertTrue(
+            any(
+                "missing NCU metric for duration_us" in diagnostic
+                for diagnostic in normalized["diagnostics"]
+            )
+        )
 
     def test_duration_extraction_and_regression_diagnostic(self) -> None:
         old_flat = {"ncu": {"gpu__time_duration.sum": {"value": 1000, "unit": "ns"}}}

--- a/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_vcs.py
@@ -6,7 +6,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from .vcs import ATTRIBUTION, AutoCommitError, commit_winner, prepare_auto_commit
+from .vcs import (
+    ATTRIBUTION,
+    AutoCommitError,
+    AutoCommitSession,
+    commit_promotion,
+    commit_rollback,
+    commit_winner,
+    prepare_auto_commit,
+)
 
 
 def _run(command: list[str], cwd: Path) -> str:
@@ -71,6 +79,82 @@ class GitAutoCommitTest(unittest.TestCase):
         self.assertIn("Fold the scale into the exponent.", message)
         self.assertEqual(message.count(ATTRIBUTION), 1)
         self.assertTrue(message.rstrip().endswith(ATTRIBUTION))
+
+    def test_sequential_promotion_commits_and_forward_rollback(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        baseline = kernel.read_text()
+        session = AutoCommitSession.create(prepare_auto_commit(kernel, baseline))
+
+        first = commit_promotion(
+            session,
+            "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n",
+            "First promotion",
+        )
+        second = commit_promotion(
+            session,
+            "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n",
+            "Second promotion",
+        )
+
+        self.assertEqual(
+            _run(["git", "rev-parse", "HEAD^"], root).strip(),
+            first.commit_revision,
+        )
+        self.assertEqual(
+            _run(["git", "rev-parse", "HEAD"], root).strip(),
+            second.commit_revision,
+        )
+        self.assertEqual(len(session.promotion_commits), 2)
+        self.assertEqual(kernel.read_text(), "A = 2\nKEEP = 1\nKEEP2 = 1\nB = 2\n")
+
+        rollback = commit_rollback(session, "Rollback promotions")
+
+        self.assertEqual(
+            _run(["git", "rev-parse", "HEAD"], root).strip(),
+            rollback.commit_revision,
+        )
+        self.assertEqual(_run(["git", "show", "HEAD:kernels/kernel.py"], root), baseline)
+        self.assertEqual(kernel.read_text(), baseline)
+        messages = _run(["git", "log", "-3", "--format=%B%x00"], root)
+        self.assertEqual(messages.count(ATTRIBUTION), 2)
+        self.assertEqual(rollback.attribution, "")
+
+    def test_sequential_promotions_preserve_dirty_target(self) -> None:
+        temporary, root, kernel = self._repo()
+        self.addCleanup(temporary.cleanup)
+        kernel.write_text("A = 2\nKEEP = 1\nKEEP2 = 1\nB = 1\n")
+        baseline = kernel.read_text()
+        session = AutoCommitSession.create(prepare_auto_commit(kernel, baseline))
+
+        commit_promotion(
+            session,
+            "A = 2\nKEEP = 1\nKEEP2 = 2\nB = 1\n",
+            "First promotion",
+            validate_committed_source=lambda source: None,
+        )
+        commit_promotion(
+            session,
+            "A = 2\nKEEP = 1\nKEEP2 = 2\nB = 2\n",
+            "Second promotion",
+            validate_committed_source=lambda source: None,
+        )
+
+        self.assertEqual(
+            _run(["git", "show", "HEAD:kernels/kernel.py"], root),
+            "A = 1\nKEEP = 1\nKEEP2 = 2\nB = 2\n",
+        )
+        self.assertEqual(
+            kernel.read_text(),
+            "A = 2\nKEEP = 1\nKEEP2 = 2\nB = 2\n",
+        )
+
+        commit_rollback(session, "Rollback promotions")
+        self.assertEqual(
+            _run(["git", "show", "HEAD:kernels/kernel.py"], root),
+            "A = 1\nKEEP = 1\nKEEP2 = 1\nB = 1\n",
+        )
+        self.assertEqual(kernel.read_text(), baseline)
 
     def test_rejects_dirty_target_without_merged_source_validation(self) -> None:
         temporary, root, kernel = self._repo()

--- a/third_party/tlx/tools/agents/kernel_optimization/vcs.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/vcs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Callable, Literal
 
@@ -29,6 +29,18 @@ class AutoCommitSnapshot:
     dirty_target_at_start: bool
     file_mode: str | None = None
     index_state: str | None = None
+
+
+@dataclass
+class AutoCommitSession:
+    initial_snapshot: AutoCommitSnapshot
+    snapshot: AutoCommitSnapshot
+    promotion_commits: list[AutoCommitResult] = field(default_factory=list)
+    rollback_commit: AutoCommitResult | None = None
+
+    @classmethod
+    def create(cls, snapshot: AutoCommitSnapshot) -> AutoCommitSession:
+        return cls(initial_snapshot=snapshot, snapshot=snapshot)
 
 
 def _run(
@@ -195,14 +207,17 @@ def merge_winner_delta(snapshot: AutoCommitSnapshot, winner_source: str) -> str:
     return completed.stdout
 
 
-def _commit_message(subject: str, body: str = "") -> str:
+def _commit_message(
+    subject: str, body: str = "", *, include_attribution: bool = True
+) -> str:
     cleaned_body = "\n".join(
         line for line in body.replace("\x00", "").splitlines() if line.strip() != ATTRIBUTION
     ).strip()
     paragraphs = [subject.rstrip()]
     if cleaned_body:
         paragraphs.append(cleaned_body)
-    paragraphs.append(ATTRIBUTION)
+    if include_attribution:
+        paragraphs.append(ATTRIBUTION)
     return "\n\n".join(paragraphs) + "\n"
 
 
@@ -234,6 +249,8 @@ def _commit_git(
     winner_source: str,
     subject: str,
     body: str = "",
+    *,
+    include_attribution: bool = True,
 ) -> str:
     assert snapshot.file_mode is not None
     root = snapshot.repo_root
@@ -264,7 +281,9 @@ def _commit_git(
     commit = _run(
         ["git", "commit-tree", tree, "-p", snapshot.base_revision],
         cwd=root,
-        input_text=_commit_message(subject, body),
+        input_text=_commit_message(
+            subject, body, include_attribution=include_attribution
+        ),
     ).stdout.strip()
     _run(
         [
@@ -303,13 +322,23 @@ def _commit_hg(
     winner_source: str,
     subject: str,
     body: str = "",
+    *,
+    include_attribution: bool = True,
 ) -> str:
     root = snapshot.repo_root
     snapshot.target_path.write_text(committed_source)
     succeeded = False
     try:
         _run(
-            ["hg", "commit", "-m", _commit_message(subject, body), snapshot.target_relpath],
+            [
+                "hg",
+                "commit",
+                "-m",
+                _commit_message(
+                    subject, body, include_attribution=include_attribution
+                ),
+                snapshot.target_relpath,
+            ],
             cwd=root,
         )
         succeeded = True
@@ -361,6 +390,119 @@ def commit_winner(
         subject=subject,
         dirty_target_at_start=snapshot.dirty_target_at_start,
     )
+
+
+def _advance_snapshot(
+    snapshot: AutoCommitSnapshot,
+    *,
+    revision: str,
+    parent_source: str,
+    baseline_source: str,
+) -> AutoCommitSnapshot:
+    index_state = snapshot.index_state
+    if snapshot.vcs == "git":
+        index_state = _run(
+            ["git", "ls-files", "-s", "--", snapshot.target_relpath],
+            cwd=snapshot.repo_root,
+        ).stdout
+    return replace(
+        snapshot,
+        base_revision=revision,
+        parent_source=parent_source,
+        baseline_source=baseline_source,
+        index_state=index_state,
+    )
+
+
+def commit_promotion(
+    session: AutoCommitSession,
+    candidate_source: str,
+    subject: str,
+    body: str = "",
+    *,
+    validate_committed_source: Callable[[str], None] | None = None,
+) -> AutoCommitResult:
+    snapshot = session.snapshot
+    result = commit_winner(
+        snapshot,
+        candidate_source,
+        subject,
+        body,
+        validate_committed_source=validate_committed_source,
+    )
+    assert result.commit_revision is not None
+    committed_source = (
+        _run(
+            ["git", "show", f"{result.commit_revision}:{snapshot.target_relpath}"],
+            cwd=snapshot.repo_root,
+        ).stdout
+        if snapshot.vcs == "git"
+        else _run(
+            ["hg", "cat", "-r", result.commit_revision, snapshot.target_relpath],
+            cwd=snapshot.repo_root,
+        ).stdout
+    )
+    session.snapshot = _advance_snapshot(
+        snapshot,
+        revision=result.commit_revision,
+        parent_source=committed_source,
+        baseline_source=candidate_source,
+    )
+    session.promotion_commits.append(result)
+    return result
+
+
+def commit_rollback(
+    session: AutoCommitSession,
+    subject: str,
+    body: str = "",
+) -> AutoCommitResult:
+    if not session.promotion_commits:
+        raise AutoCommitError("no promotion commit is available to roll back")
+    current = session.snapshot
+    initial = session.initial_snapshot
+    rollback_source = initial.baseline_source
+    committed_source = initial.parent_source
+    _verify_snapshot(current)
+    if current.vcs == "git":
+        revision = _commit_git(
+            current,
+            committed_source,
+            rollback_source,
+            subject,
+            body,
+            include_attribution=False,
+        )
+    else:
+        revision = _commit_hg(
+            current,
+            committed_source,
+            rollback_source,
+            subject,
+            body,
+            include_attribution=False,
+        )
+    result = AutoCommitResult(
+        requested=True,
+        success=True,
+        vcs=current.vcs,
+        repo_root=current.repo_root,
+        target_path=current.target_path,
+        target_relpath=current.target_relpath,
+        base_revision=current.base_revision,
+        commit_revision=revision,
+        subject=subject,
+        attribution="",
+        dirty_target_at_start=initial.dirty_target_at_start,
+    )
+    session.snapshot = _advance_snapshot(
+        current,
+        revision=revision,
+        parent_source=committed_source,
+        baseline_source=rollback_source,
+    )
+    session.rollback_commit = result
+    return result
 
 
 def failed_auto_commit(


### PR DESCRIPTION
Review the candidate-generation changes first. Add backend-selected optimization guidance for NVIDIA async TMA publication, Blackwell persistent CLC and producer-consumer pipelines, plus a backend-neutral layout-conversion workflow. Keep profiler instructions outside candidate source prompts. Add --prior-run as a bounded, read-only evidence source: validate experiment paths, recompute canonical source hashes, use every imported hash for exact deduplication, and include at most 12 sanitized outcomes in the prompt without adopting an earlier winner.

Next, review candidate persistence and promotion handling. Cache kernel.py, incremental.patch, and cumulative.patch immediately after the provider returns source, before deduplication, compilation, correctness, benchmarking, or profiling. Preserve artifacts for duplicate, failed, rejected, and promoted candidates and emit every incremental change to live.log. When --commit-winner is enabled, checkpoint each candidate that passes the confirmation gate immediately, advance the trusted Git/Hg snapshot for subsequent rounds, preserve pre-existing index and worktree state, and create a separate forward rollback commit if final revalidation fails.

Finally, review the profiling path. Parse real Proton Hatchet trees through frame.name, nested metrics including time (ns), nested launch counts, and an explicit main_scope so the target kernel is separated from preprocessing launches. Resolve B200 NCU base metric families to supported derived collection metrics without accepting incompatible sibling derivatives, canonicalize scoped names, and normalize durations and byte units. Export .ncu-rep files with ncu --import --page details --csv, retain commands, reports, CSV, and stderr as absolute-path artifacts, and feed normalized throughput, occupancy, stall, cache, and traffic evidence back to the optimizer. Document these requirements in the frozen CUDA harness contract.

Test Plan:
python -m pytest -q third_party/tlx/tools/agents/kernel_optimization 88 passed

Validated the frozen MXFP8 attention-backward harness on NVIDIA B200. Proton attributed 9293.497 us to _attn_bwd_mxf8_ws and 159.745 us to non-main kernels. NCU reported 17180 us duration, 39.83% SM throughput, 1.93% DRAM throughput, 25% achieved occupancy, 37.99% long-scoreboard stalls, 18.48% barrier stalls, and absolute .ncu-rep/details.csv artifacts.