### PR TITLE
[triton][3.8] Skip GitHub CI for release branch PRs

### DIFF
--- a/.github/workflows/b200.yml
+++ b/.github/workflows/b200.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+    branches-ignore:
+      - release/3.8.x
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: Integration Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore: ['llvm-**']
+    branches-ignore:
+      - 'llvm-**'
+      - release/3.8.x
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/compiler.yml
+++ b/.github/workflows/compiler.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches-ignore: ['llvm-**']
+    branches-ignore:
+      - 'llvm-**'
+      - release/3.8.x
   merge_group:
     branches: [main, 'dev-**']
     types: [checks_requested]

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -13,6 +13,8 @@ on:
   release:
     types: [published]
   pull_request:
+    branches-ignore:
+      - release/3.8.x
     paths: [.github/workflows/create_release.yml]
 
 jobs:

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+    branches-ignore:
+      - release/3.8.x
   schedule:
     # Every 6 hours at :30 past (00:30, 06:30, 12:30, 18:30 UTC).
     - cron: '30 */6 * * *'

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - cmake/llvm-build-info.json
   pull_request:
+    branches-ignore:
+      - release/3.8.x
     paths:
       - .github/workflows/llvm-build.yml
       - cmake/llvm-build-info.json

--- a/.github/workflows/mi350.yml
+++ b/.github/workflows/mi350.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+    branches-ignore:
+      - release/3.8.x
   schedule:
     # Every 6 hours at the top of the hour (00:00, 06:00, 12:00, 18:00 UTC).
     - cron: '0 */6 * * *'

--- a/.github/workflows/torchtlx.yml
+++ b/.github/workflows/torchtlx.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+    branches-ignore:
+      - release/3.8.x
   schedule:
     # Every 6 hours at :15 past (00:15, 06:15, 12:15, 18:15 UTC).
     - cron: '15 */6 * * *'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,8 @@ name: Wheels
 on:
   workflow_dispatch:
   pull_request:
+    branches-ignore:
+      - release/3.8.x
     paths:
       - .github/workflows/wheels.yml
   schedule:

--- a/.github/workflows/wheels_fb.yml
+++ b/.github/workflows/wheels_fb.yml
@@ -24,6 +24,8 @@ on:
       pythons:  { type: string, required: false, default: '["cp310","cp311","cp312","cp313","cp314"]' }
       arches:   { type: string, required: false, default: '["x86_64","aarch64"]' }
   pull_request:
+    branches-ignore:
+      - release/3.8.x
     paths:
       - .github/workflows/wheels_fb.yml
 


### PR DESCRIPTION
Summary: Exclude pull requests targeting release/3.8.x from all directly triggered GitHub Actions workflows in the Triton 3.8 checkout. Preserve main-branch, scheduled, and manual workflow execution.

Reviewed By: njriasan

Differential Revision: D118675946


