### PR TITLE
[autoWS] Model pure 2CTA MMA rendezvous as relaxed

### DIFF
--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -25,9 +25,14 @@ struct MemEffectsOpInfo {
   // wait publishes those op-local writes and nothing else. Use this for PTX ops
   // that perform the write and also signal the barrier via
   // `mbarrier::complete_tx`.
+  //
+  // CountOnly updates the barrier's arrival count and phase without attaching
+  // any memory or proxy frontier. Use this for relaxed control rendezvous,
+  // which do not release prior accesses to a waiter.
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
+    CountOnly,
   };
   struct Effects {
     enum RW { Read, Write } rw;

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -611,7 +611,10 @@ def TTNG_ArriveBarrierOp
     and the barrier must have the identity CGA layout `[[1], [2], ...]`. The
     default value of `ctaMask` is 0 (no multicast).
 
-    The operation accepts an optional predicate.
+    The operation accepts an optional predicate. `relaxed` may be used for a
+    pure cross-CTA control rendezvous which does not publish memory to another
+    CTA. PTX 8.6 and later encode this explicitly; earlier PTX versions retain
+    the unqualified arrival used for physical-cluster barriers.
 
     Example:
 
@@ -626,7 +629,7 @@ def TTNG_ArriveBarrierOp
       (ins Arg<TTG_MemDescType,
                "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
           I32Attr:$count, DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
-          Optional<I1>:$pred, UnitAttr:$perThread,
+          Optional<I1>:$pred, UnitAttr:$perThread, UnitAttr:$relaxed,
           OptionalAttr<DictionaryAttr>:$constraints);
 
   let assemblyFormat = [{
@@ -635,28 +638,28 @@ def TTNG_ArriveBarrierOp
 
   let builders =
       [OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "uint32_t":$ctaMask,
                      "Value":$pred),
                  [{
-      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "bool":$perThread), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread, "DictionaryAttr":$constraints),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, constraints);
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, constraints);
     }]>];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -328,8 +328,11 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = arriveOp.getPred();
+      auto mode = arriveOp.getRelaxed()
+                      ? MemEffectsOpInfo::BarrierTrackingMode::CountOnly
+                      : MemEffectsOpInfo::BarrierTrackingMode::Frontier;
       info->barriers.push_back(
-          {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
+          {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount(), mode});
     }
     auto baseInfo = ConSanTargetHooks::getMemEffectsOpInfo(op);
     if (!info)

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -139,6 +139,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
     tt.return
   }
 
