### PR TITLE
[autoWS] Prioritize descriptor-fed computed MMA operands

### DIFF
--- a/test/Hopper/WarpSpecialization/ws_memory_planner_computed_mma_operand.mlir
+++ b/test/Hopper/WarpSpecialization/ws_memory_planner_computed_mma_operand.mlir
@@ -1,0 +1,118 @@
+// RUN: triton-opt %s --nvgpu-test-ws-memory-planner="num-buffers=4 smem-alloc-algo=1 smem-budget=232448 reserve-auxiliary-smem=1" | FileCheck %s
+
+// A computed BF16 operand fed by two FP32 descriptor scratch tiles is cheaper
+// to pipeline than retaining the raw source tiles. Reserve the requested four
+// copies before growing the output TMA staging ring.
+// CHECK-LABEL: @triton_tem_fused__to_copy_mm_mul_sigmoid_0
+// CHECK: ttg.local_alloc {buffer.copy = 4 : i32, buffer.id = [[BID:[0-9]+]] : i32} : () -> !ttg.memdesc<64x128xbf16
+// CHECK-COUNT-2: ttg.local_alloc {{.*}}buffer.copy = 2 : i32{{.*}}buffer.tmaStaging = 1 : i32{{.*}}!ttg.memdesc<128x64xf32
+// CHECK: ttg.local_alloc {buffer.copy = 2 : i32, buffer.id = {{[0-9]+}} : i32} : () -> !ttg.memdesc<64x128xbf16
+// CHECK-COUNT-2: ttg.local_alloc {buffer.copy = 1 : i32, buffer.id = {{[0-9]+}} : i32} : () -> !ttg.memdesc<64x128xf32
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4, 2], threadsPerWarp = [2, 16, 1], warpsPerCTA = [8, 1, 1], order = [2, 1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [16, 0]], warp = [[32, 0], [64, 0], [0, 64]], block = []}>
+#linear1 = #ttg.linear<{register = [[0, 0, 1], [0, 0, 2], [0, 0, 4], [0, 0, 8], [0, 0, 16], [0, 0, 32]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 1, 0]], block = []}>
+#linear2 = #ttg.linear<{register = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]], lane = [[1, 0, 0], [2, 0, 0], [4, 0, 0], [8, 0, 0], [16, 0, 0]], warp = [[32, 0, 0], [64, 0, 0], [0, 0, 1]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared2 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.cluster-dim-x" = 1 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, ttg.early_tma_store_lowering = true, ttg.min_reg_auto_ws = 24 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @triton_tem_fused__to_copy_mm_mul_sigmoid_0(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf32, #shared1, #smem, mutable>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<128x64xf32, #shared1, #smem, mutable>
+    %3 = ttg.local_alloc : () -> !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+    %4 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf32, #shared1, #smem, mutable>
+    %5 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf32, #shared1, #smem, mutable>
+    %false = arith.constant {async_task_id = array<i32: 1>} false
+    %true = arith.constant {async_task_id = array<i32: 0, 1>} true
+    %c1_i64 = arith.constant {async_task_id = array<i32: 2, 3>} 1 : i64
+    %c256_i64 = arith.constant {async_task_id = array<i32: 2, 3>} 256 : i64
+    %c256_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 256 : i32
+    %c18816_i32 = arith.constant {async_task_id = array<i32: 2>} 18816 : i32
+    %c939505_i32 = arith.constant {async_task_id = array<i32: 3>} 939505 : i32
+    %c128_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 128 : i32
+    %c8_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 8 : i32
+    %c2_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 2 : i32
+    %c64_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 64 : i32
+    %c128_i64 = arith.constant {async_task_id = array<i32: 3>} 128 : i64
+    %c0_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 0 : i32
+    %c1_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 1 : i32
+    %c16_i32 = arith.constant {async_task_id = array<i32: 2, 3>} 16 : i32
+    %c100_i32 = arith.constant {async_task_id = array<i32: 0, 1, 2, 3>} 100 : i32
+    %c6400_i32 = arith.constant {async_task_id = array<i32: 3>} 6400 : i32
+    %cst = arith.constant {async_task_id = array<i32: 0>} dense<1.000000e+00> : tensor<64x128xf32, #blocked>
+    %cst_0 = arith.constant {async_task_id = array<i32: 0>} dense<0.000000e+00> : tensor<128x128xf32, #linear>
+    %6 = tt.make_tensor_descriptor %arg3, [%c18816_i32, %c256_i32], [%c256_i64, %c1_i64] {async_task_id = array<i32: 2>} : !tt.ptr<f32>, !tt.tensordesc<128x64xf32, #shared1>
+    %7 = tt.make_tensor_descriptor %arg1, [%c939505_i32, %c256_i32], [%c256_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f32>, !tt.tensordesc<64x128xf32, #shared1>
+    %8 = tt.make_tensor_descriptor %arg2, [%c939505_i32, %c256_i32], [%c256_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<f32>, !tt.tensordesc<64x128xf32, #shared1>
+    %9 = tt.get_program_id y {async_task_id = array<i32: 2, 3>} : i32
+    %10 = arith.muli %9, %c6400_i32 {async_task_id = array<i32: 3>} : i32
+    %11 = tt.make_tensor_descriptor %arg0, [%c939505_i32, %c128_i32], [%c128_i64, %c1_i64] {async_task_id = array<i32: 3>} : !tt.ptr<bf16>, !tt.tensordesc<64x128xbf16, #shared>
+    %12 = tt.get_program_id x {async_task_id = array<i32: 0, 1, 2, 3>} : i32
+    %13 = arith.subi %12, %c2_i32 {async_task_id = array<i32: 2>} : i32
+    %14 = arith.muli %9, %c128_i32 {async_task_id = array<i32: 2>} : i32
+    %15 = scf.for %arg4 = %12 to %c2_i32 step %c2_i32 iter_args(%arg5 = %13) -> (i32)  : i32 {
+      %16 = arith.divsi %arg4, %c16_i32 {async_task_id = array<i32: 3>} : i32
+      %17 = arith.muli %16, %c8_i32 {async_task_id = array<i32: 3>} : i32
+      %18 = arith.subi %c1_i32, %17 {async_task_id = array<i32: 3>} : i32
+      %19 = arith.minsi %18, %c8_i32 {async_task_id = array<i32: 3>} : i32
+      %20 = arith.remsi %arg4, %19 {async_task_id = array<i32: 3>} : i32
+      %21 = arith.addi %17, %20 {async_task_id = array<i32: 3>} : i32
+      %22 = arith.remsi %arg4, %c16_i32 {async_task_id = array<i32: 3>} : i32
+      %23 = arith.divsi %22, %19 {async_task_id = array<i32: 3>} : i32
+      %24 = arith.muli %21, %c128_i32 {async_task_id = array<i32: 3>} : i32
+      %25 = arith.muli %23, %c128_i32 {async_task_id = array<i32: 3>} : i32
+      %26:2 = scf.for %arg6 = %c0_i32 to %c100_i32 step %c1_i32 iter_args(%arg7 = %false, %arg8 = %token) -> (i1, !ttg.async.token)  : i32 {
+        %45 = arith.muli %arg6, %c64_i32 {async_task_id = array<i32: 3>, loop.cluster = 3 : i32, loop.stage = 0 : i32} : i32
+        %46 = arith.addi %10, %45 {async_task_id = array<i32: 3>, loop.cluster = 3 : i32, loop.stage = 0 : i32} : i32
+        nvws.descriptor_load %11[%46, %24] 16384 %3 {async_task_id = array<i32: 3>, loop.cluster = 3 : i32, loop.stage = 0 : i32, multicast = false} : !tt.tensordesc<64x128xbf16, #shared>, i32, i32, !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+        nvws.descriptor_load %7[%46, %25] 32768 %4 {async_task_id = array<i32: 3>, loop.cluster = 3 : i32, loop.stage = 0 : i32, multicast = false} : !tt.tensordesc<64x128xf32, #shared1>, i32, i32, !ttg.memdesc<64x128xf32, #shared1, #smem, mutable>
+        %47 = ttg.local_load %4 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : !ttg.memdesc<64x128xf32, #shared1, #smem, mutable> -> tensor<64x128xf32, #blocked>
+        nvws.descriptor_load %8[%46, %25] 32768 %5 {async_task_id = array<i32: 3>, loop.cluster = 3 : i32, loop.stage = 0 : i32, multicast = false} : !tt.tensordesc<64x128xf32, #shared1>, i32, i32, !ttg.memdesc<64x128xf32, #shared1, #smem, mutable>
+        %48 = ttg.local_load %5 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : !ttg.memdesc<64x128xf32, #shared1, #smem, mutable> -> tensor<64x128xf32, #blocked>
+        %49 = arith.negf %48 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked>
+        %50 = math.exp %49 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked>
+        %51 = arith.addf %50, %cst {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked>
+        %52 = arith.divf %cst, %51 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked>
+        %53 = arith.mulf %47, %52 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked>
+        %54 = arith.truncf %53 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xf32, #blocked> to tensor<64x128xbf16, #blocked>
+        ttg.local_store %54, %0 {async_task_id = array<i32: 0>, loop.cluster = 0 : i32, loop.stage = 3 : i32} : tensor<64x128xbf16, #blocked> -> !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>
+        %55 = ttg.memdesc_trans %3 {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 3 : i32, order = array<i32: 1, 0>} : !ttg.memdesc<64x128xbf16, #shared, #smem, mutable> -> !ttg.memdesc<128x64xbf16, #shared2, #smem, mutable>
+        %56 = ttng.tc_gen5_mma %55, %0, %result[%arg8], %arg7, %true {async_task_id = array<i32: 1>, loop.cluster = 0 : i32, loop.stage = 3 : i32, tt.self_latency = 0 : i32} : !ttg.memdesc<128x64xbf16, #shared2, #smem, mutable>, !ttg.memdesc<64x128xbf16, #shared, #smem, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+        scf.yield {async_task_id = array<i32: 0, 1>} %true, %56 : i1, !ttg.async.token
+      } {async_task_id = array<i32: 0, 1, 2, 3>, tt.scheduled_max_stage = 3 : i32}
+      %27 = arith.addi %arg5, %c2_i32 {async_task_id = array<i32: 2>} : i32
+      %28 = arith.divsi %27, %c16_i32 {async_task_id = array<i32: 2>} : i32
+      %29 = arith.muli %28, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %30 = arith.subi %c1_i32, %29 {async_task_id = array<i32: 2>} : i32
+      %31 = arith.minsi %30, %c8_i32 {async_task_id = array<i32: 2>} : i32
+      %32 = arith.remsi %27, %31 {async_task_id = array<i32: 2>} : i32
+      %33 = arith.addi %29, %32 {async_task_id = array<i32: 2>} : i32
+      %34 = arith.remsi %27, %c16_i32 {async_task_id = array<i32: 2>} : i32
+      %35 = arith.divsi %34, %31 {async_task_id = array<i32: 2>} : i32
+      %36 = arith.muli %33, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %37 = arith.muli %35, %c128_i32 {async_task_id = array<i32: 2>} : i32
+      %result_1, %token_2 = ttng.tmem_load %result[%26#1] {async_task_id = array<i32: 0>} : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #linear>
+      %38 = tt.reshape %result_1 {async_task_id = array<i32: 0>} : tensor<128x128xf32, #linear> -> tensor<128x2x64xf32, #linear1>
+      %39 = tt.trans %38 {async_task_id = array<i32: 0>, order = array<i32: 0, 2, 1>} : tensor<128x2x64xf32, #linear1> -> tensor<128x64x2xf32, #linear2>
+      %40 = ttg.convert_layout %39 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #linear2> -> tensor<128x64x2xf32, #blocked1>
+      %outLHS, %outRHS = tt.split %40 {async_task_id = array<i32: 0>} : tensor<128x64x2xf32, #blocked1> -> tensor<128x64xf32, #blocked2>
+      %41 = arith.addi %14, %36 {async_task_id = array<i32: 2>} : i32
+      ttg.local_store %outLHS, %1 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> -> !ttg.memdesc<128x64xf32, #shared1, #smem, mutable>
+      %42 = ttng.async_tma_copy_local_to_global %6[%41, %37] %1 {async_task_id = array<i32: 2>} : !tt.tensordesc<128x64xf32, #shared1>, !ttg.memdesc<128x64xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %42   {async_task_id = array<i32: 2>} : !ttg.async.token
+      %43 = arith.addi %37, %c64_i32 {async_task_id = array<i32: 2>} : i32
+      ttg.local_store %outRHS, %2 {async_task_id = array<i32: 0>} : tensor<128x64xf32, #blocked2> -> !ttg.memdesc<128x64xf32, #shared1, #smem, mutable>
+      %44 = ttng.async_tma_copy_local_to_global %6[%41, %43] %2 {async_task_id = array<i32: 2>} : !tt.tensordesc<128x64xf32, #shared1>, !ttg.memdesc<128x64xf32, #shared1, #smem, mutable> -> !ttg.async.token
+      ttng.async_tma_store_token_wait %44   {async_task_id = array<i32: 2>} : !ttg.async.token
+      scf.yield {async_task_id = array<i32: 2>} %27 : i32
+    } {async_task_id = array<i32: 0, 1, 2, 3>, tt.data_partition_factor = 1 : i32, tt.separate_epilogue_store = true, tt.warp_specialize, ttg.partition.stages = [0 : i32, 1 : i32, 0 : i32, 0 : i32], ttg.partition.types = ["epilogue", "gemm", "epilogue_store", "load"], ttg.warp_specialize.tag = 0 : i32}
+    tt.return
+  }
+}

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSMemoryPlanner.cpp
@@ -854,11 +854,12 @@ static std::string getLocName(Operation *op) {
 
 /// Priority levels for SMEM multi-buffering candidates.
 enum class WSBufferPriority {
-  P0_InnermostTMA = 0, // innermost loop + TMA channel
-  P1_InnermostNonTMA,  // innermost loop, non-TMA
-  P2_InnerTMAStaging,  // TMA staging buffer inside the innermost loop (e.g. dq)
-  P3_OuterTMAStaging,  // TMA staging buffer outside loops (e.g. dk, dv)
-  P4_Other,            // outside loop / non-innermost (regular epilogue)
+  P0_ComputedMMAOperand = 0, // computed SMEM tile consumed by an MMA
+  P1_InnermostTMA,           // innermost loop + TMA channel
+  P2_InnermostNonTMA,        // innermost loop, non-TMA
+  P3_InnerTMAStaging, // TMA staging buffer inside the innermost loop (e.g. dq)
+  P4_OuterTMAStaging, // TMA staging buffer outside loops (e.g. dk, dv)
+  P5_Other,           // outside loop / non-innermost (regular epilogue)
 };
 
 /// A wrapper around one ttg.local_alloc op for the new SMEM allocation.
@@ -1259,6 +1260,45 @@ static bool isSmemTMAChannel(Operation *alloc,
   return isa<ttnvws::DescriptorLoadOp>(srcOp);
 }
 
+/// Return true for an SMEM channel that materializes a descriptor-fed computed
+/// tensor directly consumed by an MMA. Unlike a TMA-fed operand, buffering this
+/// channel hides both the register computation and its source-load latency
+/// while retaining only the narrower, post-conversion tile in the ring.
+static bool
+isDescriptorFedComputedMMAOperandChannel(Operation *alloc,
+                                         SmallVector<Channel *> &channels) {
+  if (isSmemTMAChannel(alloc, channels))
+    return false;
+  Channel *ch = findChannelForOp(alloc, channels);
+  if (!ch || ch->channelKind != DataChannelKind::SMEMAlloc)
+    return false;
+  DenseSet<Operation *> consumers;
+  (void)getAllAcutalUsersForChannel(ch, consumers, alloc);
+  if (!llvm::any_of(consumers, [](Operation *op) {
+        return isa<ttng::MMAv5OpInterface>(op);
+      }))
+    return false;
+
+  Operation *producer = ch->getSrcOp();
+  if (!producer)
+    return false;
+  SmallVector<Value> worklist(producer->getOperands());
+  DenseSet<Value> seen;
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!seen.insert(value).second)
+      continue;
+    if (auto localLoad = value.getDefiningOp<ttg::LocalLoadOp>()) {
+      if (Operation *sourceAlloc = localLoad.getSrc().getDefiningOp();
+          sourceAlloc && isSmemTMAChannel(sourceAlloc, channels))
+        return true;
+    }
+    if (Operation *def = value.getDefiningOp())
+      llvm::append_range(worklist, def->getOperands());
+  }
+  return false;
+}
+
 /// Helper to read the loop.stage attribute from an op. Returns -1 if absent.
 static int getLoopStage(Operation *op) {
   auto attr = op->getAttrOfType<IntegerAttr>(tt::kLoopStageAttrName);
@@ -1422,7 +1462,7 @@ static unsigned computeTotalSmem(const SmallVector<WSBuffer> &wsBuffers) {
   return total;
 }
 
-/// Group P2_Other WSBuffers by their original load op (or by compatible
+/// Group P5_Other WSBuffers by their original load op (or by compatible
 /// type/size for TMA store staging buffers) and assign the same buffer.id
 /// to buffers within each group.
 static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
@@ -1476,7 +1516,7 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
       }
       continue;
     }
