### PR TITLE
[TLX.ops] Tune gfx942 long-K tail heuristic

### DIFF
--- a/python/test/tlx_benchmark/_harness/report.py
+++ b/python/test/tlx_benchmark/_harness/report.py
@@ -61,8 +61,6 @@ def table(results: Sequence[Result]) -> str:
                      f"{_tf(_stat(r.tlx, 'p50'))} "
                      f"{_tf(_stat(r.tlx, 'p95'))} "
                      f"{_tf(_stat(r.tlx, 'p99'))}  {_MARK[r.status]}")
-        for note in r.notes:
-            lines.append(f"{'':<{width}} -> {note}")
     return "\n".join(lines)
 
 
@@ -86,13 +84,19 @@ def write_json(results: Sequence[Result], env: dict, path: str | pathlib.Path) -
     return path
 
 
+def _details(results: Sequence[Result], statuses: tuple[Status, ...]) -> list[str]:
+    return [f"  {r.case.key}: {'; '.join(r.notes) or _MARK[r.status]}" for r in results if r.status in statuses]
+
+
 def render(results: Sequence[Result], env: dict, json_path: Optional[str] = None) -> str:
-    out = [table(results), "", summary(results)]
+    out = [table(results), ""]
     if json_path:
         out.append(f"artifact: {write_json(results, env, json_path)}")
+    out.append(summary(results))
+    noisy = _details(results, (Status.NOISY, ))
+    if noisy:
+        out.extend(("", "Noisy data:", *noisy))
     bad = failures(results)
     if bad:
-        out.append("")
-        out.append("Issues:")
-        out.extend(f"  {r.case.key}: {'; '.join(r.notes) or _MARK[r.status]}" for r in bad)
+        out.extend(("", "Issues:", *_details(bad, FAILING)))
     return "\n".join(out)

--- a/python/test/tlx_benchmark/test_harness.py
+++ b/python/test/tlx_benchmark/test_harness.py
@@ -206,6 +206,27 @@ def test_artifact_is_json_serializable_and_versioned():
     assert "tlx_tflops" not in doc["results"][0]
 
 
+def test_report_groups_notes_after_the_table(tmp_path):
+    from _harness import report
+
+    pip = Result(case=_case(), status=Status.PIP, notes=["speedup 0.746x is under the 0.9x floor"])
+    noisy_case = Case(op="mm", arch="gfx942", dtype="float16", shape=(2048, 1024, 512, True, True))
+    noisy = Result(case=noisy_case, status=Status.NOISY, notes=["CV 4.2% over the 3% limit"])
+
+    rendered = report.render([pip, noisy], {}, tmp_path / "mm.json")
+    table_text, footer = rendered.split("\n\n", 1)
+
+    assert "speedup 0.746x is under" not in table_text
+    assert "CV 4.2% over" not in table_text
+    artifact_at = footer.index("artifact:")
+    summary_at = footer.index("1 PIP, 1 noisy")
+    noisy_at = footer.index("Noisy data:")
+    issues_at = footer.index("Issues:")
+    assert artifact_at < summary_at < noisy_at < issues_at
+    assert "CV 4.2% over the 3% limit" in footer[noisy_at:issues_at]
+    assert "speedup 0.746x is under the 0.9x floor" in footer[issues_at:]
+
+
 # --------------------------------------------------------------------------
 # verdict: the four statuses
 # --------------------------------------------------------------------------

--- a/third_party/tlx/ops/kernels/mm/gfx942.py
+++ b/third_party/tlx/ops/kernels/mm/gfx942.py
@@ -56,6 +56,12 @@ NUM_CUS = 304
 #: 2048^3 and 4096^3 by one rung.
 _MIN_WORKGROUPS = 256
 
+# A long-running grid just over one full device wave leaves only a handful of
+# CUs working through its tail.  For those extreme-K shapes, prefer the
+# single-buffer specialization of the next ladder rung so the work decomposes
+# into several better-filled waves without consuming the full LDS budget.
+_LONG_K_TAIL_THRESHOLD = 16 * 1024
+
 # Per-workgroup LDS on CDNA3. Configs are checked against this so an oversized
 # tile is dropped before compilation instead of failing out-of-resources.
 CDNA3_LDS_BYTES = 64 * 1024
