### PR TITLE
[autoWS] Fix 2CTA TMA readiness for multiple consumers

### DIFF
--- a/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --nvgpu-warp-specialization="num-stages=3 capability=100 smem-budget=200000" | FileCheck %s
+// RUN: triton-opt %s -split-input-file --nvgpu-warp-specialization="num-stages=3 capability=100 smem-budget=200000" | FileCheck %s --check-prefix=MULTICONSUMER
 
 // Test case: Basic Blackwell matrix multiplication with TMA and warp specialization.
 // This IR represents a GEMM kernel that uses tensor memory for accumulator
@@ -84,6 +85,55 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
     %c = arith.truncf %accumulator_24 {ttg.partition = array<i32: 3>} : tensor<128x128xf32, #blocked> to tensor<128x128xf16, #blocked>
     %c_26 = ttg.convert_layout %c {ttg.partition = array<i32: 3>} : tensor<128x128xf16, #blocked> -> tensor<128x128xf16, #blocked2>
     tt.descriptor_store %c_desc[%offs_am, %offs_bn], %c_26 {ttg.partition = array<i32: 3>} : !tt.tensordesc<128x128xf16, #shared>, tensor<128x128xf16, #blocked2>
+    tt.return
+  }
+}
+
+// -----
+
+// A cooperative 2CTA TMA transfer has one physical completion even when its
+// shared-memory result feeds multiple warp-specialized consumer tasks. Relay
+// that completion from the pair leader to the follower exactly once. Each
+// consumer still needs its own readiness wait, and the cross-task consumer
+// keeps its independent release bookkeeping.
+
+// MULTICONSUMER-LABEL: @tma_2cta_multi_consumer_ready_relay
+// MULTICONSUMER-COUNT-1: ttng.async_tma_copy_global_to_local {{.*}}two_cta = true
+// MULTICONSUMER: ttng.wait_barrier {{.*}}async_task_id = array<i32: 0>
+// MULTICONSUMER: ttng.fence_async_shared
+// MULTICONSUMER: ttng.arrive_barrier {{.*}}shared_cluster_memory
+// MULTICONSUMER: ttng.wait_barrier {{.*}}async_task_id = array<i32: 0>
+// MULTICONSUMER: ttg.local_load {{.*}}async_task_id = array<i32: 0>
+// MULTICONSUMER: ttng.wait_barrier {{.*}}async_task_id = array<i32: 1>
+// MULTICONSUMER-NOT: ttng.fence_async_shared
+// MULTICONSUMER-NOT: ttng.arrive_barrier {{.*}}shared_cluster_memory
+// MULTICONSUMER: ttng.wait_barrier {{.*}}async_task_id = array<i32: 1>
+// MULTICONSUMER: ttg.local_load {{.*}}async_task_id = array<i32: 1>
+// MULTICONSUMER: ttng.arrive_barrier {{.*}}async_task_id = array<i32: 1>
+
+#blocked_multi = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared_multi = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem_multi = #ttg.shared_memory
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @tma_2cta_multi_consumer_ready_relay(%desc: !tt.tensordesc<128x64xf16, #shared_multi>, %out0: !tt.ptr<f16>, %out1: !tt.ptr<f16>) attributes {noinline = false} {
+    %c0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : i32
+    %ptrs0 = tt.splat %out0 {async_task_id = array<i32: 0>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked_multi>
+    %ptrs1 = tt.splat %out1 {async_task_id = array<i32: 1>} : !tt.ptr<f16> -> tensor<128x64x!tt.ptr<f16>, #blocked_multi>
+    %i0 = arith.constant {async_task_id = array<i32: 0, 1>} 0 : index
+    %i1 = arith.constant {async_task_id = array<i32: 0, 1>} 1 : index
+    %i4 = arith.constant {async_task_id = array<i32: 0, 1>} 4 : index
+    %buffer = ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared_multi, #smem_multi, mutable>
+    scf.for %iv = %i0 to %i4 step %i1 {
+      %tile = tt.descriptor_load %desc[%c0, %c0] {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32, two_cta_load} : !tt.tensordesc<128x64xf16, #shared_multi> -> tensor<128x64xf16, #blocked_multi>
+      ttg.local_store %tile, %buffer {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked_multi> -> !ttg.memdesc<128x64xf16, #shared_multi, #smem_multi, mutable>
+      %local = ttg.local_load %buffer {async_task_id = array<i32: 0, 1>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : !ttg.memdesc<128x64xf16, #shared_multi, #smem_multi, mutable> -> tensor<128x64xf16, #blocked_multi>
+      %consumer0 = arith.addf %local, %local {async_task_id = array<i32: 0>, loop.cluster = 1 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked_multi>
+      %consumer1 = arith.subf %local, %local {async_task_id = array<i32: 1>, loop.cluster = 2 : i32, loop.stage = 0 : i32} : tensor<128x64xf16, #blocked_multi>
+      tt.store %ptrs0, %consumer0 {async_task_id = array<i32: 0>} : tensor<128x64x!tt.ptr<f16>, #blocked_multi>
+      tt.store %ptrs1, %consumer1 {async_task_id = array<i32: 1>} : tensor<128x64x!tt.ptr<f16>, #blocked_multi>
+      scf.yield
+    } {async_task_id = array<i32: 0, 1>, tt.warp_specialize}
     tt.return
   }
 }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -350,15 +350,18 @@ void getBufferIdxAndPhase(OpBuilderWithAsyncTaskIds &builder, Operation *op,
 Value getBarrierForPipelineStage(OpBuilderWithAsyncTaskIds &builder,
                                  Value barrierAlloc, Value bufferIdx);
 
-Operation *
-optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
-                 SmallVector<triton::nvws::DescriptorLoadOp> &tmaLoads,
-                 Value barrierAlloc, Value bufferIdx, Value bufferIdxExtract,
-                 Value phase, Operation *headProducer, Operation *headConsumer,
-                 Operation *headConsumerSameLevel,
-                 ArrayRef<int> additionalConsumerTaskIds = {},
-                 DictionaryAttr consumerWaitConstraints = {},
-                 bool twoCTADirectWait = false);
+struct TMAConsumerWaitInfo {
+  AsyncTaskId taskId;
+  Operation *consumer;
+  Operation *insertionPoint;
+};
+
+Operation *optimizeTMALoads(
+    OpBuilderWithAsyncTaskIds &builder,
+    SmallVector<triton::nvws::DescriptorLoadOp> &tmaLoads, Value barrierAlloc,
+    Value bufferIdx, Value bufferIdxExtract, Value phase,
+    Operation *headProducer, ArrayRef<TMAConsumerWaitInfo> consumerWaits,
+    DictionaryAttr consumerWaitConstraints = {}, bool twoCTADirectWait = false);
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
 Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
                        Value idx);

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -4513,26 +4513,42 @@ void insertAsyncComm(
 
     // Optimize TMA loads.
     if (tmaLoads.size() > 0) {
-      // Instead of headConsumer, need to lift out to the same scope.
-      auto consumerWaitPoint = getSameLevelOp(tmaHeadProducer, headConsumer);
-      // Collect additional consumer task IDs beyond the primary headConsumer.
-      SmallVector<int> additionalConsumerTaskIds;
-      auto primaryTaskIds = getAsyncTaskIds(headConsumer);
-      for (const auto &token : commChannel.tokens) {
-        int taskId = token.first;
-        if (std::find(primaryTaskIds.begin(), primaryTaskIds.end(), taskId) ==
-            primaryTaskIds.end())
-          additionalConsumerTaskIds.push_back(taskId);
+      SmallVector<TMAConsumerWaitInfo> consumerWaits;
+      SmallVector<AsyncTaskId> readyTaskIds;
+      for (Operation *consumer : consumerOps) {
+        for (AsyncTaskId taskId : getAsyncTaskIds(consumer)) {
+          if (!llvm::is_contained(readyTaskIds, taskId))
+            readyTaskIds.push_back(taskId);
+        }
+      }
+      for (AsyncTaskId taskId : readyTaskIds) {
+        Operation *taskConsumer = nullptr;
+        Operation *taskInsertionPoint = nullptr;
+        for (Operation *candidate : consumerOps) {
+          if (!llvm::is_contained(getAsyncTaskIds(candidate), taskId))
+            continue;
+          Operation *candidateInsertionPoint =
+              getSameLevelOp(tmaHeadProducer, candidate);
+          if (!taskInsertionPoint ||
+              (candidateInsertionPoint->getBlock() ==
+                   taskInsertionPoint->getBlock() &&
+               candidateInsertionPoint->isBeforeInBlock(taskInsertionPoint))) {
+            taskConsumer = candidate;
+            taskInsertionPoint = candidateInsertionPoint;
+          }
+        }
+        assert(taskConsumer && taskInsertionPoint &&
+               "TMA channel consumer task must have an actual consumer");
+        consumerWaits.push_back({taskId, taskConsumer, taskInsertionPoint});
       }
       auto waitConstraints =
           WSBarrierAttr::forDstTaskAndDirection(
               funcOp.getContext(), masterChannel->relation.first,
               WSBarrierAttr::kDirectionForward)
               .build(funcOp.getContext());
-      optimizeTMALoads(
-          builder, tmaLoads, *commChannel.producerBarrier, bufferIdx, bufferIdx,
-          phase, tmaHeadProducer, headConsumer, consumerWaitPoint,
-          additionalConsumerTaskIds, waitConstraints, twoCTADirectWait);
+      optimizeTMALoads(builder, tmaLoads, *commChannel.producerBarrier,
+                       bufferIdx, bufferIdx, phase, tmaHeadProducer,
+                       consumerWaits, waitConstraints, twoCTADirectWait);
     }
   }
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -331,9 +331,8 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             SmallVector<ttnvws::DescriptorLoadOp> &tmaLoads,
                             Value barrierAlloc, Value bufferIdx,
                             Value bufferIdxExtract, Value phase,
-                            Operation *headProducer, Operation *headConsumer,
-                            Operation *headConsumerSameLevel,
-                            ArrayRef<int> additionalConsumerTaskIds,
+                            Operation *headProducer,
+                            ArrayRef<TMAConsumerWaitInfo> consumerWaits,
                             DictionaryAttr consumerWaitConstraints,
                             bool twoCTADirectWait) {
   // Callers group at least one load behind each fused barrier. Make the
@@ -400,68 +399,61 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     copy = copyOp;
   }
 
-  // Create a wait_barrier before the first consumer.
-  // For data-partitioned channels, shared ops (consBarrier, phase, pred)
-  // need ALL consumer task IDs so they survive specializeRegion.
-  builder.setInsertionPoint(headConsumerSameLevel);
-  SmallVector<int> consumerTaskIds;
-  for (int id : getAsyncTaskIds(headConsumer))
-    consumerTaskIds.push_back(id);
-  for (int id : additionalConsumerTaskIds)
-    consumerTaskIds.push_back(id);
-  builder.setAsynTaskIdsFromArray(consumerTaskIds);
-  builder.setLoopScheduleInfoFromOp(headConsumerSameLevel);
-  auto consBarrier =
-      getBarrierForPipelineStage(builder, barrierAlloc, bufferIdxExtract);
-  phase = builder.createWithAsyncTaskIds<arith::ExtUIOp>(
-      loc, builder.getI32Type(), phase);
-  Value waitPred =
-      builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
+  assert(!consumerWaits.empty() && "TMA load must have a consumer task");
   bool directTwoCTAWait = twoCTA && twoCTADirectWait;
-  Value followerWaitPred;
-  Value peerBarrier;
-  if (twoCTA) {
-    TwoCTAPairRank rank = buildTwoCTAPairRank(builder, loc);
-    waitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::eq, rank.rankInPair, rank.zero);
-    if (!directTwoCTAWait) {
-      followerWaitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::ne, rank.rankInPair, rank.zero);
-      peerBarrier = mapBarrierTo2CTAPeer(builder, loc, consBarrier, rank.ctaId);
+  int relayTaskId = consumerWaits.front().taskId;
+  for (int producerTaskId : getAsyncTaskIds(headProducer)) {
+    if (llvm::any_of(consumerWaits, [&](const TMAConsumerWaitInfo &wait) {
+          return wait.taskId == producerTaskId;
+        })) {
+      relayTaskId = producerTaskId;
+      break;
     }
   }
 
-  // Create one WaitBarrierOp per consumer task ID.
-  builder.setAsyncTaskIdsFromOp(headConsumer);
-  builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
-      loc, consBarrier, phase, waitPred, /*deps=*/ValueRange{},
-      consumerWaitConstraints);
-  if (twoCTA && !directTwoCTAWait) {
-    // The hardware CTA-group TMA transaction completes the leader's local
-    // mbarrier. Relay that completion to the follower's corresponding local
-    // barrier, then let the follower wait on it. A cluster barrier is not
-    // valid here: only this warp-specialized consumer partition executes the
-    // handoff, while cluster barriers require participation from every warp.
-    builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
-        loc, /*bCluster=*/false);
-    builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
-        loc, peerBarrier, /*count=*/1, waitPred);
+  // Materialize each wait at that task's own consumer and with that consumer's
+  // schedule. A multi-task boundary op must not stamp one shared wait/relay
+  // with every task ID: specialization would clone the physical 2CTA relay.
+  for (const TMAConsumerWaitInfo &wait : consumerWaits) {
+    builder.setInsertionPoint(wait.insertionPoint);
+    builder.setAsynTaskIdsFromArray({wait.taskId});
+    builder.setLoopScheduleInfoFromOp(wait.consumer);
+    auto consBarrier =
+        getBarrierForPipelineStage(builder, barrierAlloc, bufferIdxExtract);
+    Value waitPhase = builder.createWithAsyncTaskIds<arith::ExtUIOp>(
+        loc, builder.getI32Type(), phase);
+    Value waitPred =
+        builder.createWithAsyncTaskIds<arith::ConstantIntOp>(loc, 1, 1);
+    Value followerWaitPred;
+    Value peerBarrier;
+    if (twoCTA) {
+      TwoCTAPairRank rank = buildTwoCTAPairRank(builder, loc);
+      waitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, rank.rankInPair, rank.zero);
+      if (!directTwoCTAWait) {
+        followerWaitPred = builder.createWithAsyncTaskIds<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ne, rank.rankInPair, rank.zero);
+        peerBarrier =
+            mapBarrierTo2CTAPeer(builder, loc, consBarrier, rank.ctaId);
+      }
+    }
     builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
