### PR TITLE
[triton][3.8] Omit zero num_cpu_threads in Config str

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -1089,6 +1089,8 @@ class Config:
     :ivar enable_nvptx_v2i32: opt in to NVPTX v2i32 register legalization. Off by default;
         the packed form costs an unpack/repack per use and no integer op is legal on it.
     :type enable_nvptx_v2i32: bool | None
+    :ivar num_cpu_threads: number of threads to use for CPU backend kernels. 0 (default) means unset.
+    :type num_cpu_threads: int
     """
 
     @staticmethod
@@ -1220,7 +1222,8 @@ class Config:
         res.append(f"auto_tma: {self.auto_tma}")
         res.append(f"enable_tree_reduction: {self.enable_tree_reduction}")
         res.append(f"enable_nvptx_v2i32: {self.enable_nvptx_v2i32}")
-        res.append(f"num_cpu_threads: {self.num_cpu_threads}")
+        if self.num_cpu_threads:
+            res.append(f"num_cpu_threads: {self.num_cpu_threads}")
         return ", ".join(res)
 
     def __hash__(self):


### PR DESCRIPTION
Summary:
This simple fix should have been done with D118943725

---

Apply the same `Config.__str__` guard already landed on the
beta sync (D118969130) and stable shims (D118943728) to the 3.8 and
experimental copies: skip `num_cpu_threads` when it is 0 so default GPU
configs keep identical str output and autotune keys.

Very weirdly this `__str__` can cause a regression in triton bench??

```

Experiment: https://www.internalfb.com/servicelab/experiment/2679288849135789
Workload oncall: https://www.internalfb.com/omh/view/triton/frontpage

ServiceLab detected regression in the following metrics:
------------------------------------
triton_beta_downstream_h100.tritonbench:broken_target_files: 16.67%
triton_beta_downstream_h100.tritonbench:fail_tests: 7.32%
------------------------------------

Click the experiment link below for more details

Detailed logs: https://www.internalfb.com/servicelab/experiment/2679288849135789
```

Differential Revision: D118997819


