### PR TITLE
[autoWS] Schedule mixed-consumer TMA publication before reuse

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -212,6 +212,45 @@ bool hasLatenciesAssigned(scf::ForOp forOp,
   return false;
 }
 
+// A descriptor value shared by an MMA path and an ordinary register path is
+// materialized as a multi-consumer TMA buffer by Meta WS. With three or more
+// software-pipeline stages, a later single-buffer TMA acquire can be hoisted
+// ahead of the forwarding copy that publishes the current value to MMA,
+// forming a producer/consumer cycle. Keep this narrow pattern at two stages
+// until the pipeline scheduler models that cross-task dependency directly.
+static bool hasMixedDescriptorLoadConsumers(scf::ForOp forOp) {
+  auto isForwardingOp = [](Operation *op) {
+    return isa<ttg::LocalAllocOp, ttg::LocalLoadOp, ttg::MemDescTransOp,
+               ttg::MemDescReshapeOp, ttg::MemDescSubsliceOp,
+               ttg::ConvertLayoutOp, tt::TransOp, tt::ReshapeOp>(op);
+  };
+
+  for (auto load : forOp.getOps<tt::DescriptorLoadOp>()) {
+    bool hasDotConsumer = false;
+    bool hasNonDotConsumer = false;
+    SmallVector<Operation *> worklist(load->getUsers());
+    DenseSet<Operation *> visited;
+    while (!worklist.empty() && !(hasDotConsumer && hasNonDotConsumer)) {
+      Operation *consumer = worklist.pop_back_val();
+      if (!visited.insert(consumer).second)
+        continue;
+      if (isa<tt::DotOpInterface>(consumer)) {
+        hasDotConsumer = true;
+        continue;
+      }
+      if (isForwardingOp(consumer)) {
+        for (Value result : consumer->getResults())
+          llvm::append_range(worklist, result.getUsers());
+        continue;
+      }
+      hasNonDotConsumer = true;
+    }
+    if (hasDotConsumer && hasNonDotConsumer)
+      return true;
+  }
+  return false;
+}
+
 // Determine the chain of dots in the given set of users for a dot.
 std::tuple<SmallVector<ttng::MMAv5OpInterface>, bool>
 computeDotChain(ttng::MMAv5OpInterface dotOp,
@@ -396,6 +435,8 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
 
   // Schedule parallel dot pattern.
   int maxStages = getNumStagesOrDefault(forOp, defaultNumStages);
+  if (maxStages > 2 && hasMixedDescriptorLoadConsumers(forOp))
+    maxStages = 2;
   int maxPossibleDistance = maxStages - 1 + minDistance;
   // Compute the longest path to the yield for each operation reachable
   // from any latency operation. We also use this to embed stage information

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/ScheduleLoops.cpp
@@ -212,45 +212,6 @@ bool hasLatenciesAssigned(scf::ForOp forOp,
   return false;
 }
 
-// A descriptor value shared by an MMA path and an ordinary register path is
-// materialized as a multi-consumer TMA buffer by Meta WS. With three or more
-// software-pipeline stages, a later single-buffer TMA acquire can be hoisted
-// ahead of the forwarding copy that publishes the current value to MMA,
-// forming a producer/consumer cycle. Keep this narrow pattern at two stages
-// until the pipeline scheduler models that cross-task dependency directly.
-static bool hasMixedDescriptorLoadConsumers(scf::ForOp forOp) {
-  auto isForwardingOp = [](Operation *op) {
-    return isa<ttg::LocalAllocOp, ttg::LocalLoadOp, ttg::MemDescTransOp,
-               ttg::MemDescReshapeOp, ttg::MemDescSubsliceOp,
-               ttg::ConvertLayoutOp, tt::TransOp, tt::ReshapeOp>(op);
-  };
-
-  for (auto load : forOp.getOps<tt::DescriptorLoadOp>()) {
-    bool hasDotConsumer = false;
-    bool hasNonDotConsumer = false;
-    SmallVector<Operation *> worklist(load->getUsers());
-    DenseSet<Operation *> visited;
-    while (!worklist.empty() && !(hasDotConsumer && hasNonDotConsumer)) {
-      Operation *consumer = worklist.pop_back_val();
-      if (!visited.insert(consumer).second)
-        continue;
-      if (isa<tt::DotOpInterface>(consumer)) {
-        hasDotConsumer = true;
-        continue;
-      }
-      if (isForwardingOp(consumer)) {
-        for (Value result : consumer->getResults())
-          llvm::append_range(worklist, result.getUsers());
-        continue;
-      }
-      hasNonDotConsumer = true;
-    }
-    if (hasDotConsumer && hasNonDotConsumer)
-      return true;
-  }
-  return false;
-}
-
 // Determine the chain of dots in the given set of users for a dot.
 std::tuple<SmallVector<ttng::MMAv5OpInterface>, bool>
 computeDotChain(ttng::MMAv5OpInterface dotOp,
@@ -435,8 +396,6 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
 
   // Schedule parallel dot pattern.
   int maxStages = getNumStagesOrDefault(forOp, defaultNumStages);
-  if (maxStages > 2 && hasMixedDescriptorLoadConsumers(forOp))
-    maxStages = 2;
   int maxPossibleDistance = maxStages - 1 + minDistance;
   // Compute the longest path to the yield for each operation reachable
   // from any latency operation. We also use this to embed stage information
@@ -572,6 +531,59 @@ CoarseSchedule scheduleKeyOpsMetaWS(scf::ForOp forOp,
     auto [d, _] = computeDistance(latOp);
     if (d > maxDistance)
       maxDistance = d;
+  }
+
+  // A descriptor result can be consumed both as registers and through a
+  // local_alloc feeding MMA.  AutoWS lowers that shape through a staging
+  // buffer and materializes the MMA allocation with a forwarding copy on the
+  // load partition.  Keep that publication in the stage immediately after
+  // the descriptor load.  Otherwise the forwarding copy can inherit the last
+  // compute stage; the next iteration's single-buffer producer acquire may
+  // then block the same load partition before it publishes the current MMA
+  // operand, forming a cycle with MMA.
+  //
+  // MMA-only descriptor loads are fused directly into their allocation and
+  // need no adjustment.
+  for (auto load : forOp.getOps<tt::DescriptorLoadOp>()) {
+    SmallVector<ttg::LocalAllocOp> mmaAllocs;
+    bool hasRegisterConsumer = false;
+    for (Operation *user : load->getUsers()) {
+      auto alloc = dyn_cast<ttg::LocalAllocOp>(user);
+      if (!alloc) {
+        hasRegisterConsumer = true;
+        continue;
+      }
+      SmallVector<Operation *> worklist(alloc->getUsers());
+      DenseSet<Operation *> visited;
+      bool feedsMma = false;
+      while (!worklist.empty() && !feedsMma) {
+        Operation *consumer = worklist.pop_back_val();
+        if (!visited.insert(consumer).second)
+          continue;
+        if (isa<tt::DotOpInterface>(consumer)) {
+          feedsMma = true;
+          break;
+        }
+        if (!consumer->hasTrait<OpTrait::MemDescViewTrait>())
+          continue;
+        for (Value result : consumer->getResults())
+          llvm::append_range(worklist, result.getUsers());
+      }
+      if (feedsMma)
+        mmaAllocs.push_back(alloc);
+    }
+    if (!hasRegisterConsumer || mmaAllocs.empty())
+      continue;
+
+    auto loadIt = distance.find(load);
+    if (loadIt == distance.end() || loadIt->second <= 0)
+      continue;
+    int publicationDistance = loadIt->second - 1;
+    for (ttg::LocalAllocOp alloc : mmaAllocs) {
+      auto allocIt = distance.find(alloc);
+      if (allocIt != distance.end())
+        allocIt->second = std::max(allocIt->second, publicationDistance);
+    }
   }
 
   // Assign stage to each op reachable from a latency op

--- a/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_schedule.mlir
+++ b/test/Hopper/WarpSpecialization/ws_lower_mem_tma_multi_consumer_schedule.mlir
@@ -1,0 +1,25 @@
+// RUN: triton-opt %s --nvgpu-test-ws-buffer-allocation | FileCheck %s
+
+// A descriptor load with consumers in different software-pipeline stages is
+// lowered through one shared local_load.  Give that load the earliest
+// consumer's schedule so a forwarding consumer can publish the value before a
+// later producer acquire blocks the load task.
+
+// CHECK-LABEL: @tma_multi_consumer_schedule
+// CHECK: nvws.descriptor_load
+// CHECK: ttg.local_load {{.*}}loop.cluster = 1 : i32, loop.stage = 1 : i32
+// CHECK: arith.addf {{.*}}loop.cluster = 1 : i32, loop.stage = 1 : i32
+// CHECK: arith.subf {{.*}}loop.cluster = 0 : i32, loop.stage = 2 : i32
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @tma_multi_consumer_schedule(%desc: !tt.tensordesc<128x64xf16, #shared>) attributes {noinline = false} {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1, 2>} 0 : i32
+    %tile = tt.descriptor_load %desc[%c0, %c0] {async_task_id = array<i32: 0>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+    %early = arith.addf %tile, %tile {async_task_id = array<i32: 1>, loop.cluster = 1 : i32, loop.stage = 1 : i32} : tensor<128x64xf16, #blocked>
+    %late = arith.subf %tile, %tile {async_task_id = array<i32: 2>, loop.cluster = 0 : i32, loop.stage = 2 : i32} : tensor<128x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/TritonGPU/metaws-loop-schedule-mixed-descriptor-consumers.mlir
+++ b/test/TritonGPU/metaws-loop-schedule-mixed-descriptor-consumers.mlir
@@ -1,0 +1,64 @@
+// RUN: triton-opt %s -split-input-file -allow-unregistered-dialect "-tritongpu-schedule-loops=num-stages=3 use-meta-ws=true" | FileCheck %s
+
+// A descriptor load whose buffer feeds both MMA and scalar work is limited to
+// two software-pipeline stages.  This prevents the next TMA acquire from being
+// scheduled before the forwarding copy for the current MMA operand.
+
+// CHECK-LABEL: @mixed_descriptor_consumers
+// CHECK: tt.descriptor_load {{.*}}loop.stage = 0 : i32
+// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 0 : i32
+// CHECK: tt.scheduled_max_stage = 1 : i32
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mixed_descriptor_consumers(%desc: !tt.tensordesc<128x64xf16, #shared>, %b: !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %acc_tok: !ttg.async.token, %out: !tt.ptr<f16>, %lb: i32, %ub: i32, %step: i32) {
+    %c0 = arith.constant 0 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    %ptrs = tt.splat %out : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked>
+    scf.for %iv = %lb to %ub step %step iter_args(%tok = %acc_tok) -> (!ttg.async.token) : i32 {
+      %tile = tt.descriptor_load %desc[%c0, %c0] {tt.latency = 2 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      %a = ttg.local_alloc %tile : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %mma_tok = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {tt.latency = 2 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %loaded = ttg.local_load %a : !ttg.memdesc<128x64xf16, #shared, #smem> -> tensor<128x64xf16, #blocked>
+      tt.store %ptrs, %loaded : tensor<128x64x!tt.ptr<f16>, #blocked>
+      scf.yield %mma_tok : !ttg.async.token
+    } {tt.warp_specialize}
+    tt.return
+  }
+}
+
+// -----
+
+// An ordinary descriptor-to-MMA path still uses all three requested stages.
+
+// CHECK-LABEL: @mma_only_descriptor_consumer
+// CHECK: tt.descriptor_load {{.*}}loop.stage = 0 : i32
+// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 2 : i32
+// CHECK: tt.scheduled_max_stage = 2 : i32
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_t = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mma_only_descriptor_consumer(%desc: !tt.tensordesc<128x64xf16, #shared>, %b: !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, %acc: !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, %acc_tok: !ttg.async.token, %lb: i32, %ub: i32, %step: i32) {
+    %c0 = arith.constant 0 : i32
+    %false = arith.constant false
+    %true = arith.constant true
+    scf.for %iv = %lb to %ub step %step iter_args(%tok = %acc_tok) -> (!ttg.async.token) : i32 {
+      %tile = tt.descriptor_load %desc[%c0, %c0] {tt.latency = 2 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
+      %a = ttg.local_alloc %tile : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
+      %mma_tok = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {tt.latency = 2 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      scf.yield %mma_tok : !ttg.async.token
+    } {tt.warp_specialize}
+    tt.return
+  }
+}

--- a/test/TritonGPU/metaws-loop-schedule-mixed-descriptor-consumers.mlir
+++ b/test/TritonGPU/metaws-loop-schedule-mixed-descriptor-consumers.mlir
@@ -1,13 +1,17 @@
 // RUN: triton-opt %s -split-input-file -allow-unregistered-dialect "-tritongpu-schedule-loops=num-stages=3 use-meta-ws=true" | FileCheck %s
 
-// A descriptor load whose buffer feeds both MMA and scalar work is limited to
-// two software-pipeline stages.  This prevents the next TMA acquire from being
-// scheduled before the forwarding copy for the current MMA operand.
+// A descriptor load used both as registers and through an MMA allocation needs
+// the MMA publication one stage after the TMA load.  AutoWS later materializes
+// that allocation as a forwarding copy on the load partition.  Keeping it in
+// stage 1 publishes A0 before the next single-buffer producer acquire can wait
+// for MMA, without reducing the requested three-stage pipeline.
 
 // CHECK-LABEL: @mixed_descriptor_consumers
 // CHECK: tt.descriptor_load {{.*}}loop.stage = 0 : i32
-// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 0 : i32
-// CHECK: tt.scheduled_max_stage = 1 : i32
+// CHECK: ttg.local_alloc {{.*}}loop.stage = 1 : i32
+// CHECK: ttng.tc_gen5_mma {{.*}}loop.stage = 2 : i32
+// CHECK: arith.extf {{.*}}loop.stage = 2 : i32
+// CHECK: tt.scheduled_max_stage = 2 : i32
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
@@ -24,9 +28,10 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     scf.for %iv = %lb to %ub step %step iter_args(%tok = %acc_tok) -> (!ttg.async.token) : i32 {
       %tile = tt.descriptor_load %desc[%c0, %c0] {tt.latency = 2 : i32} : !tt.tensordesc<128x64xf16, #shared> -> tensor<128x64xf16, #blocked>
       %a = ttg.local_alloc %tile : (tensor<128x64xf16, #blocked>) -> !ttg.memdesc<128x64xf16, #shared, #smem>
-      %mma_tok = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {tt.latency = 2 : i32, tt.self_latency = 1 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-      %loaded = ttg.local_load %a : !ttg.memdesc<128x64xf16, #shared, #smem> -> tensor<128x64xf16, #blocked>
-      tt.store %ptrs, %loaded : tensor<128x64x!tt.ptr<f16>, #blocked>
+      %mma_tok = ttng.tc_gen5_mma %a, %b, %acc[%tok], %false, %true {tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared_t, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+      %extended = arith.extf %tile : tensor<128x64xf16, #blocked> to tensor<128x64xf32, #blocked>
+      %truncated = arith.truncf %extended : tensor<128x64xf32, #blocked> to tensor<128x64xf16, #blocked>
+      tt.store %ptrs, %truncated : tensor<128x64x!tt.ptr<f16>, #blocked>
       scf.yield %mma_tok : !ttg.async.token
     } {tt.warp_specialize}
     tt.return

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -227,7 +227,25 @@ LogicalResult doConvertDescriptorLoadsToNVWS(triton::FuncOp funcOp) {
       // original tt.descriptor_load path kept unified (SMEM/TMEM overflow in FA
       // backward).
       builder.setAsyncTaskIdsFromValueUsers(load.getResult());
-      builder.setLoopScheduleInfoFromOp(*load->getUsers().begin());
+      // A register-consumed descriptor load can feed consumers in different
+      // software-pipeline stages.  The shared local_load must be available to
+      // the earliest one; selecting an arbitrary use can delay a forwarding
+      // copy until the final compute stage and deadlock the load partition on
+      // a later single-buffer producer acquire.
+      Operation *earliestUser = nullptr;
+      auto scheduleKey = [](Operation *op) {
+        auto stage = op->getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName);
+        auto cluster =
+            op->getAttrOfType<IntegerAttr>(tt::kLoopClusterAttrName);
+        return std::make_pair(stage ? stage.getInt() : INT_MAX,
+                              cluster ? cluster.getInt() : INT_MAX);
+      };
+      for (Operation *user : load->getUsers()) {
+        if (!earliestUser || scheduleKey(user) < scheduleKey(earliestUser))
+          earliestUser = user;
+      }
+      assert(earliestUser && "live descriptor load must have a consumer");
+      builder.setLoopScheduleInfoFromOp(earliestUser);
       auto localLoad = builder.createWithAsyncTaskIds<ttg::LocalLoadOp>(
           load.getLoc(), load.getType(), buffer);
       load.replaceAllUsesWith(localLoad.getResult());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3458
* __->__ #3457

Schedule the MMA-facing publication of a descriptor result immediately after its TMA stage when the result also has register consumers. Preserve that earliest consumer schedule when descriptor lowering creates the shared local load. This prevents a later single-buffer acquire on the load partition from blocking publication of the current MMA operand.

Differential Revision: [D118712790](https://our.internmc.facebook.com/intern/diff/D118712790)