-    if (buf.priority != WSBufferPriority::P4_Other)
+    if (buf.priority != WSBufferPriority::P5_Other)
       continue;
     Channel *ch = findChannelForOp(buf.allocOp, channels);
     Operation *origLoad = findOriginalLoadForChannel(ch);
@@ -1511,13 +1551,13 @@ static void fuseEpilogueWSBuffers(SmallVector<WSBuffer> &wsBuffers,
                "TMA staging per-(descriptor,load-or-task) fusion");
 }
 
-/// Phase 3.7: Iterative copy increase for fused P2_Other groups.
+/// Phase 3.7: Iterative copy increase for fused P5_Other groups.
 /// Epilogue buffers merged in Phase 3.5 share a single bufferId but are
 /// left at numCopies=1 by Phase 4. Increase copies uniformly for each
 /// fused group while staying within the SMEM budget.
 /// Phase 3.7: Iterative copy increase for fused groups eligible for epilogue-
 /// style budget bumping. Inner-loop TMA staging is tried first (highest pay-
-/// off per slot), then outer-loop TMA staging, then regular P4_Other groups.
+/// off per slot), then outer-loop TMA staging, then regular P5_Other groups.
 // Optional cap on the fused TMA-staging pipeline depth, exposing staging copies
 // as a search/autotune axis. TRITON_WS_STAGING_COPIES=K bounds Phase 3.7's bump
 // target to min(numBuffers, K); the K|S divisibility and budget checks still
