### PR TITLE
[triton][tlx] Print nvg.cluster_id as cluster_cta_rank, not program_id

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -423,6 +423,9 @@ class compilation_knobs(base_knobs):
     override: env_bool = env_bool("TRITON_KERNEL_OVERRIDE")
     dump_ir: env_bool = env_bool("TRITON_KERNEL_DUMP")
     dump_ir_extract_di_local_variables: env_bool = env_bool("LLVM_EXTRACT_DI_LOCAL_VARIABLES")
+    # Dump the final TTGIR of each kernel as equivalent TLX Python
+    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
+    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     store_binary_only: env_bool = env_bool("TRITON_STORE_BINARY_ONLY")
     always_compile: env_bool = env_bool("TRITON_ALWAYS_COMPILE")
     # TODO: Use enum to constrain / 'typecheck' the values
@@ -633,8 +636,6 @@ class nvidia_knobs(base_knobs):
     # it (knobs.nvidia.scope()) instead of leaking global env state.
     modulo_strict_error: env_bool = env_bool("TRITON_MODULO_STRICT_ERROR")
     disable_wsbarrier_reorder: env_bool = env_bool("TRITON_DISABLE_WSBARRIER_REORDER")
-    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
-    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     # Default ON; opt out with TRITON_USE_C_DISPATCHER=0.
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER", True)

--- a/test/TLX/print-ttgir-to-tlx-clc.mlir
+++ b/test/TLX/print-ttgir-to-tlx-clc.mlir
@@ -48,10 +48,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 
-  // The CLC lowering replaces tl.program_id(0) with the cluster id; emitting
-  // program_id back re-derives the same value on recompile.
+  // Despite its name, nvg.cluster_id is the CTA's rank within its cluster, in
+  // [0, num_ctas): it lowers to %cluster_ctarank, not to a cluster index.
   // CHECK-LABEL: def cluster_id(
