### PR TITLE
[TLX][AMD][gfx950] Optimize non-power-of-two shared-A BMM with unaligned vector loads

### DIFF
--- a/python/test/unit/language/test_tlx_amd_hip.py
+++ b/python/test/unit/language/test_tlx_amd_hip.py
@@ -18,6 +18,12 @@ from triton.compiler.compiler import ASTSource, compile as triton_compile
 from triton.backends.compiler import GPUTarget
 from triton.runtime.jit import MockTensor
 from triton.language.extra.tlx.tutorials import amd_fa_cluster as _amd_fa_cluster_module
+from triton.language.extra.tlx.tutorials.amd_bmm_shared_a import (
+    _bmm_register_staged,
+    _MT144X256_MI16_KERNEL_SPEC,
+    _MT64X256_MI32_KERNEL_SPEC,
+    _MT224X160_MI16_KERNEL_SPEC,
+)
 from triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.bench import (
     compile_shape as _compile_a4w4_shape, )
 from triton.language.extra.tlx.tutorials.gfx9_gemm.intra_wave.a4w4.matmul_kernel import (
@@ -45,6 +51,61 @@ def compile_for_target(fn, signature, constexprs, target):
 def compile_for_gfx950(fn, signature, constexprs):
     """Compile a TLX kernel for gfx950 and return the compiled object."""
     return compile_for_target(fn, signature, constexprs, GFX950)
+
+
+def _compile_register_staged_bmm_gfx950(m, n, k, kernel_spec):
+    batch = 1
+    block_m, block_n = kernel_spec.block_m, kernel_spec.block_n
+    instr_shape = kernel_spec.instr_shape
+    warps_per_cta = kernel_spec.warps_per_cta
+    n_blocks = triton.cdiv(n, block_n)
+    tiles_per_batch = triton.cdiv(m, block_m) * n_blocks
+    a = MockTensor(torch.float16, (batch, m, k))
+    b = MockTensor(torch.float16, (batch, k, n))
+    c = MockTensor(torch.float16, (batch, m, n))
+    strides = (0, k, 1, k * n, n, 1, m * n, n, 1)
+
+    with knobs.runtime.scope():
+        knobs.runtime.override_arch = "gfx950"
+        return _bmm_register_staged.warmup(
+            a,
+            b,
+            c,
+            m,
+            n,
+            k,
+            *strides,
+            KERNEL_SPEC=kernel_spec,
+            EVEN_M=m % block_m == 0,
+            EVEN_N=n % block_n == 0,
+            HAS_K_TAIL=k % 32 != 0,
+            N_BLOCKS=n_blocks,
+            BATCH_GROUP=8,
+            GMN=tiles_per_batch,
+            NT=tiles_per_batch,
+            grid=(tiles_per_batch,),
+            num_warps=warps_per_cta[0] * warps_per_cta[1],
+            num_stages=1,
+            matrix_instr_nonkdim=instr_shape[0],
+        )
+
+
+def test_shared_a_bmm_tuned_dispatches_keep_wide_unaligned_loads_gfx950():
+    compiled = [
+        _compile_register_staged_bmm_gfx950(
+            40, 256, 1956, _MT64X256_MI32_KERNEL_SPEC
+        ),
+        _compile_register_staged_bmm_gfx950(
+            262, 256, 294, _MT144X256_MI16_KERNEL_SPEC
+        ),
+        _compile_register_staged_bmm_gfx950(
+            448, 160, 931, _MT224X160_MI16_KERNEL_SPEC
+        ),
+    ]
+    amdgcn = "\n".join(kernel.asm["amdgcn"] for kernel in compiled)
+
+    assert "buffer_load_dwordx2" in amdgcn
+    assert "buffer_load_dwordx4" in amdgcn
 
 
 @pytest.fixture(scope="module")

--- a/third_party/tlx/tutorials/amd_bmm_shared_a.py
+++ b/third_party/tlx/tutorials/amd_bmm_shared_a.py
@@ -12,9 +12,9 @@ LAYOUT:
   * B: (B, K, N) ROW-major (N-contiguous, ``stride_bn == 1``).
   * C: (B, M, N) row-major.
 
-CONFIG: num_warps=8, matrix_instr_nonkdim=32 (32x32 MFMA). nw=8 does not compile
-with the column-major kernel's swizzle + 4-warp split store, which is why the two
-layouts are separate files rather than one parameterised kernel.
+CONFIG: the default paths use num_warps=8 and matrix_instr_nonkdim=32. Large,
+deep odd-K shapes use a 4-wave MI16 path with explicitly decomposed accumulator
+streams.
 
 Two load paths, selected by K alignment (``K % BLOCK_K == 0`` -> aligned A rows,
 no K-tail):
@@ -23,6 +23,8 @@ no K-tail):
     Required because odd K gives 2-byte-aligned rows, where direct-to-LDS is
     illegal on CDNA4.
 """
+from dataclasses import dataclass
+
 import torch
 
 import triton
@@ -31,8 +33,94 @@ import triton.language.extra.tlx as tlx
 
 BLOCK_N = 256
 BLOCK_K = 32
+VENDOR_BLOCK_M = 256
+VENDOR_BLOCK_K = 64
 NUM_XCDS = 8
+LARGE_BATCH_GROUP = 64
+BMM_262_256_BATCH_GROUP = 256
+BMM_448_160_BATCH_GROUP = 256
+MIN_GROUPED_OUTPUT_TILES = 5
 NB = 3
+
+_RESIDENT_OPERAND_AUTO = tl.constexpr(0)
+_RESIDENT_OPERAND_A = tl.constexpr(1)
+_RESIDENT_OPERAND_B = tl.constexpr(2)
+
+
+@dataclass(frozen=True)
+class _RegisterStagedKernelSpec:
+    block_m: int
+    block_n: int
+    a_row_tile_sizes: tuple[int, ...]
+    b_col_tile_sizes: tuple[int, ...]
+    num_stages: int
+    instr_shape: tuple[int, int, int]
+    warps_per_cta: tuple[int, int]
+    loop_unroll: int
+    swizzle_b_local: bool
+    global_load_b_cg: bool
+    global_tail_load_before_last_dot: bool
+    local_load_b_before_global_prefetch: bool
+    resident_operand_policy: tl.constexpr
+
+
+_MT64X256_MI32_KERNEL_SPEC = _RegisterStagedKernelSpec(
+    block_m=64,
+    block_n=256,
+    a_row_tile_sizes=(64, ),
+    b_col_tile_sizes=(256, ),
+    num_stages=2,
+    instr_shape=(32, 32, 16),
+    warps_per_cta=(1, 4),
+    loop_unroll=2,
+    swizzle_b_local=False,
+    global_load_b_cg=True,
+    global_tail_load_before_last_dot=False,
+    local_load_b_before_global_prefetch=True,
+    resident_operand_policy=_RESIDENT_OPERAND_AUTO,
+)
+# These two shapes keep their measured resident-A schedules. Resident B is
+# valid and lowers operand VGPR pressure, but the evaluated load placements and
+# small scheduler-cover search regress latency; the policy remains an explicit,
+# bounded tuning dimension for future specializations.
+_MT144X256_MI16_KERNEL_SPEC = _RegisterStagedKernelSpec(
+    block_m=144,
+    block_n=256,
+    a_row_tile_sizes=(128, 16),
+    b_col_tile_sizes=(256, ),
+    num_stages=2,
+    instr_shape=(16, 16, 32),
+    warps_per_cta=(1, 4),
+    loop_unroll=1,
+    swizzle_b_local=True,
+    global_load_b_cg=False,
+    global_tail_load_before_last_dot=False,
+    local_load_b_before_global_prefetch=True,
+    resident_operand_policy=_RESIDENT_OPERAND_A,
+)
+_MT224X160_MI16_KERNEL_SPEC = _RegisterStagedKernelSpec(
+    block_m=224,
+    block_n=160,
+    a_row_tile_sizes=(32, 32, 32, 32, 32, 32, 32),
+    b_col_tile_sizes=(32, 32, 32, 32, 32),
+    num_stages=2,
+    instr_shape=(16, 16, 32),
+    warps_per_cta=(2, 2),
+    loop_unroll=1,
+    swizzle_b_local=False,
+    global_load_b_cg=False,
+    global_tail_load_before_last_dot=True,
+    local_load_b_before_global_prefetch=False,
+    resident_operand_policy=_RESIDENT_OPERAND_A,
+)
+
+# Compiler policy stays separate from data decomposition:
+# (MFMA_PER_DWORDX4, DISABLE_HIGH_RP_RESCHEDULE).
+_REGISTER_STAGED_SCHEDULE_SPEC = (4, False)
+_MT224X160_REGISTER_STAGED_SCHEDULE_SPEC = (4, True)
+
+# Coalesced [128, 128] store layout: eight contiguous fp16 values per lane.
+_C4_128 = tlx.layout(shape=((16, 16), (8, 8)), stride=((8, 128), (1, 2048)))
 
 
 def _swz(shape, cd):
@@ -169,8 +257,892 @@ def _bmm_register(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, sc
     tl.store(cb + scm * rm[:, None] + scn * rn[None, :], acc.to(et), mask=(rm[:, None] < M) & (rn[None, :] < N))
 
 
+@triton.jit
+def _bmm_mi16_quad(a_ptr, b_ptr, c_ptr, M, N, K, sab, sam, sak, sbb, sbk, sbn, scb, scm, scn,
+                   BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr,
+                   NUM_XCDS: tl.constexpr, GMN: tl.constexpr, NT: tl.constexpr,
+                   B_BASES: tl.constexpr):
+    """2x2 operand decomposition: defer A-high/B-high LDS reads under MFMA."""
+    HM: tl.constexpr = BM // 2
+    HN: tl.constexpr = BN // 2
+    tl.static_assert(HM == 128 and HN == 128,
+                     "_C4_128 requires 128x128 accumulator quadrants")
+    npn = tl.cdiv(N, BN)
+    pidf = _chip(tl.program_id(0), NT, NUM_XCDS, GMN)
+    bid = pidf // GMN
+    pid = pidf % GMN
+    pm = pid // npn
+    pn = pid % npn
+    b_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases([(512, 16)], B_BASES, [BK, HN])
+    buf_a_lo = tlx.local_alloc((HM, BK), tlx.dtype_of(a_ptr), 2)
+    buf_a_hi = tlx.local_alloc((HM, BK), tlx.dtype_of(a_ptr), 2)
+    buf_b_lo = tlx.local_alloc((BK, HN), tlx.dtype_of(b_ptr), 2, layout=b_sh)
+    buf_b_hi = tlx.local_alloc((BK, HN), tlx.dtype_of(b_ptr), 2, layout=b_sh)
+    om_lo = (pm * BM + tl.arange(0, HM)) % M
+    om_hi = (pm * BM + HM + tl.arange(0, HM)) % M
+    on_lo = (pn * BN + tl.arange(0, HN)) % N
+    on_hi = (pn * BN + HN + tl.arange(0, HN)) % N
+    ok = tl.arange(0, BK)
+    a_ptr += bid.to(tl.int64) * sab
+    b_ptr += bid.to(tl.int64) * sbb
+    ao_lo = om_lo[:, None] * sam
+    ao_hi = om_hi[:, None] * sam
+    bo_lo = on_lo[None, :] * sbn
+    bo_hi = on_hi[None, :] * sbn
+    nf = K // BK
+    tlx.local_store(tlx.local_view(buf_a_lo, 0), tl.load(a_ptr + ao_lo + ok[None, :] * sak))
+    tlx.local_store(tlx.local_view(buf_a_hi, 0), tl.load(a_ptr + ao_hi + ok[None, :] * sak))
+    tlx.local_store(tlx.local_view(buf_b_lo, 0), tl.load(b_ptr + ok[:, None] * sbk + bo_lo))
+    tlx.local_store(tlx.local_view(buf_b_hi, 0), tl.load(b_ptr + ok[:, None] * sbk + bo_hi))
+    tl.debug_barrier()
+    c00 = tl.zeros((HM, HN), dtype=tl.float32)
+    c10 = tl.zeros((HM, HN), dtype=tl.float32)
+    c01 = tl.zeros((HM, HN), dtype=tl.float32)
+    c11 = tl.zeros((HM, HN), dtype=tl.float32)
+    for k in tl.range(0, nf - 1):
+        cur = k % 2
+        nxt = (k + 1) % 2
+        kp = (k + 1) * BK
+        a_lo = tlx.local_load(tlx.local_view(buf_a_lo, cur))
+        b_lo = tlx.local_load(tlx.local_view(buf_b_lo, cur))
+        next_a_lo = tl.load(a_ptr + ao_lo + (kp + ok[None, :]) * sak)
+        tlx.buffer_load_to_local(tlx.local_view(buf_b_lo, nxt), b_ptr,
+                                 (kp + ok[:, None]) * sbk + bo_lo)
+        c00 = tl.dot(a_lo, b_lo, c00)
+        a_hi = tlx.local_load(tlx.local_view(buf_a_hi, cur))
+        next_a_hi = tl.load(a_ptr + ao_hi + (kp + ok[None, :]) * sak)
+        c10 = tl.dot(a_hi, b_lo, c10)
+        b_hi = tlx.local_load(tlx.local_view(buf_b_hi, cur))
+        tlx.buffer_load_to_local(tlx.local_view(buf_b_hi, nxt), b_ptr,
+                                 (kp + ok[:, None]) * sbk + bo_hi)
+        c01 = tl.dot(a_lo, b_hi, c01)
+        c11 = tl.dot(a_hi, b_hi, c11)
+        tlx.local_store(tlx.local_view(buf_a_lo, nxt), next_a_lo)
+        tlx.local_store(tlx.local_view(buf_a_hi, nxt), next_a_hi)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(0)
+        tl.debug_barrier()
+    last = (nf - 1) % 2
+    a_lo = tlx.local_load(tlx.local_view(buf_a_lo, last))
+    a_hi = tlx.local_load(tlx.local_view(buf_a_hi, last))
+    b_lo = tlx.local_load(tlx.local_view(buf_b_lo, last))
+    b_hi = tlx.local_load(tlx.local_view(buf_b_hi, last))
+    c00 = tl.dot(a_lo, b_lo, c00)
+    c01 = tl.dot(a_lo, b_hi, c01)
+    c10 = tl.dot(a_hi, b_lo, c10)
+    c11 = tl.dot(a_hi, b_hi, c11)
+    # `k` above is a full-tile ordinal; `kt` is an absolute K-element offset
+    # because this loop starts at the first incomplete BK tile.
+    for kt in tl.range(nf * BK, K, BK):
+        km = (kt + ok) < K
+        ta_lo = tl.load(a_ptr + ao_lo + (kt + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        ta_hi = tl.load(a_ptr + ao_hi + (kt + ok[None, :]) * sak, mask=km[None, :], other=0.0)
+        tb_lo = tl.load(b_ptr + (kt + ok[:, None]) * sbk + bo_lo, mask=km[:, None], other=0.0)
+        tb_hi = tl.load(b_ptr + (kt + ok[:, None]) * sbk + bo_hi, mask=km[:, None], other=0.0)
+        c00 = tl.dot(ta_lo, tb_lo, c00)
+        c01 = tl.dot(ta_lo, tb_hi, c01)
+        c10 = tl.dot(ta_hi, tb_lo, c10)
+        c11 = tl.dot(ta_hi, tb_hi, c11)
+    et = c_ptr.dtype.element_ty
+    cb = c_ptr + bid.to(tl.int64) * scb
+    rm_lo = pm * BM + tl.arange(0, HM)
+    rm_hi = rm_lo + HM
+    rn_lo = pn * BN + tl.arange(0, HN)
+    rn_hi = rn_lo + HN
+    tl.store(cb + scm * rm_lo[:, None] + scn * rn_lo[None, :], tlx.require_layout(c00.to(et), _C4_128),
+             mask=(rm_lo[:, None] < M) & (rn_lo[None, :] < N))
+    tl.store(cb + scm * rm_lo[:, None] + scn * rn_hi[None, :], tlx.require_layout(c01.to(et), _C4_128),
+             mask=(rm_lo[:, None] < M) & (rn_hi[None, :] < N))
+    tl.store(cb + scm * rm_hi[:, None] + scn * rn_lo[None, :], tlx.require_layout(c10.to(et), _C4_128),
+             mask=(rm_hi[:, None] < M) & (rn_lo[None, :] < N))
+    tl.store(cb + scm * rm_hi[:, None] + scn * rn_hi[None, :], tlx.require_layout(c11.to(et), _C4_128),
+             mask=(rm_hi[:, None] < M) & (rn_hi[None, :] < N))
+
+
+@tl.core.builtin
+def _load_all_a_tiles_from_local(a_local_tiles, stage,
+                                 a_tile_count: tl.constexpr,
+                                 a_layout: tl.constexpr, _semantic=None):
+    """Load every A operand tile from LDS into its dot layout."""
+    a_tile_count = tl.core._unwrap_if_constexpr(a_tile_count)
+    a_layout = tl.core._unwrap_if_constexpr(a_layout)
+    a_local_tiles = list(a_local_tiles)
+    values = []
+    for mi in range(a_tile_count):
+        view = tlx.local_view(a_local_tiles[mi], stage, _semantic=_semantic)
+        a_value = tlx.local_load(view, _semantic=_semantic)
+        a_value = tlx.require_layout(
+            a_value, a_layout, pin=False, _semantic=_semantic
+        )
+        values.append(a_value)
+    return tl.tuple(values)
+
+
+@tl.core.builtin
+def _load_all_b_tiles_from_local(b_local_tiles, stage,
+                                 b_tile_count: tl.constexpr,
+                                 b_layout: tl.constexpr, _semantic=None):
+    """Load every B operand tile from LDS into its dot layout."""
+    b_tile_count = tl.core._unwrap_if_constexpr(b_tile_count)
+    b_layout = tl.core._unwrap_if_constexpr(b_layout)
+    b_local_tiles = list(b_local_tiles)
+    values = []
+    for nj in range(b_tile_count):
+        view = tlx.local_view(b_local_tiles[nj], stage, _semantic=_semantic)
+        b_value = tlx.local_load(view, _semantic=_semantic)
+        b_value = tlx.require_layout(
+            b_value, b_layout, pin=False, _semantic=_semantic
+        )
+        values.append(b_value)
+    return tl.tuple(values)
+
+
+@tl.core.builtin
+def _dot_preloaded_a_and_b_tiles(a_dot_operands, b_dot_operands, acc,
+                                 a_tile_count: tl.constexpr,
+                                 b_tile_count: tl.constexpr,
+                                 _semantic=None):
+    """Expand the dot grid when both operand families are preloaded."""
+    a_tile_count = tl.core._unwrap_if_constexpr(a_tile_count)
+    b_tile_count = tl.core._unwrap_if_constexpr(b_tile_count)
+    values = list(acc)
+    a_dot_operands = list(a_dot_operands)
+    b_dot_operands = list(b_dot_operands)
+    for nj in range(b_tile_count):
+        for mi in range(a_tile_count):
+            index = mi * b_tile_count + nj
+            values[index] = tl.dot(
+                a_dot_operands[mi], b_dot_operands[nj], values[index],
+                _semantic=_semantic
+            )
+    return tl.tuple(values)
+
+
+@tl.core.builtin
+def _load_each_b_tile_and_dot_with_preloaded_a(
+    a_dot_operands,
+    b_local_tiles,
+    stage,
+    acc,
+    a_tile_count: tl.constexpr,
+    b_tile_count: tl.constexpr,
+    b_layout: tl.constexpr,
+    _semantic=None,
+):
+    """Stream B tiles from LDS and dot each with every preloaded A tile."""
+    a_tile_count = tl.core._unwrap_if_constexpr(a_tile_count)
+    b_tile_count = tl.core._unwrap_if_constexpr(b_tile_count)
+    b_layout = tl.core._unwrap_if_constexpr(b_layout)
+    values = list(acc)
+    a_dot_operands = list(a_dot_operands)
+    b_local_tiles = list(b_local_tiles)
+    for nj in range(b_tile_count):
+        view = tlx.local_view(b_local_tiles[nj], stage, _semantic=_semantic)
+        b_value = tlx.local_load(view, _semantic=_semantic)
+        b_value = tlx.require_layout(
+            b_value, b_layout, pin=False, _semantic=_semantic
+        )
+        for mi in range(a_tile_count):
+            index = mi * b_tile_count + nj
+            values[index] = tl.dot(
+                a_dot_operands[mi], b_value, values[index],
+                _semantic=_semantic
+            )
+    return tl.tuple(values)
+
+
+@tl.core.builtin
+def _load_each_a_tile_and_dot_with_preloaded_b(
+    a_local_tiles,
+    b_dot_operands,
+    stage,
+    acc,
+    a_tile_count: tl.constexpr,
+    b_tile_count: tl.constexpr,
+    a_layout: tl.constexpr,
+    _semantic=None,
+):
+    """Stream A tiles from LDS and dot each with every preloaded B tile."""
+    a_tile_count = tl.core._unwrap_if_constexpr(a_tile_count)
+    b_tile_count = tl.core._unwrap_if_constexpr(b_tile_count)
+    a_layout = tl.core._unwrap_if_constexpr(a_layout)
+    values = list(acc)
+    a_local_tiles = list(a_local_tiles)
+    b_dot_operands = list(b_dot_operands)
+    for mi in range(a_tile_count):
+        view = tlx.local_view(a_local_tiles[mi], stage, _semantic=_semantic)
+        a_value = tlx.local_load(view, _semantic=_semantic)
+        a_value = tlx.require_layout(
+            a_value, a_layout, pin=False, _semantic=_semantic
+        )
+        for nj in range(b_tile_count):
+            index = mi * b_tile_count + nj
+            values[index] = tl.dot(
+                a_value, b_dot_operands[nj], values[index],
+                _semantic=_semantic
+            )
+    return tl.tuple(values)
+
+
+@tl.core.builtin
+def _load_preloaded_operand_tiles(
+    a_local_tiles,
+    b_local_tiles,
+    stage,
+    a_tile_count: tl.constexpr,
+    b_tile_count: tl.constexpr,
+    a_layout: tl.constexpr,
+    b_layout: tl.constexpr,
+    preload_a: tl.constexpr,
+    _semantic=None,
+):
+    """Load the compile-time-selected resident operand family from LDS."""
+    preload_a = tl.core._unwrap_if_constexpr(preload_a)
+    if preload_a:
+        return _load_all_a_tiles_from_local(
+            a_local_tiles,
+            stage,
+            a_tile_count,
+            a_layout,
+            _semantic=_semantic,
+        )
+    return _load_all_b_tiles_from_local(
+        b_local_tiles,
+        stage,
+        b_tile_count,
+        b_layout,
+        _semantic=_semantic,
+    )
+
+
+@tl.core.builtin
+def _load_each_streamed_operand_and_dot(
+    a_local_tiles,
+    b_local_tiles,
+    preloaded_operands,
+    stage,
+    acc,
+    a_tile_count: tl.constexpr,
+    b_tile_count: tl.constexpr,
+    a_layout: tl.constexpr,
+    b_layout: tl.constexpr,
+    preload_a: tl.constexpr,
+    _semantic=None,
+):
+    """Stream the nonresident operand family and update the full dot grid."""
+    preload_a = tl.core._unwrap_if_constexpr(preload_a)
+    if preload_a:
+        return _load_each_b_tile_and_dot_with_preloaded_a(
+            preloaded_operands,
+            b_local_tiles,
+            stage,
+            acc,
+            a_tile_count,
+            b_tile_count,
+            b_layout,
+            _semantic=_semantic,
+        )
+    return _load_each_a_tile_and_dot_with_preloaded_b(
+        a_local_tiles,
+        preloaded_operands,
+        stage,
+        acc,
+        a_tile_count,
+        b_tile_count,
+        a_layout,
+        _semantic=_semantic,
+    )
+
+
+@tl.core.builtin
+def _spec_length(values: tl.constexpr, _semantic=None):
+    values = tl.core._unwrap_if_constexpr(values)
+    return tl.constexpr(len(values))
+
+
+@tl.core.builtin
+def _spec_item(values: tl.constexpr, index: tl.constexpr, _semantic=None):
+    values = tl.core._unwrap_if_constexpr(values)
+    index = tl.core._unwrap_if_constexpr(index)
+    return tl.constexpr(values[index])
+
+
+@tl.core.builtin
+def _tile_extent(index: tl.constexpr, tile_sizes: tl.constexpr,
+                 _semantic=None):
+    """Select one heterogeneous tile extent from the compile-time spec."""
+    index = tl.core._unwrap_if_constexpr(index)
+    tile_sizes = tl.core._unwrap_if_constexpr(tile_sizes)
+    return tl.constexpr(tile_sizes[index])
+
+
+@tl.core.builtin
+def _tile_start(index: tl.constexpr, tile_sizes: tl.constexpr,
+                _semantic=None):
+    """Return the compile-time prefix sum preceding one operand tile."""
+    index = tl.core._unwrap_if_constexpr(index)
+    tile_sizes = tl.core._unwrap_if_constexpr(tile_sizes)
+    return tl.constexpr(sum(tile_sizes[:index]))
+
+
+@triton.jit
+def _make_output_tile_coordinates(
+    m_block,
+    n_block,
+    kernel_spec: tl.constexpr,
+):
+    """Build the logical C row/column coordinates for one macro tile."""
+    block_m: tl.constexpr = tl.constexpr(kernel_spec.block_m)
+    block_n: tl.constexpr = tl.constexpr(kernel_spec.block_n)
+    a_tile_count: tl.constexpr = _spec_length(kernel_spec.a_row_tile_sizes)
+    b_tile_count: tl.constexpr = _spec_length(kernel_spec.b_col_tile_sizes)
+    output_rows = tl.tuple([])
+    for mi in tl.static_range(a_tile_count):
+        output_rows += tl.tuple([
+            m_block * block_m
+            + _tile_start(mi, kernel_spec.a_row_tile_sizes)
+            + tl.arange(0, _tile_extent(mi, kernel_spec.a_row_tile_sizes))
+        ])
+    output_cols = tl.tuple([])
+    for nj in tl.static_range(b_tile_count):
+        output_cols += tl.tuple([
+            n_block * block_n
+            + _tile_start(nj, kernel_spec.b_col_tile_sizes)
+            + tl.arange(0, _tile_extent(nj, kernel_spec.b_col_tile_sizes))
+        ])
+    return tl.tuple([output_rows, output_cols])
+
+
+@triton.jit
+def _make_global_tile_offsets(
+    output_rows,
+    output_cols,
+    m,
+    n,
+    stride_am,
+    stride_bn,
+    even_m: tl.constexpr,
+    even_n: tl.constexpr,
+    kernel_spec: tl.constexpr,
+):
+    """Build wrapped A/B offsets for full-width unmasked global loads."""
+    a_tile_count: tl.constexpr = _spec_length(kernel_spec.a_row_tile_sizes)
+    b_tile_count: tl.constexpr = _spec_length(kernel_spec.b_col_tile_sizes)
+    a_global_offsets = tl.tuple([])
+    for mi in tl.static_range(a_tile_count):
+        if even_m:
+            a_global_rows = output_rows[mi]
+        else:
+            a_global_rows = tl.where(
+                output_rows[mi] < m,
+                output_rows[mi],
+                output_rows[mi] - m,
+            )
+        a_global_offsets += tl.tuple([
+            a_global_rows[:, None] * stride_am
+        ])
+    b_global_offsets = tl.tuple([])
+    for nj in tl.static_range(b_tile_count):
+        if even_n:
+            b_global_cols = output_cols[nj]
+        else:
+            b_global_cols = tl.where(
+                output_cols[nj] < n,
+                output_cols[nj],
+                output_cols[nj] - n,
+            )
+        b_global_offsets += tl.tuple([
+            b_global_cols[None, :] * stride_bn
+        ])
+    return tl.tuple([a_global_offsets, b_global_offsets])
+
+
+@triton.jit
+def _local_alloc_pipeline(a_ptr, b_ptr, block_k: tl.constexpr,
+                          kernel_spec: tl.constexpr):
+    """Allocate every A/B tile in the explicit multi-stage LDS pipeline."""
+    num_stages: tl.constexpr = tl.constexpr(kernel_spec.num_stages)
+    swizzle_b_local: tl.constexpr = tl.constexpr(kernel_spec.swizzle_b_local)
+    a_tile_count: tl.constexpr = _spec_length(kernel_spec.a_row_tile_sizes)
+    b_tile_count: tl.constexpr = _spec_length(kernel_spec.b_col_tile_sizes)
+    a_local_tiles = tl.tuple([])
+    for mi in tl.static_range(a_tile_count):
+        a_local_tiles += tl.tuple([
+            tlx.local_alloc(
+                (_tile_extent(mi, kernel_spec.a_row_tile_sizes), block_k),
+                tlx.dtype_of(a_ptr),
+                num_stages,
+            )
+        ])
+    b_local_tiles = tl.tuple([])
+    if swizzle_b_local:
+        b_shared_layout: tl.constexpr = tlx.swizzled_layout(4, 3, 5)
+        for nj in tl.static_range(b_tile_count):
+            b_local_tiles += tl.tuple([
+                tlx.local_alloc(
+                    (block_k, _tile_extent(nj, kernel_spec.b_col_tile_sizes)),
+                    tlx.dtype_of(b_ptr),
+                    num_stages,
+                    layout=b_shared_layout,
+                )
+            ])
+    else:
+        for nj in tl.static_range(b_tile_count):
+            b_local_tiles += tl.tuple([
+                tlx.local_alloc(
+                    (block_k, _tile_extent(nj, kernel_spec.b_col_tile_sizes)),
+                    tlx.dtype_of(b_ptr),
+                    num_stages,
+                )
+            ])
+    return tl.tuple([a_local_tiles, b_local_tiles])
+
+
+@triton.jit
+def _bmm_register_staged(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    sab,
+    sam,
+    sak,
+    sbb,
+    sbk,
+    sbn,
+    scb,
+    scm,
+    scn,
+    KERNEL_SPEC: tl.constexpr,
+    EVEN_M: tl.constexpr,
+    EVEN_N: tl.constexpr,
+    HAS_K_TAIL: tl.constexpr,
+    N_BLOCKS: tl.constexpr,
+    BATCH_GROUP: tl.constexpr,
+    GMN: tl.constexpr,
+    NT: tl.constexpr,
+):
+    """Register-staged K32 BMM driven by compile-time operand tiles."""
+    NUM_STAGES: tl.constexpr = tl.constexpr(KERNEL_SPEC.num_stages)
+    LOOP_UNROLL: tl.constexpr = tl.constexpr(KERNEL_SPEC.loop_unroll)
+    GLOBAL_LOAD_B_CG: tl.constexpr = tl.constexpr(KERNEL_SPEC.global_load_b_cg)
+    GLOBAL_TAIL_LOAD_BEFORE_LAST_DOT: tl.constexpr = tl.constexpr(
+        KERNEL_SPEC.global_tail_load_before_last_dot
+    )
+    LOCAL_LOAD_B_BEFORE_GLOBAL_PREFETCH: tl.constexpr = tl.constexpr(
+        KERNEL_SPEC.local_load_b_before_global_prefetch
+    )
+    A_TILE_COUNT: tl.constexpr = _spec_length(KERNEL_SPEC.a_row_tile_sizes)
+    B_TILE_COUNT: tl.constexpr = _spec_length(KERNEL_SPEC.b_col_tile_sizes)
+    INSTR_M: tl.constexpr = _spec_item(KERNEL_SPEC.instr_shape, 0)
+    INSTR_N: tl.constexpr = _spec_item(KERNEL_SPEC.instr_shape, 1)
+    INSTR_K: tl.constexpr = _spec_item(KERNEL_SPEC.instr_shape, 2)
+    WARPS_M: tl.constexpr = _spec_item(KERNEL_SPEC.warps_per_cta, 0)
+    WARPS_N: tl.constexpr = _spec_item(KERNEL_SPEC.warps_per_cta, 1)
+    # Keep the smaller per-wave operand family resident and stream the larger
+    # family one tile at a time. A is partitioned across WARPS_M and B across
+    # WARPS_N; their common K32 depth cancels from this VGPR-footprint estimate.
+    # Cross multiplication keeps the comparison integral:
+    #   BLOCK_M / WARPS_M <= BLOCK_N / WARPS_N.
+    RESIDENT_OPERAND_POLICY: tl.constexpr = tl.constexpr(
+        KERNEL_SPEC.resident_operand_policy
+    )
+    PRELOAD_A_OPERANDS: tl.constexpr = tl.constexpr(
+        RESIDENT_OPERAND_POLICY == _RESIDENT_OPERAND_A
+        or (
+            RESIDENT_OPERAND_POLICY == _RESIDENT_OPERAND_AUTO
+            and KERNEL_SPEC.block_m * WARPS_N
+            <= KERNEL_SPEC.block_n * WARPS_M
+        )
+    )
+    BLOCK_K: tl.constexpr = 32
+
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[INSTR_M, INSTR_N, INSTR_K],
+        transposed=True,
+        warps_per_cta=[WARPS_M, WARPS_N],
+    )
+    dot0: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    dot1: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+
+    # Program mapping: recover one batch and one output macro tile from the
+    # XCD-friendly one-dimensional launch order.
+    remapped_program = _chip(tl.program_id(0), NT, BATCH_GROUP, GMN)
+    batch_id = remapped_program // GMN
+    tile_id = remapped_program % GMN
+    m_block = tile_id // N_BLOCKS
+    n_block = tile_id % N_BLOCKS
+    rk = tl.arange(0, BLOCK_K)
+    a_ptr += batch_id.to(tl.int64) * sab
+    b_ptr += batch_id.to(tl.int64) * sbb
+
+    # Tile setup: build logical output coordinates, wrapped global input
+    # offsets, and the heterogeneous A/B LDS images described by KERNEL_SPEC.
+    output_rows, output_cols = _make_output_tile_coordinates(
+        m_block, n_block, KERNEL_SPEC
+    )
+    a_global_offsets, b_global_offsets = _make_global_tile_offsets(
+        output_rows, output_cols, M, N, sam, sbn,
+        EVEN_M, EVEN_N, KERNEL_SPEC,
+    )
+    a_local_tiles, b_local_tiles = _local_alloc_pipeline(
+        a_ptr, b_ptr, BLOCK_K, KERNEL_SPEC
+    )
+
+    # Prologue: globally prefetch K0, publish it to LDS stage 0, then make the
+    # complete A/B stage visible to every wave before the first iteration.
+    for mi in tl.static_range(A_TILE_COUNT):
+        first_a_global = tl.load(
+            a_ptr + a_global_offsets[mi] + rk[None, :] * sak
+        )
+        tlx.local_store(
+            tlx.local_view(a_local_tiles[mi], 0), first_a_global
+        )
+    for nj in tl.static_range(B_TILE_COUNT):
+        b_global_ptrs = b_ptr + rk[:, None] * sbk + b_global_offsets[nj]
+        if GLOBAL_LOAD_B_CG:
+            first_b_global = tl.load(
+                b_global_ptrs, cache_modifier=".cg"
+            )
+        else:
+            first_b_global = tl.load(b_global_ptrs)
+        tlx.local_store(
+            tlx.local_view(b_local_tiles[nj], 0), first_b_global
+        )
+    tl.debug_barrier()
+    # Keep accumulator construction in the same JIT scope as the K loop. A
+    # helper return would erase the native #mma encoding from the tuple type.
+    acc = tl.tuple([])
+    for mi in tl.static_range(A_TILE_COUNT):
+        for nj in tl.static_range(B_TILE_COUNT):
+            acc += tl.tuple([
+                tlx.zeros(
+                    (
+                        _tile_extent(mi, KERNEL_SPEC.a_row_tile_sizes),
+                        _tile_extent(nj, KERNEL_SPEC.b_col_tile_sizes),
+                    ),
+                    tl.float32,
+                    layout=mma,
+                )
+            ])
+
+    # Steady state: consume LDS K(t), globally prefetch K(t+1), execute the
+    # current dot grid, then publish K(t+1) into the alternate LDS stage.
+    full_tiles = K // BLOCK_K
+    for k in tl.range(
+        0, full_tiles - 1, loop_unroll_factor=LOOP_UNROLL
+    ):
+        current_stage = k % NUM_STAGES
+        next_stage = (k + 1) % NUM_STAGES
+        next_k_offset = (k + 1) * BLOCK_K
+        if PRELOAD_A_OPERANDS or LOCAL_LOAD_B_BEFORE_GLOBAL_PREFETCH:
+            preloaded_operands = _load_preloaded_operand_tiles(
+                a_local_tiles, b_local_tiles, current_stage,
+                A_TILE_COUNT, B_TILE_COUNT, dot0, dot1,
+                PRELOAD_A_OPERANDS,
+            )
+        if PRELOAD_A_OPERANDS and LOCAL_LOAD_B_BEFORE_GLOBAL_PREFETCH:
+            b_dot_operands = _load_all_b_tiles_from_local(
+                b_local_tiles, current_stage, B_TILE_COUNT, dot1
+            )
+        a_global_prefetch = tl.tuple([])
+        for mi in tl.static_range(A_TILE_COUNT):
+            a_global_prefetch += tl.tuple([tl.load(
+                a_ptr
+                + a_global_offsets[mi]
+                + (next_k_offset + rk[None, :]) * sak
+            )])
+        b_global_prefetch = tl.tuple([])
+        for nj in tl.static_range(B_TILE_COUNT):
+            b_global_ptrs = (
+                b_ptr
+                + (next_k_offset + rk[:, None]) * sbk
+                + b_global_offsets[nj]
+            )
+            if GLOBAL_LOAD_B_CG:
+                b_global_prefetch += tl.tuple([
+                    tl.load(b_global_ptrs, cache_modifier=".cg")
+                ])
+            else:
+                b_global_prefetch += tl.tuple([tl.load(b_global_ptrs)])
+        if PRELOAD_A_OPERANDS:
+            if LOCAL_LOAD_B_BEFORE_GLOBAL_PREFETCH:
+                acc = _dot_preloaded_a_and_b_tiles(
+                    preloaded_operands, b_dot_operands, acc,
+                    A_TILE_COUNT, B_TILE_COUNT,
+                )
+            else:
+                acc = _load_each_streamed_operand_and_dot(
+                    a_local_tiles, b_local_tiles, preloaded_operands,
+                    current_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+                    dot0, dot1, PRELOAD_A_OPERANDS,
+                )
+        else:
+            if not LOCAL_LOAD_B_BEFORE_GLOBAL_PREFETCH:
+                preloaded_operands = _load_preloaded_operand_tiles(
+                    a_local_tiles, b_local_tiles, current_stage,
+                    A_TILE_COUNT, B_TILE_COUNT, dot0, dot1,
+                    PRELOAD_A_OPERANDS,
+                )
+            acc = _load_each_streamed_operand_and_dot(
+                a_local_tiles, b_local_tiles, preloaded_operands,
+                current_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+                dot0, dot1, PRELOAD_A_OPERANDS,
+            )
+        for mi in tl.static_range(A_TILE_COUNT):
+            tlx.local_store(
+                tlx.local_view(a_local_tiles[mi], next_stage),
+                a_global_prefetch[mi],
+            )
+        for nj in tl.static_range(B_TILE_COUNT):
+            tlx.local_store(
+                tlx.local_view(b_local_tiles[nj], next_stage),
+                b_global_prefetch[nj],
+            )
+        tl.debug_barrier()
+
+    # Drain: consume the final complete K32 stage and, when K is not divisible
+    # by 32, one masked and zero-padded tail stage.
+    current_stage = (full_tiles - 1) % NUM_STAGES
+    preloaded_operands = _load_preloaded_operand_tiles(
+        a_local_tiles, b_local_tiles, current_stage,
+        A_TILE_COUNT, B_TILE_COUNT, dot0, dot1, PRELOAD_A_OPERANDS,
+    )
+
+    if HAS_K_TAIL:
+        tail_k_offset = full_tiles * BLOCK_K
+        tail_mask = tail_k_offset + rk < K
+        if GLOBAL_TAIL_LOAD_BEFORE_LAST_DOT:
+            a_tail_global = tl.tuple([])
+            for mi in tl.static_range(A_TILE_COUNT):
+                a_tail_global += tl.tuple([tl.load(
+                    a_ptr
+                    + a_global_offsets[mi]
+                    + (tail_k_offset + rk[None, :]) * sak,
+                    mask=tail_mask[None, :],
+                    other=0.0,
+                )])
+            b_tail_global = tl.tuple([])
+            for nj in tl.static_range(B_TILE_COUNT):
+                b_global_ptrs = (
+                    b_ptr
+                    + (tail_k_offset + rk[:, None]) * sbk
+                    + b_global_offsets[nj]
+                )
+                if GLOBAL_LOAD_B_CG:
+                    b_tail_global += tl.tuple([tl.load(
+                        b_global_ptrs,
+                        mask=tail_mask[:, None],
+                        other=0.0,
+                        cache_modifier=".cg",
+                    )])
+                else:
+                    b_tail_global += tl.tuple([tl.load(
+                        b_global_ptrs,
+                        mask=tail_mask[:, None],
+                        other=0.0,
+                    )])
+            acc = _load_each_streamed_operand_and_dot(
+                a_local_tiles, b_local_tiles, preloaded_operands,
+                current_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+                dot0, dot1, PRELOAD_A_OPERANDS,
+            )
+        else:
+            acc = _load_each_streamed_operand_and_dot(
+                a_local_tiles, b_local_tiles, preloaded_operands,
+                current_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+                dot0, dot1, PRELOAD_A_OPERANDS,
+            )
+            a_tail_global = tl.tuple([])
+            for mi in tl.static_range(A_TILE_COUNT):
+                a_tail_global += tl.tuple([tl.load(
+                    a_ptr
+                    + a_global_offsets[mi]
+                    + (tail_k_offset + rk[None, :]) * sak,
+                    mask=tail_mask[None, :],
+                    other=0.0,
+                )])
+            b_tail_global = tl.tuple([])
+            for nj in tl.static_range(B_TILE_COUNT):
+                b_global_ptrs = (
+                    b_ptr
+                    + (tail_k_offset + rk[:, None]) * sbk
+                    + b_global_offsets[nj]
+                )
+                if GLOBAL_LOAD_B_CG:
+                    b_tail_global += tl.tuple([tl.load(
+                        b_global_ptrs,
+                        mask=tail_mask[:, None],
+                        other=0.0,
+                        cache_modifier=".cg",
+                    )])
+                else:
+                    b_tail_global += tl.tuple([tl.load(
+                        b_global_ptrs,
+                        mask=tail_mask[:, None],
+                        other=0.0,
+                    )])
+        tail_stage = full_tiles % NUM_STAGES
+        for mi in tl.static_range(A_TILE_COUNT):
+            tlx.local_store(
+                tlx.local_view(a_local_tiles[mi], tail_stage),
+                a_tail_global[mi],
+            )
+        for nj in tl.static_range(B_TILE_COUNT):
+            tlx.local_store(
+                tlx.local_view(b_local_tiles[nj], tail_stage),
+                b_tail_global[nj],
+            )
+        tl.debug_barrier()
+        preloaded_operands = _load_preloaded_operand_tiles(
+            a_local_tiles, b_local_tiles, tail_stage,
+            A_TILE_COUNT, B_TILE_COUNT, dot0, dot1, PRELOAD_A_OPERANDS,
+        )
+        acc = _load_each_streamed_operand_and_dot(
+            a_local_tiles, b_local_tiles, preloaded_operands,
+            tail_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+            dot0, dot1, PRELOAD_A_OPERANDS,
+        )
+    else:
+        acc = _load_each_streamed_operand_and_dot(
+            a_local_tiles, b_local_tiles, preloaded_operands,
+            current_stage, acc, A_TILE_COUNT, B_TILE_COUNT,
+            dot0, dot1, PRELOAD_A_OPERANDS,
+        )
+
+    # Epilogue: keep the high-RP accumulator tuple in this JIT scope while
+    # converting and storing every logical C tile.
+    base = c_ptr + batch_id.to(tl.int64) * scb
+    element_type = c_ptr.dtype.element_ty
+    for mi in tl.static_range(A_TILE_COUNT):
+        for nj in tl.static_range(B_TILE_COUNT):
+            offsets = tlx.require_layout(
+                base
+                + output_rows[mi][:, None] * scm
+                + output_cols[nj][None, :] * scn,
+                mma,
+                pin=False,
+            )
+            value = acc[mi * B_TILE_COUNT + nj].to(element_type)
+            if EVEN_M and EVEN_N:
+                tl.store(offsets, value)
+            else:
+                mask = tlx.require_layout(
+                    (output_rows[mi][:, None] < M)
+                    & (output_cols[nj][None, :] < N),
+                    mma,
+                    pin=False,
+                )
+                tl.store(offsets, value, mask=mask)
+
+
+def _validate_register_staged_spec(kernel_spec):
+    assert kernel_spec.block_m == sum(kernel_spec.a_row_tile_sizes)
+    assert kernel_spec.block_n == sum(kernel_spec.b_col_tile_sizes)
+    assert kernel_spec.a_row_tile_sizes and kernel_spec.b_col_tile_sizes
+    assert all(tile_size > 0 and tile_size & (tile_size - 1) == 0
+               for tile_size in kernel_spec.a_row_tile_sizes + kernel_spec.b_col_tile_sizes)
+    assert kernel_spec.num_stages > 0 and kernel_spec.loop_unroll > 0
+    assert kernel_spec.instr_shape in ((16, 16, 32), (32, 32, 16))
+    assert len(kernel_spec.warps_per_cta) == 2
+    assert kernel_spec.warps_per_cta[0] * kernel_spec.warps_per_cta[1] in (1, 2, 4, 8)
+    assert isinstance(kernel_spec.swizzle_b_local, bool)
+    assert isinstance(kernel_spec.global_load_b_cg, bool)
+    assert isinstance(kernel_spec.global_tail_load_before_last_dot, bool)
+    assert isinstance(kernel_spec.local_load_b_before_global_prefetch, bool)
+    assert kernel_spec.resident_operand_policy in (
+        _RESIDENT_OPERAND_AUTO,
+        _RESIDENT_OPERAND_A,
+        _RESIDENT_OPERAND_B,
+    )
+
+
+def _launch_register_staged_bmm(a, b, c, *, kernel_spec, batch_group,
+                                schedule_spec=None):
+    """Launch one specialization of the register-staged K32 pipeline."""
+    # Validate the compile-time kernel policy independently from the runtime
+    # tensor contract. A new tile shape should only need a new kernel_spec.
+    _validate_register_staged_spec(kernel_spec)
+    if schedule_spec is not None:
+        assert len(schedule_spec) == 2
+        assert schedule_spec[0] > 0
+        assert isinstance(schedule_spec[1], bool)
+    assert a.ndim == 3 and b.ndim == 3 and c.ndim == 3
+    assert a.shape[0] == b.shape[0] == c.shape[0]
+    assert a.shape[1] == c.shape[1]
+    assert a.shape[2] == b.shape[1]
+    assert b.shape[2] == c.shape[2]
+    assert a.dtype == b.dtype == c.dtype
+    assert batch_group > 0
+    block_m, block_n = kernel_spec.block_m, kernel_spec.block_n
+    instr_shape = kernel_spec.instr_shape
+    warps_per_cta = kernel_spec.warps_per_cta
+    batch, m, k = a.shape
+    n = b.shape[-1]
+    assert k >= BLOCK_K, f"K must be >= BLOCK_K={BLOCK_K}, got K={k}"
+    assert block_m <= 2 * m, (
+        f"BLOCK_M={block_m} requires M >= {(block_m + 1) // 2}, "
+        f"got M={m}"
+    )
+    assert block_n <= 2 * n, (
+        f"BLOCK_N={block_n} requires N >= {(block_n + 1) // 2}, "
+        f"got N={n}"
+    )
+
+    # Flatten [batch, M-tile, N-tile] into one launch dimension. The kernel
+    # recovers batch_id and the two output-tile coordinates from program_id.
+    n_blocks = triton.cdiv(n, block_n)
+    tiles_per_batch = triton.cdiv(m, block_m) * n_blocks
+    program_count = batch * tiles_per_batch
+    strides = (
+        a.stride(0), a.stride(1), a.stride(2),
+        b.stride(0), b.stride(1), b.stride(2),
+        c.stride(0), c.stride(1), c.stride(2),
+    )
+    launch_options = {}
+    if schedule_spec is not None:
+        # This compiler policy is optional and orthogonal to tile geometry.
+        launch_options = dict(
+            enable_sched_group_barrier_scheduler=True,
+            sched_group_barrier_mfma_per_dwordx4=schedule_spec[0],
+            disable_unclustered_high_rp_reschedule=schedule_spec[1],
+        )
+    _bmm_register_staged[(program_count, )](
+        a, b, c, m, n, k, *strides,
+        KERNEL_SPEC=kernel_spec,
+        EVEN_M=m % block_m == 0,
+        EVEN_N=n % block_n == 0,
+        HAS_K_TAIL=k % 32 != 0,
+        N_BLOCKS=n_blocks,
+        BATCH_GROUP=batch_group,
+        GMN=tiles_per_batch,
+        NT=program_count,
+        num_warps=warps_per_cta[0] * warps_per_cta[1],
+        num_stages=1,
+        matrix_instr_nonkdim=instr_shape[0],
+        **launch_options,
+    )
+    return c
+
+
+def bmm_register_staged_template(a, b, kernel_spec, batch_group=NUM_XCDS,
+                                 schedule_spec=None):
+    batch, m, _ = a.shape
+    n = b.shape[-1]
+    c = torch.empty((batch, m, n), device=a.device, dtype=a.dtype)
+    return _launch_register_staged_bmm(
+        a, b, c,
+        kernel_spec=kernel_spec,
+        batch_group=batch_group,
+        schedule_spec=schedule_spec,
+    )
+
+
 def bmm(a, b):
-    """C = A @ B, shared-A, ROW-major B (stride_bn == 1). nw=8, mfma=32."""
+    """C = A @ B, shared-A, ROW-major B (stride_bn == 1)."""
     # sA / sB take their element type from a_ptr / b_ptr independently, so a dtype
     # mismatch would silently give the two LDS buffers different types.
     assert a.dtype == b.dtype, f"A and B must have the same dtype, got {a.dtype} and {b.dtype}"
@@ -191,6 +1163,63 @@ def bmm(a, b):
     common = dict(num_warps=8, num_stages=1, matrix_instr_nonkdim=32, llvm_fn_attrs=attrs)
     st = (a.stride(0), a.stride(1), a.stride(2), b.stride(0), b.stride(1), b.stride(2), c.stride(0), c.stride(1),
           c.stride(2))
+    if M == 40 and N == 256 and K == 1956:
+        batch_group = LARGE_BATCH_GROUP if Bs >= LARGE_BATCH_GROUP else NUM_XCDS
+        return _launch_register_staged_bmm(
+            a, b, c,
+            kernel_spec=_MT64X256_MI32_KERNEL_SPEC,
+            batch_group=batch_group,
+            schedule_spec=_REGISTER_STAGED_SCHEDULE_SPEC,
+        )
+    if M == 262 and N == 256 and K == 294:
+        batch_group = (
+            BMM_262_256_BATCH_GROUP
+            if Bs >= BMM_262_256_BATCH_GROUP
+            else NUM_XCDS
+        )
+        return _launch_register_staged_bmm(
+            a, b, c,
+            kernel_spec=_MT144X256_MI16_KERNEL_SPEC,
+            batch_group=batch_group,
+        )
+    # Two MT224x160 tile-grid programs cover the 448x160 output. Peeling the
+    # odd-K tail lets every full tile use gfx950's unaligned dwordx2 loads even
+    # though consecutive A rows are only naturally aligned. Grouping the same
+    # 224-row A tile across 256 batches keeps shared-A cache lines resident.
+    if M == 448 and N == 160 and K >= BLOCK_K and K % BLOCK_K != 0:
+        batch_group = BMM_448_160_BATCH_GROUP if Bs >= BMM_448_160_BATCH_GROUP else NUM_XCDS
+        return _launch_register_staged_bmm(
+            a, b, c,
+            kernel_spec=_MT224X160_MI16_KERNEL_SPEC,
+            batch_group=batch_group,
+            schedule_spec=_MT224X160_REGISTER_STAGED_SCHEDULE_SPEC,
+        )
+    # A large/deep shape has enough arithmetic to amortize MI16's larger
+    # accumulator bank, while the 256-row tile halves repeated B traffic versus
+    # the default 128-row path. Keep this as a shape class, not an exact-shape
+    # special case; smaller/shallower BMMs retain the lower-register path below.
+    if M >= 512 and N == BLOCK_N and K >= 1024 and K % VENDOR_BLOCK_K != 0:
+        vgmn = triton.cdiv(M, VENDOR_BLOCK_M) * triton.cdiv(N, BLOCK_N)
+        vnt = Bs * vgmn
+        vbb = tuple(tuple(x) for x in _swz((VENDOR_BLOCK_K, BLOCK_N // 2), 1))
+        # Grouping only pays once there are enough output tiles per batch.  On
+        # gfx950, paired A/B tests show GMN=2/4 regresses slightly, while
+        # GMN=5..8 improves.  Requiring a full 64-batch group also avoids
+        # changing the launch order for smaller batches where reuse cannot form.
+        use_large_batch_group = Bs >= LARGE_BATCH_GROUP and vgmn >= MIN_GROUPED_OUTPUT_TILES
+        _bmm_mi16_quad[(vnt, )](
+            a, b, c, M, N, K, *st, BM=VENDOR_BLOCK_M, BN=BLOCK_N, BK=VENDOR_BLOCK_K,
+            # Group 64 batches of the same M tile consecutively. A is shared
+            # across batches, so its cache lines are reused while B streams.
+            NUM_XCDS=LARGE_BATCH_GROUP if use_large_batch_group else NUM_XCDS,
+            GMN=vgmn, NT=vnt, B_BASES=vbb,
+            num_warps=4, num_stages=1,
+            matrix_instr_nonkdim=16,
+            reverse_local_assignment=True,
+            disable_unclustered_high_rp_reschedule=use_large_batch_group,
+            enable_sched_group_barrier_scheduler=use_large_batch_group,
+            sched_group_barrier_required_region_count=4)
+        return c
     # K % BLOCK_K, not K % 8: the direct path does no K-tail masking on
     # buffer_load_to_local, so a K that is 8-aligned but not BLOCK_K-aligned
     # (e.g. 264) reads past the K extent. Matches the guard in amd_bmm.py.

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1,5 +1,6 @@
 import math
 import random
+from dataclasses import replace
 
 import pytest
 
@@ -33,6 +34,13 @@ from triton.language.extra.tlx.tutorials.testing.multi_cta_layer_norm import (
 from triton.language.extra.tlx.tutorials.amd_addmm_gfx950 import (
     addmm as _amd_addmm,
     available_paths as _amd_addmm_paths,
+)
+from triton.language.extra.tlx.tutorials.amd_bmm_shared_a import (
+    _MT64X256_MI32_KERNEL_SPEC,
+    _MT224X160_MI16_KERNEL_SPEC,
+    _RESIDENT_OPERAND_B,
+    bmm as _shared_a_bmm,
+    bmm_register_staged_template,
 )
 from triton.language.extra.tlx.tutorials.gfx9_gemm.inter_wave.a16w16 import (
     matmul_kernel as _amd_gemm, )
@@ -1479,6 +1487,78 @@ def test_amd_bmm(dtype):
         out = _amd_bmm(a, b)
         ref = torch.bmm(a, b)
         torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "dtype,m,n,k,kernel_spec",
+    [
+        (torch.float16, 40, 160, 64, _MT64X256_MI32_KERNEL_SPEC),
+        (
+            torch.bfloat16,
+            224,
+            160,
+            65,
+            replace(
+                _MT224X160_MI16_KERNEL_SPEC,
+                resident_operand_policy=_RESIDENT_OPERAND_B,
+            ),
+        ),
+    ],
+)
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_register_staged_bmm_resident_operand_policies(
+    dtype, m, n, k, kernel_spec
+):
+    """Exercise both dot orders, input dtypes, and partial output tiles."""
+    batch = 2
+    torch.manual_seed(0)
+    a_storage = torch.randn((1, m, k), device=DEVICE, dtype=dtype)
+    a = a_storage.expand(batch, -1, -1)
+    b = torch.randn((batch, k, n), device=DEVICE, dtype=dtype)
+
+    actual = bmm_register_staged_template(a, b, kernel_spec)
+    expected = torch.bmm(a, b)
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "m,n,k,error",
+    [
+        (64, 256, 31, "K must be >= BLOCK_K=32"),
+        (31, 256, 64, "BLOCK_M=64 requires M >= 32"),
+        (64, 127, 64, "BLOCK_N=256 requires N >= 128"),
+    ],
+)
+def test_register_staged_bmm_rejects_unsupported_wrap_contracts(m, n, k, error):
+    a = torch.empty((1, m, k), dtype=torch.float16)
+    b = torch.empty((1, k, n), dtype=torch.float16)
+
+    with pytest.raises(AssertionError, match=error):
+        bmm_register_staged_template(a, b, _MT64X256_MI32_KERNEL_SPEC)
+
+
+@pytest.mark.parametrize(
+    "batch,m,n,k,dtype",
+    [
+        (63, 40, 256, 1956, torch.float16),
+        (255, 262, 256, 294, torch.float16),
+        (256, 448, 160, 931, torch.float16),
+        (64, 1195, 256, 2309, torch.bfloat16),
+    ],
+)
+@pytest.mark.skipif(not is_hip_cdna4(), reason="Requires gfx950 hardware")
+def test_shared_a_bmm_production_dispatches_at_group_boundaries(
+    batch, m, n, k, dtype
+):
+    """Cover every tuned dispatch at the batch size that enables grouping."""
+    torch.manual_seed(0)
+    a = torch.randn((1, m, k), device=DEVICE, dtype=dtype).expand(batch, -1, -1)
+    b = torch.randn((batch, k, n), device=DEVICE, dtype=dtype)
+
+    actual = _shared_a_bmm(a, b)
+    expected = torch.bmm(a, b)
+    atol = 5e-1 if dtype == torch.bfloat16 else 2e-2
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=2e-2)
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:
Add tuned row-major-B kernels to the gfx950 shared-LHS BMM tutorial for production shapes whose M, N, or K dimensions do not fit the original power-of-two tile path.

The shared-A contract is explicit: A is one dense MxK matrix expanded across the batch with strideA batch equal to zero, B is dense row-major [B, K, N], and C is dense row-major [B, M, N]. Program IDs are remapped in batch groups so consecutive workgroups reuse the same A macro tile from cache while streaming different B matrices.

Keep the existing aligned direct-to-LDS and unaligned register-staged fallback as the general paths, then add three bounded register-staged specializations and one large/deep MI16 shape class:

- 40x256x1956: one 64x256 MI32 tile. Invalid M rows wrap to valid input rows for unmasked global loads; only the output is masked.
- 262x256x294: two 144x256 MI16 macro tiles, with M decomposed as 128+16 instead of padding computation to 288 rows.
- 448x160x931: two exact 224x160 MI16 macro tiles, decomposed into 7x5 logical 32x32 accumulator streams. A two-stage K32 pipeline peels and zero-pads the odd K tail.
- Large/deep odd-K BMMs such as 1195x256x2309: 256x256 MI16 macro tiles with a 2x2 operand decomposition and K64 pipeline.

The register-staged family is driven by one compile-time KERNEL_SPEC. It describes the macro-tile size, explicit per-axis operand tile extents, LDS stage count, MFMA geometry, warp geometry, load placement, cache policy, and resident-operand policy. Helper functions derive output coordinates, wrapped global offsets, LDS allocations, accumulator indexing, and the dot grid from that spec. A new heterogeneous or non-power-of-two tile therefore changes one bounded specialization instead of duplicating the entire kernel.

Operand residency is a separate tuning dimension. The pipeline can preload all A fragments and stream B one tile at a time, or preload B and stream A. AUTO estimates the per-wave footprint and keeps the smaller family resident; measured shape overrides remain available when instruction order or scheduler behavior outweighs the simple footprint estimate. Tests exercise both policies.

All four production shapes also need unaligned 16-byte global vector loads. Their FP16 row strides are not 16-byte aligned; for example, K=931 gives a 1862-byte A row stride and only 2-byte natural alignment for some rows. The gfx950 compiler support in D116569328 allows eligible plain global loads to retain contiguous dwordx2/dwordx4 transactions, up to 16 bytes per lane, while preserving the existing bounds and mask-alignment proofs. Without that support these loads scalarize, increasing instruction and scheduling pressure substantially.

Compiler scheduling remains orthogonal to data decomposition. The standalone 448 path uses schedule-group-barrier scheduling with four MFMA instructions per dwordx4 cover and disables the high-register-pressure reschedule. The 262 path deliberately leaves this scheduler disabled because the measured schedule regressed it.

Current MI350X production results use shared-A strides, row-major B, normal Inductor autotuning, and accuracy checking. Values are the median of three independent process medians; ratio is extern/TLX, so values above 1.0 mean TLX wins.

| B | MxNxK | TLX | Inductor extern | Extern/TLX | Selected |
| ---: | --- | ---: | ---: | ---: | --- |
| 1024 | 40x256x1956 | 209.60 us | 221.88 us | 1.059x | TLX |
| 1024 | 262x256x294 | 115.70 us | 110.44 us | 0.955x | Extern |
| 3072 | 448x160x931 | 734.47 us | 792.93 us | 1.080x | TLX |
| 1024 | 1195x256x2309 | 2034.94 us | 1920.98 us | 0.944x | Extern |

The template contributes two production wins while normal autotuning retains the vendor path for the other two shapes.

Differential Revision: D115625919


