### PR TITLE
[triton][tlx] Stop re-initializing loop-carried iter_args in TTGIR-to-TLX

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -423,6 +423,9 @@ class compilation_knobs(base_knobs):
     override: env_bool = env_bool("TRITON_KERNEL_OVERRIDE")
     dump_ir: env_bool = env_bool("TRITON_KERNEL_DUMP")
     dump_ir_extract_di_local_variables: env_bool = env_bool("LLVM_EXTRACT_DI_LOCAL_VARIABLES")
+    # Dump the final TTGIR of each kernel as equivalent TLX Python
+    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
+    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     store_binary_only: env_bool = env_bool("TRITON_STORE_BINARY_ONLY")
     always_compile: env_bool = env_bool("TRITON_ALWAYS_COMPILE")
     # TODO: Use enum to constrain / 'typecheck' the values
@@ -633,8 +636,6 @@ class nvidia_knobs(base_knobs):
     # it (knobs.nvidia.scope()) instead of leaking global env state.
     modulo_strict_error: env_bool = env_bool("TRITON_MODULO_STRICT_ERROR")
     disable_wsbarrier_reorder: env_bool = env_bool("TRITON_DISABLE_WSBARRIER_REORDER")
-    dump_ttgir_to_tlx: env_bool = env_bool("TRITON_DUMP_TTGIR_TO_TLX")
-    dump_tlx_benchmark: env_bool = env_bool("TRITON_DUMP_TLX_BENCHMARK")
     use_no_compile_launcher: env_bool = env_bool("TRITON_USE_NO_COMPILE_LAUNCHER")
     # Default ON; opt out with TRITON_USE_C_DISPATCHER=0.
     use_triton_dispatcher: env_bool = env_bool("TRITON_USE_C_DISPATCHER", True)

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1126,3 +1126,53 @@ module {
     tt.return %result : i32
   }
 }
+
+// -----
+
+// A loop whose iter_arg is initialized from a previous loop's result must carry
+// that accumulator over, not be re-initialized.
+//
+// The printer synthesizes an initializer for a block argument that has no
+// defining op, because a warp_specialize region capture is not bound anywhere
+// in the emitted Python. An scf loop's iter_arg is also a block argument with
+// no defining op, but it *is* bound -- by the init line above the loop and the
+// parallel copies at the end of the body. Chaining two loops makes the second
+// loop's init resolve, through the warp_specialize substitution map, onto the
+// first loop's iter_arg, so the synthetic initializer would overwrite a live
+// accumulator with -inf.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: def ws_chained_loops(
+  // CHECK: [[ACC:[a-z0-9_]+]] = cst
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  // CHECK: [[ACC]] = {{[a-z0-9_]+}}
+  // The carry between the two loops, and not a fresh -inf tensor.
+  // CHECK: [[ACC]] = [[ACC]]
+  // CHECK-NOT: tl.full({{.*}}-inf
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  tt.func public @ws_chained_loops(%n: i32) attributes {noinline = false} {
+    ttg.warp_specialize(%n) attributes {requestedRegisters = array<i32: 24>}
+    default {
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
+      %one = arith.constant dense<1.000000e+00> : tensor<256xf32, #blocked>
+      %l1 = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%acc = %zero)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %a = arith.addf %acc, %one : tensor<256xf32, #blocked>
+        scf.yield %a : tensor<256xf32, #blocked>
+      }
+      %l2 = scf.for %j = %c0_i32 to %n step %c1_i32 iter_args(%acc2 = %l1)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %b = arith.mulf %acc2, %one : tensor<256xf32, #blocked>
+        scf.yield %b : tensor<256xf32, #blocked>
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32) num_warps(1) {
+      ttg.warp_return
+    } : (i32) -> ()
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -484,6 +484,16 @@ class HIPBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         amd.passes.ttgpuir.add_update_async_wait_count(pm, options.arch)
+        # Print TTGIR to TLX mapping before final emission (for debugging/analysis)
+        tlx_dump_dir = None
+        tlx_saved_fd = None
+        tlx_capture_file = None
+        if knobs.compilation.dump_tlx_benchmark:
+            from triton.tools.tlx_benchmark_gen import setup_tlx_dump
+
+            tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
+        elif knobs.compilation.dump_ttgir_to_tlx:
+            tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         amd.passes.ttgpuir.add_warp_pipeline_conversion(pm, options.arch)
         passes.convert.add_scf_to_cf(pm)
         passes.gluon.add_inliner(pm)
