### PR TITLE
[triton][3.8] Gate MMA SMEM side-effecting address on tlx.less_reg_mma (#3459)

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -217,6 +217,22 @@ def TritonNvidiaGPUInterleaveTMemPass : Pass<"triton-nvidia-interleave-tmem", "m
   }];
 }
 
+def TritonNvidiaGPUUnifyWSBarrierLocationsPass : Pass<"triton-nvidia-unify-ws-barrier-locations", "mlir::ModuleOp"> {
+  let summary = "Co-locate related AutoWS waits around cheap load preparation.";
+
+  let description = [{
+    The `triton-nvidia-unify-ws-barrier-locations` pass raises a later
+    AutoWS-generated wait next to an earlier wait when they guard a TMA load
+    and a TMEM load feeding the same consumer, and only cheap preparation work
+    separates them.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::triton::TritonDialect",
+                           "mlir::arith::ArithDialect"];
+}
+
 def TritonNvidiaGPUTestGenerateSubtiledRegionPass
     : Pass<"triton-nvidia-gpu-test-generate-subtiled-region", "mlir::ModuleOp"> {
   let summary = "Test pass: generate subtiled_region ops from split patterns";

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TMALowering.cpp
   TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
+  UnifyWSBarrierLocations.cpp
 
   DEPENDS
   TritonNvidiaGPUTransformsIncGen

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp
@@ -1,0 +1,134 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "nvidia/hopper/include/Transforms/WSBarrierReorder.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "triton/Tools/Sys/GetEnv.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-nvidia-unify-ws-barrier-locations"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUUNIFYWSBARRIERLOCATIONSPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+bool isAllowedRegionOp(Operation *op) {
+  return isa<ttg::LocalLoadOp, TMEMLoadOp, ttg::ConvertLayoutOp,
+             tt::BroadcastOp, arith::ExtFOp, arith::TruncFOp>(op);
+}
+
+bool isBarrierBookkeepingOp(Operation *op) {
+  if (isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+          ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+          ttg::MemDescReshapeOp>(op))
+    return true;
+  if (!isa<arith::ConstantOp, arith::ExtUIOp, arith::TruncIOp,
+           arith::XOrIOp, arith::AndIOp>(op) ||
+      op->getNumResults() != 1)
+    return false;
+  return isa<IntegerType, IndexType>(op->getResult(0).getType());
+}
+
+// Unification trades away overlap to buy register relief, and only one side of
+// that trade scales with size. The relief comes from materializing a broadcast
+// value after the awaited MMA lands instead of holding it live across the wait,
+// so it is proportional to the registers that value occupies. The cost -- the
+// preparation chain feeding the broadcast no longer overlaps MMA latency -- is
+// paid whatever the value's size. Below this threshold the pass would spend the
+// serialization and get nothing back, so a small broadcast does not qualify.
+//
+// The addmm epilogue this pass was measured on carries a 128x128xf32 bias tile
+// at 128 elements per thread, so the threshold sits well under the case that
+// motivated the pass while still excluding incidental broadcasts.
+constexpr unsigned kMinBroadcastElemsPerThread = 32;
+
+bool isRegisterHeavyBroadcast(Operation *op) {
+  auto broadcast = dyn_cast<tt::BroadcastOp>(op);
+  if (!broadcast)
+    return false;
+  auto type = dyn_cast<RankedTensorType>(broadcast.getResult().getType());
+  if (!type || !type.getEncoding())
+    return false;
+  return ttg::getTotalElemsPerThread(type) >= kMinBroadcastElemsPerThread;
+}
+
+bool canUnifyWaitLocations(WaitBarrierOp earlier, WaitBarrierOp later) {
+  if (earlier->getBlock() != later->getBlock() ||
+      !earlier->isBeforeInBlock(later))
+    return false;
+
+  Operation *insertPt = earlier->getNextNode();
+  if (!insertPt || wouldBreakOperandDominance(later, insertPt))
+    return false;
+
+  bool containsRegisterHeavyBroadcast = false;
+  for (Operation *op = insertPt; op != later.getOperation();
+       op = op->getNextNode()) {
+    if (!op || !canRaiseWSWaitPast(later, op))
+      return false;
+
+    if (isBarrierLikeOp(op))
+      continue;
+    if (!isAllowedRegionOp(op) && !isBarrierBookkeepingOp(op))
+      return false;
+    containsRegisterHeavyBroadcast |= isRegisterHeavyBroadcast(op);
+  }
+  return containsRegisterHeavyBroadcast;
+}
+
+bool unifyOneWaitPair(Block &block) {
+  SmallVector<WaitBarrierOp> waits;
+  for (Operation &op : block) {
+    auto wait = dyn_cast<WaitBarrierOp>(&op);
+    if (wait && hasWSBarrierConstraints(wait.getConstraints()))
+      waits.push_back(wait);
+  }
+
+  for (unsigned i = 0; i + 1 < waits.size(); ++i) {
+    WaitBarrierOp earlier = waits[i];
+    WaitBarrierOp later = waits[i + 1];
+    if (!canUnifyWaitLocations(earlier, later))
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << "unifying adjacent WS wait regions\n");
+    later->moveAfter(earlier);
+    return true;
+  }
+  return false;
+}
+
+bool unifyBarrierLocations(Block &block) {
+  bool changed = false;
+  while (unifyOneWaitPair(block))
+    changed = true;
+  return changed;
+}
+
+} // namespace
+
+struct TritonNvidiaGPUUnifyWSBarrierLocationsPass
+    : public impl::TritonNvidiaGPUUnifyWSBarrierLocationsPassBase<
+          TritonNvidiaGPUUnifyWSBarrierLocationsPass> {
+  using impl::TritonNvidiaGPUUnifyWSBarrierLocationsPassBase<
+      TritonNvidiaGPUUnifyWSBarrierLocationsPass>::
+      TritonNvidiaGPUUnifyWSBarrierLocationsPassBase;
+
+  void runOnOperation() override {
+    if (triton::tools::getBoolEnv("TRITON_DISABLE_WSBARRIER_REORDER"))
+      return;
+
+    getOperation().walk([&](Block *block) {
+      if (!block->empty())
+        unifyBarrierLocations(*block);
+    });
+  }
+};
+
+} // namespace mlir::triton::nvidia_gpu

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -356,6 +356,14 @@ def test_autows_addmm_hoist_convert_before_broadcast():
     assert "tt.descriptor_store" not in ttgir, "Expected descriptor stores to be lowered"
     assert "can_rotate_by_buffer_count" not in ttgir, "Expected TMA store wait rotation to be resolved"
 