-  // CHECK: tl.program_id(axis=0)
+  // CHECK: tlx.cluster_cta_rank()
+  // CHECK-NOT: tl.program_id
   tt.func public @cluster_id() attributes {noinline = false} {
     %cid = "nvg.cluster_id"() : () -> i32
     tt.return

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1209,3 +1209,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// AMD buffer ops address global memory as a scalar base pointer plus a tensor
+// of offsets, which Triton spells `ptr + offsets`, and tl.assume reaches the
+// printer as llvm.intr.assume.
+//
+// mask/other/stride are optional operand *segments*, so they have to be
+// resolved through operandSegmentSizes: reading them positionally shifts every
+// operand after the first absent one, which is why the unmapped form printed
+// with inconsistent arity. The masked and unmasked loads below differ only in
+// which segments are populated.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: def amd_buffer_ops(
+  // CHECK: tl.assume(arg4)
+  // CHECK: {{[a-z0-9_]+}} = tl.load(arg0 + arg1, mask=arg2)
+  // An absent mask segment must not pull the next operand into its place.
+  // CHECK: {{[a-z0-9_]+}} = tl.load(arg0 + arg1)
+  // CHECK: {{[a-z0-9_]+}} = tl.load(arg0 + arg1, mask=arg2, other=arg3)
+  // CHECK: {{[a-z0-9_]+}} = tlx.async_load(arg0 + arg1, {{[a-z0-9_]+}}, mask=arg2)
+  // CHECK: tl.store(arg0 + arg1, arg3, mask=arg2)
+  tt.func public @amd_buffer_ops(%ptr: !tt.ptr<f16>, %offs: tensor<64x64xi32, #blocked>,
+                                 %mask: tensor<64x64xi1, #blocked>,
+                                 %val: tensor<64x64xf16, #blocked>,
+                                 %pred: i1) attributes {noinline = false} {
+    llvm.intr.assume %pred : i1
+    %masked = amdg.buffer_load %ptr[%offs], %mask : tensor<64x64xf16, #blocked>
+    %plain = amdg.buffer_load %ptr[%offs] : tensor<64x64xf16, #blocked>
+    %other = amdg.buffer_load %ptr[%offs], %mask, %val : tensor<64x64xf16, #blocked>
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %tok = amdg.buffer_load_to_local %ptr[%offs] mask = %mask into %dst : <f16>[tensor<64x64xi32, #blocked>] tensor<64x64xf16, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+    amdg.buffer_store %val, %ptr[%offs], %mask : tensor<64x64xf16, #blocked>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1126,3 +1126,53 @@ module {
     tt.return %result : i32
   }
 }
+
+// -----
+
+// A loop whose iter_arg is initialized from a previous loop's result must carry
+// that accumulator over, not be re-initialized.
+//
+// The printer synthesizes an initializer for a block argument that has no
+// defining op, because a warp_specialize region capture is not bound anywhere
+// in the emitted Python. An scf loop's iter_arg is also a block argument with
+// no defining op, but it *is* bound -- by the init line above the loop and the
+// parallel copies at the end of the body. Chaining two loops makes the second
+// loop's init resolve, through the warp_specialize substitution map, onto the
+// first loop's iter_arg, so the synthetic initializer would overwrite a live
+// accumulator with -inf.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: def ws_chained_loops(
+  // CHECK: [[ACC:[a-z0-9_]+]] = cst
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  // CHECK: [[ACC]] = {{[a-z0-9_]+}}
+  // The carry between the two loops, and not a fresh -inf tensor.
+  // CHECK: [[ACC]] = [[ACC]]
+  // CHECK-NOT: tl.full({{.*}}-inf
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  tt.func public @ws_chained_loops(%n: i32) attributes {noinline = false} {
+    ttg.warp_specialize(%n) attributes {requestedRegisters = array<i32: 24>}
+    default {
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
+      %one = arith.constant dense<1.000000e+00> : tensor<256xf32, #blocked>
+      %l1 = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%acc = %zero)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %a = arith.addf %acc, %one : tensor<256xf32, #blocked>
+        scf.yield %a : tensor<256xf32, #blocked>
+      }
+      %l2 = scf.for %j = %c0_i32 to %n step %c1_i32 iter_args(%acc2 = %l1)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %b = arith.mulf %acc2, %one : tensor<256xf32, #blocked>
+        scf.yield %b : tensor<256xf32, #blocked>
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32) num_warps(1) {
+      ttg.warp_return
+    } : (i32) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1176,3 +1176,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// A loop result consumed after the loop must print as the iter_arg the parallel
+// copy assigns, not as the loop op's own SSA name. Only warp_specialize used to
+// create the substitution map that records this, so a loop outside one emitted
+// unbound names -- which on AMD CDNA, having no warp_specialize, is every loop.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: def loop_results_outside_ws(
+  // CHECK: [[ACC:[a-z0-9_]+]] = cst
+  // CHECK: [[L:[a-z0-9_]+]] = cst_0
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  // CHECK: [[ACC]], [[L]] = {{[a-z0-9_]+}}, {{[a-z0-9_]+}}
+  // Both results resolve to their iter_args, not to %0#0 / %0#1.
+  // CHECK: = [[ACC]] / [[L]]
+  // CHECK-NOT: var_0_0
+  tt.func public @loop_results_outside_ws(%n: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
+    %one = arith.constant dense<1.000000e+00> : tensor<256xf32, #blocked>
+    %res:2 = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%acc = %zero, %l = %one)
+        -> (tensor<256xf32, #blocked>, tensor<256xf32, #blocked>) : i32 {
+      %a = arith.addf %acc, %l : tensor<256xf32, #blocked>
+      %b = arith.mulf %l, %l : tensor<256xf32, #blocked>
+      scf.yield %a, %b : tensor<256xf32, #blocked>, tensor<256xf32, #blocked>
+    }
+    %div = arith.divf %res#0, %res#1 : tensor<256xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -484,6 +484,16 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
+        # Print TTGIR to TLX mapping before final emission (for debugging/analysis)
+        tlx_dump_dir = None
+        tlx_saved_fd = None
+        tlx_capture_file = None
+        if knobs.compilation.dump_tlx_benchmark:
+            from triton.tools.tlx_benchmark_gen import setup_tlx_dump
+
+            tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
+        elif knobs.compilation.dump_ttgir_to_tlx:
+            tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         amd.passes.ttgpuir.add_warp_pipeline_conversion(pm, options.arch)
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
@@ -533,7 +543,15 @@ class HIPBackend(BaseBackend):
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, options.arch, __HIP_FTZ)
         passes.convert.add_reconcile_unrealized_casts(pm)
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
+
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1192,11 +1192,11 @@ class CUDABackend(BaseBackend):
         tlx_dump_dir = None
         tlx_saved_fd = None
         tlx_capture_file = None
