### PR TITLE
[TLX] Attach Hopper warp metadata during AST lowering (#3485)

### DIFF
--- a/python/test/unit/language/test_tlx_dot.py
+++ b/python/test/unit/language/test_tlx_dot.py
@@ -3,7 +3,10 @@ import pytest
 import torch
 import triton
 import triton.language as tl
+from triton._C.libtriton import ir
 from triton.backends.compiler import GPUTarget
+from triton.compiler import ASTSource
+from triton.compiler.compiler import make_backend
 from triton._internal_testing import is_blackwell, is_hopper
 from triton._filecheck import run_parser
 from triton.experimental import gluon
@@ -26,6 +29,74 @@ else:
     from conftest import _generate_test_params, _swizzle_scale_to_5d
 
 HIP_TARGET_CDNA4 = GPUTarget("hip", "gfx950", 64)
+
+
+@triton.jit
+def _raw_ttir_async_dot_kernel():
+    a_tiles = tlx.local_alloc((64, 32), tl.float16, 1)
+    b_tiles = tlx.local_alloc((32, 64), tl.float16, 1)
+    acc = tlx.async_dot(a_tiles[0], b_tiles[0])
+    tlx.async_dot_wait(0, acc)
+
+
+@triton.jit
+def _raw_ttir_ws_async_dot_kernel():
+    a_tiles = tlx.local_alloc((64, 32), tl.float16, 1)
+    b_tiles = tlx.local_alloc((32, 64), tl.float16, 1)
+    with tlx.async_tasks():
+        with tlx.async_task("default"):
+            _ = tl.arange(0, 1)
+        with tlx.async_task(num_warps=4):
+            acc = tlx.async_dot(a_tiles[0], b_tiles[0])
+            tlx.async_dot_wait(0, acc)
+
+
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+def test_raw_ttir_async_dot_has_num_warps():
+    target = GPUTarget("cuda", 90, 32)
+    backend = make_backend(target)
+    options = backend.parse_options({"num_warps": 8})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(fn=_raw_ttir_async_dot_kernel, signature={}, constexprs={})
+
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+
+    assert module.get_int_attr("ttg.num-warps") == 8
+    assert module.verify()
+
+
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+def test_raw_ttir_async_dot_uses_partition_num_warps():
+    target = GPUTarget("cuda", 90, 32)
+    backend = make_backend(target)
+    options = backend.parse_options({"num_warps": 8})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(fn=_raw_ttir_ws_async_dot_kernel, signature={}, constexprs={})
+
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    module_text = str(module)
+
+    assert module.get_int_attr("ttg.num-warps") == 8
+    assert module_text.count("partition0(") == 1
+    assert module_text.count("num_warps(4)") == 1
+    assert module_text.count("warpsPerCTA = [4, 1]") == 1
+    assert module.verify()
 
 
 @gluon_builtin

--- a/third_party/tlx/dialect/triton_tlx.cc
+++ b/third_party/tlx/dialect/triton_tlx.cc
@@ -645,6 +645,11 @@ void init_triton_tlx_ir(py::module_ &m) {
              auto retType = cast<RankedTensorType>(opndAcc.getType());
              auto retShapePerCTA = retType.getShape();
              Block *parentBlock = self.getBuilder().getInsertionBlock();
+             auto module = parentBlock->getParentOp()->getParentOfType<ModuleOp>();
+             if (!module->hasAttr(ttg::AttrNumWarpsName))
+               module->setAttr(
+                   ttg::AttrNumWarpsName,
+                   self.getBuilder().getI32IntegerAttr(moduleNumWarps));
              unsigned numWarps =
                  ttg::maybeLookupNumWarps(parentBlock).value_or(moduleNumWarps);
              if (auto mmaLayout = dyn_cast_or_null<ttg::NvidiaMmaEncodingAttr>(


### PR DESCRIPTION
Summary:

**The bug:**
Hopper TLX lowers `tlx.async_dot` to a WGMMA (`#ttg.nvidia_mma`) layout while the Python AST is being converted to initial TTIR. The layout builder already receives `options.num_warps` and uses it to size `warpsPerCTA`, but ordinary `ASTSource.make_ir()` does not attach that launch setting to the enclosing module.

When PyTorch asks for a half-compiled version of a TLX kernel, Triton hands back something that fails its own self-check.

**Concrete failing TTIR:** Triton caches the result of `ASTSource.make_ir()` as the kernel's `.source` artifact before any backend stage runs. Reduced from the failing non-warp-specialized DCPP artifact:

```mlir
#mma = #ttg.nvidia_mma<{
  versionMajor = 3, versionMinor = 0,
  warpsPerCTA = [4, 1], instrShape = [16, 128, 16]
}>
"builtin.module"() ({ // no ttg.num-warps
  "tt.func"() ({
    ...
    %acc = "tlx.require_layout"(%zero)
      : (tensor<64x64xbf16>) -> tensor<64x64xbf16, #ttg.dot_op<{parent = #mma, ...}>>
    %pending = "ttng.warp_group_dot"(%v, %x, %acc) ...
  })
})
```

Immediate verification fails with:

```
Operand 0 (...) has an invalid layout: Could not determine the number of
warps per CTA. Operation is not in a context with `ttg.num-warps`.
```

Torch then raises `RuntimeError: Verification for TTIR module has failed`; `identify_accessed_tensors` catches it and conservatively assumes every input is mutated. The paired post-fixup `.ttir` artifact contains `"ttg.num-warps" = 4 : i32`, showing that the normal full pipeline supplies the same missing metadata later.

**Why the module attribute is correct with warp specialization:** `moduleNumWarps` comes from the parsed backend options and represents the module/default-task warp count. It is only installed when the module attribute is absent. The MMA layout still uses `maybeLookupNumWarps(parentBlock)`, whose first branch detects `WarpSpecializePartitionsOp` and returns that region's `partitionNumWarps[idx]` before walking outward to a function or module. Consequently, the module value is a fallback and cannot override a partition-local value.

A new distinguishing regression builds raw TTIR with `num_warps=8` and places `tlx.async_dot` in a four-warp async partition. It verifies all three facts together:

```mlir
#mma = #ttg.nvidia_mma<{..., warpsPerCTA = [4, 1], ...}>
module attributes {"ttg.num-warps" = 8 : i32} {
  ttg.warp_specialize(...)
  partition0(...) num_warps(4) {
    ... tensor<64x64xf32, #mma> ...
  }
}
```

The raw module verifies. This also matches the production attention IR shape, where the WGMMA is in `partition0 num_warps(4)` and its layout remains `warpsPerCTA = [4, 1]`.

**Why this is needed:** The full Triton compilation pipeline normally hides this ordering gap. After `ASTSource.make_ir()` returns, NVIDIA's first TTIR stage runs `TritonTLXFixup`, which attaches `ttg.num-warps` together with the target, threads-per-warp, and CTA count. Raw-TTIR consumers do not run that stage. Torch's Triton mutation/access analysis is one such consumer: it calls `ASTSource.make_ir()` and immediately verifies the returned module.

TritonGPU verification requires a distributed layout's warp dimension to match the contextual `ttg.num-warps`. The raw module therefore contains a correctly sized WGMMA layout but fails verification when no function, partition, or module context supplies the warp count. This invariant belongs in TLX, where the verifier-sensitive layout is created; patching Torch/Inductor would fix only one caller and leave other raw-TTIR consumers exposed.

**Before:** Raw Hopper TLX TTIR outside a warp-specialized partition fails verification even though compiling the same kernel through the complete Triton pipeline succeeds. Torch catches that failure, abandons precise TTIR access analysis, treats every tensor input as both read and written, and sets `can_fuse_epilogue=False`. That can introduce unnecessary functionalization clones, loses accurate dependency information, and disables otherwise eligible user-defined Triton epilogue fusion.

**Implementation:** When `make_nv_mma_encoding_attr` first materializes the Hopper MMA layout, attach `ttg.num-warps` from `moduleNumWarps`, which is passed directly from the TLX builder's parsed compiler options. Only fill the attribute when it is absent. Existing module metadata remains authoritative, while function- and warp-partition-specific counts take precedence through the contextual lookup used to build the layout.

**After:** Raw Hopper TLX TTIR is self-consistent and verifies immediately. Torch can recover the kernel's actual read/write set and retain eligible epilogue fusion. Normal end-to-end compilation and generated kernel behavior are unchanged because `TritonTLXFixup` later applies the same option-derived launch count as before. AMD and paths that do not construct an NVIDIA MMA layout are unaffected.

Differential Revision: D119068355
