### PR TITLE
[TLX] Hopper FA bwd: Feed dsT fragments directly into the dK MMA (#3464)

### DIFF
--- a/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
+++ b/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
@@ -527,10 +527,10 @@ def _attn_bwd_tlx(
                 dpT = tlx.async_dot_wait(0, dpT).to(tl.float32)
                 tlx.barrier_arrive(do_empties[q_buf], 1)
                 dsT = pT * (dpT - Di[None, :])
+                dk = tlx.async_dot(dsT.to(tlx.dtype_of(desc_q)), q, dk)
                 tlx.local_store(score_smem, dsT.to(tlx.dtype_of(desc_q)))
                 tlx.fence_async_shared()
 
-                dk = tlx.async_dot(score_smem, q, dk)
                 dq = tlx.async_dot(score_smem_t, k_slice)
                 dk = tlx.async_dot_wait(1, dk)
                 tlx.barrier_arrive(q_empties[q_buf], 1)


### PR DESCRIPTION
Summary:

TLX kernel optimization agent continuation (r001-c000, 1.0115x aggregate speedup over the previous winner). Feed the live dsT register fragment directly into the dK async dot, removing one shared-memory operand reread per backward-loop iteration. The shared dsT store, fence, transposed view, and dQ dot are unchanged, as are all barriers, descriptor layouts, reduce-add stores, and public entry points.

Backward performance on H100, BF16, B=4 H=48 D=128:

| Case | Baseline us | Winner us | Speedup |
| --- | ---: | ---: | ---: |
| s1024 | 786.75 | 790.78 | 0.9949x |
| s2048 | 2316.45 | 2290.59 | 1.0113x |
| s4096 | 8063.74 | 8075.93 | 0.9985x |
| s8192 | 31049.77 | 30260.34 | 1.0261x |
| Weighted aggregate | — | — | 1.0115x |

Gains concentrate at long sequence lengths (s8192 +2.6%); s1024/s4096 are flat within noise. A follow-up candidate removing the dsT shared-memory roundtrip entirely regressed to 0.922x and was rejected.

Reviewed By: pchen7e2

Differential Revision: D118738393


