### PR TITLE
[TLX] Hopper FA : reorder backward dp and dV MMA issue (#3465)

### DIFF
--- a/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
+++ b/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
@@ -521,13 +521,13 @@ def _attn_bwd_tlx(
                 qkT = tlx.async_dot_wait(0, qkT)
                 qkT *= sm_scale * RCP_LN2
                 pT = tl.math.exp2(qkT - m[None, :])
-                dv = tlx.async_dot(pT.to(tlx.dtype_of(desc_q)), do, dv)
                 dpT = tlx.async_dot(v_slice, doT)
-                dv = tlx.async_dot_wait(1, dv)
-                dpT = tlx.async_dot_wait(0, dpT).to(tl.float32)
-                tlx.barrier_arrive(do_empties[q_buf], 1)
+                dv = tlx.async_dot(pT.to(tlx.dtype_of(desc_q)), do, dv)
+                dpT = tlx.async_dot_wait(1, dpT).to(tl.float32)
                 dsT = pT * (dpT - Di[None, :])
                 dk = tlx.async_dot(dsT.to(tlx.dtype_of(desc_q)), q, dk)
+                dv = tlx.async_dot_wait(1, dv)
+                tlx.barrier_arrive(do_empties[q_buf], 1)
                 tlx.local_store(score_smem, dsT.to(tlx.dtype_of(desc_q)))
                 tlx.fence_async_shared()
 


### PR DESCRIPTION
Summary:

TLX kernel optimization agent round 3 (r001-c000, 1.0334x aggregate speedup over the dsT-to-dK winner). Issue dpT before dV in the backward inner loop: wait for dpT first, form dsT, issue dK, then wait for dV before releasing the dO buffer. The dO empty-barrier arrival remains after dV completion; Q release, the shared dsT store and fence used by transposed dQ, dQ reduce-add stores, buffer counts, descriptor layouts, and public entry points are preserved.

Backward performance on H100, BF16, B=4 H=48 D=128:

| Case | Baseline us | Winner us | Speedup |
| --- | ---: | ---: | ---: |
| s1024 | 791.33 | 783.81 | 1.0096x |
| s2048 | 2302.75 | 2261.69 | 1.0182x |
| s4096 | 7974.87 | 7646.27 | 1.0430x |
| s8192 | 30245.97 | 29074.07 | 1.0403x |
| Weighted aggregate | — | — | 1.0334x |

tlx_fa vs flash_v3 on H100, BF16, D=128, bwd mode:

| Input (B, H, S, S_kv, D) | flash_v3 TFLOP/s | tlx_fa TFLOP/s | tlx_fa / flash_v3 |
| --- | ---: | ---: | ---: |
| (4, 48, 128, 128, 128) | 46.60 | 54.76 | 117.5% |
| (4, 48, 256, 256, 128) | 90.52 | 112.88 | 124.7% |
| (4, 48, 512, 512, 128) | 179.69 | 213.00 | 118.5% |
| (4, 48, 1024, 1024, 128) | 312.56 | 328.63 | 105.1% |
| (4, 48, 2048, 2048, 128) | 436.12 | 448.11 | 102.8% |
| (4, 48, 4096, 4096, 128) | 526.67 | 517.70 | 98.3% |
| (4, 48, 8192, 8192, 128) | 564.31 | 566.98 | 100.5% |
| Average | 308.07 | 320.29 | 104.0% |

Rejected this round: overlapping dK/dV epilogue stores (1.0298x, below the 1.01x-per-round promotion bar relative to the new winner) and moving the dsT shared store ahead of the dV wait (1.0069x).

Reviewed By: pchen7e2

Differential Revision: D118738394