@@ -287,6 +293,13 @@ _TILE_LADDER = [
 #: GROUP_M swizzle has too little to work with to keep B resident in L2.
 _NARROW_TILE = (128, 128, 32, 8, 1, 4)
 
+# The long-K tail fallback keeps the same tile geometry as the next ladder
+# rung, but uses one LDS buffer.  Its 128x128x64 two-buffer form consumes the
+# entire LDS budget; the fallback already has several device waves available,
+# so test whether freeing half of that per-workgroup LDS is worth giving up one
+# tile of prefetch distance.
+_LONG_K_TAIL_TILE = (128, 128, 64, 8, 1, 8)
+
 #: A shape is "narrow" when one side is this small while the other is large.
 _NARROW_SIDE = 1024
 _WIDE_SIDE = 4096
@@ -300,7 +313,9 @@ def heuristic_config(M, N, K):
     1. A narrow shape -- one side <= 1024 while the other is >= 4096 -- takes
        `_NARROW_TILE` regardless of how many workgroups a wider tile would make.
     2. Otherwise take the widest tile that still produces at least
-       `_MIN_WORKGROUPS`, falling back to the narrowest tile in the ladder.
+       `_MIN_WORKGROUPS`, except that an extreme-K grid between one and two
+       full device waves takes the single-buffer specialization of the next
+       rung to avoid a long under-filled tail. Fall back to the narrowest tile.
 
     Returns None when nothing in the ladder fits the LDS budget at this K, which
     sends the caller to the smoke space rather than off a cliff.
@@ -308,7 +323,18 @@ def heuristic_config(M, N, K):
     if min(M, N) <= _NARROW_SIDE <= _WIDE_SIDE <= max(M, N):
         candidates = [_NARROW_TILE]
     else:
-        candidates = [t for t in _TILE_LADDER if triton.cdiv(M, t[0]) * triton.cdiv(N, t[1]) >= _MIN_WORKGROUPS]
+        candidates = []
+        long_k_tail = False
+        for tile in _TILE_LADDER:
+            workgroups = triton.cdiv(M, tile[0]) * triton.cdiv(N, tile[1])
+            if workgroups < _MIN_WORKGROUPS:
+                continue
+            if K >= _LONG_K_TAIL_THRESHOLD and NUM_CUS < workgroups < 2 * NUM_CUS:
+                long_k_tail = True
+                continue
+            candidates.append(tile)
+        if long_k_tail:
+            candidates = [_LONG_K_TAIL_TILE]
         candidates = candidates or [_TILE_LADDER[-1]]
 
     for block_m, block_n, block_k, group_m, num_buffers, num_warps in candidates:


### PR DESCRIPTION
Tweaks the gfx942 matmul tile-selection heuristic in third_party/tlx/ops/kernels/mm/gfx942.py: when K ≥ 16K and the chosen tile yields a grid between one and two full device waves (304–608 workgroups), it now swaps in a single-buffer 128x128x64 config instead of that ladder rung, avoiding a long tail where only a few CUs are busy.


## Test plan

2048x10240x25408: 269 TFLOP/s => 407 TFLOP/s

Before
```
input                                                                                                    ref TF/s  tlx TF/s  speedup  compile  samples    CV%  p50 TF/s  p95 TF/s  p99 TF/s  status
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
((), {'dtype': 'fp16', 'strides': '[[1024, 1], [192, 1]]', 'M': '819200', 'N': '192', 'K': '1024'})           358       268   0.749x    0.24s      515    1.0       268       272       273  PIP
                                                                                                        -> speedup 0.749x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[1894, 1], [242432, 1]]', 'M': '4096', 'N': '242432', 'K': '1894'})       452       370   0.819x    0.45s      488    0.5       370       373       374  PIP
                                                                                                        -> speedup 0.819x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[6144, 1], [20480, 1]]', 'M': '1024', 'N': '20480', 'K': '6144'})         475       357   0.752x    0.00s      509    1.0       358       363       365  PIP
                                                                                                        -> speedup 0.752x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[25408, 1], [10240, 1]]', 'M': '2048', 'N': '10240', 'K': '25408'})       512       269   0.524x    0.39s      478    1.3       269       273       275  PIP
                                                                                                        -> speedup 0.524x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[2048, 1], [5120, 1]]', 'M': '61440', 'N': '5120', 'K': '2048'})          548       473   0.863x    0.00s      520    0.7       473       479       481  PIP
                                                                                                        -> speedup 0.863x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[256, 1], [256, 1]]', 'M': '2252800', 'N': '256', 'K': '256'})            283       239   0.847x    0.00s      504    0.9       239       243       244  PIP
                                                                                                        -> speedup 0.847x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[4096, 1], [3840, 1]]', 'M': '61440', 'N': '3840', 'K': '4096'})          568       490   0.863x    0.00s      523    0.7       490       495       497  PIP
                                                                                                        -> speedup 0.863x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[2048, 1], [4096, 1]]', 'M': '4096', 'N': '4096', 'K': '2048'})           549       431   0.784x    0.00s      799    3.5       430       456       460  PIP
                                                                                                        -> speedup 0.784x is under the 0.9x floor
                                                                                                        -> CV 3.5% is also over the 3% limit
((), {'dtype': 'fp16', 'strides': '[[7744, 1], [5120, 1]]', 'M': '61440', 'N': '5120', 'K': '7744'})          583       481   0.824x    0.01s      503    0.4       481       484       486  PIP
                                                                                                        -> speedup 0.824x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[4096, 1], [6144, 1]]', 'M': '1024', 'N': '6144', 'K': '4096'})           438       302   0.689x    0.00s      783    2.2       304       310       311  PIP
                                                                                                        -> speedup 0.689x is under the 0.9x floor
```

After
```
input                                                                                                    ref TF/s  tlx TF/s  speedup  compile  samples    CV%  p50 TF/s  p95 TF/s  p99 TF/s  status
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
((), {'dtype': 'fp16', 'strides': '[[1024, 1], [192, 1]]', 'M': '819200', 'N': '192', 'K': '1024'})           357       268   0.750x    0.24s      514    1.0       268       272       273  PIP
                                                                                                        -> speedup 0.750x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[1894, 1], [242432, 1]]', 'M': '4096', 'N': '242432', 'K': '1894'})       451       370   0.820x    0.44s      496    0.5       370       372       374  PIP
                                                                                                        -> speedup 0.820x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[6144, 1], [20480, 1]]', 'M': '1024', 'N': '20480', 'K': '6144'})         474       360   0.760x    0.00s      520    1.0       361       366       368  PIP
                                                                                                        -> speedup 0.760x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[25408, 1], [10240, 1]]', 'M': '2048', 'N': '10240', 'K': '25408'})       512       407   0.795x    0.23s      497    1.8       405       420       423  PIP
                                                                                                        -> speedup 0.795x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[2048, 1], [5120, 1]]', 'M': '61440', 'N': '5120', 'K': '2048'})          548       475   0.867x    0.39s      520    0.8       475       481       484  PIP
                                                                                                        -> speedup 0.867x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[256, 1], [256, 1]]', 'M': '2252800', 'N': '256', 'K': '256'})            283       242   0.853x    0.00s      502    0.8       242       245       246  PIP
                                                                                                        -> speedup 0.853x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[4096, 1], [3840, 1]]', 'M': '61440', 'N': '3840', 'K': '4096'})          568       490   0.862x    0.00s      525    0.7       490       495       497  PIP
                                                                                                        -> speedup 0.862x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[2048, 1], [4096, 1]]', 'M': '4096', 'N': '4096', 'K': '2048'})           551       437   0.794x    0.00s      856    2.9       438       455       459  PIP
                                                                                                        -> speedup 0.794x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[7744, 1], [5120, 1]]', 'M': '61440', 'N': '5120', 'K': '7744'})          583       481   0.825x    0.01s      501    0.4       481       484       486  PIP
                                                                                                        -> speedup 0.825x is under the 0.9x floor
((), {'dtype': 'fp16', 'strides': '[[4096, 1], [6144, 1]]', 'M': '1024', 'N': '6144', 'K': '4096'})           447       301   0.673x    0.00s      792    2.9       303       310       312  PIP
                                                                                                        -> speedup 0.673x is under the 0.9x floor
```