### PR TITLE
[TLX][AMD] Add Inductor shared-A BMM templates with epilogue fusion (#3494)

### DIFF
--- a/python/test/unit/language/test_torchtlx_templates.py
+++ b/python/test/unit/language/test_torchtlx_templates.py
@@ -447,6 +447,63 @@ class TestLocalBufferRetention(TestCase):
 @instantiate_parametrized_tests
 class TestTLXTemplates(TestCase):
 
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_bmm_shared_a_rejects_non_gfx950(self):
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry
+
+        class _KernelInputs:
+            pass
+
+        with (
+            mock.patch.object(_tlx_registry, "MMKernelInputs", _KernelInputs),
+            mock.patch.object(_tlx_registry, "_is_gfx950", return_value=False),
+        ):
+            configs = list(
+                _tlx_registry.ROCmBMMSharedATemplateConfigHeuristic._get_template_configs_impl(
+                    object(), _KernelInputs(), "bmm"
+                )
+            )
+
+        self.assertEqual(configs, [])
+
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_amd_compile_meta_marks_only_proven_pointer_ranges(self):
+        from triton.language.extra.tlx.inductor import registry as _tlx_registry
+
+        compile_meta = {
+            "backend_options": {},
+            "configs": [{}],
+            "signature": {
+                "arg_A": "*fp16",
+                "arg_B": "*fp16",
+                "in_ptr2": "*fp16",
+                "out_ptr3": "*fp16",
+                "xnumel": "i32",
+            },
+        }
+        config_args = {
+            "matrix_instr_nonkdim": 16,
+            "inductor_32bit_pointer_range": (
+                "arg_A",
+                "arg_B",
+                "out_ptr*",
+            ),
+        }
+
+        result = _tlx_registry._update_tlx_amd_compile_meta(
+            compile_meta, config_args, "hip"
+        )
+
+        self.assertEqual(result["backend_options"], {"matrix_instr_nonkdim": 16})
+        self.assertEqual(
+            result["configs"][0],
+            {
+                (0,): [["tt.pointer_range", 32]],
+                (1,): [["tt.pointer_range", 32]],
+                (3,): [["tt.pointer_range", 32]],
+            },
+        )
+
     @unittest.skipIf(
         not has_datacenter_blackwell_tma_device(),
         "Need Blackwell with device-side TMA support in Triton",
@@ -1062,6 +1119,113 @@ class TestTLXTemplates(TestCase):
 
         code_str = "\n".join(code)
         self.assertIn("triton_tem", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX shared-A bmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    @parametrize(
+        "shape",
+        (
+            (40, 1956, 256),
+            (262, 294, 256),
+            (448, 931, 160),
+            (1195, 2309, 256),
+        ),
+    )
+    def test_tlx_bmm_shared_a(self, shape: tuple[int, int, int]):
+        """The specialized shared-LHS BMMs lower through their Inductor template."""
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+        from triton.language.extra.tlx.inductor import (
+            registry as _tlx_registry,  # noqa: F401
+        )
+
+        batch = 2
+        M, K, N = shape
+        base = torch.randn(M, K, device=GPU_TYPE, dtype=torch.float16)
+        a = base.unsqueeze(0).expand(batch, -1, -1)
+        b = torch.randn(batch, K, N, device=GPU_TYPE, dtype=torch.float16)
+
+        def bmm(a, b):
+            return torch.bmm(a, b)
+
+        def _only_shared_a(templates, op_name="mm"):
+            from torch._inductor.kernel.bmm import bmm_template
+
+            uids = {getattr(template, "uid", None) for template in templates}
+            if op_name == "bmm" and bmm_template.uid in uids:
+                templates.append(_tlx_mm.amd_bmm_shared_a_template)
+            return templates
+
+        with (
+            mock.patch.object(_tlx_mm, "append_tlx", _only_shared_a),
+            config.patch(
+                {
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }
+            ),
+        ):
+            actual, code = run_and_get_code(torch.compile(bmm), a, b)
+
+        expected = torch.bmm(a.float(), b.float()).to(torch.float16)
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        self.assertEqual(a.stride(0), 0)
+        code_str = "\n".join(code)
+        self.assertIn("gfx950 shared-LHS BMM candidates", code_str)
+        self.assertIn("tlx.local_alloc", code_str)
+
+    @unittest.skipIf(
+        not is_gfx950(),
+        "Need AMD MI350X (gfx950) for the TLX shared-A bmm template",
+    )
+    @unittest.skipIf(not has_tlx(), "TLX not available")
+    def test_tlx_bmm_shared_a_fused_row_bias(self):
+        """Inductor injects a broadcast row bias into the TLX output hook."""
+        from triton.language.extra.tlx.inductor import mm_templates as _tlx_mm
+        from triton.language.extra.tlx.inductor import (
+            registry as _tlx_registry,  # noqa: F401
+        )
+
+        batch, m, k, n = 2, 448, 931, 160
+        base = torch.randn(m, k, device=GPU_TYPE, dtype=torch.float16)
+        a = base.unsqueeze(0).expand(batch, -1, -1)
+        b = torch.randn(batch, k, n, device=GPU_TYPE, dtype=torch.float16)
+        bias = torch.randn(m, 1, device=GPU_TYPE, dtype=torch.float16)
+
+        def bmm_bias(a, b, bias):
+            return torch.bmm(a, b) + bias
+
+        def _only_shared_a(templates, op_name="mm"):
+            if op_name == "bmm":
+                templates[:] = [_tlx_mm.amd_bmm_shared_a_template]
+            return templates
+
+        with (
+            mock.patch.object(_tlx_mm, "append_tlx", _only_shared_a),
+            config.patch(
+                {
+                    "triton.tlx_mode": "force",
+                    "force_disable_caches": True,
+                    "max_autotune": True,
+                    "max_autotune_gemm_backends": "TRITON",
+                    "enable_caching_generated_triton_templates": False,
+                }
+            ),
+        ):
+            actual, code = run_and_get_code(torch.compile(bmm_bias), a, b, bias)
+
+        expected = torch.bmm(a, b) + bias
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        code_str = "\n".join(code)
+        self.assertIn("gfx950 shared-LHS BMM candidates", code_str)
+        self.assertIn("tl.load(in_ptr2", code_str)
+        self.assertIn("tl.store(tlx.require_layout(out_ptr", code_str)
+        self.assertEqual(code_str.count(".run("), 1)
 
     @unittest.skipIf(
         not is_gfx950(),

--- a/third_party/tlx/language/tlx/inductor/amd_bmm_shared_a.py.jinja
+++ b/third_party/tlx/language/tlx/inductor/amd_bmm_shared_a.py.jinja
@@ -1,0 +1,431 @@
+import triton.language.extra.tlx as tlx
+
+{{def_kernel("A", "B")}}
+    # gfx950 shared-LHS BMM candidates ported from amd_bmm_shared_a.py.
+    # A is [BATCH, M, K] with stride_aq == 0, B is row-major [BATCH, K, N].
+    M = {{size("A", -2)}}
+    N = {{size("B", -1)}}
+    K = {{size("A", -1)}}
+    BATCH = {{size("A", 0)}}
+    stride_aq = {{stride("A", 0)}}
+    stride_am = {{stride("A", 1)}}
+    stride_ak = {{stride("A", 2)}}
+    stride_bq = {{stride("B", 0)}}
+    stride_bk = {{stride("B", 1)}}
+    stride_bn = {{stride("B", 2)}}
+
+    grid_m = (M + BLOCK_M - 1) // BLOCK_M
+    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    grid_mn = grid_m * grid_n
+    num_tiles = BATCH * grid_mn
+    pidf = tl.program_id(0).to(INDEX_DTYPE)
+
+    # The standalone kernel's _chip mapping. BATCH_GROUP controls how many
+    # batches of the same output tile are issued consecutively.
+    aligned = (num_tiles // (BATCH_GROUP * grid_mn)) * (BATCH_GROUP * grid_mn)
+    if pidf < aligned:
+        group = pidf % BATCH_GROUP
+        local_pid = pidf // BATCH_GROUP
+        pidf = ((local_pid // grid_mn) * BATCH_GROUP * grid_mn
+                + group * grid_mn + local_pid % grid_mn)
+
+    batch_id = pidf // grid_mn
+    pid = pidf % grid_mn
+    A = A + batch_id.to(tl.int64) * stride_aq
+    B = B + batch_id.to(tl.int64) * stride_bq
+
+{% if KERNEL_KIND == 40 %}
+    # 40x256x1956: one 64x256 MI32 tile. Duplicate the 24 invalid A rows
+    # during loads and mask them only at the output.
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4, instr_shape=[32, 32, 16], transposed=True,
+        warps_per_cta=[1, 4])
+    dot0: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    dot1: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+    raw_m = tl.arange(0, 64)
+    rm = tl.where(raw_m < M, raw_m, raw_m - M)
+    rn = tl.arange(0, 256)
+    rk = tl.arange(0, 32)
+    ao = rm[:, None] * stride_am
+    bo = rn[None, :] * stride_bn
+    a_buf = tlx.local_alloc((64, 32), tl.float16, 2)
+    b_buf = tlx.local_alloc((32, 256), tl.float16, 2)
+    tlx.local_store(tlx.local_view(a_buf, 0),
+                    tl.load(A + ao + rk[None, :] * stride_ak))
+    tlx.local_store(tlx.local_view(b_buf, 0),
+                    tl.load(B + rk[:, None] * stride_bk + bo,
+                            cache_modifier=".cg"))
+    tl.debug_barrier()
+    acc = tlx.zeros((64, 256), tl.float32, layout=mma)
+    full_tiles = K // 32
+    for k in tl.range(0, full_tiles - 1, loop_unroll_factor=2):
+        cur = k % 2
+        nxt = (k + 1) % 2
+        av = tlx.require_layout(
+            tlx.local_load(tlx.local_view(a_buf, cur)), dot0, pin=False)
+        bv = tlx.require_layout(
+            tlx.local_load(tlx.local_view(b_buf, cur)), dot1, pin=False)
+        kp = (k + 1) * 32
+        next_a = tl.load(A + ao + (kp + rk[None, :]) * stride_ak)
+        next_b = tl.load(B + (kp + rk[:, None]) * stride_bk + bo,
+                         cache_modifier=".cg")
+        acc = tl.dot(av, bv, acc)
+        tlx.local_store(tlx.local_view(a_buf, nxt), next_a)
+        tlx.local_store(tlx.local_view(b_buf, nxt), next_b)
+        tl.debug_barrier()
+    cur = (full_tiles - 1) % 2
+    av = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a_buf, cur)), dot0, pin=False)
+    bv = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b_buf, cur)), dot1, pin=False)
+    acc = tl.dot(av, bv, acc)
+    tail = full_tiles * 32
+    km = tail + rk < K
+    nxt = full_tiles % 2
+    tail_a = tl.load(A + ao + (tail + rk[None, :]) * stride_ak,
+                     mask=km[None, :], other=0.0)
+    tail_b = tl.load(B + (tail + rk[:, None]) * stride_bk + bo,
+                     mask=km[:, None], other=0.0, cache_modifier=".cg")
+    tlx.local_store(tlx.local_view(a_buf, nxt), tail_a)
+    tlx.local_store(tlx.local_view(b_buf, nxt), tail_b)
+    tl.debug_barrier()
+    av = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a_buf, nxt)), dot0, pin=False)
+    bv = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b_buf, nxt)), dot1, pin=False)
+    acc = tl.dot(av, bv, acc)
+    idx_q = batch_id
+    idx_m = raw_m[:, None]
+    idx_n = rn[None, :]
+    mask = (idx_m < M) & (idx_n < N)
+    out = acc.to(tl.float16)
+    {{store_output(("idx_q", "idx_m", "idx_n"), "out", "mask", val_shape=("64", "256"), output_layout="mma")}}
+
+{% elif KERNEL_KIND == 262 %}
+    # 262x256x294: two 144x256 MI16 tiles represented as 128+16 rows.
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4, instr_shape=[16, 16, 32], transposed=True,
+        warps_per_cta=[1, 4])
+    dot0: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    dot1: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+    pm = pid
+    r128 = tl.arange(0, 128)
+    r16 = tl.arange(0, 16)
+    rn = tl.arange(0, 256)
+    rk = tl.arange(0, 32)
+    raw_m0 = pm * 144 + r128
+    raw_m1 = pm * 144 + 128 + r16
+    rm0 = tl.where(raw_m0 < M, raw_m0, raw_m0 - M)
+    rm1 = tl.where(raw_m1 < M, raw_m1, raw_m1 - M)
+    ao0 = rm0[:, None] * stride_am
+    ao1 = rm1[:, None] * stride_am
+    bo = rn[None, :] * stride_bn
+    a0_buf = tlx.local_alloc((128, 32), tl.float16, 2)
+    a1_buf = tlx.local_alloc((16, 32), tl.float16, 2)
+    b_layout: tl.constexpr = tlx.swizzled_layout(4, 3, 5)
+    b_buf = tlx.local_alloc((32, 256), tl.float16, 2, layout=b_layout)
+    tlx.local_store(tlx.local_view(a0_buf, 0),
+                    tl.load(A + ao0 + rk[None, :] * stride_ak))
+    tlx.local_store(tlx.local_view(a1_buf, 0),
+                    tl.load(A + ao1 + rk[None, :] * stride_ak))
+    tlx.local_store(tlx.local_view(b_buf, 0),
+                    tl.load(B + rk[:, None] * stride_bk + bo))
+    tl.debug_barrier()
+    acc0 = tlx.zeros((128, 256), tl.float32, layout=mma)
+    acc1 = tlx.zeros((16, 256), tl.float32, layout=mma)
+    full_tiles = K // 32
+    for k in tl.range(0, full_tiles - 1):
+        cur = k % 2
+        nxt = (k + 1) % 2
+        av0 = tlx.require_layout(
+            tlx.local_load(tlx.local_view(a0_buf, cur)), dot0, pin=False)
+        av1 = tlx.require_layout(
+            tlx.local_load(tlx.local_view(a1_buf, cur)), dot0, pin=False)
+        bv = tlx.require_layout(
+            tlx.local_load(tlx.local_view(b_buf, cur)), dot1, pin=False)
+        kp = (k + 1) * 32
+        next_a0 = tl.load(A + ao0 + (kp + rk[None, :]) * stride_ak)
+        next_a1 = tl.load(A + ao1 + (kp + rk[None, :]) * stride_ak)
+        next_b = tl.load(B + (kp + rk[:, None]) * stride_bk + bo)
+        acc0 = tl.dot(av0, bv, acc0)
+        acc1 = tl.dot(av1, bv, acc1)
+        tlx.local_store(tlx.local_view(a0_buf, nxt), next_a0)
+        tlx.local_store(tlx.local_view(a1_buf, nxt), next_a1)
+        tlx.local_store(tlx.local_view(b_buf, nxt), next_b)
+        tl.debug_barrier()
+    cur = (full_tiles - 1) % 2
+    av0 = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a0_buf, cur)), dot0, pin=False)
+    av1 = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a1_buf, cur)), dot0, pin=False)
+    bv = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b_buf, cur)), dot1, pin=False)
+    acc0 = tl.dot(av0, bv, acc0)
+    acc1 = tl.dot(av1, bv, acc1)
+    tail = full_tiles * 32
+    km = tail + rk < K
+    nxt = full_tiles % 2
+    tail_a0 = tl.load(A + ao0 + (tail + rk[None, :]) * stride_ak,
+                      mask=km[None, :], other=0.0)
+    tail_a1 = tl.load(A + ao1 + (tail + rk[None, :]) * stride_ak,
+                      mask=km[None, :], other=0.0)
+    tail_b = tl.load(B + (tail + rk[:, None]) * stride_bk + bo,
+                     mask=km[:, None], other=0.0)
+    tlx.local_store(tlx.local_view(a0_buf, nxt), tail_a0)
+    tlx.local_store(tlx.local_view(a1_buf, nxt), tail_a1)
+    tlx.local_store(tlx.local_view(b_buf, nxt), tail_b)
+    tl.debug_barrier()
+    av0 = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a0_buf, nxt)), dot0, pin=False)
+    av1 = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a1_buf, nxt)), dot0, pin=False)
+    bv = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b_buf, nxt)), dot1, pin=False)
+    acc0 = tl.dot(av0, bv, acc0)
+    acc1 = tl.dot(av1, bv, acc1)
+    idx_q = batch_id
+    idx_m0 = raw_m0[:, None]
+    idx_m1 = raw_m1[:, None]
+    idx_n = rn[None, :]
+    mask0 = (idx_m0 < M) & (idx_n < N)
+    mask1 = (idx_m1 < M) & (idx_n < N)
+    out0 = acc0.to(tl.float16)
+    out1 = acc1.to(tl.float16)
+    {{store_output(("idx_q", "idx_m0", "idx_n"), "out0", "mask0", val_shape=("128", "256"), output_layout="mma")}}
+    {{store_output(("idx_q", "idx_m1", "idx_n"), "out1", "mask1", val_shape=("16", "256"), output_layout="mma")}}
+
+{% elif KERNEL_KIND == 448 %}
+    # 448x160x931: two 224x160 tiles, expressed as a Jinja-generated 7x5
+    # grid of independent 32x32 MI16 streams. Rendering produces the same
+    # explicit operation order as the standalone oracle.
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4, instr_shape=[16, 16, 32], transposed=True,
+        warps_per_cta=[2, 2])
+    dot0: tl.constexpr = tlx.dot_operand_layout(0, mma, k_width=8)
+    dot1: tl.constexpr = tlx.dot_operand_layout(1, mma, k_width=8)
+    pm = pid
+    r = tl.arange(0, 32)
+{% for mi in range(7) %}
+    a{{mi}} = tlx.local_alloc((32, 32), tl.float16, 2)
+{% endfor %}
+{% for nj in range(5) %}
+    b{{nj}} = tlx.local_alloc((32, 32), tl.float16, 2)
+{% endfor %}
+{% for mi in range(7) %}
+    rm{{mi}} = pm * 224 + r + {{mi * 32}}
+{% endfor %}
+{% for nj in range(5) %}
+    rn{{nj}} = r + {{nj * 32}}
+{% endfor %}
+{% for mi in range(7) %}
+    tlx.local_store(tlx.local_view(a{{mi}}, 0),
+                    tl.load(A + rm{{mi}}[:, None] * stride_am
+                            + r[None, :] * stride_ak))
+{% endfor %}
+{% for nj in range(5) %}
+    tlx.local_store(tlx.local_view(b{{nj}}, 0),
+                    tl.load(B + r[:, None] * stride_bk
+                            + rn{{nj}}[None, :] * stride_bn))
+{% endfor %}
+    tl.debug_barrier()
+    z = tlx.zeros((32, 32), tl.float32, layout=mma)
+{% for mi in range(7) %}
+{% for nj in range(5) %}
+    c{{mi}}{{nj}} = z
+{% endfor %}
+{% endfor %}
+    full_tiles = K // 32
+    for k in tl.range(0, full_tiles - 1):
+        cur = k % 2
+        nxt = (k + 1) % 2
+{% for mi in range(7) %}
+        av{{mi}} = tlx.require_layout(
+            tlx.local_load(tlx.local_view(a{{mi}}, cur)), dot0, pin=False)
+{% endfor %}
+        kp = (k + 1) * 32
+{% for mi in range(7) %}
+        na{{mi}} = tl.load(A + rm{{mi}}[:, None] * stride_am
+                           + (kp + r[None, :]) * stride_ak)
+{% endfor %}
+{% for nj in range(5) %}
+        nb{{nj}} = tl.load(B + (kp + r[:, None]) * stride_bk
+                           + rn{{nj}}[None, :] * stride_bn)
+{% endfor %}
+{% for nj in range(5) %}
+        bv{{nj}} = tlx.require_layout(
+            tlx.local_load(tlx.local_view(b{{nj}}, cur)), dot1, pin=False)
+{% for mi in range(7) %}
+        c{{mi}}{{nj}} = tl.dot(av{{mi}}, bv{{nj}}, c{{mi}}{{nj}})
+{% endfor %}
+{% endfor %}
+{% for mi in range(7) %}
+        tlx.local_store(tlx.local_view(a{{mi}}, nxt), na{{mi}})
+{% endfor %}
+{% for nj in range(5) %}
+        tlx.local_store(tlx.local_view(b{{nj}}, nxt), nb{{nj}})
+{% endfor %}
+        tl.debug_barrier()
+    cur = (full_tiles - 1) % 2
+    nxt = full_tiles % 2
+{% for mi in range(7) %}
+    av{{mi}} = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a{{mi}}, cur)), dot0, pin=False)
+{% endfor %}
+    kp = full_tiles * 32
+    km = kp + r < K
+{% for mi in range(7) %}
+    na{{mi}} = tl.load(A + rm{{mi}}[:, None] * stride_am
+                       + (kp + r[None, :]) * stride_ak,
+                       mask=km[None, :], other=0.0)
+{% endfor %}
+{% for nj in range(5) %}
+    nb{{nj}} = tl.load(B + (kp + r[:, None]) * stride_bk
+                       + rn{{nj}}[None, :] * stride_bn,
+                       mask=km[:, None], other=0.0)
+{% endfor %}
+{% for nj in range(5) %}
+    bv{{nj}} = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b{{nj}}, cur)), dot1, pin=False)
+{% for mi in range(7) %}
+    c{{mi}}{{nj}} = tl.dot(av{{mi}}, bv{{nj}}, c{{mi}}{{nj}})
+{% endfor %}
+{% endfor %}
+{% for mi in range(7) %}
+    tlx.local_store(tlx.local_view(a{{mi}}, nxt), na{{mi}})
+{% endfor %}
+{% for nj in range(5) %}
+    tlx.local_store(tlx.local_view(b{{nj}}, nxt), nb{{nj}})
+{% endfor %}
+    tl.debug_barrier()
+{% for mi in range(7) %}
+    av{{mi}} = tlx.require_layout(
+        tlx.local_load(tlx.local_view(a{{mi}}, nxt)), dot0, pin=False)
+{% endfor %}
+{% for nj in range(5) %}
+    bv{{nj}} = tlx.require_layout(
+        tlx.local_load(tlx.local_view(b{{nj}}, nxt)), dot1, pin=False)
+{% for mi in range(7) %}
+    c{{mi}}{{nj}} = tl.dot(av{{mi}}, bv{{nj}}, c{{mi}}{{nj}})
+{% endfor %}
+{% endfor %}
+    idx_q = batch_id
+{% for mi in range(7) %}
+    idx_m{{mi}} = rm{{mi}}[:, None]
+{% endfor %}
+{% for nj in range(5) %}
+    idx_n{{nj}} = rn{{nj}}[None, :]
+{% endfor %}
+    store_mask = tl.full((32, 32), 1, tl.int1)
+{% for mi in range(7) %}
+{% for nj in range(5) %}
+    out{{mi}}{{nj}} = c{{mi}}{{nj}}.to(tl.float16)
+    {{store_output(("idx_q", "idx_m" ~ mi, "idx_n" ~ nj), "out" ~ mi ~ nj, "store_mask", val_shape=("32", "32"), output_layout="mma")}}
+{% endfor %}
+{% endfor %}
+
+{% elif KERNEL_KIND == 1195 %}
+    # 1195x256x2309: 256x256 MI16 macro tile with 2x2 operand
+    # decomposition and shared-A batch grouping.
+    HM: tl.constexpr = 128
+    HN: tl.constexpr = 128
+    BK: tl.constexpr = 64
+    pm = pid // grid_n
+    pn = pid % grid_n
+    b_bases: tl.constexpr = (
+        (0, 1), (0, 2), (0, 4), (0, 8), (0, 16), (0, 32), (0, 64),
+        (16, 0), (32, 0), (1, 0), (2, 0), (4, 0), (8, 0))
+    b_sh: tl.constexpr = tlx.padded_shared_layout_encoding.with_bases(
+        [(512, 16)], b_bases, [BK, HN])
+    buf_a_lo = tlx.local_alloc((HM, BK), tl.float16, 2)
+    buf_a_hi = tlx.local_alloc((HM, BK), tl.float16, 2)
+    buf_b_lo = tlx.local_alloc((BK, HN), tl.float16, 2, layout=b_sh)
+    buf_b_hi = tlx.local_alloc((BK, HN), tl.float16, 2, layout=b_sh)
+    om_lo = (pm * 256 + tl.arange(0, HM)) % M
+    om_hi = (pm * 256 + HM + tl.arange(0, HM)) % M
+    on_lo = (pn * 256 + tl.arange(0, HN)) % N
+    on_hi = (pn * 256 + HN + tl.arange(0, HN)) % N
+    ok = tl.arange(0, BK)
+    ao_lo = om_lo[:, None] * stride_am
+    ao_hi = om_hi[:, None] * stride_am
+    bo_lo = on_lo[None, :] * stride_bn
+    bo_hi = on_hi[None, :] * stride_bn
+    nf = K // BK
+    tlx.local_store(tlx.local_view(buf_a_lo, 0),
+                    tl.load(A + ao_lo + ok[None, :] * stride_ak))
+    tlx.local_store(tlx.local_view(buf_a_hi, 0),
+                    tl.load(A + ao_hi + ok[None, :] * stride_ak))
+    tlx.local_store(tlx.local_view(buf_b_lo, 0),
+                    tl.load(B + ok[:, None] * stride_bk + bo_lo))
+    tlx.local_store(tlx.local_view(buf_b_hi, 0),
+                    tl.load(B + ok[:, None] * stride_bk + bo_hi))
+    tl.debug_barrier()
+    c00 = tl.zeros((HM, HN), dtype=tl.float32)
+    c10 = tl.zeros((HM, HN), dtype=tl.float32)
+    c01 = tl.zeros((HM, HN), dtype=tl.float32)
+    c11 = tl.zeros((HM, HN), dtype=tl.float32)
+    for k in tl.range(0, nf - 1):
+        cur = k % 2
+        nxt = (k + 1) % 2
+        kp = (k + 1) * BK
+        a_lo = tlx.local_load(tlx.local_view(buf_a_lo, cur))
+        b_lo = tlx.local_load(tlx.local_view(buf_b_lo, cur))
+        next_a_lo = tl.load(A + ao_lo + (kp + ok[None, :]) * stride_ak)
+        tlx.buffer_load_to_local(tlx.local_view(buf_b_lo, nxt), B,
+                                 (kp + ok[:, None]) * stride_bk + bo_lo)
+        c00 = tl.dot(a_lo, b_lo, c00)
+        a_hi = tlx.local_load(tlx.local_view(buf_a_hi, cur))
+        next_a_hi = tl.load(A + ao_hi + (kp + ok[None, :]) * stride_ak)
+        c10 = tl.dot(a_hi, b_lo, c10)
+        b_hi = tlx.local_load(tlx.local_view(buf_b_hi, cur))
+        tlx.buffer_load_to_local(tlx.local_view(buf_b_hi, nxt), B,
+                                 (kp + ok[:, None]) * stride_bk + bo_hi)
+        c01 = tl.dot(a_lo, b_hi, c01)
+        c11 = tl.dot(a_hi, b_hi, c11)
+        tlx.local_store(tlx.local_view(buf_a_lo, nxt), next_a_lo)
+        tlx.local_store(tlx.local_view(buf_a_hi, nxt), next_a_hi)
+        tlx.async_load_commit_group()
+        tlx.async_load_wait_group(0)
+        tl.debug_barrier()
+    last = (nf - 1) % 2
+    a_lo = tlx.local_load(tlx.local_view(buf_a_lo, last))
+    a_hi = tlx.local_load(tlx.local_view(buf_a_hi, last))
+    b_lo = tlx.local_load(tlx.local_view(buf_b_lo, last))
+    b_hi = tlx.local_load(tlx.local_view(buf_b_hi, last))
+    c00 = tl.dot(a_lo, b_lo, c00)
+    c01 = tl.dot(a_lo, b_hi, c01)
+    c10 = tl.dot(a_hi, b_lo, c10)
+    c11 = tl.dot(a_hi, b_hi, c11)
+    for kt in tl.range(nf * BK, K, BK):
+        km = kt + ok < K
+        ta_lo = tl.load(A + ao_lo + (kt + ok[None, :]) * stride_ak,
+                        mask=km[None, :], other=0.0)
+        ta_hi = tl.load(A + ao_hi + (kt + ok[None, :]) * stride_ak,
+                        mask=km[None, :], other=0.0)
+        tb_lo = tl.load(B + (kt + ok[:, None]) * stride_bk + bo_lo,
+                        mask=km[:, None], other=0.0)
+        tb_hi = tl.load(B + (kt + ok[:, None]) * stride_bk + bo_hi,
+                        mask=km[:, None], other=0.0)
+        c00 = tl.dot(ta_lo, tb_lo, c00)
+        c01 = tl.dot(ta_lo, tb_hi, c01)
+        c10 = tl.dot(ta_hi, tb_lo, c10)
+        c11 = tl.dot(ta_hi, tb_hi, c11)
+    c_layout: tl.constexpr = tlx.layout(
+        shape=((16, 16), (8, 8)), stride=((8, 128), (1, 2048)))
+    out00 = tlx.require_layout(c00.to(tl.float16), c_layout)
+    out01 = tlx.require_layout(c01.to(tl.float16), c_layout)
+    out10 = tlx.require_layout(c10.to(tl.float16), c_layout)
+    out11 = tlx.require_layout(c11.to(tl.float16), c_layout)
+    idx_q = batch_id
+    idx_m0 = (pm * 256 + tl.arange(0, HM))[:, None]
+    idx_m1 = (pm * 256 + HM + tl.arange(0, HM))[:, None]
+    idx_n0 = (pn * 256 + tl.arange(0, HN))[None, :]
+    idx_n1 = (pn * 256 + HN + tl.arange(0, HN))[None, :]
+    mask00 = (idx_m0 < M) & (idx_n0 < N)
+    mask01 = (idx_m0 < M) & (idx_n1 < N)
+    mask10 = (idx_m1 < M) & (idx_n0 < N)
+    mask11 = (idx_m1 < M) & (idx_n1 < N)
+    {{store_output(("idx_q", "idx_m0", "idx_n0"), "out00", "mask00", val_shape=("128", "128"), output_layout="c_layout")}}
+    {{store_output(("idx_q", "idx_m0", "idx_n1"), "out01", "mask01", val_shape=("128", "128"), output_layout="c_layout")}}
+    {{store_output(("idx_q", "idx_m1", "idx_n0"), "out10", "mask10", val_shape=("128", "128"), output_layout="c_layout")}}
+    {{store_output(("idx_q", "idx_m1", "idx_n1"), "out11", "mask11", val_shape=("128", "128"), output_layout="c_layout")}}
+{% endif %}

