### PR TITLE
[TLX][AMD][NFC] Document explicit MFMA and register-class controls

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -126,27 +126,27 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
       triton::tlx::DumpLayoutOp, triton::gpu::WarpVoteOp,
       triton::amdgpu::BufferLoadOp, triton::amdgpu::BufferStoreOp,
       triton::amdgpu::BufferLoadToLocalOp,
-      triton::amdgpu::RematerializedRangeOp, triton::amdgpu::RegisterHandoffOp>(
-      [&](Operation *op) -> bool {
-        // make sure every RankedTensorType operand has encoding
-        for (auto operandType : op->getOperandTypes()) {
-          if (auto rankedTensorType = dyn_cast<RankedTensorType>(operandType)) {
-            if (rankedTensorType.getEncoding() == nullptr) {
-              return false;
-            }
-          }
+      triton::amdgpu::RematerializedRangeOp,
+      triton::amdgpu::RegisterClassAnchorOp>([&](Operation *op) -> bool {
+    // make sure every RankedTensorType operand has encoding
+    for (auto operandType : op->getOperandTypes()) {
+      if (auto rankedTensorType = dyn_cast<RankedTensorType>(operandType)) {
+        if (rankedTensorType.getEncoding() == nullptr) {
+          return false;
         }
+      }
+    }
 
-        // make sure result type has encoding if it is RankedTensorType
-        for (auto resultType : op->getResultTypes()) {
-          if (auto rankedTensorType = dyn_cast<RankedTensorType>(resultType)) {
-            if (rankedTensorType.getEncoding() == nullptr) {
-              return false;
-            }
-          }
+    // make sure result type has encoding if it is RankedTensorType
+    for (auto resultType : op->getResultTypes()) {
+      if (auto rankedTensorType = dyn_cast<RankedTensorType>(resultType)) {
+        if (rankedTensorType.getEncoding() == nullptr) {
+          return false;
         }
-        return true;
-      });
+      }
+    }
+    return true;
+  });
 
   addDynamicallyLegalOp<triton::FuncOp>([](triton::FuncOp funcOp) -> bool {
     auto check = [](auto types) {

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -695,7 +695,7 @@ void populateTLXPatterns(TritonGPUTypeConverter &typeConverter,
                                                                   context);
   patterns.add<GenericOpPattern<triton::amdgpu::RematerializedRangeOp>>(
       typeConverter, context);
-  patterns.add<GenericOpPattern<triton::amdgpu::RegisterHandoffOp>>(
+  patterns.add<GenericOpPattern<triton::amdgpu::RegisterClassAnchorOp>>(
       typeConverter, context);
 }
 

--- a/python/test/unit/language/test_tlx_amd.py
+++ b/python/test/unit/language/test_tlx_amd.py
@@ -2097,10 +2097,10 @@ def test_amd_late_address_compute_compiles_gfx950():
 
 
 @triton.jit
-def _amd_register_handoff_kernel(x_ptr, y_ptr, REGISTER_CLASS: tl.constexpr):
+def _amd_register_class_anchor_kernel(x_ptr, y_ptr, REGISTER_CLASS: tl.constexpr):
     offsets = tl.arange(0, 2048)
     values = tl.load(x_ptr + offsets)
-    values = tlx.amd_register_handoff(values, register_class=REGISTER_CLASS)
+    values = tlx.amd_register_class_anchor(values, register_class=REGISTER_CLASS)
     tl.store(y_ptr + offsets, values)
 
 
@@ -2112,37 +2112,37 @@ def _amd_register_handoff_kernel(x_ptr, y_ptr, REGISTER_CLASS: tl.constexpr):
         pytest.param("agpr", "fp32", id="agpr-fp32"),
     ],
 )
-def test_amd_register_handoff_compiles_gfx950(register_class, element_type):
+def test_amd_register_class_anchor_compiles_gfx950(register_class, element_type):
     compiled = compile_for_gfx950(
-        _amd_register_handoff_kernel,
+        _amd_register_class_anchor_kernel,
         signature={"x_ptr": f"*{element_type}", "y_ptr": f"*{element_type}"},
         constexprs={"REGISTER_CLASS": register_class},
     )
     ttir = compiled.asm["ttir"]
-    assert ttir.count("amdg.register_handoff") == 1
+    assert ttir.count("amdg.register_class_anchor") == 1
     assert f'class "{register_class}"' in ttir
     assert "groups" not in ttir
     assert "tt.elementwise_inline_asm" not in ttir
     assert "amdg.register_resident" not in ttir
     llir = compiled.asm["llir"]
-    assert "amdg.register_handoff" not in llir
+    assert "amdg.register_class_anchor" not in llir
     register_constraint = "a" if register_class == "agpr" else "v"
     constraint = f'"={register_constraint},0"'
-    handoff_asm = [line for line in llir.splitlines() if constraint in line]
+    anchor_asm = [line for line in llir.splitlines() if constraint in line]
     expected_asm = 4 if element_type == "fp16" else 8
-    assert len(handoff_asm) == expected_asm
-    assert all("sideeffect" in line for line in handoff_asm)
+    assert len(anchor_asm) == expected_asm
+    assert all("sideeffect" in line for line in anchor_asm)
 
 
 @triton.jit
-def _invalid_amd_register_handoff_kernel(
+def _invalid_amd_register_class_anchor_kernel(
     x_ptr,
     y_ptr,
     REGISTER_CLASS: tl.constexpr,
 ):
     offsets = tl.arange(0, 1024)
     values = tl.load(x_ptr + offsets)
-    values = tlx.amd_register_handoff(
+    values = tlx.amd_register_class_anchor(
         values,
         register_class=REGISTER_CLASS,
     )
@@ -2156,10 +2156,10 @@ def _invalid_amd_register_handoff_kernel(
         pytest.param("vgpr", "i8", "value elements must be 16 or 32 bits", id="element-width"),
     ],
 )
-def test_amd_register_handoff_rejects_invalid_contract(register_class, element_type, message):
+def test_amd_register_class_anchor_rejects_invalid_contract(register_class, element_type, message):
     with pytest.raises(CompilationError, match=message):
         compile_for_gfx950(
-            _invalid_amd_register_handoff_kernel,
+            _invalid_amd_register_class_anchor_kernel,
             signature={"x_ptr": f"*{element_type}", "y_ptr": f"*{element_type}"},
             constexprs={
                 "REGISTER_CLASS": register_class,
@@ -2169,10 +2169,10 @@ def test_amd_register_handoff_rejects_invalid_contract(register_class, element_t
 
 @pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
 @pytest.mark.parametrize("register_class", ["vgpr", "agpr"])
-def test_amd_register_handoff_correct_gfx950(register_class):
+def test_amd_register_class_anchor_correct_gfx950(register_class):
     x = torch.arange(2048, device="cuda", dtype=torch.float32)
     actual = torch.empty_like(x)
-    _amd_register_handoff_kernel[(1, )](x, actual, register_class, num_warps=4)
+    _amd_register_class_anchor_kernel[(1, )](x, actual, register_class, num_warps=4)
     torch.testing.assert_close(actual, x)
 
 

--- a/test/TritonGPU/amd/invalid.mlir
+++ b/test/TritonGPU/amd/invalid.mlir
@@ -358,13 +358,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
-#handoff_distributed = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#anchor_distributed = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func @register_handoff_requires_complete_native_groups(
-      %arg0: tensor<64xf16, #handoff_distributed>) {
+  tt.func @register_class_anchor_requires_complete_native_groups(
+      %arg0: tensor<64xf16, #anchor_distributed>) {
     // expected-error @+1 {{requires 1 elements per thread to be divisible by the 2-element native tuple}}
-    %0 = amdg.register_handoff %arg0 class "vgpr"
-        : tensor<64xf16, #handoff_distributed>
+    %0 = amdg.register_class_anchor %arg0 class "vgpr"
+        : tensor<64xf16, #anchor_distributed>
     tt.return
   }
 }

--- a/test/TritonGPU/amd/mfma-double-rate.mlir
+++ b/test/TritonGPU/amd/mfma-double-rate.mlir
@@ -288,9 +288,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 
 // -----
 
-// CHECK-LABEL: llvm.func @register_handoff_vgpr
-// CSE-LABEL: tt.func public @register_handoff_vgpr
-// CSE-COUNT-2: amdg.register_handoff
+// CHECK-LABEL: llvm.func @register_class_anchor_vgpr
+// CSE-LABEL: tt.func public @register_class_anchor_vgpr
+// CSE-COUNT-2: amdg.register_class_anchor
 // CHECK: llvm.inline_asm
 // CHECK-SAME: "=v,0"
 // CHECK: llvm.inline_asm
@@ -307,36 +307,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
 // CHECK-SAME: "=v,0"
 // CHECK: llvm.inline_asm
 // CHECK-SAME: "=v,0"
-// CHECK-NOT: amdg.register_handoff
+// CHECK-NOT: amdg.register_class_anchor
 
-#handoff_fp32 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#anchor_fp32 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @register_handoff_vgpr(
-      %arg: tensor<256xf32, #handoff_fp32>) -> tensor<256xf32, #handoff_fp32> {
-    %result = amdg.register_handoff %arg class "vgpr"
-        : tensor<256xf32, #handoff_fp32>
-    %independent = amdg.register_handoff %arg class "vgpr"
-        : tensor<256xf32, #handoff_fp32>
-    %sum = arith.addf %result, %independent : tensor<256xf32, #handoff_fp32>
-    tt.return %sum : tensor<256xf32, #handoff_fp32>
+  tt.func public @register_class_anchor_vgpr(
+      %arg: tensor<256xf32, #anchor_fp32>) -> tensor<256xf32, #anchor_fp32> {
+    %result = amdg.register_class_anchor %arg class "vgpr"
+        : tensor<256xf32, #anchor_fp32>
+    %independent = amdg.register_class_anchor %arg class "vgpr"
+        : tensor<256xf32, #anchor_fp32>
+    %sum = arith.addf %result, %independent : tensor<256xf32, #anchor_fp32>
+    tt.return %sum : tensor<256xf32, #anchor_fp32>
   }
 }
 
 // -----
 
-// CHECK-LABEL: llvm.func @register_handoff_packs_fp16_registers
+// CHECK-LABEL: llvm.func @register_class_anchor_packs_fp16_registers
 // CHECK: llvm.inline_asm
 // CHECK-SAME: "=a,0"
 // CHECK: llvm.inline_asm
 // CHECK-SAME: "=a,0"
-// CHECK-NOT: amdg.register_handoff
+// CHECK-NOT: amdg.register_class_anchor
 
-#handoff_fp16 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
+#anchor_fp16 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [64], warpsPerCTA = [1], order = [0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  tt.func public @register_handoff_packs_fp16_registers(
-      %arg: tensor<256xf16, #handoff_fp16>) -> tensor<256xf16, #handoff_fp16> {
-    %result = amdg.register_handoff %arg class "agpr"
-        : tensor<256xf16, #handoff_fp16>
-    tt.return %result : tensor<256xf16, #handoff_fp16>
+  tt.func public @register_class_anchor_packs_fp16_registers(
+      %arg: tensor<256xf16, #anchor_fp16>) -> tensor<256xf16, #anchor_fp16> {
+    %result = amdg.register_class_anchor %arg class "agpr"
+        : tensor<256xf16, #anchor_fp16>
+    tt.return %result : tensor<256xf16, #anchor_fp16>
   }
 }

--- a/test/TritonGPU/amd/scheduled-mfma-gfx942.mlir
+++ b/test/TritonGPU/amd/scheduled-mfma-gfx942.mlir
@@ -134,7 +134,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.tar
 // the MFMA that wrote the register. The commit-time diagnostic cannot cover
 // that: it needs the producing scheduled_mfma to be visible from an
 // mfma_commit, and an epilogue with no commit -- or one behind an
-// amd_register_handoff -- silently miscompiles instead.
+// amd_register_class_anchor -- silently miscompiles instead.
 //
 // The commit-time AGPR/live-operand interaction is still covered on CDNA4, in
 // scheduled-mfma-gfx950.mlir, where the explicit class is legal.

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -768,18 +768,19 @@ def RematerializedRangeOp : TT_AMDGPU_Op<"rematerialized_range", [
 
 def RegisterResidentOp : TT_AMDGPU_Op<"register_resident", [
     Pure, SameOperandsAndResultType]> {
-  let summary = "Keep a distributed tensor in native AMD register tuples";
+  let summary = "Constrain native AMD register tuples at one allocation point";
   let description = [{
-    Returns `input` unchanged while assigning its packed per-thread values to
-    the requested AMD vector register class. `registers_per_group` is the
-    number of consecutive 32-bit registers represented by each
-    allocator-visible tuple. The distributed tensor encoding is preserved
-    exactly, so this allocation-only identity does not introduce a layout
-    conversion or an LDS round trip.
+    Returns `input` unchanged while exposing all packed per-thread groups to
+    the allocator at one common point in the requested AMD vector register
+    class. `registers_per_group` is the number of consecutive 32-bit registers
+    in each tuple; separate tuples need not be adjacent. The distributed tensor
+    encoding is preserved exactly, so this identity does not introduce a
+    layout conversion or an LDS round trip.
 
-    This is a general lifetime contract for values intentionally carried
-    across a software pipeline. It does not prescribe physical register
-    numbers, and target lowering emits no machine instruction.
+    This does not prescribe physical register numbers, reserve the registers
+    for the value's entire lifetime, prevent copies or spills, or guarantee an
+    occupancy level. The empty target-assembly boundary itself emits no ISA
+    instruction, although satisfying its constraints can affect allocation.
   }];
 
   let arguments = (ins TT_Tensor:$input, StrAttr:$register_class,
@@ -795,24 +796,26 @@ def RegisterResidentOp : TT_AMDGPU_Op<"register_resident", [
 }
 
 //===----------------------------------------------------------------------===//
-// RegisterHandoffOp
+// RegisterClassAnchorOp
 //===----------------------------------------------------------------------===//
 
-def RegisterHandoffOp : TT_AMDGPU_Op<"register_handoff", [
+def RegisterClassAnchorOp : TT_AMDGPU_Op<"register_class_anchor", [
     SameOperandsAndResultType]> {
-  let summary = "Start independent native AMD register-allocation intervals";
+  let summary = "Apply independent native AMD register-class anchors";
   let description = [{
     Returns `input` unchanged while passing each per-thread 32-bit native
-    register value through an independent tied register constraint. This starts
-    local allocation intervals without requiring the complete tensor to be
-    resident at one point.
+    register value through an independent tied register constraint. This
+    creates a source-local allocation and scheduling anchor without requiring
+    the complete tensor to be resident at one point. A tied input and output
+    may be coalesced, so the operation does not guarantee a distinct physical
+    live interval, a copy, a shorter live range, spill avoidance, or an
+    occupancy level.
 
     Use `register_resident` when simultaneous whole-tensor residency is the
-    software-pipeline contract. Neither operation prescribes physical register
-    numbers or changes numerical results. The operation is intentionally
-    side-effecting: distinct source occurrences are distinct allocation
-    boundaries and must not be merged by CSE or moved out of their surrounding
-    software-pipeline stage.
+    software-pipeline contract. Neither operation changes numerical results.
+    The operation is intentionally side-effecting: distinct source occurrences
+    are distinct anchors and must not be merged by CSE or moved out of their
+    surrounding software-pipeline stage.
   }];
 
   let arguments = (ins TT_Tensor:$input, StrAttr:$register_class);
@@ -852,6 +855,8 @@ def MfmaCommitOp : TT_AMDGPU_Op<"mfma_commit", [
 
     The operation is intentionally side-effecting so the completion and
     liveness boundary cannot be deleted or moved across memory operations.
+    It is a wave-local MFMA boundary, not a waitcnt, hardware memory fence,
+    workgroup barrier, or cross-wave synchronization operation.
   }];
 
   let arguments = (ins Variadic<TT_Tensor>:$inputs);
@@ -876,17 +881,20 @@ def ScheduledMfmaOp : TT_AMDGPU_Op<"scheduled_mfma"> {
     returning to an accumulator dependency chain, while preserving one SSA
     chain per output fragment.
 
-    `resident_operand` is `none`, `lhs`, or `rhs` and identifies an input
-    intentionally carried through the surrounding software pipeline.
+    On the persistent lowering path, `resident_operand` is `none`, `lhs`, or
+    `rhs` and selects an input to constrain to AGPRs; the other input uses
+    VGPRs. The transient intrinsic path does not add those source-class
+    constraints, so a carried source needs a separate `register_resident`
+    boundary when hard residency is required.
     `accumulator_role` is `transient` for a phase-local result or `persistent`
     for an accumulator carried across phases. `accumulator_register_class` is
-    `auto`, `agpr`, or `vgpr`; `auto` means VGPRs for `transient` and AGPRs for
-    `persistent` on every target, while an explicit class supports kernels
-    whose two persistent accumulator sets intentionally occupy complementary
-    physical files. On CDNA3 the compiler-generated AGPR read is not ordered
-    against the MFMA drain, so any AGPR accumulator is rejected there,
-    including one named by `auto`: a persistent accumulator must request
-    `vgpr`.
+    `auto`, `agpr`, or `vgpr`. Persistent lowering honors this field: `auto`
+    selects AGPRs, while an explicit class supports kernels whose persistent
+    accumulator sets intentionally occupy complementary register classes. The
+    transient intrinsic path leaves physical accumulator placement to LLVM.
+    On CDNA3 the compiler-generated AGPR read is not ordered against the MFMA
+    drain, so any AGPR accumulator request is rejected, including persistent
+    `auto`: a persistent accumulator must request `vgpr`.
     `initialize` starts the native accumulators from zero. Completion
     of transient result fragments is represented separately by `mfma_commit`.
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/IR/Dialect.cpp
@@ -787,7 +787,7 @@ LogicalResult RegisterResidentOp::verify() {
       getRegistersPerGroup(), /*allowUnencoded=*/false);
 }
 
-LogicalResult RegisterHandoffOp::verify() {
+LogicalResult RegisterClassAnchorOp::verify() {
   return verifyRegisterAllocationContract(
       getOperation(), getInput().getType(), getRegisterClass(),
       /*registersPerGroup=*/1, /*allowUnencoded=*/true);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -1131,15 +1131,15 @@ public:
   }
 };
 
-class RegisterHandoffOpConversion
-    : public ConvertOpToLLVMPattern<triton::amdgpu::RegisterHandoffOp> {
+class RegisterClassAnchorOpConversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::RegisterClassAnchorOp> {
 public:
   using ConvertOpToLLVMPattern<
-      triton::amdgpu::RegisterHandoffOp>::ConvertOpToLLVMPattern;
-  using OpAdaptor = triton::amdgpu::RegisterHandoffOp::Adaptor;
+      triton::amdgpu::RegisterClassAnchorOp>::ConvertOpToLLVMPattern;
+  using OpAdaptor = triton::amdgpu::RegisterClassAnchorOp::Adaptor;
 
   LogicalResult
-  matchAndRewrite(triton::amdgpu::RegisterHandoffOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::amdgpu::RegisterClassAnchorOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
@@ -1878,7 +1878,7 @@ void mlir::triton::AMD::populateMemoryOpToLLVMPatterns(
                                                   benefit.getBenefit() + 1);
   patterns.add<RematerializedRangeOpConversion>(typeConverter, targetInfo,
                                                 transBenefit);
-  patterns.add<RegisterResidentOpConversion, RegisterHandoffOpConversion>(
+  patterns.add<RegisterResidentOpConversion, RegisterClassAnchorOpConversion>(
       typeConverter, transBenefit);
   patterns.add<MfmaCommitOpConversion, ScheduledMfmaOpConversion>(
       typeConverter, targetInfo, transBenefit);

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -204,12 +204,12 @@ void init_triton_tlx_ir(py::module_ &m) {
                  input.getType(), input, registerClassAttr,
                  registersPerGroupAttr);
            })
-      .def("create_amd_register_handoff",
+      .def("create_amd_register_class_anchor",
            [](TritonOpBuilder &self, Value input,
               const std::string &registerClass) -> Value {
              auto registerClassAttr =
                  self.getBuilder().getStringAttr(registerClass);
-             return self.create<amdgpu::RegisterHandoffOp>(
+             return self.create<amdgpu::RegisterClassAnchorOp>(
                  input.getType(), input, registerClassAttr);
            })
       .def("create_amd_mfma_commit",

--- a/third_party/tlx/language/tlx/__init__.py
+++ b/third_party/tlx/language/tlx/__init__.py
@@ -71,7 +71,7 @@ from .mem_ops import (
 )
 from .mma_ops import (
     amd_mfma_commit,
-    amd_register_handoff,
+    amd_register_class_anchor,
     amd_register_resident,
     amd_scheduled_mfma,
     async_dot,
@@ -156,7 +156,7 @@ __all__ = [
     "storage_kind",
     "layout",
     "amd_mfma_commit",
-    "amd_register_handoff",
+    "amd_register_class_anchor",
     "amd_register_resident",
     "amd_scheduled_mfma",
     "extract_slice",

--- a/third_party/tlx/language/tlx/mma_ops.py
+++ b/third_party/tlx/language/tlx/mma_ops.py
@@ -79,10 +79,16 @@ def amd_register_resident(
     registers_per_group: tl.constexpr = 1,
     _semantic=None,
 ):
-    """Keep a distributed tensor in native AGPR or VGPR tuples.
+    """Constrain a distributed tensor's native register groups at one point.
 
-    ``registers_per_group`` is the power-of-two number of consecutive 32-bit
-    registers exposed to the allocator as one tuple.
+    Returns ``value`` unchanged while making all of its packed per-thread
+    groups visible to the allocator together. ``register_class`` is ``"agpr"``
+    or ``"vgpr"``. ``registers_per_group`` is the power-of-two number of
+    consecutive 32-bit registers in each group, from 1 through 32; separate
+    groups need not be adjacent.
+
+    This does not select physical register numbers, prevent spills, reserve the
+    registers for the value's entire lifetime, or guarantee an occupancy level.
     """
     register_class = tl._unwrap_if_constexpr(register_class)
     registers_per_group = tl._unwrap_if_constexpr(registers_per_group)
@@ -97,25 +103,30 @@ def amd_register_resident(
 
 
 @tl.builtin
-def amd_register_handoff(
+def amd_register_class_anchor(
     value,
     register_class: tl.constexpr = "vgpr",
     _semantic=None,
 ):
-    """Start a new AMD register-allocation interval for a tensor value.
+    """Anchor each native AMD value in a requested register class.
 
-    Each 32-bit native register value is passed unchanged through an independent
-    tied register constraint, so this expresses a local allocation/scheduling
-    handoff without requiring the complete tensor to be resident at one point.
-    Use :func:`amd_register_resident` when simultaneous whole-tensor residency
-    is the intended software-pipeline contract.
+    Returns ``value`` unchanged. Each packed 32-bit register value crosses an
+    independent, side-effecting tied ``"agpr"`` or ``"vgpr"`` constraint, so
+    the operation is an allocator and scheduling anchor without a whole-tensor
+    residency requirement.
+
+    LLVM may coalesce a tied input and output. This operation therefore does
+    not guarantee a new physical live interval, a copy, a shorter live range,
+    spill avoidance, or a particular occupancy. Use
+    :func:`amd_register_resident` when all groups must be allocatable at one
+    common point, and always consume the value returned by this operation.
     """
     register_class = tl._unwrap_if_constexpr(register_class)
     assert isinstance(value, tl.tensor) and value.type.is_block(), "value must be a distributed tensor"
     assert value.dtype.is_int() or value.dtype.is_floating(), "value elements must be integer or floating-point"
     assert value.dtype.primitive_bitwidth in (16, 32), "value elements must be 16 or 32 bits"
     assert register_class in ("agpr", "vgpr"), ('register_class must be either "agpr" or "vgpr"')
-    handle = _semantic.builder.create_amd_register_handoff(value.handle, register_class)
+    handle = _semantic.builder.create_amd_register_class_anchor(value.handle, register_class)
     return tl.tensor(handle, value.type)
 
 
@@ -130,27 +141,32 @@ def amd_scheduled_mfma(
     initialize: tl.constexpr = False,
     _semantic=None,
 ):
-    """Update native CDNA3/CDNA4 MFMA fragments with source scheduling.
+    """Update native CDNA3/CDNA4 MFMA fragments in explicit source order.
 
-    Unlike ``tl.dot``, which represents one logical matrix product and carries
-    no accumulator-lifetime or register-class contract, this operation exposes
-    independent native fragment chains in source order. A ``tl.dot`` result can
-    still remain live across phases through ordinary SSA uses; its backend
-    lowering infers that lifetime instead of receiving an explicit role.
+    With ``initialize=False``, computes ``acc + a @ b`` over native fragments.
+    The operation keeps one SSA chain per output fragment and creates updates
+    in K-major, N-major, M-minor order. LLVM may reschedule independent updates
+    on the transient intrinsic path. With ``initialize=True``, the first native
+    K update starts from zero and the result is ``a @ b``; the supplied
+    accumulator value is ignored.
 
-    ``accumulator_role`` controls the lowering contract, not the numerical
-    operation. ``"transient"`` describes a phase-local chain: default storage
-    selects VGPRs and lowering uses ROCDL MFMA intrinsics so LLVM can model
-    instruction latency and hazards. ``"persistent"`` describes a chain
-    carried across phases and lowering uses register-constrained inline
-    assembly; default storage selects AGPRs on every target. An explicit
-    ``accumulator_register_class`` overrides that default, allowing two
-    persistent accumulator sets to occupy complementary register files.
+    ``accumulator_role`` changes lowering, not the numerical operation.
+    ``"transient"`` describes a phase-local chain and uses LLVM-visible MFMA
+    intrinsics. ``"persistent"`` describes a chain carried across phases and
+    uses register-constrained inline assembly. Because LLVM cannot model an
+    MFMA hidden in inline assembly, that path adds target-specific input and
+    result wait padding. On the persistent path,
+    ``resident_operand=0`` or ``1`` selects the left or right input for AGPR
+    placement, and ``accumulator_register_class`` may select ``"agpr"`` or
+    ``"vgpr"``. Persistent ``auto`` selects AGPRs. The transient intrinsic path
+    does not apply these class constraints and leaves physical placement to
+    LLVM; use :func:`amd_register_resident` for a hard source residency point.
 
-    On CDNA3 the compiler-generated AGPR read is not ordered against the MFMA
-    drain, so AGPR accumulators are rejected there and a ``"persistent"`` chain
-    must pass ``accumulator_register_class="vgpr"``; the default is an error
-    rather than a silent downgrade.
+    CDNA3 rejects AGPR accumulators, so a persistent chain on gfx942 must pass
+    ``accumulator_register_class="vgpr"``. The inputs must be matching rank-two
+    BF16 or F16 dot operands with ``kWidth`` 4 or 8, the accumulator must be
+    rank-two F32 with the corresponding unit-tile MFMA layout, and all active
+    lanes of a wave must execute the operation uniformly.
     """
     resident_operand = tl._unwrap_if_constexpr(resident_operand)
     accumulator_role = tl._unwrap_if_constexpr(accumulator_role)
@@ -181,12 +197,19 @@ def amd_scheduled_mfma(
 
 @tl.builtin
 def amd_mfma_commit(value, preserve=None, _semantic=None):
-    """Commit MFMA results and optionally thread a live dot operand.
+    """Apply an MFMA completion boundary and return every value unchanged.
 
-    ``value`` may be one tensor or a tuple of independent transient
-    ``amd_scheduled_mfma`` results. The returned copy of ``preserve`` can be
-    consumed by the next source stage to make its residency explicit. With no
-    ``preserve``, the values form one persistent-AGPR epilogue boundary.
+    ``value`` is one F32 MFMA-layout tensor or a nonempty tuple of independent
+    results. An optional BF16 or F16 dot-operand ``preserve`` is threaded
+    through the same boundary. To carry that dependency forward, consume its
+    returned copy. A single value is returned directly; tuples keep the same
+    arity; supplying ``preserve`` appends its returned copy to the result.
+
+    With ``preserve``, F32 results cross the boundary in VGPRs and the preserved
+    operand in AGPRs; without it, results cross in AGPRs. An AGPR-resident
+    scheduled-MFMA result therefore cannot be committed together with
+    ``preserve``. This is a target-specific wave-local hazard and liveness
+    boundary, not a memory fence, workgroup barrier, or cross-wave wait.
     """
     single_value = isinstance(value, tl.tensor)
     values = (value, ) if single_value else value

--- a/third_party/tlx/tutorials/amd_fa_bwd.py
+++ b/third_party/tlx/tutorials/amd_fa_bwd.py
@@ -6274,8 +6274,8 @@ def _attn_bwd_dq_d64_causal_step(
     scores = scores + row_lse_full
     scores = tl.dot(q, kt, acc=scores, out_dtype=tl.float32)
     if BLOCK_N == 64:
-        # End the score-MFMA allocation interval before the exp tail.
-        scores = tlx.amd_register_handoff(scores, register_class="vgpr")
+        # Anchor the score value in VGPRs before the exp tail.
+        scores = tlx.amd_register_class_anchor(scores, register_class="vgpr")
         scores = tlx.require_layout(scores, mma_mn, pin=False)
 
     # Match the independent MFMA cadence used by the tuned reference: issue
@@ -6311,7 +6311,7 @@ def _attn_bwd_dq_d64_causal_step(
         )
         scores = tl.where(valid, scores, negative_inf)
     p = tlx.require_layout(tl.math.exp2(scores), mma_mn, pin=False)
-    ds = tlx.amd_register_handoff(
+    ds = tlx.amd_register_class_anchor(
         p * dp,
         register_class="vgpr",
     )
@@ -6375,7 +6375,7 @@ def _attn_bwd_dq_d64_causal_finish32(
     dp = tlx.require_layout(dp, mma_mn, pin=False)
     k_nd = tlx.require_layout(k_nd, k_op1_md, pin=False)
     p = tlx.require_layout(tl.math.exp2(scores), mma_mn, pin=False)
-    ds = tlx.amd_register_handoff(
+    ds = tlx.amd_register_class_anchor(
         p * dp,
         register_class="vgpr",
     )
@@ -8034,7 +8034,7 @@ def _d64_gqa8_signed_front(
         do_t = tlx.local_load(tlx.local_trans(do_view), token=stage_wait, layout=q_t_op1_nm)
     dp = tl.dot(v_nm, do_t, acc=dp, out_dtype=tl.float32)
     ds = p * dp
-    ds = tlx.amd_register_handoff(
+    ds = tlx.amd_register_class_anchor(
         ds,
         register_class="vgpr",
     )
@@ -8105,7 +8105,7 @@ def _d64_gqa8_signed_front_loaded_stats(
     )
     do_t = tlx.local_load(tlx.local_trans(do_view), token=stage_wait, layout=q_t_op1_nm)
     dp = tl.dot(v_nm, do_t, acc=dp, out_dtype=tl.float32)
-    ds = tlx.amd_register_handoff(
+    ds = tlx.amd_register_class_anchor(
         p * dp,
         register_class="vgpr",
     )

--- a/website/async-compute.html
+++ b/website/async-compute.html
@@ -144,25 +144,72 @@
     acc = tlx.async_dot_wait(tl.constexpr(0), acc)
     tl.store(C_ptrs, acc)</code></pre>
 <h2 id="explicit-mfma-scheduling">Explicit MFMA scheduling</h2>
-<blockquote><p><strong>[gfx950]</strong> — the source-scheduled operations are restricted to CDNA4 (<code>gfx950</code>) native BF16 MFMA layouts.</p></blockquote>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tl.dot(a, b, acc)</code> preserves a TLX-pinned accumulator layout, so whole dots</div></div>
-<p>need no AMD-specific wrapper.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.extract_slice(source, shape, offsets)</code> selects an aligned register</div></div>
-<p>fragment without cross-thread movement.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.rematerialized_range(start, end, anchor, placement=None)</code> recreates</div></div>
-<p>inexpensive distributed coordinates near a use instead of carrying them through a long software pipeline.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.amd_register_resident(value, register_class=&quot;agpr&quot;, registers_per_group=1)</code></div></div>
-<p>keeps every native-register group in one allocator-visible whole-tensor residency interval.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.amd_register_handoff(value, register_class=&quot;vgpr&quot;)</code> starts an</div></div>
-<p>independent allocation interval for each 32-bit native register value, shortening a local live range without requiring simultaneous whole-tensor residency. Both register-boundary operations accept <code>&quot;vgpr&quot;</code> or <code>&quot;agpr&quot;</code>; <code>amd_register_resident</code> additionally accepts a power-of-two <code>registers_per_group</code> from 1 through 32.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.amd_scheduled_mfma(...)</code> exposes independent native MFMA accumulator</div></div>
-<p>chains in deterministic N-major, M-minor, K-reduction source order.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.amd_mfma_commit(value, preserve)</code> applies the CDNA4 MFMA result hazard</div></div>
-<p>boundary while threading a live dot-operand dependency.</p>
-<div class="list-item depth-0"><span aria-hidden="true">•</span><div><code>tlx.amd_sched_barrier(mask=0)</code> prevents selected AMD machine-instruction</div></div>
-<p>classes from crossing a source boundary. It is a scheduling marker, not a workgroup barrier or memory fence.</p>
-<p>These primitives describe fragments, lifetimes, and ordering without assigning physical registers. Their verifiers reject unsupported targets, layouts, element types, and native fragment widths before lowering.</p>
-<p>Unlike <code>tl.dot</code>, <code>amd_scheduled_mfma</code> carries an explicit <code>accumulator_role</code>. <code>transient</code> selects the latency-aware intrinsic path for phase-local work; <code>persistent</code> selects register-constrained lowering for a chain carried across phases. Neither role changes the numerical matrix operation.</p>
+<blockquote><p><code>amd_scheduled_mfma</code> and <code>amd_mfma_commit</code> support <strong>[gfx942, gfx950]</strong> native BF16/F16 MFMA layouts. The register-class constraint operations are AMD-only and currently verified on <strong>[gfx950]</strong>.</p></blockquote>
+<p>These are low-level backend-tuning controls. Prefer <code>tl.dot</code> unless a kernel needs explicit native accumulator chains, register-class constraints, or an MFMA completion boundary. Inspect the generated code and benchmark any use; the register allocator still chooses physical registers.</p>
+<table><thead><tr><th>API</th><th>Verified targets</th><th>Purpose</th></tr></thead><tbody><tr><td><code>tlx.amd_scheduled_mfma</code></td><td>gfx942, gfx950</td><td>Update explicitly ordered native MFMA accumulator chains.</td></tr><tr><td><code>tlx.amd_mfma_commit</code></td><td>gfx942, gfx950</td><td>Join one or more chains at an MFMA completion and liveness boundary.</td></tr><tr><td><code>tlx.amd_register_class_anchor</code></td><td>gfx950</td><td>Add a separate local register-class anchor for each native 32-bit value.</td></tr><tr><td><code>tlx.amd_register_resident</code></td><td>gfx950</td><td>Require every tensor group to be allocatable together in native register tuples.</td></tr></tbody></table>
+<p>Related operations are <code>tlx.extract_slice</code>, which selects an aligned register fragment without cross-thread movement; <code>tlx.rematerialized_range</code>, which recreates inexpensive coordinates near a use; and <code>tlx.amd_sched_barrier</code>, which prevents selected AMD instruction classes from crossing a source boundary. None of these operations is a workgroup barrier or memory fence.</p>
+<h3 id="tlx-amd-register-resident"><code>tlx.amd_register_resident</code></h3>
+<pre><code class="language-python">value = tlx.amd_register_resident(
+    value,
+    register_class=&quot;agpr&quot;,
+    registers_per_group=1,
+)</code></pre>
+<p>Returns <code>value</code> unchanged, with the same shape, element type, and distributed layout. At one allocator-visible point, every packed per-thread group must be available in the requested <code>&quot;agpr&quot;</code> or <code>&quot;vgpr&quot;</code> class.</p>
+<p><code>registers_per_group</code> is the number of consecutive 32-bit registers in each group, not the number of groups. It must be one of <code>1</code>, <code>2</code>, <code>4</code>, <code>8</code>, <code>16</code>, or <code>32</code>. A group of width <code>R</code> contains <code>R</code> 32-bit elements or <code>2 * R</code> 16-bit elements, and the per-thread element count must divide evenly into groups. Registers are consecutive within one group; different groups need not be adjacent.</p>
+<p>This constraint does not select physical register numbers, reserve registers for the value's full lifetime, prevent copies or spills, or guarantee a particular occupancy. Wider groups strengthen the tuple constraint and can reduce allocator flexibility. Always use the returned value.</p>
+<h3 id="tlx-amd-register-class-anchor"><code>tlx.amd_register_class_anchor</code></h3>
+<pre><code class="language-python">value = tlx.amd_register_class_anchor(value, register_class=&quot;vgpr&quot;)</code></pre>
+<p>Returns <code>value</code> unchanged after passing each packed 32-bit register value through a separate, side-effecting tied <code>&quot;agpr&quot;</code> or <code>&quot;vgpr&quot;</code> constraint. This provides a source-local allocation and scheduling anchor without requiring all tensor groups to meet at one point.</p>
+<p>A tied input and output may be coalesced by LLVM. The operation does not guarantee a distinct physical register or live interval, emit a copy, shorten a live range, prevent spills, or improve occupancy. Use <code>amd_register_resident</code> when simultaneous all-group allocation is required, and use the value returned by <code>amd_register_class_anchor</code> for downstream work.</p>
+<p>Both register-class operations accept distributed integer or floating-point tensors with 16-bit or 32-bit elements. They constrain allocation at a source point; they do not wait for MFMA completion or synchronize lanes, waves, or memory.</p>
+<h3 id="tlx-amd-scheduled-mfma"><code>tlx.amd_scheduled_mfma</code></h3>
+<pre><code class="language-python">acc = tlx.amd_scheduled_mfma(
+    a,
+    b,
+    acc,
+    accumulator_role=&quot;transient&quot;,
+    resident_operand=None,
+    accumulator_register_class=None,
+    initialize=False,
+)</code></pre>
+<p>With <code>initialize=False</code>, the operation computes the native-fragment equivalent of <code>acc + a @ b</code>. It keeps one SSA chain per output fragment and creates updates in K-major, N-major, M-minor order:</p>
+<pre><code class="language-python">for k in native_k_fragments:
+    for n in output_n_fragments:
+        for m in output_m_fragments:
+            acc[m, n] = mfma(a[m, k], b[k, n], acc[m, n])</code></pre>
+<p>This source order round-robins a K slice over independent accumulators before returning to the same dependency chain. LLVM may still reschedule independent instructions on the transient intrinsic path.</p>
+<p><code>a</code> and <code>b</code> must be matching rank-two BF16 or F16 tensors with dot-operand layouts using <code>kWidth=4</code> or <code>8</code>. <code>acc</code> must be rank-two F32 with the corresponding unit-tile MFMA layout. Matrix shapes and per-wave native fragments must match.</p>
+<table><thead><tr><th>Argument</th><th>Meaning</th></tr></thead><tbody><tr><td><code>accumulator_role=&quot;transient&quot;</code></td><td>Phase-local chain lowered through LLVM-visible MFMA intrinsics, so LLVM models latency and hazards.</td></tr><tr><td><code>accumulator_role=&quot;persistent&quot;</code></td><td>Chain carried across phases and lowered through register-constrained, side-effecting inline assembly.</td></tr><tr><td><code>resident_operand=None</code></td><td>No persistent source operand is selected for AGPR placement.</td></tr><tr><td><code>resident_operand=0</code> / <code>1</code></td><td>On the persistent path, select <code>a</code> / <code>b</code> for AGPR placement; the other source uses VGPRs.</td></tr><tr><td><code>accumulator_register_class=None</code></td><td><code>auto</code>: persistent work uses AGPR; transient placement is left to LLVM.</td></tr><tr><td><code>accumulator_register_class=&quot;vgpr&quot;</code> / <code>&quot;agpr&quot;</code></td><td>Select the persistent accumulator class explicitly.</td></tr><tr><td><code>initialize=True</code></td><td>Start each output chain's first native K update from zero, ignoring the supplied accumulator.</td></tr></tbody></table>
+<p><code>resident_operand</code> and an explicit accumulator class impose hard class constraints only on the current persistent lowering. The transient intrinsic path leaves physical placement to LLVM; use <code>amd_register_resident</code> separately when a transient source needs an explicit allocation point. Set <code>initialize=True</code> only for the first band of a multi-band accumulation, or the earlier accumulated value will be discarded.</p>
+<p>Because LLVM cannot model the latency or hazards of an MFMA hidden in inline assembly, persistent lowering currently adds target-specific input wait padding and a result drain. Those waits and the inline-assembly representation are implementation details and should be included when comparing the two roles.</p>
+<table><thead><tr><th>Target</th><th>MFMA layout</th><th>Native instruction shapes</th><th>Persistent accumulator</th></tr></thead><tbody><tr><td>gfx942 / CDNA3</td><td>version 3</td><td><code>32x32x8</code>, <code>16x16x16</code></td><td>Must explicitly use <code>accumulator_register_class=&quot;vgpr&quot;</code>.</td></tr><tr><td>gfx950 / CDNA4</td><td>version 4</td><td><code>32x32x16</code>, <code>16x16x32</code></td><td><code>auto</code> selects AGPR; explicit VGPR or AGPR is supported.</td></tr></tbody></table>
+<p>gfx942 rejects every explicit <code>accumulator_register_class=&quot;agpr&quot;</code> request. Because persistent <code>auto</code> also resolves to AGPR, persistent gfx942 calls must select <code>&quot;vgpr&quot;</code> explicitly.</p>
+<p>All active lanes of a wave must execute <code>amd_scheduled_mfma</code> uniformly.</p>
+<h3 id="tlx-amd-mfma-commit"><code>tlx.amd_mfma_commit</code></h3>
+<pre><code class="language-python">committed = tlx.amd_mfma_commit(acc)
+committed, live = tlx.amd_mfma_commit(acc, preserve=live)</code></pre>
+<p>Applies the target-specific MFMA result-readiness boundary and returns every input numerically unchanged. <code>value</code> may be one F32 MFMA-layout tensor or a nonempty tuple of independent results. Optional <code>preserve</code> is one BF16 or F16 dot-operand tensor threaded through the same liveness and allocation boundary; it is not another numerical MFMA operand.</p>
+<table><thead><tr><th>Call</th><th>Return value</th></tr></thead><tbody><tr><td><code>amd_mfma_commit(acc)</code></td><td><code>committed_acc</code></td></tr><tr><td><code>amd_mfma_commit((acc0, acc1))</code></td><td><code>(committed0, committed1)</code></td></tr><tr><td><code>amd_mfma_commit(acc, live)</code></td><td><code>(committed_acc, live_out)</code></td></tr><tr><td><code>amd_mfma_commit((acc0, acc1), live)</code></td><td><code>(committed0, committed1, live_out)</code></td></tr></tbody></table>
+<p>Each F32 input must be consumed only by this boundary, and downstream code must use the returned result. When a <code>preserve</code> dependency remains live after the boundary, its downstream uses must similarly use the returned <code>live_out</code>; the returned dependency may be discarded when it is no longer needed.</p>
+<p>The current lowering constrains a results-only boundary to AGPRs. A boundary with <code>preserve</code> constrains its F32 results to VGPRs and the preserved dot operand to AGPRs; directly committing an AGPR-resident scheduled-MFMA result with <code>preserve</code> is rejected. These placement choices and the exact wait padding are implementation details, not portable synchronization semantics.</p>
+<p><code>amd_mfma_commit</code> is not an MFMA queue instruction, <code>s_waitcnt</code>, hardware memory fence, workgroup barrier, or cross-wave synchronization operation.</p>
+<h3 id="transient-chain-example">Transient-chain example</h3>
+<p>Assume <code>a</code>, <code>b</code>, and <code>acc</code> already carry matching dot-operand and MFMA layouts:</p>
+<pre><code class="language-python">b_live = tlx.amd_register_resident(
+    b,
+    register_class=&quot;agpr&quot;,
+    registers_per_group=4,
+)
+acc = tlx.amd_scheduled_mfma(
+    a,
+    b_live,
+    acc,
+    accumulator_role=&quot;transient&quot;,
+    initialize=True,
+)
+acc, _ = tlx.amd_mfma_commit(acc, b_live)
+tl.store(output_ptrs, acc)</code></pre>
+<p>For later accumulation bands, pass <code>initialize=False</code>. Here, <code>amd_register_resident</code> creates a common allocation point for <code>b_live</code>, while <code>preserve</code> keeps it live through the commit boundary. If later code needs that operand, consume the returned value instead of <code>_</code>. <code>resident_operand</code> controls only persistent lowering.</p>
 <h2 id="scaled-dot">Scaled dot</h2>
 <p><code>tlx.dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None, *, fast_math=False, lhs_k_pack=True, rhs_k_pack=True, out_dtype=tl.float32, tiles_per_warp=None)</code> is a thin wrapper around <code>tl.dot_scaled</code>. Without <code>tiles_per_warp</code> it is exactly equivalent to <code>tl.dot_scaled</code> — pass it only when you need the AMD-specific WMMA scheduling hint described below.</p>
 <h3 id="tiles-per-warp-what-it-controls"><code>tiles_per_warp</code> — what it controls</h3>

--- a/website/content/async-compute.md
+++ b/website/content/async-compute.md
@@ -137,47 +137,203 @@
 
 ## Explicit MFMA scheduling
 
-> **[gfx942, gfx950]** — the source-scheduled operations support CDNA3 and
-> CDNA4 native BF16/F16 MFMA layouts.
+> `amd_scheduled_mfma` and `amd_mfma_commit` support **[gfx942, gfx950]**
+> native BF16/F16 MFMA layouts. The register-class constraint operations are
+> AMD-only and currently verified on **[gfx950]**.
 
-- `tl.dot(a, b, acc)` preserves a TLX-pinned accumulator layout, so whole dots
-  need no AMD-specific wrapper.
-- `tlx.extract_slice(source, shape, offsets)` selects an aligned register
-  fragment without cross-thread movement.
-- `tlx.rematerialized_range(start, end, anchor, placement=None)` recreates
-  inexpensive distributed coordinates near a use instead of carrying them
-  through a long software pipeline.
-- `tlx.amd_register_resident(value, register_class="agpr", registers_per_group=1)`
-  keeps every native-register group in one allocator-visible whole-tensor
-  residency interval.
-- `tlx.amd_register_handoff(value, register_class="vgpr")` starts an
-  independent allocation interval for each 32-bit native register value,
-  shortening a local live range without requiring simultaneous whole-tensor
-  residency. Both register-boundary operations accept `"vgpr"` or `"agpr"`;
-  `amd_register_resident` additionally accepts a power-of-two
-  `registers_per_group` from 1 through 32.
-- `tlx.amd_scheduled_mfma(...)` exposes independent native MFMA accumulator
-  chains in deterministic N-major, M-minor, K-reduction source order.
-- `tlx.amd_mfma_commit(value, preserve)` applies the target MFMA result hazard
-  boundary while threading a live dot-operand dependency.
-- `tlx.amd_sched_barrier(mask=0)` prevents selected AMD machine-instruction
-  classes from crossing a source boundary. It is a scheduling marker, not a
-  workgroup barrier or memory fence.
+These are low-level backend-tuning controls. Prefer `tl.dot` unless a kernel
+needs explicit native accumulator chains, register-class constraints, or an
+MFMA completion boundary. Inspect the generated code and benchmark any use;
+the register allocator still chooses physical registers.
 
-These primitives describe fragments, lifetimes, and ordering without assigning
-physical registers. Their verifiers reject unsupported targets, layouts,
-element types, and native fragment widths before lowering.
+| API | Verified targets | Purpose |
+|-----|------------------|---------|
+| `tlx.amd_scheduled_mfma` | gfx942, gfx950 | Update explicitly ordered native MFMA accumulator chains. |
+| `tlx.amd_mfma_commit` | gfx942, gfx950 | Join one or more chains at an MFMA completion and liveness boundary. |
+| `tlx.amd_register_class_anchor` | gfx950 | Add a separate local register-class anchor for each native 32-bit value. |
+| `tlx.amd_register_resident` | gfx950 | Require every tensor group to be allocatable together in native register tuples. |
 
-Unlike `tl.dot`, `amd_scheduled_mfma` carries an explicit `accumulator_role`.
-`transient` selects the latency-aware intrinsic path for phase-local work;
-`persistent` selects register-constrained lowering for a chain carried across
-phases. Its default `auto` accumulator storage follows the role alone, the same
-way on every target: VGPRs for `transient` and AGPRs for `persistent`. An
-explicit register class overrides that choice, and CDNA3 requires one — the
-compiler-generated AGPR read is not ordered against the MFMA drain there, so a
-persistent accumulator must ask for `"vgpr"` rather than be silently
-downgraded.
-Neither role changes the numerical matrix operation.
+Related operations are `tlx.extract_slice`, which selects an aligned register
+fragment without cross-thread movement; `tlx.rematerialized_range`, which
+recreates inexpensive coordinates near a use; and `tlx.amd_sched_barrier`,
+which prevents selected AMD instruction classes from crossing a source
+boundary. None of these operations is a workgroup barrier or memory fence.
+
+### `tlx.amd_register_resident`
+
+```python
+value = tlx.amd_register_resident(
+    value,
+    register_class="agpr",
+    registers_per_group=1,
+)
+```
+
+Returns `value` unchanged, with the same shape, element type, and distributed
+layout. At one allocator-visible point, every packed per-thread group must be
+available in the requested `"agpr"` or `"vgpr"` class.
+
+`registers_per_group` is the number of consecutive 32-bit registers in each
+group, not the number of groups. It must be one of `1`, `2`, `4`, `8`, `16`,
+or `32`. A group of width `R` contains `R` 32-bit elements or `2 * R` 16-bit
+elements, and the per-thread element count must divide evenly into groups.
+Registers are consecutive within one group; different groups need not be
+adjacent.
+
+This constraint does not select physical register numbers, reserve registers
+for the value's full lifetime, prevent copies or spills, or guarantee a
+particular occupancy. Wider groups strengthen the tuple constraint and can
+reduce allocator flexibility. Always use the returned value.
+
+### `tlx.amd_register_class_anchor`
+
+```python
+value = tlx.amd_register_class_anchor(value, register_class="vgpr")
+```
+
+Returns `value` unchanged after passing each packed 32-bit register value
+through a separate, side-effecting tied `"agpr"` or `"vgpr"` constraint. This
+provides a source-local allocation and scheduling anchor without requiring all
+tensor groups to meet at one point.
+
+A tied input and output may be coalesced by LLVM. The operation does not
+guarantee a distinct physical register or live interval, emit a copy, shorten
+a live range, prevent spills, or improve occupancy. Use
+`amd_register_resident` when simultaneous all-group allocation is required,
+and use the value returned by `amd_register_class_anchor` for downstream work.
+
+Both register-class operations accept distributed integer or floating-point
+tensors with 16-bit or 32-bit elements. They constrain allocation at a source
+point; they do not wait for MFMA completion or synchronize lanes, waves, or
+memory.
+
+### `tlx.amd_scheduled_mfma`
+
+```python
+acc = tlx.amd_scheduled_mfma(
+    a,
+    b,
+    acc,
+    accumulator_role="transient",
+    resident_operand=None,
+    accumulator_register_class=None,
+    initialize=False,
+)
+```
+
+With `initialize=False`, the operation computes the native-fragment equivalent
+of `acc + a @ b`. It keeps one SSA chain per output fragment and creates
+updates in K-major, N-major, M-minor order:
+
+```python
+for k in native_k_fragments:
+    for n in output_n_fragments:
+        for m in output_m_fragments:
+            acc[m, n] = mfma(a[m, k], b[k, n], acc[m, n])
+```
+
+This source order round-robins a K slice over independent accumulators before
+returning to the same dependency chain. LLVM may still reschedule independent
+instructions on the transient intrinsic path.
+
+`a` and `b` must be matching rank-two BF16 or F16 tensors with dot-operand
+layouts using `kWidth=4` or `8`. `acc` must be rank-two F32 with the
+corresponding unit-tile MFMA layout. Matrix shapes and per-wave native
+fragments must match.
+
+| Argument | Meaning |
+|----------|---------|
+| `accumulator_role="transient"` | Phase-local chain lowered through LLVM-visible MFMA intrinsics, so LLVM models latency and hazards. |
+| `accumulator_role="persistent"` | Chain carried across phases and lowered through register-constrained, side-effecting inline assembly. |
+| `resident_operand=None` | No persistent source operand is selected for AGPR placement. |
+| `resident_operand=0` / `1` | On the persistent path, select `a` / `b` for AGPR placement; the other source uses VGPRs. |
+| `accumulator_register_class=None` | `auto`: persistent work uses AGPR; transient placement is left to LLVM. |
+| `accumulator_register_class="vgpr"` / `"agpr"` | Select the persistent accumulator class explicitly. |
+| `initialize=True` | Start each output chain's first native K update from zero, ignoring the supplied accumulator. |
+
+`resident_operand` and an explicit accumulator class impose hard class
+constraints only on the current persistent lowering. The transient intrinsic
+path leaves physical placement to LLVM; use `amd_register_resident` separately
+when a transient source needs an explicit allocation point. Set
+`initialize=True` only for the first band of a multi-band accumulation, or the
+earlier accumulated value will be discarded.
+
+Because LLVM cannot model the latency or hazards of an MFMA hidden in inline
+assembly, persistent lowering currently adds target-specific input wait padding
+and a result drain. Those waits and the inline-assembly representation are
+implementation details and should be included when comparing the two roles.
+
+| Target | MFMA layout | Native instruction shapes | Persistent accumulator |
+|--------|-------------|---------------------------|------------------------|
+| gfx942 / CDNA3 | version 3 | `32x32x8`, `16x16x16` | Must explicitly use `accumulator_register_class="vgpr"`. |
+| gfx950 / CDNA4 | version 4 | `32x32x16`, `16x16x32` | `auto` selects AGPR; explicit VGPR or AGPR is supported. |
+
+gfx942 rejects every explicit `accumulator_register_class="agpr"` request.
+Because persistent `auto` also resolves to AGPR, persistent gfx942 calls must
+select `"vgpr"` explicitly.
+
+All active lanes of a wave must execute `amd_scheduled_mfma` uniformly.
+
+### `tlx.amd_mfma_commit`
+
+```python
+committed = tlx.amd_mfma_commit(acc)
+committed, live = tlx.amd_mfma_commit(acc, preserve=live)
+```
+
+Applies the target-specific MFMA result-readiness boundary and returns every
+input numerically unchanged. `value` may be one F32 MFMA-layout tensor or a
+nonempty tuple of independent results. Optional `preserve` is one BF16 or F16
+dot-operand tensor threaded through the same liveness and allocation boundary;
+it is not another numerical MFMA operand.
+
+| Call | Return value |
+|------|--------------|
+| `amd_mfma_commit(acc)` | `committed_acc` |
+| `amd_mfma_commit((acc0, acc1))` | `(committed0, committed1)` |
+| `amd_mfma_commit(acc, live)` | `(committed_acc, live_out)` |
+| `amd_mfma_commit((acc0, acc1), live)` | `(committed0, committed1, live_out)` |
+
+Each F32 input must be consumed only by this boundary, and downstream code must
+use the returned result. When a `preserve` dependency remains live after the
+boundary, its downstream uses must similarly use the returned `live_out`; the
+returned dependency may be discarded when it is no longer needed.
+
+The current lowering constrains a results-only boundary to AGPRs. A boundary
+with `preserve` constrains its F32 results to VGPRs and the preserved dot
+operand to AGPRs; directly committing an AGPR-resident scheduled-MFMA result
+with `preserve` is rejected. These placement choices and the exact wait padding
+are implementation details, not portable synchronization semantics.
+
+`amd_mfma_commit` is not an MFMA queue instruction, `s_waitcnt`, hardware
+memory fence, workgroup barrier, or cross-wave synchronization operation.
+
+### Transient-chain example
+
+Assume `a`, `b`, and `acc` already carry matching dot-operand and MFMA layouts:
+
+```python
+b_live = tlx.amd_register_resident(
+    b,
+    register_class="agpr",
+    registers_per_group=4,
+)
+acc = tlx.amd_scheduled_mfma(
+    a,
+    b_live,
+    acc,
+    accumulator_role="transient",
+    initialize=True,
+)
+acc, _ = tlx.amd_mfma_commit(acc, b_live)
+tl.store(output_ptrs, acc)
+```
+
+For later accumulation bands, pass `initialize=False`. Here,
+`amd_register_resident` creates a common allocation point for `b_live`, while
+`preserve` keeps it live through the commit boundary. If later code needs that
+operand, consume the returned value instead of `_`. `resident_operand` controls
+only persistent lowering.
 
 ## Scaled dot
 


### PR DESCRIPTION
## Summary

This PR documents TLX’s explicit AMD MFMA and register-allocation controls:

- tlx.amd_scheduled_mfma
- tlx.amd_mfma_commit
- tlx.amd_register_resident
- tlx.amd_register_class_anchor

It also renames:

- tlx.amd_register_handoff → tlx.amd_register_class_anchor
- amdg.register_handoff → amdg.register_class_anchor
- RegisterHandoffOp → RegisterClassAnchorOp

All bindings, compiler conversions, kernel callers, tests, and generated website documentation are updated.

## Motivation

“Register handoff” implied that the operation creates a new physical register, copy, or live interval. Its actual contract is narrower: each packed native 32-bit value passes through an independent, side-effecting, tied AGPR/VGPR constraint, creating a source-local register class and a scheduling anchor.

LLVM may coalesce the tied input and output, so the operation does not guarantee a distinct register, shorter live range, spill avoidance, or higher occupancy. The new name reflects that behavior more accurately.