-        loc, consBarrier, phase, followerWaitPred, /*deps=*/ValueRange{},
-        consumerWaitConstraints);
-  }
-  for (int extraTaskId : additionalConsumerTaskIds) {
-    builder.setAsynTaskIdsFromArray({extraTaskId});
-    builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
-        loc, consBarrier, phase, waitPred,
+        loc, consBarrier, waitPhase, waitPred,
         /*deps=*/ValueRange{}, consumerWaitConstraints);
     if (twoCTA && !directTwoCTAWait) {
-      builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
-          loc, /*bCluster=*/false);
-      builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
-          loc, peerBarrier, /*count=*/1, waitPred);
+      if (wait.taskId == relayTaskId) {
+        // The hardware CTA-group TMA transaction completes the leader's local
+        // mbarrier. Relay that completion to the follower's corresponding
+        // local barrier exactly once per physical transfer. A relay per
+        // consumer would over-arrive the barrier and advance its phase before
+        // the next pipeline iteration.
+        builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
+            loc, /*bCluster=*/false);
+        builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
+            loc, peerBarrier, /*count=*/1, waitPred);
+      }
       builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
-          loc, consBarrier, phase, followerWaitPred, /*deps=*/ValueRange{},
+          loc, consBarrier, waitPhase, followerWaitPred, /*deps=*/ValueRange{},
           consumerWaitConstraints);
     }
   }


### PR DESCRIPTION
## Summary

- place TMA-readiness waits at each consumer task’s earliest actual consumer, instead of cloning one head-consumer schedule across tasks
- emit exactly one physical 2CTA leader-to-follower completion relay per TMA transfer, while retaining one readiness wait per consumer task
- prevent multiple consumers from over-arriving the follower barrier or observing readiness after their first use

## Scope

This is a narrow AutoWS correctness mechanism for a TMA-loaded shared buffer consumed by multiple warp-specialized tasks. It is not required by the validated 1CTA cat/cast decompose-K path, and it does not solve general multi-source computed operands or rotating intermediate-buffer lifetimes.

## Current status

Parked draft. The mechanism is not present on current fb-triton, but this branch is stale and conflicts with current signatures. The hosted B200 compiler suite passed; the hosted LIT job failed with exit 1 and the B200 TLX library job timed out. Before review, rebase it independently on current main, diagnose the LIT failure, and add changing-input runtime stress coverage for the exact multi-consumer 2CTA path.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3458
* #3457

Differential Revision: [D118712791](https://our.internmc.facebook.com/intern/diff/D118712791)