+  // CHECK-LABEL: arrive_barrier_remote_relaxed
+  // CHECK: mbarrier.arrive.shared::cluster.b64
+  // PTX85-LABEL: arrive_barrier_remote_relaxed
+  // PTX85: mbarrier.arrive.shared::cluster.b64
+  // PTX86-LABEL: arrive_barrier_remote_relaxed
+  // PTX86: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  // PTX88-LABEL: arrive_barrier_remote_relaxed
+  // PTX88: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  tt.func @arrive_barrier_remote_relaxed(%alloc: !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>, %pred: i1) {
+    ttng.arrive_barrier %alloc, 2, %pred {relaxed} : !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>
+    tt.return
+  }
+
   // CHECK-LABEL: arrive_barrier_per_thread_remote
   tt.func @arrive_barrier_per_thread_remote(%alloc: !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>) {
     // CHECK-NOT: nvvm.read.ptx.sreg.tid.x

--- a/test/Hopper/TwoCTA/insert_2cta_sync.mlir
+++ b/test/Hopper/TwoCTA/insert_2cta_sync.mlir
@@ -23,7 +23,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: scf.for
     // CHECK:   nvg.cluster_id
     // CHECK:   ttng.map_to_remote_buffer
-    // CHECK:   ttng.arrive_barrier
+    // CHECK:   ttng.arrive_barrier {{.*}} {relaxed}
     // CHECK:   ttng.wait_barrier
     // CHECK:   ttng.tc_gen5_mma
     scf.for %iv = %c0 to %c4 step %c1 {

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -828,6 +828,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#relaxed_data = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+#relaxed_writer = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#relaxed_reader = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // A relaxed arrive remains a real barrier arrival, but must not make any
+  // preceding access visible to the peer CTA. This preserves the runtime
+  // visibility check that reports a race if relaxed is misused for publishing.
+  // CHECK-LABEL: @relaxed_arrive_is_count_only
+  tt.func public @relaxed_arrive_is_count_only() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %values = arith.constant dense<1> : tensor<8x32xi32, #relaxed_writer>
+    %buf = ttg.local_alloc %values {allocation.offset = 0 : i32} : (tensor<8x32xi32, #relaxed_writer>) -> !ttg.memdesc<8x32xi32, #relaxed_data, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: ttng.init_barrier
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
+    // CHECK-NOT: tt.call @__triton_consan_track_proxy_accesses
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tti.experimental_lock_release
+    // CHECK: ttng.arrive_barrier {{.*}} {relaxed}
+    ttng.arrive_barrier %bar, 1, %true {relaxed} : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // The matching wait still completes, but transfers an empty frontier.
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: ttng.wait_barrier
+    // CHECK: tt.call @__triton_consan_transfer_visible_writes
+    // CHECK: tt.call @__triton_consan_transfer_visible_reads
+    // The reader layout reaches both CTA rows. The retained visibility check
+    // reports the missing peer publication at runtime.
+    // CHECK: %[[READ_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[READ_CTAS]]
+    // CHECK: ttg.local_load
+    %value = ttg.local_load %buf : !ttg.memdesc<8x32xi32, #relaxed_data, #smem, mutable> -> tensor<8x32xi32, #relaxed_reader>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -203,7 +203,12 @@ static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
       builder, loc, remoteBarType, barrierView, leaderRank);
 
   // Both CTAs arrive on leader's barrier (count=1 each, total=2).
-  ttng::ArriveBarrierOp::create(builder, loc, remoteBar, /*count=*/1u);
+  auto arrive =
+      ttng::ArriveBarrierOp::create(builder, loc, remoteBar, /*count=*/1u);
+  // This barrier only rendezvous the two CTAs before issuing a 2-CTA MMA. The
+  // operands have their own completion barriers, so there is no memory to
+  // publish here. A release.cluster arrive serializes the inner K loop.
+  arrive.setRelaxed(true);
 
   // Compute phase from iterations within the barrier's lifetime.
   // WaitBarrierOp expects I32 for the phase parameter.

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -490,6 +490,11 @@ struct ArriveBarrierOpConversion
       auto emitArrive = [&](Value targetBarrier, Value multicastMask = {}) {
         std::stringstream ptxAsm;
         ptxAsm << "@$0 mbarrier.arrive.";
+        bool needsClusterScope =
+            isCrossClusterBarrier || isRemoteBarrier || op.isMulticast();
+        if (needsClusterScope && op.getRelaxed() &&
+            targetInfo->getPtxVersion() >= 86)
+          ptxAsm << "relaxed.cluster.";
         ptxAsm << (isRemoteBarrier || isCrossClusterBarrier || op.isMulticast()
                        ? "shared::cluster"
                        : "shared::cta");


### PR DESCRIPTION
## Summary

- mark only `Insert2CTASync`'s pure pre-MMA 2CTA rendezvous as `relaxed`
- emit the explicit PTX 8.6+ `mbarrier.arrive.relaxed.cluster` spelling while retaining current main's unqualified arrival on older PTX
- model the relaxed arrival in ConSan as count/phase synchronization without publishing a memory frontier

The A/B producer-consumer barriers are unchanged. They still carry operand visibility and must not use this attribute.

Current main already emits unqualified physical-cluster arrivals after #3509, so this rebased PR does not claim a runtime speedup. Its remaining scope is to encode the rendezvous intent explicitly and make ConSan's visibility model match that intent.

## Validation

- native build
- `test/Conversion/tritonnvidiagpu_to_llvm.mlir`
- `test/Hopper/TwoCTA/insert_2cta_sync.mlir`
- `test/TritonGPU/consan.mlir`
- B200 production-shape correctness: max absolute error `16`, relative L2 error `3.46e-4`
- generated executable SASS instruction stream is identical to current main for the measured kernel

## B200 performance

BF16 `(256, 939505) @ (939505, 424)`, split 37, complete Triton 2CTA partial-plus-reduction plan; 200 warmup and 1000 measured iterations:

| current main | this PR | direct ATen | PR vs main |
|---:|---:|---:|---:|
| 0.5869 ms | 0.5888 ms | 0.4229 ms | +0.3% (noise) |

This should be reviewed as an IR/sanitizer semantics change, not as a performance optimization. If an explicit distinction between control rendezvous and publication barriers is not useful to the compiler, the PR is superseded by current main and can be closed.
