### PR TITLE
[TLX] Avoid quadratic symbol-use scans in layout fixup

### DIFF
--- a/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/Fixup.cpp
@@ -218,6 +218,11 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod, bool &changed) {
   // look like a conflict. Encoding-free callers retain the original.
   SmallVector<std::pair<::mlir::triton::CallOp, ::mlir::triton::FuncOp>>
       concreteClones;
+  // Build the symbol-to-user index once. Calling getSymbolUses(callee, mod)
+  // for each concrete call repeatedly walks the whole module and is quadratic
+  // for large helper-heavy TLX kernels.
+  SymbolTableCollection symbolTables;
+  SymbolUserMap symbolUsers(symbolTables, mod);
   mod.walk([&](::mlir::triton::CallOp call) {
     if (!llvm::any_of(call.getOperandTypes(), isConcreteDistributed))
       return;
@@ -225,15 +230,7 @@ static LogicalResult synchronizeConcreteHelperABI(ModuleOp mod, bool &changed) {
         call, call.getCalleeAttr());
     if (!callee || callee.getBody().empty())
       return;
-    auto uses = SymbolTable::getSymbolUses(callee, mod);
-    if (!uses)
-      return;
-    unsigned useCount = 0;
-    for (const auto &use : *uses) {
-      (void)use;
-      ++useCount;
-    }
-    if (useCount > 1)
+    if (symbolUsers.getUsers(callee).size() > 1)
       concreteClones.emplace_back(call, callee);
   });
   for (auto [call, callee] : concreteClones) {


### PR DESCRIPTION
Summary:
TLX Fixup specializes encoding-free triton.jit helper ABIs when concrete distributed layouts reach a call boundary. A helper shared by multiple call sites must first be privatized so each caller can acquire its own concrete argument and result layouts.

The existing implementation calls SymbolTable::getSymbolUses(callee, mod) for every concrete call during every layout-reconciliation fixpoint iteration. Each query walks the module. The motivating helper-heavy persistent GEMM requires 57 iterations, making synchronizeConcreteHelperABI consume 160.62 seconds and TritonTLXFixup consume 165.77 seconds of a 170.67-second cold JIT.

Build MLIR's SymbolUserMap once per fixpoint iteration and reuse it for every callee query. The index includes all symbol users and is rebuilt on the next iteration after helper cloning, preserving the existing conservative privatization semantics. No validation, layout propagation, ABI specialization, or helper cloning is skipped.

Measured on gfx950 for the expanded (1024, 20480, 6144) TN FP16 persistent GEMM with a fresh Triton cache:

| Metric | Before | After | Result |
| --- | ---: | ---: | ---: |
| TritonTLXFixup | 165.771 s | 1.555 s | 106.6x faster |
| TTIR pipeline | 166.414 s | 2.206 s | 75.4x faster |
| TTGIR pipeline | 2.003 s | 1.985 s | unchanged |
| LLVM lowering | 0.862 s | 0.854 s | unchanged |
| End-to-end cold JIT | 170.671 s | 6.439 s | 26.5x faster |

The generated TTIR, TTGIR, and complete AMDGCN are byte-identical before and after this change. Runtime remains approximately 0.25 ms.

Reviewed By: htyu

Differential Revision: D118827696