@@ -1541,9 +1581,9 @@ static void increaseFusedEpilogueCopies(SmallVector<WSBuffer> &wsBuffers,
     numBuffers = std::min(numBuffers, cap);
   // Eligible priority tiers, in the order Phase 3.7 should try to bump them.
   static const WSBufferPriority kPhase45Order[] = {
-      WSBufferPriority::P2_InnerTMAStaging, // dq \u2014 highest payoff per slot
-      WSBufferPriority::P3_OuterTMAStaging, // dk / dv
-      WSBufferPriority::P4_Other,           // regular epilogue / non-innermost
+      WSBufferPriority::P3_InnerTMAStaging, // dq \u2014 highest payoff per slot
+      WSBufferPriority::P4_OuterTMAStaging, // dk / dv
+      WSBufferPriority::P5_Other,           // regular epilogue / non-innermost
   };
   auto isEligible = [&](WSBufferPriority p) {
     for (auto q : kPhase45Order)
@@ -2471,7 +2511,7 @@ static unsigned allocateSmemBuffers(
     buf.isCrossStage = isSmemCrossStage(alloc, channels);
     buf.bufferId = nextBufferId++;
     buf.numCopies = 1;
-    buf.priority = WSBufferPriority::P4_Other;
+    buf.priority = WSBufferPriority::P5_Other;
     buf.isAllocated = true; // default: every buffer gets dedicated SMEM
 
     // Check for annotation-based pre-assignment.
@@ -2490,7 +2530,7 @@ static unsigned allocateSmemBuffers(
       // WSAtomicBroadcast stamped the requested tile-prefetch depth on the
       // alloc. Pin the buffer to it so the planner honors the depth exactly and
       // accounts for the extra copies against the SMEM budget, instead of
-      // leaving this non-innermost (P4_Other) channel single-buffered.
+      // leaving this non-innermost (P5_Other) channel single-buffered.
       buf.numCopies = copies.getInt();
       buf.minCopies = copies.getInt();
       buf.isPinned = true;
@@ -2608,14 +2648,17 @@ static unsigned allocateSmemBuffers(
     if (buf.isPinned)
       continue;
     if (buf.tmaStaging > 0) {
-      buf.priority = buf.isInnermost ? WSBufferPriority::P2_InnerTMAStaging
-                                     : WSBufferPriority::P3_OuterTMAStaging;
+      buf.priority = buf.isInnermost ? WSBufferPriority::P3_InnerTMAStaging
+                                     : WSBufferPriority::P4_OuterTMAStaging;
+    } else if (buf.isInnermost && isDescriptorFedComputedMMAOperandChannel(
+                                      buf.allocOp, channels)) {
+      buf.priority = WSBufferPriority::P0_ComputedMMAOperand;
     } else if (buf.isInnermost && buf.isTMA) {
-      buf.priority = WSBufferPriority::P0_InnermostTMA;
+      buf.priority = WSBufferPriority::P1_InnermostTMA;
     } else if (buf.isInnermost) {
-      buf.priority = WSBufferPriority::P1_InnermostNonTMA;
+      buf.priority = WSBufferPriority::P2_InnermostNonTMA;
     } else {
-      buf.priority = WSBufferPriority::P4_Other;
+      buf.priority = WSBufferPriority::P5_Other;
     }
     LDBG("Phase 3: WSBuffer["
          << buf.bufferId << "] priority=" << static_cast<int>(buf.priority)
@@ -2625,7 +2668,7 @@ static unsigned allocateSmemBuffers(
     LLVM_DEBUG(buf.allocOp->dump());
   }
 
-  // ── Phase 3.5: Merge P4_Other buffers from the same original load ───
+  // ── Phase 3.5: Merge P5_Other buffers from the same original load ───
   // Epilogue buffers (e.g., from splitting a tmem_load result into sub-tiles
   // stored to separate SMEM buffers) have disjoint liveness and can share
   // the same buffer.id to reduce SMEM usage before the copy increase pass.
@@ -2735,15 +2778,34 @@ static unsigned allocateSmemBuffers(
   // TMA store/reduce staging is on the output critical path. Reserve its
   // legal copy depth before discretionary P0/P1 operand buffering consumes
   // the remaining budget (notably FA-bwd dQ versus the small m/Di buffers).
-  increaseFusedEpilogueCopies(wsBuffers, channels, numBuffers, smemBudget);
+  // Reserve the bytes needed to take computed MMA operands to the requested
+  // depth before opportunistically growing TMA-store staging.  Without this,
+  // an output ring is grown first and a compact producer result can be left at
+  // one slot even though it sits on the critical input path of every MMA.
+  unsigned epilogueBudget = smemBudget;
+  for (const auto &buf : wsBuffers) {
+    if (buf.isPinned ||
+        buf.priority != WSBufferPriority::P0_ComputedMMAOperand ||
+        buf.numCopies >= numBuffers)
+      continue;
+    uint64_t reserve =
+        uint64_t(numBuffers - buf.numCopies) * uint64_t(buf.sizeBytes);
+    epilogueBudget = reserve < epilogueBudget
+                         ? epilogueBudget - static_cast<unsigned>(reserve)
+                         : 0;
+  }
+  increaseFusedEpilogueCopies(wsBuffers, channels, numBuffers, epilogueBudget);
 
   LDBG("Phase 3.7 epilogue copies complete: totalSmem="
        << computeTotalSmem(wsBuffers));
 
   // ── Phase 4: Iterative copy increase ────────────────────────────────
-  // Process P0 then P1. P2 is never increased.
-  for (auto priority : {WSBufferPriority::P0_InnermostTMA,
-                        WSBufferPriority::P1_InnermostNonTMA}) {
+  // Prefer the compact computed MMA tile, then direct TMA operands and other
+  // innermost allocations.  This avoids spending the budget on wide FP32
+  // descriptor scratch before buffering a narrowed BF16 producer result.
+  for (auto priority : {WSBufferPriority::P0_ComputedMMAOperand,
+                        WSBufferPriority::P1_InnermostTMA,
+                        WSBufferPriority::P2_InnermostNonTMA}) {
     // Collect candidate indices at this priority.
     SmallVector<unsigned> candidateIndices;
     for (unsigned i = 0; i < wsBuffers.size(); ++i) {


### PR DESCRIPTION
## Summary

Prioritize deeply buffering a compact, descriptor-fed computed MMA operand before spending the shared-memory budget on wider descriptor scratch or opportunistic output staging.

The classifier is intentionally narrow: the channel must be an innermost non-TMA shared-memory allocation, be consumed by MMAv5, and have a backward producer slice containing a local load from a descriptor/TMA channel. Other computed operands retain the existing policy.

## Motivation

For the fused decompose-K shape `M=128, N=256, K=939505`, two FP32 descriptor tiles are transformed into one BF16 B operand. The existing planner spends the shared-memory budget on the wide source/output channels and leaves computed B single-buffered, forcing the kernel out of the intended deep MetaWS pipeline. This change produces:

- computed B: 4 copies
- direct A: 2 copies
- x/gate FP32 scratch: 1 copy each
- output staging: 2 copies
- total shared memory: 230,248 bytes (within the 232,448-byte target limit)

The generated stage-4 kernel is correct and bitwise repeatable. Its best current-stack complete-region sample is 0.4024 ms, at parity with the rebuilt handwritten source-aware oracle (~0.399--0.401 ms). Stable percentage claims are intentionally omitted because the development B200 downclocks between short samples even after accepting an 1830 MHz clock-floor request.

## Testing

- Added an exact post-WS `nvgpu-test-ws-memory-planner` fixture for the allocation policy.
- `test/Hopper/WarpSpecialization`: 137 passed, 9 expected failures (146 discovered).
- Rebuilt `libtriton.so` and `triton-opt` after rebasing onto current `main`.
- End-to-end stage 4/5/6 and non-WS correctness: max absolute error 8.0 versus BF16 reference and bitwise repeatable launches.

## Dependency / scope

This PR contains only the Triton memory-planner policy and its regression. End-to-end source generation additionally requires separate PyTorch/Inductor descriptor plumbing (`f4a50d7fc02` in the local frontend worktree). That frontend change should be reviewed and landed independently; the compiler patch and lit test do not depend on it.