@@ -533,7 +543,15 @@ class HIPBackend(BaseBackend):
 
         amd.passes.ttgpuir.add_builtin_func_to_llvmir(pm, options.arch, __HIP_FTZ)
         passes.convert.add_reconcile_unrealized_casts(pm)
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
+
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1192,11 +1192,11 @@ class CUDABackend(BaseBackend):
         tlx_dump_dir = None
         tlx_saved_fd = None
         tlx_capture_file = None
-        if knobs.nvidia.dump_tlx_benchmark:
+        if knobs.compilation.dump_tlx_benchmark:
             from triton.tools.tlx_benchmark_gen import setup_tlx_dump
 
             tlx_dump_dir, tlx_saved_fd, tlx_capture_file = setup_tlx_dump(pm, tlx.tlx_passes)
-        elif knobs.nvidia.dump_ttgir_to_tlx:
+        elif knobs.compilation.dump_ttgir_to_tlx:
             tlx.tlx_passes.add_tlx_print_ttgir_to_tlx(pm)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if CUDABackend.instrumentation:
@@ -1238,13 +1238,15 @@ class CUDABackend(BaseBackend):
         if CUDABackend.instrumentation:
             CUDABackend.instrumentation.patch("llvmir_to_llvm", pm, mod.context)
 
-        pm.run(mod, "make_llir")
+        try:
+            pm.run(mod, "make_llir")
+        finally:
+            # finalize_tlx_dump restores the stdout fd setup_tlx_dump redirected,
+            # so it has to run even when the pipeline raises.
+            if tlx_dump_dir is not None:
+                from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
 
-        # After pm.run(), restore stdout and generate TLX benchmark artifacts
-        if tlx_dump_dir is not None:
-            from triton.tools.tlx_benchmark_gen import finalize_tlx_dump
-
-            finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
+                finalize_tlx_dump(tlx_dump_dir, tlx_saved_fd, tlx_capture_file, metadata)
 
         if knobs.compilation.dump_ir_extract_di_local_variables:
             # comments below on why separate it

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -872,6 +872,19 @@ static Value resolveThroughCasts(Value v) {
   return v;
 }
 
+// An scf loop's region arguments are bound in the emitted Python, by the
+// iter_args init line and the body's parallel copies; captures are not.
+static bool isLoopCarriedBlockArg(Value v) {
+  auto blockArg = dyn_cast<BlockArgument>(v);
+  if (!blockArg)
+    return false;
+  Operation *parent = blockArg.getOwner()->getParentOp();
+  if (!parent)
+    return false;
+  StringRef parentName = parent->getName().getStringRef();
+  return parentName == "scf.for" || parentName == "scf.while";
+}
+
 // Forward declarations
 void printRegion(Region &region, llvm::raw_ostream &os,
                  const llvm::StringMap<StringRef> &opNameMap,
@@ -977,7 +990,8 @@ void printForOp(Operation *op, llvm::raw_ostream &os,
     // and need proper initialization (e.g., from ub.poison in the TTIR).
     // Detect by checking: no defining op + is BlockArgument + is tensor/f32
     bool needsInit = false;
-    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved)) {
+    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved) &&
+        !isLoopCarriedBlockArg(resolved)) {
       Type type = resolved.getType();
       if (isa<RankedTensorType>(type) || type.isF32())
         needsInit = true;


### PR DESCRIPTION
Summary:
When an `scf.for` iter_arg is initialized from a previous loop's result, the
printer emitted a fresh `tl.full(..., float('-inf'), ...)` instead of carrying
the accumulator over. The generated kernel still compiles and still runs -- it
just computes the wrong answer from the second loop onward.

The synthetic initializer exists for a real reason: a `ttg.warp_specialize`
capture reaches the printer as a block argument with no defining op, and nothing
in the emitted Python binds it, so the printer invents a value rather than
naming something that does not exist. An `scf.for` iter_arg looks identical --
block argument, no defining op -- but is bound, by the init line the printer
emits above the loop and the parallel copies at the end of the body. Chaining
two loops brings the two cases into contact: `printForLoop` maps a loop result
onto its iter_arg, so the second loop's init resolves onto the first loop's
iter_arg and the rule fires on a live accumulator.

Restrict the rule to block arguments that are not `scf.for` / `scf.while` region
arguments. Captures, and the `ub.poison` case below it, are unaffected.

This is a pre-existing bug on the NVIDIA path, reachable inside any
warp_specialize region; no tutorial kernel chains two loops that way, which is
why it went unnoticed. It is also a prerequisite for the diff above: without it,
recording the loop-result mapping for loops outside a warp_specialize would
extend the same silent miscompile to every AMD kernel with a steady-state plus
drain loop.

Authored with Claude.

Reviewed By: manman-ren

Differential Revision: D118548051


