### PR TITLE
[triton][3.8] Unify AutoWS barrier wait locations

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/Passes.td
@@ -217,6 +217,22 @@ def TritonNvidiaGPUInterleaveTMemPass : Pass<"triton-nvidia-interleave-tmem", "m
   }];
 }
 
+def TritonNvidiaGPUUnifyWSBarrierLocationsPass : Pass<"triton-nvidia-unify-ws-barrier-locations", "mlir::ModuleOp"> {
+  let summary = "Co-locate related AutoWS waits around cheap load preparation.";
+
+  let description = [{
+    The `triton-nvidia-unify-ws-barrier-locations` pass raises a later
+    AutoWS-generated wait next to an earlier wait when they guard a TMA load
+    and a TMEM load feeding the same consumer, and only cheap preparation work
+    separates them.
+  }];
+
+  let dependentDialects = ["mlir::triton::gpu::TritonGPUDialect",
+                           "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
+                           "mlir::triton::TritonDialect",
+                           "mlir::arith::ArithDialect"];
+}
+
 def TritonNvidiaGPUTestGenerateSubtiledRegionPass
     : Pass<"triton-nvidia-gpu-test-generate-subtiled-region", "mlir::ModuleOp"> {
   let summary = "Test pass: generate subtiled_region ops from split patterns";

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_triton_library(TritonNvidiaGPUTransforms
   TMALowering.cpp
   TMAStoreBufferReuse.cpp
   TMAUtilities.cpp
+  UnifyWSBarrierLocations.cpp
 
   DEPENDS
   TritonNvidiaGPUTransformsIncGen

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp
@@ -1,0 +1,134 @@
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "nvidia/hopper/include/Transforms/WSBarrierReorder.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
+#include "triton/Tools/Sys/GetEnv.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-nvidia-unify-ws-barrier-locations"
+
+namespace tt = mlir::triton;
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir::triton::nvidia_gpu {
+
+#define GEN_PASS_DEF_TRITONNVIDIAGPUUNIFYWSBARRIERLOCATIONSPASS
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h.inc"
+
+namespace {
+
+bool isAllowedRegionOp(Operation *op) {
+  return isa<ttg::LocalLoadOp, TMEMLoadOp, ttg::ConvertLayoutOp,
+             tt::BroadcastOp, arith::ExtFOp, arith::TruncFOp>(op);
+}
+
+bool isBarrierBookkeepingOp(Operation *op) {
+  if (isa<ttg::MemDescIndexOp, ttg::MemDescSubsliceOp,
+          ttg::MemDescReinterpretOp, ttg::MemDescTransOp,
+          ttg::MemDescReshapeOp>(op))
+    return true;
+  if (!isa<arith::ConstantOp, arith::ExtUIOp, arith::TruncIOp,
+           arith::XOrIOp, arith::AndIOp>(op) ||
+      op->getNumResults() != 1)
+    return false;
+  return isa<IntegerType, IndexType>(op->getResult(0).getType());
+}
+
+// Unification trades away overlap to buy register relief, and only one side of
+// that trade scales with size. The relief comes from materializing a broadcast
+// value after the awaited MMA lands instead of holding it live across the wait,
+// so it is proportional to the registers that value occupies. The cost -- the
+// preparation chain feeding the broadcast no longer overlaps MMA latency -- is
+// paid whatever the value's size. Below this threshold the pass would spend the
+// serialization and get nothing back, so a small broadcast does not qualify.
+//
+// The addmm epilogue this pass was measured on carries a 128x128xf32 bias tile
+// at 128 elements per thread, so the threshold sits well under the case that
+// motivated the pass while still excluding incidental broadcasts.
+constexpr unsigned kMinBroadcastElemsPerThread = 32;
+
+bool isRegisterHeavyBroadcast(Operation *op) {
+  auto broadcast = dyn_cast<tt::BroadcastOp>(op);
+  if (!broadcast)
+    return false;
+  auto type = dyn_cast<RankedTensorType>(broadcast.getResult().getType());
+  if (!type || !type.getEncoding())
+    return false;
+  return ttg::getTotalElemsPerThread(type) >= kMinBroadcastElemsPerThread;
+}
+
+bool canUnifyWaitLocations(WaitBarrierOp earlier, WaitBarrierOp later) {
+  if (earlier->getBlock() != later->getBlock() ||
+      !earlier->isBeforeInBlock(later))
+    return false;
+
+  Operation *insertPt = earlier->getNextNode();
+  if (!insertPt || wouldBreakOperandDominance(later, insertPt))
+    return false;
+
+  bool containsRegisterHeavyBroadcast = false;
+  for (Operation *op = insertPt; op != later.getOperation();
+       op = op->getNextNode()) {
+    if (!op || !canRaiseWSWaitPast(later, op))
+      return false;
+
+    if (isBarrierLikeOp(op))
+      continue;
+    if (!isAllowedRegionOp(op) && !isBarrierBookkeepingOp(op))
+      return false;
+    containsRegisterHeavyBroadcast |= isRegisterHeavyBroadcast(op);
+  }
+  return containsRegisterHeavyBroadcast;
+}
+
+bool unifyOneWaitPair(Block &block) {
+  SmallVector<WaitBarrierOp> waits;
+  for (Operation &op : block) {
+    auto wait = dyn_cast<WaitBarrierOp>(&op);
+    if (wait && hasWSBarrierConstraints(wait.getConstraints()))
+      waits.push_back(wait);
+  }
+
+  for (unsigned i = 0; i + 1 < waits.size(); ++i) {
+    WaitBarrierOp earlier = waits[i];
+    WaitBarrierOp later = waits[i + 1];
+    if (!canUnifyWaitLocations(earlier, later))
+      continue;
+    LLVM_DEBUG(llvm::dbgs() << "unifying adjacent WS wait regions\n");
+    later->moveAfter(earlier);
+    return true;
+  }
+  return false;
+}
+
+bool unifyBarrierLocations(Block &block) {
+  bool changed = false;
+  while (unifyOneWaitPair(block))
+    changed = true;
+  return changed;
+}
+
+} // namespace
+
+struct TritonNvidiaGPUUnifyWSBarrierLocationsPass
+    : public impl::TritonNvidiaGPUUnifyWSBarrierLocationsPassBase<
+          TritonNvidiaGPUUnifyWSBarrierLocationsPass> {
+  using impl::TritonNvidiaGPUUnifyWSBarrierLocationsPassBase<
+      TritonNvidiaGPUUnifyWSBarrierLocationsPass>::
+      TritonNvidiaGPUUnifyWSBarrierLocationsPassBase;
+
+  void runOnOperation() override {
+    if (triton::tools::getBoolEnv("TRITON_DISABLE_WSBARRIER_REORDER"))
+      return;
+
+    getOperation().walk([&](Block *block) {
+      if (!block->empty())
+        unifyBarrierLocations(*block);
+    });
+  }
+};
+
+} // namespace mlir::triton::nvidia_gpu

--- a/python/test/unit/language/test_autows_addmm.py
+++ b/python/test/unit/language/test_autows_addmm.py
@@ -356,6 +356,14 @@ def test_autows_addmm_hoist_convert_before_broadcast():
     assert "tt.descriptor_store" not in ttgir, "Expected descriptor stores to be lowered"
     assert "can_rotate_by_buffer_count" not in ttgir, "Expected TMA store wait rotation to be resolved"
 
+    unified_waits = re.search(
+        r"ttng\.wait_barrier[^\n]*dstTask = 3[^\n]*\n\s*"
+        r"ttng\.wait_barrier[^\n]*dstTask = 1[^\n]*\n\s*"
+        r"%[^\n]* = ttg\.local_load",
+        ttgir,
+    )
+    assert unified_waits, "Expected adjacent bias-TMA and accumulator-TMEM waits before the bias load"
+
     # Check that convert_layout on bias happens before broadcast (on 1xN, not MxN)
     cvt_before_bc = re.search(r"convert_layout.*tensor<1x\d+xf32.*\n.*tt\.broadcast.*tensor<1x\d+xf32", ttgir)
     bc_before_cvt = re.search(

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -642,6 +642,8 @@ class nvidia_knobs(base_knobs):
     # Default ON; set TRITON_ENABLE_INTERLEAVE_TMEM=0 to opt out for A/B
     # testing against the operand-D back-edge channel fix.
     enable_interleave_tmem: env_bool = env_bool("TRITON_ENABLE_INTERLEAVE_TMEM", True)
+    # Default ON; opt out with TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS=0.
+    enable_unify_ws_barrier_locations: env_bool = env_bool("TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS", True)
     enable_tileir: env_bool = env_bool("ENABLE_TILE")
     disable_budget_aware_layout_conversion: env_bool = env_bool("TRITON_DISABLE_BUDGET_AWARE_LAYOUT_CONVERSION")
     # Gate opt-in perf-benchmark tests (do_bench sweeps) so unit-test runs do

--- a/test/TritonNvidiaGPU/interleave_tmem.mlir
+++ b/test/TritonNvidiaGPU/interleave_tmem.mlir
@@ -344,6 +344,27 @@ tt.func @raise_wait_stops_at_non_ws_wait(
   tt.return
 }
 
+// A WS wait cannot be raised above an init_barrier. Nothing about init is
+// arrive-like, so the older hasArriveLikeSemantics fallthrough let the wait
+// cross it; routing raiseWSWaits through canRaiseWSWaitPast rejects every
+// barrier-like op instead, which keeps a wait from rising above the
+// initialization of the barrier it waits on. The tmem_load still sinks past
+// the init, so the expected order is init, load, wait.
+// CHECK-LABEL: @raise_wait_stops_at_init_barrier
+tt.func @raise_wait_stops_at_init_barrier(
+    %bar1: !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>,
+    %phase: i32) {
+  %alloc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  %unused = ttng.tmem_load %alloc : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear128>
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.tmem_load
+  // CHECK-NEXT: ttng.wait_barrier
+  // CHECK-SAME: WSBarrier
+  ttng.init_barrier %bar1, 1 : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  ttng.wait_barrier %bar1, %phase {constraints = {WSBarrier = {channelGraph = array<i32: 2>}}} : !ttg.memdesc<1xi64, #barrier_shared, #smem, mutable>
+  tt.return
+}
+
 // WS barriers cannot move past non-barrier ops with arrive-like semantics.
 // CHECK-LABEL: @no_reorder_across_arrive_like_op
 tt.func @no_reorder_across_arrive_like_op(

--- a/test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir
+++ b/test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir
@@ -1,0 +1,200 @@
+// RUN: triton-opt %s --triton-nvidia-unify-ws-barrier-locations --allow-unregistered-dialect | FileCheck %s
+// RUN: env TRITON_DISABLE_WSBARRIER_REORDER=1 triton-opt %s --triton-nvidia-unify-ws-barrier-locations --allow-unregistered-dialect | FileCheck %s --check-prefix=DISABLED
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 0, transposed = false, elementBitWidth = 16}>
+#barrier = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+// CHECK-LABEL: @unify_cast_broadcast
+// CHECK:       ttng.wait_barrier %{{.*}}, %{{.*}}, %{{.*}} {{.*}}dstTask = 3
+// CHECK-NEXT:  ttng.wait_barrier %{{.*}}, %{{.*}} {{.*}}dstTask = 1
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK-NEXT:  ttng.arrive_barrier
+// CHECK-NEXT:  %[[EXT:.*]] = arith.extf %[[BIAS]]
+// CHECK-NEXT:  %[[CVT:.*]] = ttg.convert_layout %[[EXT]]
+// CHECK-NEXT:  %[[BCAST:.*]] = tt.broadcast %[[CVT]]
+// CHECK:       %[[ACC:.*]] = ttng.tmem_load
+// CHECK-NEXT:  ttng.arrive_barrier
+// CHECK-NEXT:  arith.addf %[[ACC]], %[[BCAST]]
+// DISABLED-LABEL: @unify_cast_broadcast
+// DISABLED:       ttng.wait_barrier
+// DISABLED-NEXT:  ttg.local_load
+// DISABLED:       tt.broadcast
+// DISABLED-NEXT:  ttng.wait_barrier
+tt.func @unify_cast_broadcast(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  ttng.arrive_barrier %tma_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias_tile = tt.broadcast %bias_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  ttng.arrive_barrier %tmem_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %out = arith.addf %acc, %bias_tile : tensor<128x128xf32, #linear>
+  "use"(%out) : (tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// A broadcast small enough that hoisting the accumulator wait buys no register
+// relief does not qualify. The register saving scales with the broadcast value,
+// the lost overlap does not, so the waits stay where they are and the bias
+// preparation keeps covering MMA latency. Same shape as @unify_cast_broadcast
+// except the broadcast result is 1x128 (1 element per thread) rather than
+// 128x128 (128 per thread).
+// CHECK-LABEL: @keep_small_broadcast
+// CHECK:       ttng.wait_barrier %{{.*}}, %{{.*}}, %{{.*}} {{.*}}dstTask = 3
+// CHECK-NEXT:  ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+tt.func @keep_small_broadcast(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  ttng.arrive_barrier %tma_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_row = tt.broadcast %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #blocked>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  ttng.arrive_barrier %tmem_barrier, 1 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 4 : i32, minRegionId = 4 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  "use"(%acc) : (tensor<128x128xf32, #linear>) -> ()
+  "use"(%bias_row) : (tensor<1x128xf32, #blocked>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @unify_to_fixed_point
+// CHECK:       ttng.wait_barrier {{.*}}dstTask = 3
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 2
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+// CHECK-NEXT:  %[[BIAS0:.*]] = ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK:       %[[BIAS1:.*]] = ttg.local_load
+// CHECK:       tt.broadcast
+// CHECK:       ttng.tmem_load
+tt.func @unify_to_fixed_point() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer0 = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %bias_buffer1 = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias0 = ttg.local_load %bias_buffer0 : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias0_f32 = arith.extf %bias0 : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias0_layout = ttg.convert_layout %bias0_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias0_tile = tt.broadcast %bias0_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 2 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias1 = ttg.local_load %bias_buffer1 : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias1_f32 = arith.extf %bias1 : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias1_layout = ttg.convert_layout %bias1_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias1_tile = tt.broadcast %bias1_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  ttng.wait_barrier %barrier2, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  %sum0 = arith.addf %acc, %bias0_tile : tensor<128x128xf32, #linear>
+  %sum1 = arith.addf %sum0, %bias1_tile : tensor<128x128xf32, #linear>
+  "use"(%sum1) : (tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_region_without_broadcast
+// CHECK:       ttng.wait_barrier
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK-NEXT:  arith.extf %[[BIAS]]
+// CHECK-NEXT:  ttg.convert_layout
+// CHECK-NEXT:  ttng.wait_barrier
+tt.func @keep_region_without_broadcast() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  "use"(%bias_layout, %acc) : (tensor<1x128xf32, #linear>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_non_ws_barrier
+// CHECK:       ttng.wait_barrier {{.*}}dstTask = 3
+// CHECK-NEXT:  %[[BIAS:.*]] = ttg.local_load
+// CHECK:       %[[BCAST:.*]] = tt.broadcast
+// CHECK-NEXT:  ttng.wait_barrier
+// CHECK-NEXT:  ttng.wait_barrier {{.*}}dstTask = 1
+tt.func @keep_non_ws_barrier() {
+  %c0 = arith.constant 0 : i32
+  %barrier0 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %barrier1 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %plain_barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.wait_barrier %barrier0, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_tile = tt.broadcast %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<128x128xf32, #blocked>
+  ttng.wait_barrier %plain_barrier, %c0 : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %barrier1, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  "use"(%bias_tile, %acc) : (tensor<128x128xf32, #blocked>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+// CHECK-LABEL: @keep_substantive_work
+// CHECK:       ttng.wait_barrier
+// CHECK-NEXT:  ttg.local_load
+// CHECK:       arith.addf
+// CHECK-NEXT:  ttng.wait_barrier
+tt.func @keep_substantive_work(%desc: !tt.tensordesc<1x128xf16, #shared>) {
+  %c0 = arith.constant 0 : i32
+  %true = arith.constant true
+  %zero = arith.constant dense<0.0> : tensor<128x128xf32, #linear>
+  %tma_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %tmem_barrier = ttg.local_alloc {ttg.ws_generated_barrier} : () -> !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias_buffer = ttg.local_alloc : () -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  %accumulator = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+  ttng.barrier_expect %tma_barrier, 256, %true : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %bias_buffer, %tma_barrier, %true :
+    !tt.tensordesc<1x128xf16, #shared>, !ttg.memdesc<1xi64, #barrier, #smem, mutable> -> !ttg.memdesc<1x128xf16, #shared, #smem, mutable>
+  ttng.tc_gen5_commit %tmem_barrier : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  ttng.wait_barrier %tma_barrier, %c0, %true {constraints = {WSBarrier = {channelGraph = array<i32: 1, 3>, direction = "forward", dstTask = 3 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %bias = ttg.local_load %bias_buffer : !ttg.memdesc<1x128xf16, #shared, #smem, mutable> -> tensor<1x128xf16, #blocked>
+  %bias_f32 = arith.extf %bias : tensor<1x128xf16, #blocked> to tensor<1x128xf32, #blocked>
+  %bias_layout = ttg.convert_layout %bias_f32 : tensor<1x128xf32, #blocked> -> tensor<1x128xf32, #linear>
+  %bias_tile = tt.broadcast %bias_layout : tensor<1x128xf32, #linear> -> tensor<128x128xf32, #linear>
+  %work = arith.addf %zero, %zero : tensor<128x128xf32, #linear>
+  ttng.wait_barrier %tmem_barrier, %c0 {constraints = {WSBarrier = {channelGraph = array<i32: 2>, direction = "forward", dstTask = 1 : i32, maxRegionId = 2 : i32, minRegionId = 2 : i32, parentId = 1 : i32}}} : !ttg.memdesc<1xi64, #barrier, #smem, mutable>
+  %acc = ttng.tmem_load %accumulator : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+  %out = arith.addf %acc, %bias_tile : tensor<128x128xf32, #linear>
+  "use"(%out, %work) : (tensor<128x128xf32, #linear>, tensor<128x128xf32, #linear>) -> ()
+  tt.return
+}
+
+}

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -1025,6 +1025,8 @@ class CUDABackend(BaseBackend):
         nvidia.passes.ttnvgpuir.add_prune_unused_barriers(pm)
         if knobs.nvidia.enable_interleave_tmem:
             nvidia.passes.ttnvgpuir.add_interleave_tmem(pm)
+        if knobs.nvidia.enable_unify_ws_barrier_locations:
+            nvidia.passes.ttnvgpuir.add_unify_ws_barrier_locations(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
         passes.ttgpuir.add_reorder_instructions(pm)
         passes.ttir.add_loop_aware_cse(pm)

--- a/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
+++ b/third_party/nvidia/hopper/include/Transforms/WSBarrierReorder.h
@@ -125,6 +125,34 @@ inline bool wouldBreakOperandDominance(Operation *op, Operation *insertPt) {
   return false;
 }
 
+// Check the barrier-specific part of raising `wait` before `crossedOp`.
+// Profitability and non-barrier side-effect checks remain the caller's
+// responsibility.
+//
+// Safety against crossing an unrelated barrier rests on the WSBarrier
+// constraint metadata, not on comparing mbarrier values: a crossed arrive is
+// admitted only when canAdvanceWSBarrierArrivePastWait proves disjoint channel
+// graphs or a strict ordered-region precedence. An arrive on the very barrier
+// this wait is waiting on shares that wait's channel graph, so it fails
+// disjointness and, being in the same region, fails the ordering proof too.
+//
+// The isBarrierLikeOp rejection below is deliberately stricter than the
+// hasArriveLikeSemantics fallthrough it replaced in raiseWSWaits: it also
+// rejects InitBarrierOp, so a wait can never be raised above the
+// initialization of its own barrier.
+inline bool canRaiseWSWaitPast(WaitBarrierOp wait, Operation *crossedOp) {
+  if (crossedOp->getNumRegions() != 0)
+    return false;
+  if (auto otherWait = dyn_cast<WaitBarrierOp>(crossedOp))
+    return hasWSBarrierConstraints(otherWait.getConstraints());
+  if (auto arrive = dyn_cast<ArriveBarrierOp>(crossedOp))
+    return canAdvanceWSBarrierArrivePastWait(arrive.getConstraints(),
+                                             wait.getConstraints());
+  if (isBarrierLikeOp(crossedOp))
+    return false;
+  return !hasArriveLikeSemantics(crossedOp);
+}
+
 // Return the latest same-block operation that an arrive must follow when it is
 // restored near its associated memory op.
 inline Operation *getArriveAnchorAfterOperands(ArriveBarrierOp arrive,
@@ -193,7 +221,6 @@ inline bool raiseWSWaits(Block &block) {
       waits.push_back(wait);
 
   for (auto wait : llvm::reverse(waits)) {
-    auto constraints = wait.getConstraints();
     Operation *insertPt = wait.getOperation();
     for (auto *cur = wait->getPrevNode(); cur; cur = cur->getPrevNode()) {
       // Don't raise past the definition of any of our operands.
@@ -206,14 +233,7 @@ inline bool raiseWSWaits(Block &block) {
       }
       if (definesOperand)
         break;
-      if (auto otherWait = dyn_cast<WaitBarrierOp>(cur)) {
-        if (!hasWSBarrierConstraints(otherWait.getConstraints()))
-          break;
-      } else if (auto arrive = dyn_cast<ArriveBarrierOp>(cur)) {
-        if (!canAdvanceWSBarrierArrivePastWait(arrive.getConstraints(),
-                                               constraints))
-          break;
-      } else if (!canAdvanceWSBarrier(constraints, cur)) {
+      if (!canRaiseWSWaitPast(wait, cur)) {
         break;
       }
       insertPt = cur;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/BarrierConstraints.md
@@ -244,7 +244,8 @@ attribute directly (as currently defined). The two approaches can coexist:
 
 **Files:**
 - `nvidia/hopper/include/Transforms/WSBarrierReorder.h` — `canAdvanceWSBarrier`, `canAdvanceWSBarrierArrivePastWait`, `sinkWSArrives`, `raiseWSWaits`, `buildBarrierToMemoryOpMap`, `optimizeWSBarrierLocations`
-- `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp` — consumer of the above
+- `lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp` — liveness-oriented consumer of the above
+- `lib/Dialect/TritonNvidiaGPU/Transforms/UnifyWSBarrierLocations.cpp` — codegen-oriented wait co-location
 
 ### Motivation
 
@@ -283,6 +284,13 @@ before the existing tmem_load sinking. Four steps:
 4. **`optimizeWSBarrierLocations`** — After sinking, relocate each barrier
    back to an optimal position right next to its associated memory op
    (arrives after, waits before), respecting SSA dominance.
+
+5. **`triton-nvidia-unify-ws-barrier-locations`** — In the following pass,
+   identify AutoWS TMA-ready and TMEM-ready waits whose load chains meet at the
+   same consumer. Raise the later wait beside the earlier wait only when the
+   crossed range contains load preparation, broadcast/cast work, and barriers
+   accepted by the same channel-graph or ordered-region safety rules. See
+   [WS Barrier Location Unification](WSBarrierLocationUnification.md).
 
 ### `canAdvanceWSBarrier`
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/Overview.md
@@ -45,6 +45,13 @@ elementwise users. This keeps broadcasts and their value materialization, such
 as a descriptor load followed by an extend, associated with their use after
 other operands, such as TMEM loads, have been prepared.
 
+After physical AutoWS lowering, `triton-nvidia-interleave-tmem` chooses TMEM
+load locations for latency and register liveness. The immediately following
+`triton-nvidia-unify-ws-barrier-locations` pass can then co-locate a related
+TMA-ready wait and TMEM-ready wait when only load preparation, casts, and a
+broadcast separate them. See
+[WS Barrier Location Unification](WSBarrierLocationUnification.md).
+
 The TMA store wait pipeline is enabled by default and can be disabled with the
 `nvgpu-warp-specialization` pass option `tma-store-pipelining=false`. Disabling
 it skips wait annotation, annotation validation, and wait reordering; it does
@@ -98,6 +105,8 @@ recognizes the `scf.while` outer loop (same doc).
 | `WSTMAStoreLowering.cpp` | `doTMAStoreWaitReorder` | Reschedule TMA store waits using SWP CoarseSchedule |
 | `TMEMAlloc1D.cpp` | `TMEM1DAllocator` | 1D tensor memory allocation for cross-partition values |
 | `TMemBarrierInsertion.cpp` | `triton-nvidia-gpu-tmem-barrier-insertion` | Inserts CTA barriers for TMEM reuse and elides hazards proven warp-local; see [TMEMBarrierInsertion.md](TMEMBarrierInsertion.md) |
+| `InterleaveTMem.cpp` | `triton-nvidia-interleave-tmem` | Sinks TMEM allocations and loads, then restores their WS barriers |
+| `UnifyWSBarrierLocations.cpp` | `triton-nvidia-unify-ws-barrier-locations` | Co-locates related AutoWS TMA/TMEM waits around broadcast and cast preparation |
 | `CodePartitionUtility.cpp` | — | Channel data structures, operand D handling, barrier fusion, buffer management |
 | `Utility.cpp` | — | `AsyncTaskId` helpers, `OpBuilderWithAsyncTaskIds` |
 
@@ -147,6 +156,7 @@ recognizes the `scf.while` outer loop (same doc).
 - [Barrier Fusion](BarrierFusion.md) — TMA fusion, tcgen05_commit combining
 - [Barrier Constraints](BarrierConstraints.md) — generic barrier constraints and WSBarrier reordering metadata
 - [WS Barrier Ordered Region Tracking](WSBarrierOrderedRegionTracking.md) — V2 ordered-region metadata for overlapping channel graphs
+- [WS Barrier Location Unification](WSBarrierLocationUnification.md) — post-interleave co-location of related TMA-ready and TMEM-ready waits
 - [Reuse Groups](ReuseGroups.md) — buffer sharing mechanics
 - [Ping-Pong Scheduling](PingPongScheduling.md) — named barrier insertion for expensive ops
 - [Utilities](Utilities.md) — `OpBuilderWithAsyncTaskIds`, task ID helpers, location utilities

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/TMEMInterleave.md
@@ -101,21 +101,35 @@ and is blind to the durational pressure and latency exposure this pass targets;
 an integral over the liveness curve would subsume the old metric rather than
 trade against it.
 
-## Out of Scope: Reshaping Barriers for Codegen
+## Follow-up Barrier Placement
 
-The barrier movement described above is in scope. It exists to unblock legal
-TMEM movement, and every barrier still ends up near the memory operation it
-guards.
+After this pass restores each wait beside its guarded load,
+`triton-nvidia-unify-ws-barrier-locations` may raise a related AutoWS wait to a
+common location when only load preparation, casts, and broadcast work separate
+the waits. See
+[WS Barrier Location Unification](WSBarrierLocationUnification.md).
 
-What is out of scope is reshaping barrier placement to unlock a downstream
-codegen optimization. The motivating example is hoisting several
-`ttng.wait_barrier` ops to a common program point so that a value broadcast to
-their consumers becomes optimizable in PTX. That is driven by codegen quality
-rather than by TMEM liveness or MMA latency, and on a given block the two
-objectives can pull in opposite directions: the placement that best exposes a
-broadcast is not generally the placement that best distances a load from its
-producer. Handle it in future work on barrier placement rather than adding
-cases here.
+An earlier revision of this document declared that reshaping barriers for
+codegen was out of scope, on the grounds that the placement which best exposes
+a broadcast to ptxas is not generally the placement which best distances a load
+from its producer. The observation stands: on a block where both apply, the two
+objectives really can want different placements. What has changed is that there
+is now a basis for deciding between them.
+
+Running the unification pass second does not by itself resolve anything — it
+just means the codegen objective always wins where it applies. The resolution
+is that "where it applies" is now narrow. Unification requires a broadcast
+whose result is register-heavy, because that is the only case where the
+register relief it buys outweighs the MMA-latency overlap it gives up. On the
+`addmm` epilogue that motivated it, that trade removed a 23 KB spill, which is
+a larger effect than the scheduling distance this pass gives up on the same
+block. Where the broadcast is small, unification declines and this pass's
+placement stands.
+
+So the conflict is decided in favor of codegen only on measured evidence, and
+only for the shape of block where that evidence applies. If a case turns up
+where the distance mattered more despite a large broadcast, the floor in
+unification is the knob to revisit — not the ordering of the two passes.
 
 ## Testing
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierLocationUnification.md
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/docs/WSBarrierLocationUnification.md
@@ -1,0 +1,140 @@
+# WS Barrier Location Unification
+
+`triton-nvidia-unify-ws-barrier-locations` co-locates related AutoWS wait
+barriers when the instructions separating them are too small to form a useful
+scheduling region. The initial use case is an epilogue that combines a
+broadcast bias with an MMA accumulator.
+
+The pass runs immediately after `triton-nvidia-interleave-tmem`. TMEM
+interleaving first chooses load locations for latency and register liveness;
+barrier unification then adjusts only the waits to expose one region to PTX
+scheduling.
+
+## Motivation
+
+After TMEM interleaving, a one-dimensional-bias `addmm` epilogue can have this
+shape:
+
+```mlir
+ttng.wait_barrier %bias_ready, %bias_phase
+%bias = ttg.local_load %bias_smem
+ttng.arrive_barrier %bias_empty, 1
+%bias_f32 = arith.extf %bias
+%bias_layout = ttg.convert_layout %bias_f32
+%bias_tile = tt.broadcast %bias_layout
+ttng.wait_barrier %acc_ready, %acc_phase
+%acc = ttng.tmem_load %accumulator
+ttng.arrive_barrier %acc_empty, 1
+%out = arith.addf %acc, %bias_tile
+```
+
+There is no substantive independent work between the waits. Keeping them
+separate can prevent ptxas from scheduling the broadcast and accumulator add
+as one region, while extending the lifetime of the broadcast value. The pass
+raises the later wait next to the earlier wait:
+
+```mlir
+ttng.wait_barrier %bias_ready, %bias_phase
+ttng.wait_barrier %acc_ready, %acc_phase
+%bias = ttg.local_load %bias_smem
+...
+%bias_tile = tt.broadcast %bias_layout
+%acc = ttng.tmem_load %accumulator
+...
+%out = arith.addf %acc, %bias_tile
+```
+
+Both barriers remain distinct. Their operands, phases, predicates,
+constraints, and corresponding arrive operations are unchanged.
+
+### The Trade
+
+This is not a free win, and the two sides of it do not scale together.
+
+What is gained is register relief, and it is proportional to the size of the
+broadcast value. In the original order `%bias_tile` is materialized before
+`%acc_ready` is awaited, so it stays live across that wait; afterwards it is
+produced only once the MMA has landed and lives just as far as the `addf`. On
+the measured `addmm` epilogue that value is a `128x128xf32` bias tile at 128
+elements per thread, and removing it from the wait's live range is what
+eliminates the spill.
+
+What is lost is overlap, and that cost is the same at any size. Before the
+move, `local_load` → `extf` → `convert_layout` → `broadcast` runs while the
+MMA is still in flight. After it, the consumer blocks on the accumulator
+before doing any bias preparation at all, so that chain no longer hides MMA
+latency.
+
+For a large broadcast the relief dominates. For a small one there is no
+meaningful relief and the serialization is pure loss, which is why eligibility
+carries a minimum broadcast size rather than firing on the shape alone.
+
+## Candidate Recognition
+
+The pass operates within one basic block. It collects waits carrying
+`constraints.WSBarrier` and examines consecutive pairs in program order. A
+pair is eligible only when:
+
+- every operation between the waits is an allowed load, broadcast, or cast;
+- every intervening barrier is also a `WSBarrier` and passes the barrier-order
+  proof;
+- the later wait's operands dominate the earlier insertion point; and
+- the interval contains a `tt.broadcast` whose result is at least
+  `kMinBroadcastElemsPerThread` (32) elements per thread.
+
+The size floor is what keeps the pass on the side of the trade described
+above. A `tt.broadcast` alone is a shape-only signal: it identifies the PTXAS
+optimization opportunity but says nothing about how many registers the hoist
+frees, while the overlap it costs is unconditional. Requiring a register-heavy
+result means the pass fires on the case it was measured on and declines the
+ones where it would only serialize. The `128x128xf32` bias tile that motivated
+the pass sits at 128 elements per thread, so the floor leaves a wide margin.
+
+After moving one wait, the pass rescans the block. This continues until no
+consecutive pair can be unified, allowing a sequence of compatible regions to
+collapse to one wait location.
+
+## Profitability Rule
+
+The first version deliberately uses a narrow allowlist between the two waits:
+
+- `ttg.local_load` and `ttng.tmem_load`;
+- `ttg.convert_layout`;
+- `tt.broadcast`;
+- `arith.extf` and `arith.truncf`;
+- memdesc views and scalar integer barrier-phase bookkeeping; and
+- WS barrier operations that pass the movement proof.
+
+At least one `tt.broadcast` must be present. Loads and casts alone do not make
+a region profitable. Arithmetic, reductions, unknown side effects, and every
+other operation keep the waits separate.
+
+## Safety
+
+The later wait is moved immediately after the earlier wait only if all of its
+operands already dominate that location. Every crossed operation is checked:
+
+- regions and unsupported barrier-like operations reject the move;
+- another wait must carry `WSBarrier` constraints;
+- crossing an arrive requires
+  `canAdvanceWSBarrierArrivePastWait`, using either disjoint channel graphs or
+  the ordered-region proof;
+- TMA, MMAv5, `tc_gen5_commit`, and other arrive-like operations reject the
+  move; and
+- any operation outside the explicit profitability allowlist rejects the
+  move.
+
+The pass moves only the later wait. Loads and arrive/release endpoints retain
+the locations chosen by TMEM interleaving, preserving buffer and TMEM reuse
+lifetimes.
+
+## Pipeline and Controls
+
+The NVIDIA backend schedules the pass directly after
+`triton-nvidia-interleave-tmem` and before generic data-duplication and
+instruction-reordering passes. It is enabled independently by default; set
+`TRITON_ENABLE_UNIFY_WS_BARRIER_LOCATIONS=0` to disable it. The pass also
+honors `TRITON_DISABLE_WSBARRIER_REORDER=1`.
+
+Focused coverage is in
+`test/TritonNvidiaGPU/unify_ws_barrier_locations.mlir`.

--- a/third_party/nvidia/triton_nvidia.cc
+++ b/third_party/nvidia/triton_nvidia.cc
@@ -218,6 +218,8 @@ void init_triton_nvidia_passes_ttnvgpuir(py::module &&m) {
                      ttng::createTritonNvidiaGPUOptimizeTMemLayoutsPass);
   ADD_PASS_WRAPPER_0("add_interleave_tmem",
                      ttng::createTritonNvidiaGPUInterleaveTMemPass);
+  ADD_PASS_WRAPPER_0("add_unify_ws_barrier_locations",
+                     ttng::createTritonNvidiaGPUUnifyWSBarrierLocationsPass);
   ADD_PASS_WRAPPER_0("add_prune_unused_barriers",
                      ttng::createTritonNvidiaGPUPruneUnusedBarriersPass);
   ADD_PASS_WRAPPER_0("add_clc_split", ttng::createTritonNvidiaGPUCLCSplitPass);


### PR DESCRIPTION
Summary:
Port D117430071 to the Triton 3.8 snapshot. Add a dedicated pass that repeatedly co-locates compatible AutoWS waits across load preparation, casts, and broadcasts when the region contains a PTX-optimizable broadcast. Register it behind its own default-enabled knob after InterleaveTMem.

Authored with Claude.

Reviewed By: fengxizhou

Differential Revision: D117484321


