### PR TITLE
[CPU] Recover num_cpu_threads in Config for torch dynamo HOP

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1097,6 +1097,8 @@ class Config:
     :ivar enable_nvptx_v2i32: opt in to NVPTX v2i32 register legalization. Off by default;
         the packed form costs an unpack/repack per use and no integer op is legal on it.
     :type enable_nvptx_v2i32: bool | None
+    :ivar num_cpu_threads: number of threads to use for CPU backend kernels. 0 (default) means unset.
+    :type num_cpu_threads: int
     """
 
     @staticmethod
@@ -1110,6 +1112,7 @@ class Config:
         num_warps=4,
         num_stages=3,
         num_ctas=1,
+        num_cpu_threads=0,
         maxnreg=None,
         pre_hook=None,
         ir_override=None,
@@ -1135,6 +1138,7 @@ class Config:
         self.num_warps = num_warps
         self.num_ctas = num_ctas
         self.num_stages = num_stages
+        self.num_cpu_threads = num_cpu_threads
         self.maxnreg = maxnreg
         self.pre_hook = pre_hook
         self.ir_override = ir_override
@@ -1161,6 +1165,7 @@ class Config:
         self.num_warps = state.get("num_warps", 4)
         self.num_stages = state.get("num_stages", 3)
         self.num_ctas = state.get("num_ctas", 1)
+        self.num_cpu_threads = state.get("num_cpu_threads", 0)
         self.maxnreg = state.get("maxnreg", None)
         self.pre_hook = state.get("pre_hook", None)
         self.ir_override = state.get("ir_override", None)
@@ -1187,6 +1192,8 @@ class Config:
                     ("num_warps", self.num_warps),
                     ("num_ctas", self.num_ctas),
                     ("num_stages", self.num_stages),
+                    # Omit when 0: unknown to GPU options and rejected by _pack_args.
+                    ("num_cpu_threads", self.num_cpu_threads or None),
                     ("maxnreg", self.maxnreg),
                     ("ir_override", self.ir_override),
                     ("minRegAutoWS", self.minRegAutoWS),
@@ -1213,6 +1220,8 @@ class Config:
         res.append(f"num_warps: {self.num_warps}")
         res.append(f"num_ctas: {self.num_ctas}")
         res.append(f"num_stages: {self.num_stages}")
+        if self.num_cpu_threads:
+            res.append(f"num_cpu_threads: {self.num_cpu_threads}")
         res.append(f"maxnreg: {self.maxnreg}")
         res.append(f"ir_override: {self.ir_override}")
         res.append(f"minRegAutoWS: {self.minRegAutoWS}")


### PR DESCRIPTION
Restore the num_cpu_threads Config parameter dropped during over-aggressive CPU isolation, fixing TypeError on CPU HOP launches.

- torch's triton_kernel_wrap passes num_cpu_threads into Config(...) unconditionally (pytorch/pytorch#166255 contract).
- Caller-side CPU-only gating does not help: the crash is in wrap->Config, not in the caller.
- Affected: test_triton_hop_cpu, test_triton_hop_cpu_dynamic_scalar_arg (sigmoid/inference/test:test_passes).
- Same removal propagated fbtriton -> beta -> 3.8/stable; internal experimental broke the same way via retrofit D118849259.
- Eager path unaffected (launch kwargs flow via parse_options to CPUOptions without Config).
- GPU Options untouched (nothing reads it there).

Validation: py_compile; fbsource sigmoid CPU HOP tests pass.