--- a/third_party/tlx/language/tlx/inductor/local_buffer_retention_gfx950.py
+++ b/third_party/tlx/language/tlx/inductor/local_buffer_retention_gfx950.py
@@ -552,7 +552,10 @@ def create_kernel_choices(
     if is_scan:
         kernel_kwargs["override_cooperative_reduction"] = False
 
-    kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
+    # The pinned TritonBench torch wheel can predate this hook. On those
+    # versions, TritonKernel construction retains the legacy override behavior.
+    if hasattr(kernel_type, "apply_feature_required_overrides"):
+        kernel_type.apply_feature_required_overrides(kernel_features, kernel_kwargs)
 
     kernel_kwargs = V.choices.triton_kernel_kwargs(
         kernel_type, kernel_features, kernel_args, kernel_kwargs

--- a/third_party/tlx/language/tlx/inductor/mm_templates.py
+++ b/third_party/tlx/language/tlx/inductor/mm_templates.py
@@ -105,6 +105,16 @@ gfx950_bmm_warppipe_template = TritonTemplate(
     source=load_tlx_template("gfx950_bmm_warppipe"),
 )
 
+# Shared-LHS gfx950 BMM candidate.  Unlike the general warp-pipe template,
+# this preserves the regime-specific macro tiles, LDS layouts, batch ordering,
+# and scheduling options validated by amd_bmm_shared_a.py.  Its heuristic only
+# yields configs for the validated shapes, a dense shared A, and dense batched B.
+amd_bmm_shared_a_template = TritonTemplate(
+    name="tlx_amd_bmm_shared_a",
+    grid=_bmm_grid_warppipe,
+    source=load_tlx_template("amd_bmm_shared_a"),
+)
+
 # Persistent variant of the gfx950 warp-pipe addmm: same warp-pipe body, but the grid
 # is capped at NUM_SMS (_persistent_mm_grid_split_k) and the kernel loops over output
 # tiles. Competes as an additional addmm candidate so per-template selection can be
@@ -153,8 +163,11 @@ def _append_tlx_amd(templates, op_name):
         from torch._inductor.kernel.bmm import bmm_template
 
         uids = {getattr(t, "uid", None) for t in templates}
-        if bmm_template.uid in uids and gfx950_bmm_warppipe_template.uid not in uids:
-            templates.append(gfx950_bmm_warppipe_template)
+        if bmm_template.uid in uids:
+            if gfx950_bmm_warppipe_template.uid not in uids:
+                templates.append(gfx950_bmm_warppipe_template)
+            if amd_bmm_shared_a_template.uid not in uids:
+                templates.append(amd_bmm_shared_a_template)
     # else: no AMD TLX template for plain mm (or any other op) yet. Proposing
     # the Blackwell one here is the bug reported in P2462423082: it cannot be
     # selected on gfx9xx and only produces log noise.

--- a/third_party/tlx/language/tlx/inductor/registry.py
+++ b/third_party/tlx/language/tlx/inductor/registry.py
@@ -18,6 +18,7 @@ Both live outside this subpackage so the standalone tutorial kernels can share
 them without importing torch._inductor.
 """
 
+import contextlib
 import dataclasses
 import logging
 import os
@@ -71,6 +72,7 @@ def _sizevar_hint(sizevars, expr, fallback):
 
 from . import tlx_config
 from .mm_templates import (
+    amd_bmm_shared_a_template,
     gfx950_addmm_persistent_warppipe_template,
     gfx950_addmm_warppipe_template,
     gfx950_bmm_warppipe_template,
@@ -1507,6 +1509,148 @@ class Gfx950BMMWarpPipeConfigHeuristic(ROCmMMTemplateConfigHeuristic):
 
 
 @register_template_heuristic(
+    amd_bmm_shared_a_template.uid, "cuda", register=IS_ROCM, op_name="bmm"
+)
+class ROCmBMMSharedATemplateConfigHeuristic(ROCmMMTemplateConfigHeuristic):
+    """Validated gfx950 shared-LHS BMM configs.
+
+    This is deliberately a separate candidate from the general BMM warp-pipe.
+    It is only offered for row-major fp16 inputs whose mat1 batch stride is
+    zero, which is the shared-A contract the launch ordering relies on.
+    """
+
+    def _get_template_configs_impl(self, kernel_inputs, op_name):
+        import sympy
+        from torch._inductor.virtualized import V
+
+        if not isinstance(kernel_inputs, MMKernelInputs):
+            raise AssertionError(f"{self.__class__.__name__} requires MMKernelInputs")
+        if not _is_gfx950():
+            return
+        if (
+            kernel_inputs.dtype(kernel_inputs._mat1_idx) != torch.float16
+            or kernel_inputs.dtype(kernel_inputs._mat2_idx) != torch.float16
+            or kernel_inputs.out_dtype() != torch.float16
+        ):
+            return
+
+        symbolic_shapes = kernel_inputs.shapes_symbolic()
+        symbolic_strides = kernel_inputs.strides_symbolic()
+        a_strides = symbolic_strides[kernel_inputs._mat1_idx]
+        b_strides = symbolic_strides[kernel_inputs._mat2_idx]
+        if (
+            len(a_strides) != 3
+            or len(b_strides) != 3
+        ):
+            return
+
+        m, n, k = kernel_inputs.mnk_symbolic()
+        out_dtype = kernel_inputs.out_dtype()
+        sizevars = V.graph.sizevars
+        dense_shared_a_b = sympy.And(
+            sympy.Eq(a_strides[0], 0),
+            sympy.Eq(a_strides[1], k),
+            sympy.Eq(a_strides[2], 1),
+            sympy.Eq(b_strides[0], k * n),
+            sympy.Eq(b_strides[1], n),
+            sympy.Eq(b_strides[2], 1),
+        )
+        if not sizevars.statically_known_true(dense_shared_a_b):
+            return
+
+        # `tt.pointer_range=32` is what lets AMD lowering use buffer operations
+        # for the non-affine chip mapping below.  Match Inductor's own 32-bit
+        # indexing contract before adding that specialization: every logical
+        # input span and the contiguous output must fit in signed 32-bit bytes.
+        # Requiring a static proof also keeps dynamic/very-large batches on the
+        # generic BMM path rather than speculating from an example-size hint.
+        def storage_span(shape, stride):
+            if len(shape) != len(stride):
+                return None
+            return 1 + sum((dim - 1) * step for dim, step in zip(shape, stride))
+
+        a_shape = symbolic_shapes[kernel_inputs._mat1_idx]
+        b_shape = symbolic_shapes[kernel_inputs._mat2_idx]
+        a_stride = a_strides
+        b_stride = b_strides
+        a_span = storage_span(a_shape, a_stride)
+        b_span = storage_span(b_shape, b_stride)
+        if a_span is None or b_span is None:
+            return
+        batch = a_shape[0]
+        int32_max = torch.iinfo(torch.int32).max
+        pointer_range_is_32bit = sympy.And(
+            *(sympy.Ge(step, 0) for step in (*a_stride, *b_stride)),
+            sympy.Le(2 * a_span, int32_max),
+            sympy.Le(2 * b_span, int32_max),
+            sympy.Le(2 * batch * m * n, int32_max),
+        )
+        if not sizevars.statically_known_true(pointer_range_is_32bit):
+            return
+
+        configs = (
+            # kind, M, N, K, BM, BN, BK, batch group, warps, MI non-K dim,
+            # scheduling enabled, dwordx4 cover, required region count,
+            # reverse local assignment, disable high-RP reschedule
+            # Inductor specializes sizes and strides into the template IR.
+            # Preserve the schedules measured on that shorter dependency graph
+            # instead of copying the standalone JIT schedules mechanically.
+            (40, 40, 256, 1956, 64, 256, 32, 64, 4, 32, False, 4, 0, False, False),
+            (262, 262, 256, 294, 144, 256, 32, 256, 4, 16, True, 6, 0, False, False),
+            (448, 448, 160, 931, 224, 160, 32, 256, 4, 16, True, 2, 0, False, False),
+            (1195, 1195, 256, 2309, 256, 256, 64, 64, 4, 16, True, 4, 4, True, True),
+        )
+        for (
+            kind,
+            expected_m,
+            expected_n,
+            expected_k,
+            block_m,
+            block_n,
+            block_k,
+            batch_group,
+            num_warps,
+            matrix_instr_nonkdim,
+            enable_schedule,
+            cover,
+            required_regions,
+            reverse_local_assignment,
+            disable_high_rp_reschedule,
+        ) in configs:
+            matches = sympy.And(
+                sympy.Eq(m, expected_m),
+                sympy.Eq(n, expected_n),
+                sympy.Eq(k, expected_k),
+            )
+            if not sizevars.statically_known_true(matches):
+                continue
+            triton_config = self.triton_config(
+                1,
+                num_warps,
+                BLOCK_M=block_m,
+                BLOCK_N=block_n,
+                BLOCK_K=block_k,
+                BATCH_GROUP=batch_group,
+                KERNEL_KIND=kind,
+                matrix_instr_nonkdim=matrix_instr_nonkdim,
+                waves_per_eu=0,
+                kpack=get_default_kpack(block_k),
+                enable_sched_group_barrier_scheduler=enable_schedule,
+                sched_group_barrier_mfma_per_dwordx4=cover,
+                sched_group_barrier_required_region_count=required_regions,
+                reverse_local_assignment=reverse_local_assignment,
+                sink_insts_to_avoid_spills=kind == 1195,
+                regclass_priority_trumps_globalness=kind == 1195,
+                disable_unclustered_high_rp_reschedule=disable_high_rp_reschedule,
+                inductor_32bit_pointer_range=("arg_A", "arg_B", "out_ptr*"),
+            )
+            yield self._convert_config_to_template_kwargs(
+                triton_config, m, n, k, out_dtype
+            )
+            return
+
+
+@register_template_heuristic(
     gfx950_addmm_persistent_warppipe_template.uid,
     "cuda",
     register=IS_ROCM,
@@ -1693,7 +1837,78 @@ from torch._inductor.select_algorithm import (
     TritonTemplateCaller,
     TritonTemplateKernel,
 )
+from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 from torch._inductor.virtualized import V
+
+# TritonTemplate renders every config kwarg as a source-level constexpr, but
+# these AMD controls are also backend options consumed by triton.compile.  They
+# therefore do not appear in the runtime Config.kwargs that upstream's generic
+# backend-option extraction sees.  Copy the values from Inductor's preserved
+# template config into the dedicated backend_options dictionary.
+_TLX_AMD_BACKEND_OPTIONS = (
+    "matrix_instr_nonkdim",
+    "waves_per_eu",
+    "kpack",
+    "enable_sched_group_barrier_scheduler",
+    "sched_group_barrier_mfma_per_dwordx4",
+    "sched_group_barrier_required_region_count",
+    "reverse_local_assignment",
+    "sink_insts_to_avoid_spills",
+    "regclass_priority_trumps_globalness",
+    "disable_unclustered_high_rp_reschedule",
+)
+
+
+def _update_tlx_amd_compile_meta(compile_meta, config_args, device_type):
+    backend_options = dict(compile_meta.get("backend_options", {}))
+    for name in _TLX_AMD_BACKEND_OPTIONS:
+        if name in config_args:
+            backend_options[name] = config_args[name]
+
+    pointer_range_args = config_args.get("inductor_32bit_pointer_range", ())
+    backend_options.pop("inductor_32bit_pointer_range", None)
+    compile_meta["backend_options"] = backend_options
+    if device_type != "hip" or not pointer_range_args:
+        return compile_meta
+
+    signature = compile_meta["signature"]
+    pointer_range_names = set()
+    for arg_pattern in pointer_range_args:
+        matches = (
+            [name for name in signature if name.startswith(arg_pattern[:-1])]
+            if arg_pattern.endswith("*")
+            else [arg_pattern] if arg_pattern in signature else []
+        )
+        if len(matches) != 1:
+            raise AssertionError(
+                f"expected one signature argument for {arg_pattern}, got {matches}"
+            )
+        pointer_range_names.add(matches[0])
+
+    specialization = compile_meta["configs"][0]
+    for index, (name, ty) in enumerate(signature.items()):
+        if name not in pointer_range_names:
+            continue
+        if not isinstance(ty, str) or not ty.startswith("*"):
+            raise AssertionError(f"{name} must be a pointer argument, got {ty}")
+        attrs = specialization.setdefault((index,), [])
+        if ["tt.pointer_range", 32] not in attrs:
+            attrs.append(["tt.pointer_range", 32])
+    return compile_meta
+
+
+if not hasattr(CachingAutotuner, "_tlx_amd_backend_options"):
+    _orig_create_compile_meta = CachingAutotuner._create_compile_meta
+
+    def _tlx_create_compile_meta(self, cfg):  # type: ignore[no-untyped-def]
+        compile_meta = _orig_create_compile_meta(self, cfg)
+        config_args = self.inductor_meta.get("config_args", {})
+        return _update_tlx_amd_compile_meta(
+            compile_meta, config_args, self.device_props.type
+        )
+
+    CachingAutotuner._create_compile_meta = _tlx_create_compile_meta
+    CachingAutotuner._tlx_amd_backend_options = True
 
 # -- generate: inject split-K workspace_arg via the standard mechanism ------
 # The workspace_arg must flow through generate() so the autotuning benchmark
@@ -1809,10 +2024,48 @@ TritonTemplateKernel.__init__ = _tlx_ttk_init  # type: ignore[method-assign]
 
 # -- store_output: accept async_tma_store_buf_idx, set mode="async_tma" -----
 _orig_store_output = TritonTemplateKernel.store_output
+_orig_set_subgraph_body = TritonTemplateKernel.set_subgraph_body
+
+
+@contextlib.contextmanager
+def _tlx_set_subgraph_body(self, body_name):  # type: ignore[no-untyped-def]
+    """Restore TLX-specific state for one deferred store subgraph."""
+    previous_output_layout = getattr(self, "_tlx_output_layout", None)
+    layouts = getattr(self, "_tlx_output_layout_by_subgraph", {})
+    if body_name in layouts:
+        self._tlx_output_layout = layouts[body_name]
+    try:
+        with _orig_set_subgraph_body(self, body_name):
+            # TritonTemplate's range tree is shared by store_output hooks. Keep
+            # the fix local to TLX stores carrying an explicit output layout:
+            # restore the coordinate names captured for this fragment before
+            # Inductor lowers its fused epilogue.
+            index_states = getattr(
+                self, "_tlx_output_indices_by_subgraph", {}
+            )
+            if body_name in index_states:
+                names, lengths = index_states[body_name]
+                entries = self.range_trees[0].construct_entries(lengths)
+                if len(entries) != len(names):
+                    raise AssertionError(
+                        "TLX output index rank does not match output rank"
+                    )
+                for name, entry in zip(names, entries):
+                    old_symbol = entry.symbol()
+                    entry.set_name(name)
+                    if self.range_tree_nodes.get(old_symbol) is entry:
+                        del self.range_tree_nodes[old_symbol]
+                    self.range_tree_nodes[entry.symbol()] = entry
+            yield
+    finally:
+        self._tlx_output_layout = previous_output_layout
+
+
+TritonTemplateKernel.set_subgraph_body = _tlx_set_subgraph_body  # type: ignore[method-assign]
 
 
 def _tlx_store_output(  # type: ignore[no-untyped-def]
-    self, *args, async_tma_store_buf_idx=None, **kwargs
+    self, *args, async_tma_store_buf_idx=None, output_layout=None, **kwargs
 ):
     if getattr(self, "async_tma_store", False):
         if async_tma_store_buf_idx is not None:
@@ -1820,6 +2073,8 @@ def _tlx_store_output(  # type: ignore[no-untyped-def]
         # Signal the store override to use async TMA mode instead of
         # the regular TMA mode that OSS store_output will select.
         self._tlx_async_tma_store_active = True
+    previous_output_layout = getattr(self, "_tlx_output_layout", None)
+    self._tlx_output_layout = output_layout
     try:
         if not hasattr(V.interpreter, "current_node") and hasattr(
             V.graph, "current_node"
@@ -1828,10 +2083,34 @@ def _tlx_store_output(  # type: ignore[no-untyped-def]
             # the separate interpreter virtual is installed. CSEProxy still
             # needs the active FX node while rendering the addmm epilogue.
             with V.set_interpreter_handler(V.graph):
-                return _orig_store_output(self, *args, **kwargs)
-        return _orig_store_output(self, *args, **kwargs)
+                result = _orig_store_output(self, *args, **kwargs)
+        else:
+            result = _orig_store_output(self, *args, **kwargs)
+        if output_layout is not None:
+            layouts = getattr(self, "_tlx_output_layout_by_subgraph", None)
+            if layouts is None:
+                layouts = self._tlx_output_layout_by_subgraph = {}
+            layouts[result] = output_layout
+            block_indexing = kwargs.get(
+                "block_indexing", args[5] if len(args) > 5 else False
+            )
+            if not block_indexing:
+                index_states = getattr(
+                    self, "_tlx_output_indices_by_subgraph", None
+                )
+                if index_states is None:
+                    index_states = self._tlx_output_indices_by_subgraph = {}
+                index_states[result] = (
+                    tuple(self.template_indices),
+                    tuple(
+                        V.graph.sizevars.simplify(s)
+                        for s in self.output_node.get_size()
+                    ),
+                )
+        return result
     finally:
         self._tlx_async_tma_store_active = False
+        self._tlx_output_layout = previous_output_layout
 
 
 # Jinja template_env uses fn.__name__ to build the dict key — preserve it.
@@ -1843,6 +2122,42 @@ _orig_tk_store = TritonTemplateKernel.store
 
 
 def _tlx_store(self, name, index, value, mode=None):  # type: ignore[no-untyped-def]
+    output_layout = getattr(self, "_tlx_output_layout", None)
+    if mode is None and output_layout is not None:
+        # Explicitly laid-out TLX accumulators (for example an AMD MFMA
+        # accumulator) cannot be stored through Inductor's default blocked
+        # pointer encoding.  Keep the normal store_output epilogue generation,
+        # then align its final pointer, value, and mask at the store boundary.
+        var = self.args.output(name)
+        indexing = self.indexing(
+            index,
+            dense_indexing=True,
+            block_ptr=False,
+            tma_compatibility_checker=None,
+        )
+        if not hasattr(indexing, "index_str"):
+            raise AssertionError("output_layout requires tensor indexing")
+        if self._has_stride1_on_rdim(indexing.index):
+            self.stores_with_contiguous_rdim.append(name)
+        if name in self.args.inplace_buffers and self.is_broadcasted(index):
+            self.stores.writeline(DeferredLine(name, "tl.debug_barrier()"))
+
+        ptr = (
+            f"tlx.require_layout({var} + ({indexing.index_str}), "
+            f"{output_layout}, pin=False)"
+        )
+        stored_value = (
+            f"tlx.require_layout({value}, {output_layout}, pin=False)"
+        )
+        mask = indexing.mask_str
+        if mask != "None":
+            mask = f"tlx.require_layout({mask}, {output_layout}, pin=False)"
+        self.stores.writeline(
+            DeferredLine(name, f"tl.store({ptr}, {stored_value}, {mask})")
+        )
+        if not self.inside_reduction:
+            self.outside_loop_vars.add(value)
+        return
     if mode == "tma" and getattr(self, "_tlx_async_tma_store_active", False):
         # Redirect from regular TMA store to async TMA store.
         var = self.args.output(name)


### PR DESCRIPTION
Summary:

Expose the four validated gfx950 shared-LHS BMM kernels from D115625919 as additional TritonTemplate candidates for normal Inductor BMM autotuning, including fused output epilogues.

The generated template preserves each tuned dataflow: 64x256 MI32 for 40x256x1956, 128+16 row fragments for the 144x256 MI16 tile on 262x256x294, the explicit 7x5 stream decomposition for 448x160x931, and the 2x2 K64 pipeline for 1195x256x2309. It uses Inductor's def_kernel, size, stride, and store_output interfaces rather than calling the standalone tutorial entry point.

A ROCm-only heuristic offers the candidate only for fp16 gfx950 inputs with a dense shared LHS, strideA batch equal to zero, dense batched row-major B, one of the four validated shapes, and statically proven signed-32-bit byte ranges. Distinct-A, unsupported layouts, dynamic ranges that cannot be proven safe, and other shapes remain on the existing candidate set.

Forward the template's cache-keyed AMD options into Triton compilation, including MFMA geometry, schedule-group controls, register-assignment controls, and the statically guarded pointer-range specialization. These values are rendered as source constexprs by TritonTemplate and otherwise are not present in the generic runtime Config path. Each Inductor template keeps its separately measured schedule; copying the standalone schedule mechanically caused regressions as large as 46 percent.

Make multi-store epilogue fusion correct. The 448 template exposes its 7x5 accumulator grid through 35 store_output hooks. Inductor previously reused one mutable range tree across all hooks, so deferred epilogue lowering observed the coordinates assigned by the final fragment. A fused row-bias graph consequently loaded and stored every fragment with the last fragment's indices. SubgraphInfo now snapshots each hook's template index names and restores them before lowering that subgraph. TLX also records the explicit MFMA output layout per store subgraph so its final pointer, value, and mask retain the required layout. Single-store templates are unchanged.

Current MI350X base-BMM results use production shared-A strides. Values are the median of three independent process medians; ratios are baseline/TLX, so values above 1.0 mean TLX wins.

| B | MxNxK | TLX shared-A | Stock shared-A | Extern | Stock/TLX | Extern/TLX | Selected |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | --- |
| 1024 | 40x256x1956 | 209.60 us | 243.42 us | 221.88 us | 1.161x | 1.059x | TLX |
| 1024 | 262x256x294 | 115.70 us | 160.36 us | 110.44 us | 1.386x | 0.955x | Extern |
| 3072 | 448x160x931 | 734.47 us | 1285.25 us | 792.93 us | 1.750x | 1.080x | TLX |
| 1024 | 1195x256x2309 | 2034.94 us | 3036.07 us | 1920.98 us | 1.492x | 0.944x | Extern |

The candidate table is intentionally a base-BMM comparison. For the 3072x448x160x931 graph with a fused broadcast row bias, forced-choice end-to-end measurements include the complete graph:

| Full graph | Latency | Baseline/TLX |
| --- | ---: | ---: |
| TLX shared-A with fused bias | 935.13 us | 1.000x |
| Extern BMM plus pointwise epilogue | 1019.31 us | 1.090x |
| Stock shared-A with fused bias | 1286.74 us | 1.376x |

Normal autotuning selects TLX for the fused 448 graph. TLX reduces full-graph latency by 8.3 percent versus extern and 27.3 percent versus stock shared-A.

Reviewed By: marvinfan-prism, htyu

Differential Revision: D115751366


