### PR TITLE
[TLX] Optimize Blackwell MXFP8 attention backward

### DIFF
--- a/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
+++ b/third_party/tlx/tutorials/blackwell_fa_ws_pipelined_persistent_mxfp8.py
@@ -1357,7 +1357,7 @@ def _attn_bwd_preprocess(
     o = tl.load(O + o_offsets, mask=o_mask, other=0.0)
     do = tl.load(DO + o_offsets, mask=o_mask, other=0.0).to(tl.float32)
     delta = tl.sum(o * do, axis=1)
-    tl.store(DQ + o_offsets, 0.0, mask=o_mask)
+    tl.store(DQ + o_offsets, 0.0, mask=o_mask, eviction_policy="evict_first")
     tl.store(Delta + base + off_m, delta, mask=off_m < N_CTX)
 
 
@@ -2813,15 +2813,7 @@ def _attn_bwd_mxf8_ws(
                     do_scale_smem[do_buf_id],
                     [sf_off_seq_h, do_scale_m, 0, 0, 0],
                     do_fulls[do_buf_id],
-                )
-                d_buf_id, d_phase = get_bufidx_phase(blk_idx, D_STAGE)
-                tlx.barrier_wait(d_empties[d_buf_id], d_phase ^ 1)
-                tlx.barrier_expect_bytes(d_fulls[d_buf_id], 4 * BLOCK_M1)
-                tlx.async_descriptor_load(
-                    desc_delta,
-                    sD_tiles[d_buf_id],
-                    [(base_q + curr_m).to(tl.int32)],
-                    d_fulls[d_buf_id],
+                    eviction_policy="evict_last",
                 )
                 tlx.barrier_wait(do_dv_empties[do_buf_id], do_phase ^ 1)
                 tlx.barrier_expect_bytes(
@@ -2839,6 +2831,16 @@ def _attn_bwd_mxf8_ws(
                     do_scale_dv_smem[do_buf_id],
                     [sf_off_seq_h, 0, do_scale_m, 0, 0],
                     do_dv_fulls[do_buf_id],
+                    eviction_policy="evict_last",
+                )
+                d_buf_id, d_phase = get_bufidx_phase(blk_idx, D_STAGE)
+                tlx.barrier_wait(d_empties[d_buf_id], d_phase ^ 1)
+                tlx.barrier_expect_bytes(d_fulls[d_buf_id], 4 * BLOCK_M1)
+                tlx.async_descriptor_load(
+                    desc_delta,
+                    sD_tiles[d_buf_id],
+                    [(base_q + curr_m).to(tl.int32)],
+                    d_fulls[d_buf_id],
                 )
                 tlx.barrier_wait(k_dq_empties[kv_buf_id], kv_phase ^ 1)
                 tlx.barrier_expect_bytes(
@@ -2893,6 +2895,55 @@ def _attn_bwd_mxf8_ws(
                         [(base_q + curr_m).to(tl.int32)],
                         m_fulls[m_buf_id],
                     )
+                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
+                    tlx.barrier_expect_bytes(
+                        do_fulls[do_buf_id],
+                        (DO_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES,
+                    )
+                    tlx.async_descriptor_load(
+                        desc_do,
+                        do_smem[do_buf_id],
+                        [off_z, off_h, curr_m, 0],
+                        do_fulls[do_buf_id],
+                    )
+                    tlx.async_descriptor_load(
+                        desc_do_scale,
+                        do_scale_smem[do_buf_id],
+                        [sf_off_seq_h, do_scale_m, 0, 0, 0],
+                        do_fulls[do_buf_id],
+                        eviction_policy="evict_last",
+                    )
+                    tlx.barrier_wait(do_dv_empties[do_buf_id], do_phase ^ 1)
+                    tlx.barrier_expect_bytes(
+                        do_dv_fulls[do_buf_id],
+                        (DO_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES,
+                    )
+                    tlx.async_descriptor_load(
+                        desc_do_dv,
+                        do_dv_smem[do_buf_id],
+                        [off_z, off_h, curr_m, 0],
+                        do_dv_fulls[do_buf_id],
+                    )
+                    tlx.async_descriptor_load(
+                        desc_do_dv_scale,
+                        do_scale_dv_smem[do_buf_id],
+                        [sf_off_seq_h, 0, do_scale_m, 0, 0],
+                        do_dv_fulls[do_buf_id],
+                        eviction_policy="evict_last",
+                    )
+                    d_buf_id, d_phase = get_bufidx_phase(blk_idx, D_STAGE)
+                    tlx.barrier_wait(d_empties[d_buf_id], d_phase ^ 1)
+                    tlx.barrier_expect_bytes(d_fulls[d_buf_id], 4 * BLOCK_M1)
+                    tlx.async_descriptor_load(
+                        desc_delta,
+                        sD_tiles[d_buf_id],
+                        [(base_q + curr_m).to(tl.int32)],
+                        d_fulls[d_buf_id],
+                    )
+                    # Q-for-dK is consumed after the current Q, dO, and Delta
+                    # paths. Defer its reuse wait so it cannot prevent those
+                    # critical-path TMA requests from being issued. The same
+                    # empty/full phase still protects the single staging slot.
                     tlx.barrier_wait(q_dk_empties[prev_q_buf_id], prev_q_phase ^ 1)
                     tlx.barrier_expect_bytes(
                         q_dk_fulls[prev_q_buf_id],
@@ -2911,50 +2962,6 @@ def _attn_bwd_mxf8_ws(
                         q_dk_scale_smem[prev_q_buf_id],
                         [sf_off_seq_h, 0, (prev_m // 128) * REP_M, 0, 0],
                         q_dk_fulls[prev_q_buf_id],
-                    )
-
-                    tlx.barrier_wait(do_empties[do_buf_id], do_phase ^ 1)
-                    tlx.barrier_expect_bytes(
-                        do_fulls[do_buf_id],
-                        (DO_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES,
-                    )
-                    tlx.async_descriptor_load(
-                        desc_do,
-                        do_smem[do_buf_id],
-                        [off_z, off_h, curr_m, 0],
-                        do_fulls[do_buf_id],
-                    )
-                    tlx.async_descriptor_load(
-                        desc_do_scale,
-                        do_scale_smem[do_buf_id],
-                        [sf_off_seq_h, do_scale_m, 0, 0, 0],
-                        do_fulls[do_buf_id],
-                    )
-                    d_buf_id, d_phase = get_bufidx_phase(blk_idx, D_STAGE)
-                    tlx.barrier_wait(d_empties[d_buf_id], d_phase ^ 1)
-                    tlx.barrier_expect_bytes(d_fulls[d_buf_id], 4 * BLOCK_M1)
-                    tlx.async_descriptor_load(
-                        desc_delta,
-                        sD_tiles[d_buf_id],
-                        [(base_q + curr_m).to(tl.int32)],
-                        d_fulls[d_buf_id],
-                    )
-                    tlx.barrier_wait(do_dv_empties[do_buf_id], do_phase ^ 1)
-                    tlx.barrier_expect_bytes(
-                        do_dv_fulls[do_buf_id],
-                        (DO_BYTES * BLOCK_M1 * HEAD_DIM) + SCALE_BYTES,
-                    )
-                    tlx.async_descriptor_load(
-                        desc_do_dv,
-                        do_dv_smem[do_buf_id],
-                        [off_z, off_h, curr_m, 0],
-                        do_dv_fulls[do_buf_id],
-                    )
-                    tlx.async_descriptor_load(
-                        desc_do_dv_scale,
-                        do_scale_dv_smem[do_buf_id],
-                        [sf_off_seq_h, 0, do_scale_m, 0, 0],
-                        do_dv_fulls[do_buf_id],
                     )
                     curr_m += BLOCK_M1
                     blk_idx += 1


### PR DESCRIPTION
Improve the Blackwell MXFP8 persistent backward pipeline without adding shape, mode, scale, or device specialization.
    
Mark the preprocessing dQ zero-initialization store as `evict_first`, since it is a streaming write that should not displace inputs used by the following persistent kernel. Mark the compact dO scale descriptor loads as `evict_last` for both the normal dO path and the transposed dO-for-dV path, in both the prologue and steady-state loop, while leaving the larger dO payload streams unchanged.
    
Reorder two independent parts of the Load task to reduce head-of-line blocking. Issue the dO-for-dV payload and scale loads before waiting for the Delta staging slot, allowing those TMA requests to overlap Delta-buffer backpressure. In the steady-state loop, defer the single-slot previous-Q-for-dK reuse wait and its payload and scale loads until after the current dO, dO-for-dV, and Delta requests, since Q-for-dK is consumed later by MMA 4.
    
he prologue and final Q-for-dK loads are unchanged. Existing buffer indices, barrier phases and byte counts, descriptor coordinates, task topology, TMEM aliases, dQ reduce-add publication, and separate dS encodings are preserved.
    
Test Plan:
 Compared the complete combined change against 7d493eb884 on B200 for B=4, H=32, HEAD_DIM=128, causal=false, backward, and sm_scale=0.5. Each sequence length used shared inputs and 10 alternating baseline/optimized measurements.
    
    | N_CTX | Baseline (us) | Optimized (us) | Speedup | Correct |
    |------:|--------------:|---------------:|--------:|:-------:|
    | 1,024 |        256.99 |         256.63 | 1.0014x |  pass   |
    | 2,048 |        928.20 |         923.76 | 1.0048x |  pass   |
    | 4,096 |      3,465.55 |       3,426.31 | 1.0115x |  pass   |
    | 8,192 |     13,298.75 |      13,145.76 | 1.0116x |  pass   |
    
Correctness was checked against the frozen original, including repeat stability. The worst reference cosine was 0.99999988.
    
TLX agent authored