+    unified_waits = re.search(
+        r"ttng\.wait_barrier[^\n]*dstTask = 3[^\n]*\n\s*"
+        r"ttng\.wait_barrier[^\n]*dstTask = 1[^\n]*\n\s*"
+        r"%[^\n]* = ttg\.local_load",
+        ttgir,
+    )
+    assert unified_waits, "Expected adjacent bias-TMA and accumulator-TMEM waits before the bias load"
+
     # Check that convert_layout on bias happens before broadcast (on 1xN, not MxN)
     cvt_before_bc = re.search(r"convert_layout.*tensor<1x\d+xf32.*\n.*tt\.broadcast.*tensor<1x\d+xf32", ttgir)
     bc_before_cvt = re.search(

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -642,6 +642,8 @@ class nvidia_knobs(base_knobs):
     # Default ON; set TRITON_ENABLE_INTERLEAVE_TMEM=0 to opt out for A/B
     # testing against the operand-D back-edge channel fix.
     enable_interleave_tmem: env_bool = env_bool("TRITON_ENABLE_INTERLEAVE_TMEM", True)
+    # Default ON; opt out with TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS=0.
+    enable_unify_ws_barrier_locations: env_bool = env_bool("TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS", True)
     enable_tileir: env_bool = env_bool("ENABLE_TILE")
     disable_budget_aware_layout_conversion: env_bool = env_bool("TRITON_DISABLE_BUDGET_AWARE_LAYOUT_CONVERSION")
     # Gate opt-in perf-benchmark tests (do_bench sweeps) so unit-test runs do

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -1551,25 +1551,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
-// Regression test for "Shorten live range of SMEM operand of MMA".
+// Regression test for "Shorten live range of SMEM operand of MMA", gated on
+// `tlx.less_reg_mma`.
 //
-// The MMA SMEM operand base address is computed with a *side-effecting* inline
-// PTX `add.s32` instead of a plain `llvm.add`. The side effect is what stops
-// LLVM from CSE-ing the address across MMAs: two MMAs reading the same SMEM
-// operand would otherwise share one address computation, giving that value a
-// very long live range and spilling registers in MMA-heavy kernels.
+// With the gate set, the MMA SMEM operand base address is computed with a
+// *side-effecting* inline PTX `add.s32` instead of a plain `llvm.add`. The side
+// effect is what stops LLVM from CSE-ing the address across MMAs: two MMAs
+// reading the same SMEM operand would otherwise share one address computation,
+// giving that value a very long live range and spilling registers in MMA-heavy
+// kernels. The module attribute is propagated by the TLX Fixup pass from
+// `tlx.async_tasks(less_reg_mma=True)`.
 //
 // The two tc_gen5_mma ops below share the same A and B SMEM operands at the same
 // offsets, so their per-operand address computations are structurally identical
 // -- exactly what CSE folds (this file's RUN line runs -cse). Each MMA still
-// emits its own side-effecting add.s32 for A and B, so all FOUR survive: a plain
-// (non-side-effecting) add would let CSE collapse them to 2.
-#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
+// emits its own side-effecting add.s32 for A and B, so all FOUR survive.
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, tlx.less_reg_mma} {
   // CHECK-LABEL: @two_mma_shared_smem_operand_no_cse
   // Two MMAs, one side-effecting add.s32 per SMEM operand each -> 4 total, none
   // folded by CSE despite the shared operands.
@@ -1584,6 +1585,48 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
                        %barrierPred: i1) {
     // Both MMAs read the same %a and %b, so the operand-descriptor addresses are
     // identical CSE candidates; the side effect keeps them separate.
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
+       !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+       !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+       !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>
+    tt.return
+  }
+}
+
+// -----
+
+// Same kernel without `tlx.less_reg_mma`: the default lowering keeps the plain
+// `llvm.add`, so no side-effecting add.s32 is emitted at all and CSE is free to
+// share one address computation between the two MMAs.
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16}>
+#shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 64, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32} {
+  // Each operand's address computation is emitted just before its MMA, so the
+  // CHECK-NOTs must be interleaved with the MMAs to cover the whole body: a
+  // single trailing CHECK-NOT would only scan from the last MMA to the end and
+  // pass vacuously.
+  // CHECK-LABEL: @two_mma_shared_smem_operand_default
+  // CHECK-NOT: add.s32
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16
+  // CHECK-NOT: add.s32
+  // CHECK: tcgen05.mma.cta_group::1.kind::f16
+  // CHECK-NOT: add.s32
+  // CHECK: llvm.return
+  tt.func @two_mma_shared_smem_operand_default(%a: !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
+                       %b: !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,
+                       %c: !ttg.memdesc<64x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+                       %useAcc: i1,
+                       %pred: i1,
+                       %barrier: !ttg.memdesc<1xi64, #shared2, #ttg.shared_memory>,
+                       %barrierPred: i1) {
     ttng.tc_gen5_mma %a, %b, %c, %useAcc, %pred, %barrier[%barrierPred] {is_async} :
        !ttg.memdesc<64x16xf16, #shared, #ttg.shared_memory>,
        !ttg.memdesc<16x64xf16, #shared1, #ttg.shared_memory>,

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -344,6 +344,27 @@ tt.func @raise_wait_stops_at_non_ws_wait(
   tt.return
 }
 
+// A WS wait cannot be raised above an init_barrier. Nothing about init is
+// arrive-like, so the older hasArriveLikeSemantics fallthrough let the wait
+// cross it; routing raiseWSWaits through canRaiseWSWaitPast rejects every
+// barrier-like op instead, which keeps a wait from rising above the
+// initialization of the barrier it waits on. The tmem_load still sinks past
+// the init, so the expected order is init, load, wait.
+// CHECK-LABEL: @raise_wait_stops_at_init_barrier
+tt.func @raise_wait_stops_at_init_barrier(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: WSBarrier
+  ttng.init_barrier %bar1, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
 // WS barriers cannot move past non-barrier ops with arrive-like semantics.
 // CHECK-LABEL: @no_reorder_across_arrive_like_op
 tt.func @no_reorder_across_arrive_like_op(

--- a/test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir
+++ b/test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir
@@ -1,0 +1,200 @@
+// RUN: triton-opt %s --triton-nvidia-unify-ws-barrier-locations --allow-unregistered-dialect | FileCheck %s
+// RUN: env TRITON_DISABLE_WSBARRIER_REORDER=1 triton-opt %s --triton-nvidia-unify-ws-barrier-locations --allow-unregistered-dialect | FileCheck %s --check-prefix=DISABLED
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @unify_cast_broadcast
+// CHECK:       ttng.wait_barrier %{{.*}}, %{{.*}}, %{{.*}} {{.*}}dstTask = 3
+// CHECK-NEXT:  ttng.wait_barrier %{{.*}}, %{{.*}} {{.*}}dstTask = 1
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK-NEXT:  ttng.arrive_barrier
+// CHECK-NEXT:  %[[EXT:.*]] = arith.extf %[[BIAS]]
+// CHECK-NEXT:  %[[CVT:.*]] = ttg.convert_layout %[[EXT]]
+// CHECK-NEXT:  %[[BCAST:.*]] = tt.broadcast %[[CVT]]
+// CHECK:       %[[ACC:.*]] = ttng.tmem_load
+// CHECK-NEXT:  ttng.arrive_barrier
+// CHECK-NEXT:  arith.addf %[[ACC]], %[[BCAST]]
+// DISABLED-LABEL: @unify_cast_broadcast
+// DISABLED:       ttng.wait_barrier
+// DISABLED-NEXT:  ttg.local_load
+// DISABLED:       tt.broadcast
+// DISABLED-NEXT:  ttng.wait_barrier
+tt.func @unify_cast_broadcast(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  ttng.arrive_barrier %tma_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias_tile = tt.broadcast %bias_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  ttng.arrive_barrier %tmem_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %out = arith.addf %acc, %bias_tile : tensor<128x128xf32, #linear>
+  "use"(%out) : (tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// A broadcast small enough that hoisting the accumulator wait buys no register
+// relief does not qualify. The register saving scales with the broadcast value,
+// the lost overlap does not, so the waits stay where they are and the bias
+// preparation keeps covering MMA latency. Same shape as @unify_cast_broadcast
+// except the broadcast result is 1x128 (1 element per thread) rather than
+// 128x128 (128 per thread).
+// CHECK-LABEL: @keep_small_broadcast
+// CHECK:       ttng.wait_barrier %{{.*}}, %{{.*}}, %{{.*}} {{.*}}dstTask = 3
+// CHECK-NEXT:  ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+tt.func @keep_small_broadcast(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  ttng.arrive_barrier %tma_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_row = tt.broadcast %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #blocked>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  ttng.arrive_barrier %tmem_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  "use"(%acc) : (tensor<128x128xf32, #linear>) -> ()
+  "use"(%bias_row) : (tensor<1x128xf32, #blocked>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @unify_to_fixed_point
+// CHECK:       ttng.wait_barrier {{.*}}dstTask = 3
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 2
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+// CHECK-NEXT:  %[[BIAS0:.*]] = ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK:       %[[BIAS1:.*]] = ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK:       ttng.tmem_load
+tt.func @unify_to_fixed_point() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer0 = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %bias_buffer1 = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias0 = ttg.local_load %bias_buffer0 : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias0_f32 = arith.extf %bias0 : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias0_layout = ttg.convert_layout %bias0_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias0_tile = tt.broadcast %bias0_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias1 = ttg.local_load %bias_buffer1 : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias1_f32 = arith.extf %bias1 : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias1_layout = ttg.convert_layout %bias1_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias1_tile = tt.broadcast %bias1_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %barrier2, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  %sum0 = arith.addf %acc, %bias0_tile : tensor<128x128xf32, #linear>
+  %sum1 = arith.addf %sum0, %bias1_tile : tensor<128x128xf32, #linear>
+  "use"(%sum1) : (tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_region_without_broadcast
+// CHECK:       ttng.wait_barrier
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK-NEXT:  arith.extf %[[BIAS]]
+// CHECK-NEXT:  ttg.convert_layout
+// CHECK-NEXT:  ttng.wait_barrier
+tt.func @keep_region_without_broadcast() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  "use"(%bias_layout, %acc) : (tensor<1x128xf32, #linear>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_non_ws_barrier
+// CHECK:       ttng.wait_barrier {{.*}}dstTask = 3
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK:       %[[BCAST:.*]] = tt.broadcast
+// CHECK-NEXT:  ttng.wait_barrier
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+tt.func @keep_non_ws_barrier() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %plain_barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_tile = tt.broadcast %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+  ttng.wait_barrier %plain_barrier, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  "use"(%bias_tile, %acc) : (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_substantive_work
+// CHECK:       ttng.wait_barrier
+// CHECK-NEXT:  ttg.local_load
+// CHECK:       arith.addf
+// CHECK-NEXT:  ttng.wait_barrier
+tt.func @keep_substantive_work(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #linear>
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias_tile = tt.broadcast %bias_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  %work = arith.addf %zero, %zero : tensor<128x128xf32, #linear>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 2>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  %out = arith.addf %acc, %bias_tile : tensor<128x128xf32, #linear>
+  "use"(%out, %work) : (tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1025,6 +1025,8 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttnvgpuir.add_prune_unused_barriers(pm)
         if knobs.nvidia.enable_interleave_tmem:
             nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
+        if knobs.nvidia.enable_unify_ws_barrier_locations:
+            nvidia.passes.ttnvgpuir.add_unify_ws_barrier_locations(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.ttir.add_loop_aware_cse(pm)

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -125,6 +125,34 @@ inline bool wouldBreakOperandDominance(Operation *op, Operation *insertPt) {
   return false;
 }
 
+// Check the barrier-specific part of raising `wait` before `crossedOp`.
+// Profitability and non-barrier side-effect checks remain the caller's
+// responsibility.
+//
+// Safety against crossing an unrelated barrier rests on the WSBarrier
+// constraint metadata, not on comparing mbarrier values: a crossed arrive is
+// admitted only when canAdvanceWSBarrierArrivePastWait proves disjoint channel
+// graphs or a strict ordered-region precedence. An arrive on the very barrier
+// this wait is waiting on shares that wait's channel graph, so it fails
+// disjointness and, being in the same region, fails the ordering proof too.
+//
+// The isBarrierLikeOp rejection below is deliberately stricter than the
+// hasArriveLikeSemantics fallthrough it replaced in raiseWSWaits: it also
+// rejects InitBarrierOp, so a wait can never be raised above the
+// initialization of its own barrier.
+inline bool canRaiseWSWaitPast(WaitBarrierOp wait, Operation *crossedOp) {
+  if (crossedOp->getNumRegions() != 0)
+    return false;
+  if (auto otherWait = dyn_cast<WaitBarrierOp>(crossedOp))
+    return hasWSBarrierConstraints(otherWait.getConstraints());
+  if (auto arrive = dyn_cast<ArriveBarrierOp>(crossedOp))
+    return canAdvanceWSBarrierArrivePastWait(arrive.getConstraints(),
+                                             wait.getConstraints());
+  if (isBarrierLikeOp(crossedOp))
+    return false;
+  return !hasArriveLikeSemantics(crossedOp);
+}
+
 // Return the latest same-block operation that an arrive must follow when it is
 // restored near its associated memory op.
 inline Operation *getArriveAnchorAfterOperands(ArriveBarrierOp arrive,
@@ -193,7 +221,6 @@ inline bool raiseWSWaits(Block &block) {
       waits.push_back(wait);
 
   for (auto wait : llvm::reverse(waits)) {
-    auto constraints = wait.getConstraints();
     Operation *insertPt = wait.getOperation();
     for (auto *cur = wait->getPrevNode(); cur; cur = cur->getPrevNode()) {
       // Don't raise past the definition of any of our operands.
@@ -206,14 +233,7 @@ inline bool raiseWSWaits(Block &block) {
       }
       if (definesOperand)
         break;
-      if (auto otherWait = dyn_cast<WaitBarrierOp>(cur)) {
-        if (!hasWSBarrierConstraints(otherWait.getConstraints()))
-          break;
-      } else if (auto arrive = dyn_cast<ArriveBarrierOp>(cur)) {
-        if (!canAdvanceWSBarrierArrivePastWait(arrive.getConstraints(),
-                                               constraints))
-          break;
-      } else if (!canAdvanceWSBarrier(constraints, cur)) {
+      if (!canRaiseWSWaitPast(wait, cur)) {
         break;
       }
       insertPt = cur;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
@@ -244,7 +244,8 @@ attribute directly (as currently defined). The two approaches can coexist:
 
 **Files:**
 - `nvidia/hopper/include/Transforms/WSBarrierReorder.h` — `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations`
-- `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp` — consumer of the above
+- `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp` — liveness-oriented consumer of the above
+- `lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp` — codegen-oriented wait co-location
 
 ### Motivation
 
@@ -283,6 +284,13 @@ before the existing tmem_load sinking. Four steps:
 4. **`optimizeWSBarrierLocations`** — After sinking, relocate each barrier
    back to an optimal position right next to its associated memory op
    (arrives after, waits before), respecting SSA dominance.
+
+5. **`triton-nvidia-unify-ws-barrier-locations`** — In the following pass,
+   identify AutoWS TMA-ready and TMEM-ready waits whose load chains meet at the
+   same consumer. Raise the later wait beside the earlier wait only when the
+   crossed range contains load preparation, broadcast/cast work, and barriers
+   accepted by the same channel-graph or ordered-region safety rules. See
+   [WS Barrier Location Unification](WSBarrierLocationUnification.md).
 
 ### `canAdvanceWSBarrier`
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -45,6 +45,13 @@ elementwise users. This keeps broadcasts and their value materialization, such
 as a descriptor load followed by an extend, associated with their use after
 other operands, such as TMEM loads, have been prepared.
 
+After physical AutoWS lowering, `triton-nvidia-interleave-tmem` chooses TMEM
+load locations for latency and register liveness. The immediately following
+`triton-nvidia-unify-ws-barrier-locations` pass can then co-locate a related
+TMA-ready wait and TMEM-ready wait when only load preparation, casts, and a
+broadcast separate them. See
+[WS Barrier Location Unification](WSBarrierLocationUnification.md).
+
 The TMA store wait pipeline is enabled by default and can be disabled with the
 `nvgpu-warp-specialization` pass option `tma-store-pipelining=false`. Disabling
 it skips wait annotation, annotation validation, and wait reordering; it does
@@ -98,6 +105,8 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSTMAStoreLowering.cpp` | `doTMAStoreWaitReorder` | Reschedule TMA store waits using SWP CoarseSchedule |
 | `TMEMAlloc1D.cpp` | `TMEM1DAllocator` | 1D tensor memory allocation for cross-partition values |
 | `TMemBarrierInsertion.cpp` | `triton-nvidia-gpu-tmem-barrier-insertion` | Inserts CTA barriers for TMEM reuse and elides hazards proven warp-local; see [TMEMBarrierInsertion.md](TMEMBarrierInsertion.md) |
+| `InterleaveTMem.cpp` | `triton-nvidia-interleave-tmem` | Sinks TMEM allocations and loads, then restores their WS barriers |
+| `UnifyWSBarrierLocations.cpp` | `triton-nvidia-unify-ws-barrier-locations` | Co-locates related AutoWS TMA/TMEM waits around broadcast and cast preparation |
 | `CodePartitionUtility.cpp` | — | Channel data structures, operand D handling, barrier fusion, buffer management |
 | `Utility.cpp` | — | `AsyncTaskId` helpers, `OpBuilderWithAsyncTaskIds` |
 
@@ -147,6 +156,7 @@ recognizes the `scf.while` outer loop (same doc).
 - [Barrier Fusion](BarrierFusion.md) — TMA fusion, tcgen05_commit combining
 - [Barrier Constraints](BarrierConstraints.md) — generic barrier constraints and WSBarrier reordering metadata
 - [WS Barrier Ordered Region Tracking](WSBarrierOrderedRegionTracking.md) — V2 ordered-region metadata for overlapping channel graphs
+- [WS Barrier Location Unification](WSBarrierLocationUnification.md) — post-interleave co-location of related TMA-ready and TMEM-ready waits
 - [Reuse Groups](ReuseGroups.md) — buffer sharing mechanics
 - [Ping-Pong Scheduling](PingPongScheduling.md) — named barrier insertion for expensive ops
 - [Utilities](Utilities.md) — `OpBuilderWithAsyncTaskIds`, task ID helpers, location utilities

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
@@ -101,21 +101,35 @@ and is blind to the durational pressure and latency exposure this pass targets;
 an integral over the liveness curve would subsume the old metric rather than
 trade against it.
 
-## Out of Scope: Reshaping Barriers for Codegen
+## Follow-up Barrier Placement
 
-The barrier movement described above is in scope. It exists to unblock legal
-TMEM movement, and every barrier still ends up near the memory operation it
-guards.
+After this pass restores each wait beside its guarded load,
+`triton-nvidia-unify-ws-barrier-locations` may raise a related AutoWS wait to a
+common location when only load preparation, casts, and broadcast work separate
+the waits. See
+[WS Barrier Location Unification](WSBarrierLocationUnification.md).
 
-What is out of scope is reshaping barrier placement to unlock a downstream
-codegen optimization. The motivating example is hoisting several
-`ttng.wait_barrier` ops to a common program point so that a value broadcast to
-their consumers becomes optimizable in PTX. That is driven by codegen quality
-rather than by TMEM liveness or MMA latency, and on a given block the two
-objectives can pull in opposite directions: the placement that best exposes a
-broadcast is not generally the placement that best distances a load from its
-producer. Handle it in future work on barrier placement rather than adding
-cases here.
+An earlier revision of this document declared that reshaping barriers for
+codegen was out of scope, on the grounds that the placement which best exposes
+a broadcast to ptxas is not generally the placement which best distances a load
+from its producer. The observation stands: on a block where both apply, the two
+objectives really can want different placements. What has changed is that there
+is now a basis for deciding between them.
+
+Running the unification pass second does not by itself resolve anything — it
+just means the codegen objective always wins where it applies. The resolution
+is that "where it applies" is now narrow. Unification requires a broadcast
+whose result is register-heavy, because that is the only case where the
+register relief it buys outweighs the MMA-latency overlap it gives up. On the
+`addmm` epilogue that motivated it, that trade removed a 23 KB spill, which is
+a larger effect than the scheduling distance this pass gives up on the same
+block. Where the broadcast is small, unification declines and this pass's
+placement stands.
+
+So the conflict is decided in favor of codegen only on measured evidence, and
+only for the shape of block where that evidence applies. If a case turns up
+where the distance mattered more despite a large broadcast, the floor in
+unification is the knob to revisit — not the ordering of the two passes.
 
 ## Testing
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierLocationUnification.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierLocationUnification.md
@@ -1,0 +1,140 @@
+# WS Barrier Location Unification
+
+`triton-nvidia-unify-ws-barrier-locations` co-locates related AutoWS wait
+barriers when the instructions separating them are too small to form a useful
+scheduling region. The initial use case is an epilogue that combines a
+broadcast bias with an MMA accumulator.
+
+The pass runs immediately after `triton-nvidia-interleave-tmem`. TMEM
+interleaving first chooses load locations for latency and register liveness;
+barrier unification then adjusts only the waits to expose one region to PTX
+scheduling.
+
+## Motivation
+
+After TMEM interleaving, a one-dimensional-bias `addmm` epilogue can have this
+shape:
+
+```mlir
+ttng.wait_barrier %bias_ready, %bias_phase
+%bias = ttg.local_load %bias_smem
+ttng.arrive_barrier %bias_empty, 1
+%bias_f32 = arith.extf %bias
+%bias_layout = ttg.convert_layout %bias_f32
+%bias_tile = tt.broadcast %bias_layout
+ttng.wait_barrier %acc_ready, %acc_phase
+%acc = ttng.tmem_load %accumulator
+ttng.arrive_barrier %acc_empty, 1
+%out = arith.addf %acc, %bias_tile
+```
+
+There is no substantive independent work between the waits. Keeping them
+separate can prevent ptxas from scheduling the broadcast and accumulator add
+as one region, while extending the lifetime of the broadcast value. The pass
+raises the later wait next to the earlier wait:
+
+```mlir
+ttng.wait_barrier %bias_ready, %bias_phase
+ttng.wait_barrier %acc_ready, %acc_phase
+%bias = ttg.local_load %bias_smem
+...
+%bias_tile = tt.broadcast %bias_layout
+%acc = ttng.tmem_load %accumulator
+...
+%out = arith.addf %acc, %bias_tile
+```
+
+Both barriers remain distinct. Their operands, phases, predicates,
+constraints, and corresponding arrive operations are unchanged.
+
+### The Trade
+
+This is not a free win, and the two sides of it do not scale together.
+
+What is gained is register relief, and it is proportional to the size of the
+broadcast value. In the original order `%bias_tile` is materialized before
+`%acc_ready` is awaited, so it stays live across that wait; afterwards it is
+produced only once the MMA has landed and lives just as far as the `addf`. On
+the measured `addmm` epilogue that value is a `128x128xf32` bias tile at 128
+elements per thread, and removing it from the wait's live range is what
+eliminates the spill.
+
+What is lost is overlap, and that cost is the same at any size. Before the
+move, `local_load` → `extf` → `convert_layout` → `broadcast` runs while the
+MMA is still in flight. After it, the consumer blocks on the accumulator
+before doing any bias preparation at all, so that chain no longer hides MMA
+latency.
+
+For a large broadcast the relief dominates. For a small one there is no
+meaningful relief and the serialization is pure loss, which is why eligibility
+carries a minimum broadcast size rather than firing on the shape alone.
+
+## Candidate Recognition
+
+The pass operates within one basic block. It collects waits carrying
+`constraints.WSBarrier` and examines consecutive pairs in program order. A
+pair is eligible only when:
+
+- every operation between the waits is an allowed load, broadcast, or cast;
+- every intervening barrier is also a `WSBarrier` and passes the barrier-order
+  proof;
+- the later wait's operands dominate the earlier insertion point; and
+- the interval contains a `tt.broadcast` whose result is at least
+  `kMinBroadcastElemsPerThread` (32) elements per thread.
+
+The size floor is what keeps the pass on the side of the trade described
+above. A `tt.broadcast` alone is a shape-only signal: it identifies the PTXAS
+optimization opportunity but says nothing about how many registers the hoist
+frees, while the overlap it costs is unconditional. Requiring a register-heavy
+result means the pass fires on the case it was measured on and declines the
+ones where it would only serialize. The `128x128xf32` bias tile that motivated
+the pass sits at 128 elements per thread, so the floor leaves a wide margin.
+
+After moving one wait, the pass rescans the block. This continues until no
+consecutive pair can be unified, allowing a sequence of compatible regions to
+collapse to one wait location.
+
+## Profitability Rule
+
+The first version deliberately uses a narrow allowlist between the two waits:
+
+- `ttg.local_load` and `ttng.tmem_load`;
+- `ttg.convert_layout`;
+- `tt.broadcast`;
+- `arith.extf` and `arith.truncf`;
+- memdesc views and scalar integer barrier-phase bookkeeping; and
+- WS barrier operations that pass the movement proof.
+
+At least one `tt.broadcast` must be present. Loads and casts alone do not make
+a region profitable. Arithmetic, reductions, unknown side effects, and every
+other operation keep the waits separate.
+
+## Safety
+
+The later wait is moved immediately after the earlier wait only if all of its
+operands already dominate that location. Every crossed operation is checked:
+
+- regions and unsupported barrier-like operations reject the move;
+- another wait must carry `WSBarrier` constraints;
+- crossing an arrive requires
+  `canAdvanceWSBarrierArrivePastWait`, using either disjoint channel graphs or
+  the ordered-region proof;
+- TMA, MMAv5, `tc_gen5_commit`, and other arrive-like operations reject the
+  move; and
+- any operation outside the explicit profitability allowlist rejects the
+  move.
+
+The pass moves only the later wait. Loads and arrive/release endpoints retain
+the locations chosen by TMEM interleaving, preserving buffer and TMEM reuse
+lifetimes.
+
+## Pipeline and Controls
+
+The NVIDIA backend schedules the pass directly after
+`triton-nvidia-interleave-tmem` and before generic data-duplication and
+instruction-reordering passes. It is enabled independently by default; set
+`TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS=0` to disable it. The pass also
+honors `TRITON_DISABLE_WSBARRIER_REORDER=1`.
+
+Focused coverage is in
+`test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir`.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -38,6 +38,13 @@ struct MemDescOperand {
   std::optional<int> offset;
 };
 
+// `tlx.less_reg_mma`, propagated to the module by the TLX Fixup pass from
+// `tlx.async_tasks(less_reg_mma=True)`. See `DotOpMmaSmemLoader::smemLoad`.
+inline bool hasLessRegMMA(Operation *op) {
+  auto mod = op->getParentOfType<ModuleOp>();
+  return mod && mod->hasAttr("tlx.less_reg_mma");
+}
+
 // Abstract class to calculate the address of a shared or tensor memory slice.
 class DotOpMmaMemLoader {
 public:
@@ -54,13 +61,14 @@ public:
   DotOpMmaSmemLoader() = default;
 
   DotOpMmaSmemLoader(MMASMEMDescriptor desc, Value baseSrcb128,
-                     LinearLayout llInv)
-      : desc(desc), baseSrcb128(baseSrcb128), ll(std::move(llInv)) {}
+                     LinearLayout llInv, bool lessRegMMA)
+      : desc(desc), baseSrcb128(baseSrcb128), ll(std::move(llInv)),
+        lessRegMMA(lessRegMMA) {}
 
   static FailureOr<DotOpMmaSmemLoader>
   build(Location loc, RewriterBase &rewriter, gpu::MemDescType memTy,
         Value smemBase, ArrayRef<unsigned> instrShape, unsigned MNdim,
-        int mmaVersion, bool isFp4 = false,
+        int mmaVersion, bool lessRegMMA, bool isFp4 = false,
         std::optional<RankedTensorType> mmaTy = std::nullopt) {
     auto ctx = rewriter.getContext();
     auto kOffset = str_attr("offset");
@@ -86,13 +94,13 @@ public:
       // The instr_shape comes in number of elements already
     }
     return build(loc, rewriter, llInv, bitwidth, smemBase, instrShape, MNdim,
-                 mmaVersion, mmaTy);
+                 mmaVersion, lessRegMMA, mmaTy);
   }
 
   static FailureOr<DotOpMmaSmemLoader>
   build(Location loc, RewriterBase &rewriter, const LinearLayout &ll,
         int bitwidth, Value smemBase, ArrayRef<unsigned> instrShape,
-        unsigned MNdim, int mmaVersion,
+        unsigned MNdim, int mmaVersion, bool lessRegMMA,
         std::optional<RankedTensorType> mmaTy = std::nullopt) {
     // ll is a map from two dimensions (dim0, dim1) or (row, col) into offsets
     // and blocks
@@ -159,7 +167,7 @@ public:
     if (failed(desc))
       return failure();
 
-    return DotOpMmaSmemLoader{*desc, baseSrcb128, ll};
+    return DotOpMmaSmemLoader{*desc, baseSrcb128, ll, lessRegMMA};
   }
 
   Value smemLoad(int a, int b, ConversionPatternRewriter &rewriter,
@@ -185,21 +193,28 @@ public:
     // Compute the base address at runtime to prevent LLVM from folding the
     // per-tile offset into a unique 64-bit constant. This produces a short
     // dependency chain (add→and→zext→add) that helps hide WGMMA latency.
-
-    // NOTE: intentionally use inline PTX with *side-effecting* here to
-    // compute an address. This hack is to prevent LLVM CSE which could
-    // cause two distant MMA sharing the same SMEM operand which would have
-    // a very long live range and cause register spill when there're many mma
-    // instructions. This way each MMA computes its own operand.
-    // TODO: do it for TMEM operand too?
-    PTXBuilder ptxBuilder;
-    auto &addInstr = *ptxBuilder.create("add.s32");
-    auto *addOut = ptxBuilder.newOperand("=r");
-    auto *addLhs = ptxBuilder.newOperand(baseSrcb128, "r");
-    auto *addRhs = ptxBuilder.newOperand(tb.i32_val(smemByteOffsetb128), "r");
-    addInstr(addOut, addLhs, addRhs);
-    Value fullAddrb128 =
-        ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffect=*/true);
+    Value fullAddrb128;
+    if (lessRegMMA) {
+      // NOTE: intentionally use inline PTX with *side-effecting* here to
+      // compute an address. This hack is to prevent LLVM CSE which could
+      // cause two distant MMA sharing the same SMEM operand which would have
+      // a very long live range and cause register spill when there're many mma
+      // instructions. This way each MMA computes its own operand.
+      // Opt-in via `tlx.async_tasks(less_reg_mma=True)`: it costs one extra
+      // add per MMA operand, so it only pays off in MMA-heavy tasks that
+      // actually spill.
+      // TODO: do it for TMEM operand too?
+      PTXBuilder ptxBuilder;
+      auto &addInstr = *ptxBuilder.create("add.s32");
+      auto *addOut = ptxBuilder.newOperand("=r");
+      auto *addLhs = ptxBuilder.newOperand(baseSrcb128, "r");
+      auto *addRhs = ptxBuilder.newOperand(tb.i32_val(smemByteOffsetb128), "r");
+      addInstr(addOut, addLhs, addRhs);
+      fullAddrb128 =
+          ptxBuilder.launch(rewriter, loc, i32_ty, /*hasSideEffect=*/true);
+    } else {
+      fullAddrb128 = tb.add(baseSrcb128, tb.i32_val(smemByteOffsetb128));
+    }
     Value addrMasked = tb.and_(fullAddrb128, tb.i32_val(0x7FFF));
     Value addr64 = tb.zext(i64_ty, addrMasked);
     Value descVal = tb.add(tb.int_val(64, currDesc.descriptor), addr64);
@@ -216,6 +231,9 @@ private:
   MMASMEMDescriptor desc;
   Value baseSrcb128;
   LinearLayout ll;
+  // Initialized here, unlike its neighbours, because the defaulted default
+  // constructor is used (`DotOpMmaSmemLoader aLoader;` in WGMMA.cpp).
+  bool lessRegMMA = false;
 
   static FailureOr<MMASMEMDescriptor>
   getDescriptor(Location loc, const LinearLayout &ll,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -531,15 +531,13 @@ struct DotConversion {
   CreateMMAInstFn createMMAInst;
 };
 
-LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
-                             ConversionPatternRewriter &rewriter, Location loc,
-                             Value a, Value b, Value loadedA, Value loadedB,
-                             MemDescType dTensorTy, Value useDFlag, Value pred,
-                             ValueRange barriers, ValueRange barrierPreds,
-                             bool twoCTAs, bool tlxPairedMMA,
-                             ValueRange commitDescs, bool opKindIsMXFP4,
-                             const ttng::TargetFeatures &targetFeatures,
-                             const DotConversion &op) {
+LogicalResult convertDotImpl(
+    const LLVMTypeConverter &typeConverter, ConversionPatternRewriter &rewriter,
+    Location loc, Value a, Value b, Value loadedA, Value loadedB,
+    MemDescType dTensorTy, Value useDFlag, Value pred, ValueRange barriers,
+    ValueRange barrierPreds, bool twoCTAs, bool tlxPairedMMA,
+    ValueRange commitDescs, bool opKindIsMXFP4, bool lessRegMMA,
+    const ttng::TargetFeatures &targetFeatures, const DotConversion &op) {
   auto tb = TritonLLVMOpBuilder(loc, rewriter);
 
   // Only run mma on one thread. We currently use elect as ptxas is not able to
@@ -630,8 +628,9 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
         std::make_unique<DotOpMmaV5TmemLoader>(DotOpMmaV5TmemLoader::build(
             loc, rewriter, aTensorTy, baseA, op.numBitsPerElementA));
   } else {
-    auto loader = DotOpMmaSmemLoader::build(loc, rewriter, aTensorTy, baseA,
-                                            aOperandShape, 0, 5, isFp4a);
+    auto loader =
+        DotOpMmaSmemLoader::build(loc, rewriter, aTensorTy, baseA,
+                                  aOperandShape, 0, 5, lessRegMMA, isFp4a);
     if (failed(loader)) {
       return mlir::emitError(loc, "failed to find valid tcgen05.mma layout for "
                                   "operand A in shared memory ")
@@ -643,8 +642,8 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   }
 
   auto isFp4b = op.numBitsPerElementB == 4;
-  auto bLoader = DotOpMmaSmemLoader::build(loc, rewriter, bTensorTy, baseB,
-                                           bOperandShape, 1, 5, isFp4b);
+  auto bLoader = DotOpMmaSmemLoader::build(
+      loc, rewriter, bTensorTy, baseB, bOperandShape, 1, 5, lessRegMMA, isFp4b);
   if (failed(bLoader)) {
     return mlir::emitError(loc, "failed to find valid tcgen05.mma layout for "
                                 "operand B in shared memory ")
@@ -784,12 +783,12 @@ LogicalResult convertDot(const LLVMTypeConverter &typeConverter,
                   useInitAcc, desc.aInTmem, twoCTAs, collectorB);
   };
 
-  return convertDotImpl(typeConverter, rewriter, loc, op.getA(), op.getB(),
-                        adaptor.getA(), adaptor.getB(), dTensorTy,
-                        adaptor.getUseD(), adaptor.getPred(),
-                        adaptor.getBarriers(), adaptor.getBarrierPreds(),
-                        twoCTAs, tlx::tlxEnablePairedMMA(op), commitDescs,
-                        /*opKindIsMXFP4=*/false, targetFeatures, dot);
+  return convertDotImpl(
+      typeConverter, rewriter, loc, op.getA(), op.getB(), adaptor.getA(),
+      adaptor.getB(), dTensorTy, adaptor.getUseD(), adaptor.getPred(),
+      adaptor.getBarriers(), adaptor.getBarrierPreds(), twoCTAs,
+      tlx::tlxEnablePairedMMA(op), commitDescs,
+      /*opKindIsMXFP4=*/false, hasLessRegMMA(op), targetFeatures, dot);
 }
 
 int64_t getFormatBitSize(ScaleDotElemType type) {
@@ -977,7 +976,7 @@ LogicalResult convertScaledDot(const LLVMTypeConverter &typeConverter,
                         adaptor.getUseD(), adaptor.getPred(),
                         adaptor.getBarriers(), adaptor.getBarrierPreds(),
                         twoCTAs, tlx::tlxEnablePairedMMA(op), commitDescs,
-                        opKindIsMXFP4, targetFeatures, dot);
+                        opKindIsMXFP4, hasLessRegMMA(op), targetFeatures, dot);
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -223,9 +223,9 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   SmallVector<Value> structA;
   bool transA = false;
   if (aInShared) {
-    auto loader =
-        DotOpMmaSmemLoader::build(loc, rewriter, cast<MemDescType>(aTensorTy),
-                                  baseA, {M, K}, 0, 3, false, dTensorTy);
+    auto loader = DotOpMmaSmemLoader::build(
+        loc, rewriter, cast<MemDescType>(aTensorTy), baseA, {M, K}, 0, 3,
+        hasLessRegMMA(op), /*isFp4=*/false, dTensorTy);
     if (failed(loader)) {
       return mlir::emitError(loc, "failed to find valid wgmma layout for "
                                   "operand A in shared memory ")
@@ -238,7 +238,8 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
     structA = unpackLLElements(loc, loadedA, rewriter);
   }
   auto bLoader = DotOpMmaSmemLoader::build(loc, rewriter, bTensorTy, baseB,
-                                           {K, N}, 1, 3, false, dTensorTy);
+                                           {K, N}, 1, 3, hasLessRegMMA(op),
+                                           /*isFp4=*/false, dTensorTy);
   if (failed(bLoader)) {
     return mlir::emitError(loc, "failed to find valid wgmma layout for "
                                 "operand B in shared memory ")

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -731,8 +731,9 @@ static LogicalResult copySharedToTmem(ConversionPatternRewriter &rewriter,
                                  {kBlock, cvt.getInDimSize(kBlock)}})
                      .sublayout({kRow, kCol}, to_vector(cvt.getOutDimNames()));
 
-  auto loader = DotOpMmaSmemLoader::build(loc, rewriter, cvtWarp, bitwidth,
-                                          smemBase, instrShape, 0, 5);
+  auto loader =
+      DotOpMmaSmemLoader::build(loc, rewriter, cvtWarp, bitwidth, smemBase,
+                                instrShape, 0, 5, hasLessRegMMA(op));
   if (failed(loader)) {
     return op->emitOpError("failed to find valid tcgen05.copy layout from "
                            "shared memory descriptor ")

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -218,6 +218,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
   ADD_PASS_WRAPPER_0("add_interleave_tmem",
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
+  ADD_PASS_WRAPPER_0("add_unify_ws_barrier_locations",
+                     ttng::createTritonNvidiaGPUUnifyWSBarrierLocationsPass);
   ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
                      ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
   ADD_PASS_WRAPPER_0("add_clc_split", ttng::createTritonNvidiaGPUCLCSplitPass);

--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -633,6 +633,7 @@ public:
       int numWarpSpecializeOps = 0;
       bool hasExclusiveWS = false;
       bool hasNoEndingClusterSync = false;
+      bool hasLessRegMMA = false;
       std::optional<int32_t> mbarrierTryWaitSuspendNs;
       mod.walk([&](ttg::WarpSpecializeOp op) {
         ++numWarpSpecializeOps;
@@ -640,6 +641,8 @@ public:
           hasExclusiveWS = true;
         if (op->hasAttr("tlx.no_ending_cluster_sync"))
           hasNoEndingClusterSync = true;
+        if (op->hasAttr("tlx.less_reg_mma"))
+          hasLessRegMMA = true;
         if (auto attr = op->getAttrOfType<IntegerAttr>(
                 "tlx.mbarrier_try_wait_suspend_ns")) {
           int32_t value = attr.getInt();
@@ -650,6 +653,11 @@ public:
       if (mbarrierTryWaitSuspendNs)
         mod->setAttr("tlx.mbarrier_try_wait_suspend_ns",
                      b.getI32IntegerAttr(*mbarrierTryWaitSuspendNs));
+      // `less_reg_mma`: give every MMA its own SMEM operand address
+      // computation instead of letting LLVM CSE one across distant MMAs. The
+      // NVIDIA MMA lowering reads this off the module.
+      if (hasLessRegMMA)
+        mod->setAttr("tlx.less_reg_mma", b.getUnitAttr());
       if (hasExclusiveWS) {
         if (numWarpSpecializeOps != 1) {
           mod.emitError()

--- a/third_party/tlx/language/tlx/async_task_utils.py
+++ b/third_party/tlx/language/tlx/async_task_utils.py
@@ -55,11 +55,17 @@ class async_tasks:
         exclusive=False,
         no_ending_cluster_sync=False,
         mbarrier_try_wait_suspend_ns=None,
+        less_reg_mma=False,
         **kwargs,
     ):
         self.exclusive = core._unwrap_if_constexpr(exclusive)
         self.no_ending_cluster_sync = core._unwrap_if_constexpr(no_ending_cluster_sync)
         self.mbarrier_try_wait_suspend_ns = core._unwrap_if_constexpr(mbarrier_try_wait_suspend_ns)
+        # Lower each MMA's SMEM operand descriptor with its own side-effecting
+        # address computation so LLVM cannot CSE it across distant MMAs. Trades
+        # a few extra ALU ops for a much shorter live range, which avoids
+        # register spilling in MMA-heavy tasks (e.g. FA4 backward).
+        self.less_reg_mma = core._unwrap_if_constexpr(less_reg_mma)
         if self.mbarrier_try_wait_suspend_ns is not None:
             if not isinstance(self.mbarrier_try_wait_suspend_ns, int) or self.mbarrier_try_wait_suspend_ns < 0:
                 raise ValueError("mbarrier_try_wait_suspend_ns must be a non-negative integer")

--- a/third_party/tlx/language/tlx/compiler/code_generator.py
+++ b/third_party/tlx/language/tlx/compiler/code_generator.py
@@ -168,6 +168,7 @@ def visit_withAsyncTasks(self, node):
     exclusive = False
     no_ending_cluster_sync = False
     mbarrier_try_wait_suspend_ns = None
+    less_reg_mma = False
     for kw in getattr(ws_context, "keywords", []):
         if kw.arg == "exclusive":
             exclusive = bool(_unwrap_if_constexpr(self.visit(kw.value)))
@@ -177,6 +178,8 @@ def visit_withAsyncTasks(self, node):
             mbarrier_try_wait_suspend_ns = _unwrap_if_constexpr(self.visit(kw.value))
             if not isinstance(mbarrier_try_wait_suspend_ns, int) or mbarrier_try_wait_suspend_ns < 0:
                 raise ValueError("mbarrier_try_wait_suspend_ns must be a non-negative integer")
+        elif kw.arg == "less_reg_mma":
+            less_reg_mma = bool(_unwrap_if_constexpr(self.visit(kw.value)))
 
     with enter_sub_region(self) as sr:
         liveins, _ = sr
@@ -297,6 +300,8 @@ def visit_withAsyncTasks(self, node):
                 "tlx.mbarrier_try_wait_suspend_ns",
                 self.builder.get_int32_attr(mbarrier_try_wait_suspend_ns),
             )
+        if less_reg_mma:
+            ws_op.set_attr("tlx.less_reg_mma", self.builder.get_unit_attr())
 
         # dry visit async task body to calculate captures
         index = 0

--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent.py
@@ -2841,7 +2841,10 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    with tlx.async_tasks(exclusive=True):
+    # `less_reg_mma`: the MMA task issues many dots over the same SMEM
+    # operands, so a CSE-d operand descriptor stays live across all of them and
+    # spills. Give each MMA its own address computation instead.
+    with tlx.async_tasks(exclusive=True, less_reg_mma=True):
         # compute
         with tlx.async_task("default"):
             blk_idx = 0


### PR DESCRIPTION
Summary:

Port D118577041 to the Triton 3.8 snapshot. Thread a `lessRegMMA` flag through `DotOpMmaSmemLoader` so the side-effecting `add.s32` SMEM operand address computation (which blocks LLVM CSE across distant MMAs) is opt-in via `tlx.async_tasks(less_reg_mma=True)`, plumbed through the TLX Fixup pass as a `tlx.less_reg_mma` module attribute. Default lowering keeps the plain `llvm.add`. The beta `flash_attn/sm100.py` kernel has no 3.8 counterpart (`ops/kernels` does not exist in 3.8) and is skipped; the 3.8 tutorial uses `exclusive=True` instead of `exclusive=not DIRECT_DQ_OUTPUT`.

Reviewed By: agron911

Differential Revision: D118717214


