### PR TITLE
[triton][beta] Restrict mbarrier arrive cluster-release to the logical num-ctas model

### DIFF
--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -887,54 +887,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg
 
 // -----
 
-// An arrive on a peer-CTA barrier under the physical `ctas_per_cga` cluster
-// model (num-ctas == 1, cluster-dim-x == 2) must NOT take cluster-scope release
-// semantics. TLX / AutoWS emit that arrive from a single thread of one
-// warp-specialized partition, and ptxas expands `.release.cluster` there into
-// MEMBAR.ALL.GPU / ERRBAR / CGAERRBAR, which faults at runtime on Blackwell.
-// The logical num-ctas counterpart, which must keep `.release.cluster`, is
-// covered by @arrive_barrier_cluster_broadcast above.
-
-// CHECK-LABEL: remote_arrive_physical_cluster_no_release
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
-  tt.func public @remote_arrive_physical_cluster_no_release(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttng.map_to_remote_buffer %arg, %c0_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    // CHECK-NOT: mbarrier.arrive.release.cluster
-    // CHECK: mbarrier.arrive.shared::cluster.b64
-    ttng.arrive_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    tt.return
-  }
-}
-
-// -----
-
-// An arrive on a peer-CTA barrier under the physical `ctas_per_cga` cluster
-// model (num-ctas == 1, cluster-dim-x == 2) must NOT take cluster-scope release
-// semantics. TLX / AutoWS emit that arrive from a single thread of one
-// warp-specialized partition, and ptxas expands `.release.cluster` there into
-// MEMBAR.ALL.GPU / ERRBAR / CGAERRBAR, which faults at runtime on Blackwell.
-// The logical num-ctas counterpart, which must keep `.release.cluster`, is
-// covered by @arrive_barrier_cluster_broadcast above.
-
-// CHECK-LABEL: remote_arrive_physical_cluster_no_release
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
-  tt.func public @remote_arrive_physical_cluster_no_release(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = ttng.map_to_remote_buffer %arg, %c0_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    // CHECK-NOT: mbarrier.arrive.release.cluster
-    // CHECK: mbarrier.arrive.shared::cluster.b64
-    ttng.arrive_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
-    tt.return
-  }
-}
-
-// -----
-
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -863,6 +863,78 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+// An arrive on a peer-CTA barrier under the physical `ctas_per_cga` cluster
+// model (num-ctas == 1, cluster-dim-x == 2) must NOT take cluster-scope release
+// semantics. TLX / AutoWS emit that arrive from a single thread of one
+// warp-specialized partition, and ptxas expands `.release.cluster` there into
+// MEMBAR.ALL.GPU / ERRBAR / CGAERRBAR, which faults at runtime on Blackwell.
+// The logical num-ctas counterpart, which must keep `.release.cluster`, is
+// covered by @arrive_barrier_cluster_broadcast above.
+
+// CHECK-LABEL: remote_arrive_physical_cluster_no_release
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @remote_arrive_physical_cluster_no_release(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttng.map_to_remote_buffer %arg, %c0_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    // CHECK-NOT: mbarrier.arrive.release.cluster
+    // CHECK: mbarrier.arrive.shared::cluster.b64
+    ttng.arrive_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// An arrive on a peer-CTA barrier under the physical `ctas_per_cga` cluster
+// model (num-ctas == 1, cluster-dim-x == 2) must NOT take cluster-scope release
+// semantics. TLX / AutoWS emit that arrive from a single thread of one
+// warp-specialized partition, and ptxas expands `.release.cluster` there into
+// MEMBAR.ALL.GPU / ERRBAR / CGAERRBAR, which faults at runtime on Blackwell.
+// The logical num-ctas counterpart, which must keep `.release.cluster`, is
+// covered by @arrive_barrier_cluster_broadcast above.
+
+// CHECK-LABEL: remote_arrive_physical_cluster_no_release
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @remote_arrive_physical_cluster_no_release(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttng.map_to_remote_buffer %arg, %c0_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    // CHECK-NOT: mbarrier.arrive.release.cluster
+    // CHECK: mbarrier.arrive.shared::cluster.b64
+    ttng.arrive_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+// An arrive on a peer-CTA barrier under the physical `ctas_per_cga` cluster
+// model (num-ctas == 1, cluster-dim-x == 2) must NOT take cluster-scope release
+// semantics. TLX / AutoWS emit that arrive from a single thread of one
+// warp-specialized partition, and ptxas expands `.release.cluster` there into
+// MEMBAR.ALL.GPU / ERRBAR / CGAERRBAR, which faults at runtime on Blackwell.
+// The logical num-ctas counterpart, which must keep `.release.cluster`, is
+// covered by @arrive_barrier_cluster_broadcast above.
+
+// CHECK-LABEL: remote_arrive_physical_cluster_no_release
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65536 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+  tt.func public @remote_arrive_physical_cluster_no_release(%arg: !ttg.memdesc<1xi64, #shared, #smem, mutable>) {
+    %c0_i32 = arith.constant 0 : i32
+    %0 = ttng.map_to_remote_buffer %arg, %c0_i32: !ttg.memdesc<1xi64, #shared, #smem, mutable> -> !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    // CHECK-NOT: mbarrier.arrive.release.cluster
+    // CHECK: mbarrier.arrive.shared::cluster.b64
+    ttng.arrive_barrier %0, 1 : !ttg.memdesc<1xi64, #shared, #ttng.shared_cluster_memory, mutable>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -484,11 +484,23 @@ struct ArriveBarrierOpConversion
       if (op.getPred())
         pred = b.and_(pred, adaptor.getPred());
 
+      // Cluster-scope release semantics only apply to the logical num-ctas
+      // cluster model, where every CTA of the cluster runs the arrive. TLX /
+      // AutoWS instead use the physical ctas_per_cga model (num-ctas == 1, so
+      // each CTA is its own program): there the arrive is emitted from a single
+      // thread of one warp-specialized partition, and its peer-CTA barriers are
+      // already ordered by explicit bar.sync + fence_async_shared. ptxas
+      // expands .release.cluster into MEMBAR.ALL.CTA / MEMBAR.ALL.GPU / ERRBAR
+      // / CGAERRBAR, and issuing that sequence from one partition faults at
+      // runtime on Blackwell (CUDA 719, unspecified launch failure).
+      bool isPerCTAProgramCluster =
+          getPhysicalClusterInfo(op).hasPerCTAProgramIds;
       auto emitArrive = [&](Value targetBarrier, Value multicastMask = {}) {
         std::stringstream ptxAsm;
         ptxAsm << "@$0 mbarrier.arrive.";
-        if (isCrossCluster || isCrossClusterBarrier || isRemoteBarrier ||
-            op.isMulticast())
+        if (op.isMulticast() ||
+            (!isPerCTAProgramCluster &&
+             (isCrossCluster || isCrossClusterBarrier || isRemoteBarrier)))
           ptxAsm << "release.cluster.";
         ptxAsm << (isRemoteBarrier || isCrossClusterBarrier || op.isMulticast()
                        ? "shared::cluster"


### PR DESCRIPTION
Fixes a `CUDA error: unspecified launch failure` (719) regression on Blackwell
introduced by #3386 (`4c91905cb`, the 37-PR upstream cherry-pick bundle). Its
parent `2d0a178778` is clean.

Repro — the TLX warp-specialized Blackwell GEMM in tritonbench:

    python run.py --op gemm --only tlx_matmul_ws --metrics tflops --rep 3000 \
        --sleep 1.0 --force --layout nt --shapes 1024x12800x1152 --simple-output

The fault is raised while the autotuner benchmarks one config of
`matmul_kernel_tma_ws_blackwell` (BM128/BN64/BK64, NUM_SMEM_BUFFERS=8,
NUM_TMEM_BUFFERS=3, NUM_MMA_GROUPS=1, EPILOGUE_SUBTILE=8, NUM_CTAS=2). A single
launch of that config succeeds; it needs the autotuner's back-to-back
benchmarking to trip, and it disappears under compute-sanitizer, which reports a
clean memcheck.

## Root cause

#3386 changed `ArriveBarrierOpConversion` to add `.release.cluster` semantics
whenever the barrier is remote, cross-cluster, or the module is cross-cluster —
previously only multicast arrives took cluster-scope release, and `isRemoteBarrier`
only selected the *addressing* (`shared::cluster` vs `shared::cta`), which is
mandatory and free.

That is the entire codegen delta for this kernel. Comparing the generated code
against the parent commit, TTIR/TTGIR are identical apart from a cosmetic
`tmem_subslice {N=} -> {offset=}` attribute rename, and the PTX differs at
exactly 11 sites:

    - mbarrier.arrive.shared::cluster.b64
    + mbarrier.arrive.release.cluster.shared::cluster.b64

Every one of those is an arrive on a peer-CTA barrier reached through
`ttng.map_to_remote_buffer`. ptxas expands each into a predicated
`MEMBAR.ALL.CTA; MEMBAR.ALL.GPU; ERRBAR; CGAERRBAR` sequence, so a single thread
of one warp-specialized partition now executes a device-scope membar plus a
cluster error barrier eleven times while the other partitions sit in
`mbarrier.try_wait` spin loops. The precise reason the hardware then returns 719
was not established, but the evidence is consistent: the failure scales with the
number of these sequences (only EPILOGUE_SUBTILE=8 fails; 1/2/4 with the same
2-CTA setup are fine), it is timing-sensitive, and the driver reports
`Sticky error detected` rather than an addressing fault.

The companion module-level gate that was supposed to pair this with
`.acquire.cluster` on the waits keys on `TritonGPUDialect::getNumCTAs`, i.e. the
*logical* `ttg.num-ctas`. TLX/AutoWS build their 2-CTA cluster physically via
`ttg.cluster-dim-*` and keep `ttg.num-ctas = 1`, so that gate is false for
exactly the kernels that actually run clusters, and the release was emitted
without its acquire. Making the gate physical-cluster-aware was tried and does
**not** fix the crash — with acquire and release correctly paired the kernel
still fails 3/3, and the added acquires cost ~5.7% (893.7 -> ~842 TFLOPS). The
trigger is the cluster release on the arrive itself, not the missing pairing.

## Fix

Take cluster-scope release on an arrive only under the logical num-ctas cluster
model, where every CTA of the cluster runs the arrive. The physical
`ctas_per_cga` model (`num-ctas == 1`, each CTA its own program) keeps the plain
arrive it had before #3386; its peer-CTA barriers are already ordered by explicit
`bar.sync` + `fence_async_shared`. The predicate reuses `getPhysicalClusterInfo`,
which already lives in this file and names this distinction `hasPerCTAProgramIds`.

Multicast arrives are unchanged and still take `.release.cluster`
unconditionally, as before #3386.

The `num-ctas == 1` conjunct is load-bearing: some modules set both
`ttg.cluster-dim-x = 2` and `ttg.num-ctas = 2`
(`tritonnvidiagpu_to_llvm.mlir:189,207`). Those are logical-model kernels and
must keep their release; a broader "is physical cluster" predicate silently
dropped it for them.

Deliberately left alone: `isCrossCluster` in `TritonGPUToLLVM.cpp` and the CLC
branch of `isDistributedMultiCTAOp` still key on the logical CTA count, so both
remain false for TLX/AutoWS. That is now intentional rather than accidental. If
cluster-scope barrier semantics are ever wanted on the physical path, those are
the two places to change — and the arrive side needs to be shown safe under warp
specialization first.


## Test plan

Verified on B200 (`cuda:100`), on top of `4c91905cb`:

- The tritonbench repro above: fails 3/3 before, passes after at **893.6727
  TFLOPS**, matching the pre-regression build exactly.
- Generated **LLIR, PTX and SASS for the failing kernel are byte-identical** to
  the `2d0a178778` build; zero `CGAERRBAR` (was 11).
- `test/Conversion/tritonnvidiagpu_to_llvm.mlir` 6/6 RUN lines,
  `clc_to_llvm.mlir` 1/1, `tritongpu_to_llvm.mlir` 1/1 — these pin
  `mbarrier.arrive.release.cluster` on the logical-cluster path and confirm it is
  preserved.
- `blackwell_gemm_2cta`, `blackwell_gemm_clc`, `blackwell_gemm_ws`,
  `blackwell_gemm_pipelined` all correct against torch (max abs err 4.9e-4).

New regression test `@remote_arrive_physical_cluster_no_release` in
`test/Conversion/tritonnvidiagpu_to_llvm.mlir` pins a `num-ctas = 1` /
`cluster-dim-x = 2` module with a `map_to_remote_buffer` arrive emitting
`mbarrier.arrive.shared::cluster` and no `.release.cluster`. The logical-model
counterpart is already covered by the existing
`@arrive_barrier_cluster_broadcast`.

Authored with Claude.