### PR TITLE
[triton][tlx] Round-trip loop results outside warp_specialize in TTGIR-to-TLX

### DIFF
--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1126,3 +1126,53 @@ module {
     tt.return %result : i32
   }
 }
+
+// -----
+
+// A loop whose iter_arg is initialized from a previous loop's result must carry
+// that accumulator over, not be re-initialized.
+//
+// The printer synthesizes an initializer for a block argument that has no
+// defining op, because a warp_specialize region capture is not bound anywhere
+// in the emitted Python. An scf loop's iter_arg is also a block argument with
+// no defining op, but it *is* bound -- by the init line above the loop and the
+// parallel copies at the end of the body. Chaining two loops makes the second
+// loop's init resolve, through the warp_specialize substitution map, onto the
+// first loop's iter_arg, so the synthetic initializer would overwrite a live
+// accumulator with -inf.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: def ws_chained_loops(
+  // CHECK: [[ACC:[a-z0-9_]+]] = cst
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  // CHECK: [[ACC]] = {{[a-z0-9_]+}}
+  // The carry between the two loops, and not a fresh -inf tensor.
+  // CHECK: [[ACC]] = [[ACC]]
+  // CHECK-NOT: tl.full({{.*}}-inf
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  tt.func public @ws_chained_loops(%n: i32) attributes {noinline = false} {
+    ttg.warp_specialize(%n) attributes {requestedRegisters = array<i32: 24>}
+    default {
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
+      %one = arith.constant dense<1.000000e+00> : tensor<256xf32, #blocked>
+      %l1 = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%acc = %zero)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %a = arith.addf %acc, %one : tensor<256xf32, #blocked>
+        scf.yield %a : tensor<256xf32, #blocked>
+      }
+      %l2 = scf.for %j = %c0_i32 to %n step %c1_i32 iter_args(%acc2 = %l1)
+          -> (tensor<256xf32, #blocked>) : i32 {
+        %b = arith.mulf %acc2, %one : tensor<256xf32, #blocked>
+        scf.yield %b : tensor<256xf32, #blocked>
+      }
+      ttg.warp_yield
+    }
+    partition0(%arg0: i32) num_warps(1) {
+      ttg.warp_return
+    } : (i32) -> ()
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1176,3 +1176,36 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// A loop result consumed after the loop must print as the iter_arg the parallel
+// copy assigns, not as the loop op's own SSA name. Only warp_specialize used to
+// create the substitution map that records this, so a loop outside one emitted
+// unbound names -- which on AMD CDNA, having no warp_specialize, is every loop.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: def loop_results_outside_ws(
+  // CHECK: [[ACC:[a-z0-9_]+]] = cst
+  // CHECK: [[L:[a-z0-9_]+]] = cst_0
+  // CHECK: for {{[a-z0-9_]+}} in range(
+  // CHECK: [[ACC]], [[L]] = {{[a-z0-9_]+}}, {{[a-z0-9_]+}}
+  // Both results resolve to their iter_args, not to %0#0 / %0#1.
+  // CHECK: = [[ACC]] / [[L]]
+  // CHECK-NOT: var_0_0
+  tt.func public @loop_results_outside_ws(%n: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %zero = arith.constant dense<0.000000e+00> : tensor<256xf32, #blocked>
+    %one = arith.constant dense<1.000000e+00> : tensor<256xf32, #blocked>
+    %res:2 = scf.for %i = %c0_i32 to %n step %c1_i32 iter_args(%acc = %zero, %l = %one)
+        -> (tensor<256xf32, #blocked>, tensor<256xf32, #blocked>) : i32 {
+      %a = arith.addf %acc, %l : tensor<256xf32, #blocked>
+      %b = arith.mulf %l, %l : tensor<256xf32, #blocked>
+      scf.yield %a, %b : tensor<256xf32, #blocked>, tensor<256xf32, #blocked>
+    }
+    %div = arith.divf %res#0, %res#1 : tensor<256xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -872,6 +872,19 @@ static Value resolveThroughCasts(Value v) {
   return v;
 }
 
+// An scf loop's region arguments are bound in the emitted Python, by the
+// iter_args init line and the body's parallel copies; captures are not.
+static bool isLoopCarriedBlockArg(Value v) {
+  auto blockArg = dyn_cast<BlockArgument>(v);
+  if (!blockArg)
+    return false;
+  Operation *parent = blockArg.getOwner()->getParentOp();
+  if (!parent)
+    return false;
+  StringRef parentName = parent->getName().getStringRef();
+  return parentName == "scf.for" || parentName == "scf.while";
+}
+
 // Forward declarations
 void printRegion(Region &region, llvm::raw_ostream &os,
                  const llvm::StringMap<StringRef> &opNameMap,
@@ -977,7 +990,8 @@ void printForOp(Operation *op, llvm::raw_ostream &os,
     // and need proper initialization (e.g., from ub.poison in the TTIR).
     // Detect by checking: no defining op + is BlockArgument + is tensor/f32
     bool needsInit = false;
-    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved)) {
+    if (!resolved.getDefiningOp() && isa<BlockArgument>(resolved) &&
+        !isLoopCarriedBlockArg(resolved)) {
       Type type = resolved.getType();
       if (isa<RankedTensorType>(type) || type.isF32())
         needsInit = true;

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -2955,6 +2955,12 @@ void printRegion(Region &region, llvm::raw_ostream &os,
                  llvm::DenseSet<Operation *> &skippedOps, unsigned indent,
                  DenseMap<Value, Value> *argSubstitutionMap,
                  ArrayRef<Value> yieldTargets) {
+  // A substitution recorded while printing an op (scf.for maps its results
+  // onto its iter_args) must outlive it for the siblings that consume it.
+  DenseMap<Value, Value> ownedSubstitutionMap;
+  if (!argSubstitutionMap)
+    argSubstitutionMap = &ownedSubstitutionMap;
+
   // For multi-block regions with CF control flow, use the CF-aware printer
   if (std::distance(region.begin(), region.end()) > 1) {
     printCFRegion(region, os, opNameMap, allocInfoMap, skippedOps, indent,


### PR DESCRIPTION
Summary:
A loop result consumed after its loop printed as the loop op's own SSA name
(`acc_44_0`, `acc_1`), which is bound to nothing, so the generated TLX does not
import.

`printForLoop` already maps each `scf.for` result onto the iter_arg that the
body's parallel copies assign, recording it into the substitution map passed
down the region walk. But only `printWarpSpecialize` ever created such a map, so
everywhere else the pointer was null and the mapping was dropped.

Give `printRegion` its own map when the caller supplies none. Region scope is
the right lifetime: the consumers of a loop result are siblings printed later
from that same region. Warp-specialized code still gets the caller's map.

Blackwell kernels put their loops inside `ttg.warp_specialize`, which is why
this held there. AMD CDNA has no `ttg.warp_specialize`, so on AMD it is every
loop in every kernel.

Depends on the diff below: without it, mapping a loop result onto an iter_arg
makes a chained loop's init look like an unbound capture and reset it to -inf,
trading an unbound name for silently wrong numerics.

Authored with Claude.

Reviewed By: njriasan

Differential Revision: D118558715