-        if knobs.nvidia.dump_tlx_benchmark:
+        if knobs.compilation.dump_tlx_benchmark:
             from triton.tools.tlx_benchmark_gen import setup_tlx_dump
 
             tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
-        elif knobs.nvidia.dump_ttgir_to_tlx:
+        elif knobs.compilation.dump_ttgir_to_tlx:
             tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if CUDABackend.instrumentation:
@@ -1238,13 +1238,15 @@ class CUDABackend(BaseBackend):
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("llvmir_to_llvm", pm, mod.context)
 
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
 
-        # After pm.run(), restore stdout and generate TLX benchmark artifacts
-        if tlx_dump_dir is not None:
-            from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
-
-            finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1331,6 +1331,21 @@ void printLocComment(Operation *op, llvm::raw_ostream &os) {
   os << "\n";
 }
 
+// Resolve an operand of an AttrSizedOperandSegments op by declared position.
+// Absent optional groups have size 0, so positional reads shift.
+static Value getSegmentOperand(Operation *op, unsigned segmentIdx) {
+  auto segments = op->getAttrOfType<DenseI32ArrayAttr>("operandSegmentSizes");
+  if (!segments)
+    return nullptr;
+  ArrayRef<int32_t> sizes = segments.asArrayRef();
+  if (segmentIdx >= sizes.size() || sizes[segmentIdx] == 0)
+    return nullptr;
+  unsigned start = 0;
+  for (unsigned i = 0; i < segmentIdx; ++i)
+    start += sizes[i];
+  return start < op->getNumOperands() ? op->getOperand(start) : nullptr;
+}
+
 // Print operation in simplified TLX format
 void printSimplifiedOp(
     Operation *op, llvm::raw_ostream &os,
@@ -1990,6 +2005,75 @@ void printSimplifiedOp(
       os << " = ";
     os << "tlx._clc_query("
        << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // AMD buffer ops address global memory as base pointer + offset tensor,
+  // which Triton spells `ptr + offsets`. `stride` is a codegen hint.
+  if (opName == "amdg.buffer_load" || opName == "amdg.buffer_store" ||
+      opName == "amdg.buffer_load_to_local") {
+    // Declared operand order differs per op; see TritonAMDGPUOps.td.
+    Value value, dest, ptr, offsets, mask, other;
+    if (opName == "amdg.buffer_load") {
+      ptr = getSegmentOperand(op, 0);
+      offsets = getSegmentOperand(op, 1);
+      mask = getSegmentOperand(op, 3);
+      other = getSegmentOperand(op, 4);
+    } else if (opName == "amdg.buffer_store") {
+      value = getSegmentOperand(op, 0);
+      ptr = getSegmentOperand(op, 1);
+      offsets = getSegmentOperand(op, 2);
+      mask = getSegmentOperand(op, 4);
+    } else {
+      dest = getSegmentOperand(op, 0);
+      ptr = getSegmentOperand(op, 1);
+      offsets = getSegmentOperand(op, 2);
+      mask = getSegmentOperand(op, 3);
+      other = getSegmentOperand(op, 4);
+    }
+
+    // Guard every non-optional segment, not just ptr/offsets: getValueName
+    // dereferences the Value, so a missing one would crash rather than print.
+    if (!ptr || !offsets || (opName == "amdg.buffer_store" && !value) ||
+        (opName == "amdg.buffer_load_to_local" && !dest)) {
+      op->emitError("buffer op is missing a required operand and does not "
+                    "round-trip to TLX");
+      os << "# unsupported: " << opName << " (malformed operands)";
+      printLocComment(op, os);
+      return;
+    }
+
+    std::string addr = getValueName(ptr, argSubstitutionMap) + " + " +
+                       getValueName(offsets, argSubstitutionMap);
+
+    if (opName == "amdg.buffer_store") {
+      os << "tl.store(" << addr << ", "
+         << getValueName(value, argSubstitutionMap);
+    } else if (opName == "amdg.buffer_load") {
+      if (op->getNumResults() > 0)
+        os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+      os << "tl.load(" << addr;
+    } else {
+      // buffer_load_to_local returns an async token, like tlx.async_load.
+      if (op->getNumResults() > 0)
+        os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+      os << "tlx.async_load(" << addr << ", "
+         << getValueName(dest, argSubstitutionMap);
+    }
+    if (mask)
+      os << ", mask=" << getValueName(mask, argSubstitutionMap);
+    if (other)
+      os << ", other=" << getValueName(other, argSubstitutionMap);
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
+  // llvm.intr.assume is a tl.assume from the source kernel.
+  if (opName == "llvm.intr.assume" && op->getNumOperands() == 1) {
+    os << "tl.assume(" << getValueName(op->getOperand(0), argSubstitutionMap)
+       << ")";
     printLocComment(op, os);
     return;
   }

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -872,6 +872,19 @@ static Value resolveThroughCasts(Value v) {
   return v;
 }
 
+// An scf loop's region arguments are bound in the emitted Python, by the
+// iter_args init line and the body's parallel copies; captures are not.
+static bool isLoopCarriedBlockArg(Value v) {
+  auto blockArg = dyn_cast<BlockArgument>(v);
+  if (!blockArg)
+    return false;
+  Operation *parent = blockArg.getOwner()->getParentOp();
+  if (!parent)
+    return false;
+  StringRef parentName = parent->getName().getStringRef();
+  return parentName == "scf.for" || parentName == "scf.while";
+}
+
 // Forward declarations
 void printRegion(Region &region, llvm::raw_ostream &os,
                  const llvm::StringMap<StringRef> &opNameMap,
@@ -977,7 +990,8 @@ void printForOp(Operation *op, llvm::raw_ostream &os,
     // and need proper initialization (e.g., from ub.poison in the TTIR).
     // Detect by checking: no defining op + is BlockArgument + is tensor/f32
     bool needsInit = false;
-    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved)) {
+    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved) &&
+        !isLoopCarriedBlockArg(resolved)) {
       Type type = resolved.getType();
       if (isa<RankedTensorType>(type) || type.isF32())
         needsInit = true;

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -2955,6 +2955,12 @@ void printRegion(Region &region, llvm::raw_ostream &os,
                  llvm::DenseSet<Operation *> &skippedOps, unsigned indent,
                  DenseMap<Value, Value> *argSubstitutionMap,
                  ArrayRef<Value> yieldTargets) {
+  // A substitution recorded while printing an op (scf.for maps its results
+  // onto its iter_args) must outlive it for the siblings that consume it.
+  DenseMap<Value, Value> ownedSubstitutionMap;
+  if (!argSubstitutionMap)
+    argSubstitutionMap = &ownedSubstitutionMap;
+
   // For multi-block regions with CF control flow, use the CF-aware printer
   if (std::distance(region.begin(), region.end()) > 1) {
     printCFRegion(region, os, opNameMap, allocInfoMap, skippedOps, indent,

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1975,16 +1975,6 @@ void printSimplifiedOp(
     return;
   }
 
-  // nvg.cluster_id: the CLC-persistent lowering replaces the source's
-  // tl.program_id(0) with the cluster id, identical for single-CTA clusters.
-  if (opName == "nvg.cluster_id") {
-    if (op->getNumResults() > 0)
-      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
-    os << "tl.program_id(axis=0)";
-    printLocComment(op, os);
-    return;
-  }
-
   // ttng.async_clc_try_cancel(mbar, response): TLX takes (response, barrier).
   if (opName == "ttng.async_clc_try_cancel") {
     os << "tlx._clc_issue("


### PR DESCRIPTION
Summary:
D117188473 (https://github.com/facebookexperimental/triton/pull/3309) added a
special case printing `nvg.cluster_id` as `tl.program_id(axis=0)`, on the
mistaken premise that the CLC-persistent lowering substitutes the cluster id
for the source kernel's `tl.program_id(0)`. It does not, and the two ops are
never the same value.

This drops the special case and lets the generic
path handle it. The CLC additions in that diff -- `_alloc_clc_responses`,
`_clc_issue` and `_clc_query` -- are unaffected.

The regression is not confined to CLC kernels. `blackwell_gemm_2cta` calls
`tlx.cluster_cta_rank()` directly to pick the leader of each CTA pair, and
since D117188473 its generated TLX reads:

```counterexample
  cluster_cta_rank = tl.program_id(axis=0)  # blackwell_gemm_2cta.py:41
  pred_leader_cta = cluster_cta_rank % 2
```

With num_ctas = 2 that is `%clusterid.x % 2`, which is identical for both CTAs
of a pair, so both or neither take the leader path. In the CLC kernels the same
value is added to the tile claimed by `_clc_query` as a per-CTA offset, where
the correct addend is 0 for the single-CTA clusters those kernels launch. Both
spellings compile, which is why this went unnoticed.

Authored with Claude.

Differential Revision: D118807183
