### PR TITLE
[autoWS] Optimize 2CTA TMA shared-memory publication

### DIFF
--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -29,11 +29,16 @@ struct MemEffectsOpInfo {
   // for PTX ops that perform the write and also signal the barrier via
   // `mbarrier::complete_tx`.
   //
+  // SharedFrontier snapshots shared-memory reads/writes and proxy ordering,
+  // but excludes unrelated tensor-memory accesses. Use this for a split
+  // sync-restrict shared-memory release/relaxed-arrive protocol.
+  //
   // CountOnly updates the barrier's arrival count and phase without attaching
   // any memory or proxy frontier. Use this for relaxed control rendezvous,
   // which do not release prior accesses to a waiter.
   enum class BarrierTrackingMode {
     Frontier,
+    SharedFrontier,
     EffectWrites,
     CountOnly,
   };
@@ -90,6 +95,8 @@ struct BarrierWaitInfo {
   Value alloc;
   Value phase;
   Value pred;
+  // Acquire shared/proxy visibility without importing tensor-memory state.
+  bool sharedOnly = false;
 };
 
 struct BarrierInvalidateInfo {

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -28,9 +28,14 @@ struct MemEffectsOpInfo {
   // those op-local writes and proxy-ordering facts, and nothing else. Use this
   // for PTX ops that perform the write and also signal the barrier via
   // `mbarrier::complete_tx`.
+  //
+  // CountOnly updates the barrier's arrival count and phase without attaching
+  // any memory or proxy frontier. Use this for relaxed control rendezvous,
+  // which do not release prior accesses to a waiter.
   enum class BarrierTrackingMode {
     Frontier,
     EffectWrites,
+    CountOnly,
   };
   struct Effects {
     struct StaticSharedBuffer {

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -611,7 +611,9 @@ def TTNG_ArriveBarrierOp
     and the barrier must have the identity CGA layout `[[1], [2], ...]`. The
     default value of `ctaMask` is 0 (no multicast).
 
-    The operation accepts an optional predicate.
+    The operation accepts an optional predicate. `relaxed` may be used for a
+    pure cross-CTA control rendezvous which does not publish memory to another
+    CTA. On targets below PTX 8.6, it conservatively lowers as a release.
 
     Example:
 
@@ -626,7 +628,7 @@ def TTNG_ArriveBarrierOp
       (ins Arg<TTG_MemDescType,
                "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
           I32Attr:$count, DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
-          Optional<I1>:$pred, UnitAttr:$perThread,
+          Optional<I1>:$pred, UnitAttr:$perThread, UnitAttr:$relaxed,
           OptionalAttr<DictionaryAttr>:$constraints);
 
   let assemblyFormat = [{
@@ -635,28 +637,28 @@ def TTNG_ArriveBarrierOp
 
   let builders =
       [OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "uint32_t":$ctaMask,
                      "Value":$pred),
                  [{
-      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "bool":$perThread), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread, "DictionaryAttr":$constraints),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, constraints);
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, constraints);
     }]>];
 
   let extraClassDeclaration = [{

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -553,6 +553,10 @@ def TTNG_WaitBarrierOp
 
     This lowers a waitloop using the PTX instruction
     mbarrier.try_wait.parity{.acquire.cluster}.shared::cta.b64.
+    `syncRestrict` separates the barrier's count/phase synchronization from
+    its shared-memory acquire semantics. On PTX 8.6+, the wait is relaxed and
+    followed by an acquire sync-restrict fence. Older PTX falls back to the
+    ordinary acquire wait.
 
     Accepts an optional list of memory dependencies. If present, it is assumed
     that any of the dependencies may be accessed until the barrier completes.
@@ -565,22 +569,22 @@ def TTNG_WaitBarrierOp
       (ins Arg<TTG_MemDescType,
                "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
           I32:$phase, Optional<I1>:$pred, Variadic<TTG_MemDescType>:$deps,
-          OptionalAttr<DictionaryAttr>:$constraints);
+          OptionalAttr<DictionaryAttr>:$constraints, UnitAttr:$syncRestrict);
 
   let builders =
       [OpBuilder<(ins "Value":$alloc, "Value":$phase), [{
-    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), /*deps=*/{}, /*constraints=*/DictionaryAttr());
+    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), /*deps=*/{}, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "Value":$phase, "Value":$pred), [{
-    build($_builder, $_state, alloc, phase, pred, /*deps=*/{}, /*constraints=*/DictionaryAttr());
+    build($_builder, $_state, alloc, phase, pred, /*deps=*/{}, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "Value":$phase, "ValueRange":$deps), [{
-    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), deps, /*constraints=*/DictionaryAttr());
+    build($_builder, $_state, alloc, phase, /*pred=*/static_cast<mlir::Value>(nullptr), deps, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "Value":$phase, "Value":$pred,
                      "ValueRange":$deps),
                  [{
-    build($_builder, $_state, alloc, phase, pred, deps, /*constraints=*/DictionaryAttr());
+    build($_builder, $_state, alloc, phase, pred, deps, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
   ];
 
@@ -614,6 +618,9 @@ def TTNG_ArriveBarrierOp
     The operation accepts an optional predicate. `relaxed` may be used for a
     pure cross-CTA control rendezvous which does not publish memory to another
     CTA. On targets below PTX 8.6, it conservatively lowers as a release.
+    `syncRestrict` publishes only local shared-memory accesses: on PTX 8.6+
+    it emits a release sync-restrict fence followed by a relaxed remote
+    arrival, and on older PTX it falls back to a release arrival.
 
     Example:
 
@@ -629,7 +636,7 @@ def TTNG_ArriveBarrierOp
                "", [MemRead<SharedMemory>, MemWrite<SharedMemory>]>:$alloc,
           I32Attr:$count, DefaultValuedOptionalAttr<I32Attr, "0">:$ctaMask,
           Optional<I1>:$pred, UnitAttr:$perThread, UnitAttr:$relaxed,
-          OptionalAttr<DictionaryAttr>:$constraints);
+          OptionalAttr<DictionaryAttr>:$constraints, UnitAttr:$syncRestrict);
 
   let assemblyFormat = [{
     $alloc `,` $count (`,` $pred^)? attr-dict `:` qualified(type($alloc))
@@ -637,28 +644,28 @@ def TTNG_ArriveBarrierOp
 
   let builders =
       [OpBuilder<(ins "Value":$alloc, "uint32_t":$count), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "uint32_t":$ctaMask,
                      "Value":$pred),
                  [{
-      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, ctaMask, pred, /*perThread=*/false, /*relaxed=*/false, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "bool":$perThread), [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, /*pred=*/Value(), perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr());
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, /*constraints=*/DictionaryAttr(), /*syncRestrict=*/false);
     }]>,
        OpBuilder<(ins "Value":$alloc, "uint32_t":$count, "Value":$pred,
                      "bool":$perThread, "DictionaryAttr":$constraints),
                  [{
-      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, constraints);
+      return build($_builder, $_state, alloc, count, /*ctaMask=*/0u, pred, perThread, /*relaxed=*/false, constraints, /*syncRestrict=*/false);
     }]>];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -829,7 +829,7 @@ private:
         // listener and return early)
         b.setListener(nullptr);
         instrumentBarrierWait(op, info->alloc, info->phase, info->pred, thread,
-                              baseThread, funcBuilder);
+                              baseThread, info->sharedOnly, funcBuilder);
         return WalkResult::advance();
       }
 
@@ -991,6 +991,7 @@ private:
 
   void instrumentBarrierWait(Operation *op, Value alloc, Value phase,
                              Value pred, int thread, int baseThread,
+                             bool sharedOnly,
                              tti::FunctionBuilder &funcBuilder) {
     ImplicitLocOpBuilder wb(op->getLoc(), op);
     pred = tti::maybeAnd(wb, pred, hooks.getIssuerCTAPred(wb, op));
@@ -1011,6 +1012,8 @@ private:
     wb.setInsertionPointAfter(op);
     tti::ExperimentalLockAcquireOp::create(wb, lock, pred);
     for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+      if (sharedOnly && memType != MemType::SHARED_MEM)
+        continue;
       funcBuilder.createTransferVisibleWritesCall(
           wb, alloc, getThreadPeersMask(thread, auxData.threadLayout), pred,
           memType, op);
@@ -1149,10 +1152,16 @@ private:
       funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
                                                      op, recipientCTAs);
       if (barrierInfo.trackingMode ==
-          MemEffectsOpInfo::BarrierTrackingMode::Frontier) {
+              MemEffectsOpInfo::BarrierTrackingMode::Frontier ||
+          barrierInfo.trackingMode ==
+              MemEffectsOpInfo::BarrierTrackingMode::SharedFrontier) {
         // If the op has barriers, we treat it as a commit emitted for each
         // barrier.
         for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+          if (barrierInfo.trackingMode ==
+                  MemEffectsOpInfo::BarrierTrackingMode::SharedFrontier &&
+              memType != MemType::SHARED_MEM)
+            continue;
           funcBuilder.createTrackVisibleWritesCall(
               b, barrier, thread, combinedPred, memType, op, recipientCTAs);
           funcBuilder.createTrackVisibleReadsCall(

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -573,6 +573,14 @@ TypedValue<MemDescType> BarrierExpectOp::getBarrier() { return getAlloc(); }
 LogicalResult WaitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))
     return failure();
+  if (getSyncRestrict()) {
+    auto barrierTy = cast<MemDescType>(getAlloc().getType());
+    if (!isa<SharedMemorySpaceAttr>(barrierTy.getMemorySpace()))
+      return emitOpError(
+          "syncRestrict wait requires a CTA-local shared-memory barrier");
+    if (!gpu::isPhysicalCluster(getOperation()))
+      return emitOpError("syncRestrict wait requires a physical cluster");
+  }
   return success();
 }
 
@@ -601,6 +609,18 @@ LogicalResult ArriveBarrierOp::verify() {
     return failure();
   if (getCount() < 1)
     return emitOpError("count must be greater than or equal to 1");
+  if (getSyncRestrict()) {
+    auto barrierTy = cast<MemDescType>(getAlloc().getType());
+    if (!isa<SharedClusterMemorySpaceAttr>(barrierTy.getMemorySpace()))
+      return emitOpError(
+          "syncRestrict arrive requires a remote shared-memory barrier");
+    if (getPerThread())
+      return emitOpError("syncRestrict arrive does not support perThread");
+    if (getRelaxed())
+      return emitOpError("syncRestrict and relaxed are mutually exclusive");
+    if (!gpu::isPhysicalCluster(getOperation()))
+      return emitOpError("syncRestrict arrive requires a physical cluster");
+  }
   if (isMulticast()) {
     if (getPerThread())
       return emitOpError("multicast arrive does not support perThread");

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -348,8 +348,11 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = arriveOp.getPred();
+      auto mode = arriveOp.getRelaxed()
+                      ? MemEffectsOpInfo::BarrierTrackingMode::CountOnly
+                      : MemEffectsOpInfo::BarrierTrackingMode::Frontier;
       info->barriers.push_back(
-          {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount()});
+          {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount(), mode});
     }
     auto baseInfo = ConSanTargetHooks::getMemEffectsOpInfo(op);
     if (failed(baseInfo))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -75,7 +75,7 @@ public:
   getBarrierWaitInfo(Operation *op) const override {
     if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op))
       return BarrierWaitInfo{waitOp.getBarrier(), waitOp.getPhase(),
-                             waitOp.getPred()};
+                             waitOp.getPred(), waitOp.getSyncRestrict()};
     return std::nullopt;
   }
 
@@ -348,9 +348,11 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = arriveOp.getPred();
-      auto mode = arriveOp.getRelaxed()
-                      ? MemEffectsOpInfo::BarrierTrackingMode::CountOnly
-                      : MemEffectsOpInfo::BarrierTrackingMode::Frontier;
+      auto mode = MemEffectsOpInfo::BarrierTrackingMode::Frontier;
+      if (arriveOp.getRelaxed())
+        mode = MemEffectsOpInfo::BarrierTrackingMode::CountOnly;
+      else if (arriveOp.getSyncRestrict())
+        mode = MemEffectsOpInfo::BarrierTrackingMode::SharedFrontier;
       info->barriers.push_back(
           {arriveOp.getBarrier(), nullptr, (int)arriveOp.getCount(), mode});
     }

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -135,7 +135,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_remote
   tt.func @arrive_barrier_remote(%alloc: !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>, %pred: i1) {
     // CHECK: "@$0 mbarrier.arrive.release.cluster.shared::cluster.b64 _, [$1], 2;", "b,r" %{{.*}}
+    // PTX85: mbarrier.arrive.release.cluster.shared::cluster.b64
+    // PTX86: mbarrier.arrive.release.cluster.shared::cluster.b64
+    // PTX88: mbarrier.arrive.release.cluster.shared::cluster.b64
     ttng.arrive_barrier %alloc, 2, %pred : !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>
+    tt.return
+  }
+
+  // CHECK-LABEL: arrive_barrier_remote_relaxed
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // PTX85-LABEL: arrive_barrier_remote_relaxed
+  // PTX85: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // PTX86-LABEL: arrive_barrier_remote_relaxed
+  // PTX86: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  // PTX88-LABEL: arrive_barrier_remote_relaxed
+  // PTX88: mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  tt.func @arrive_barrier_remote_relaxed(%alloc: !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>, %pred: i1) {
+    ttng.arrive_barrier %alloc, 2, %pred {relaxed} : !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>
     tt.return
   }
 

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -18,6 +18,38 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 
 // -----
 
+#shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // CHECK-LABEL: sync_restrict_barrier_handoff
+  // CHECK: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // CHECK: mbarrier.try_wait.parity.shared::cta.b64
+  // CHECK-NOT: sync_restrict
+  // PTX85-LABEL: sync_restrict_barrier_handoff
+  // PTX85: mbarrier.arrive.release.cluster.shared::cluster.b64
+  // PTX85: mbarrier.try_wait.parity.shared::cta.b64
+  // PTX85-NOT: sync_restrict
+  // PTX86-LABEL: sync_restrict_barrier_handoff
+  // PTX86: fence.release.sync_restrict::shared::cta.cluster
+  // PTX86-NEXT: {{.*}}mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  // PTX86: mbarrier.try_wait.parity.relaxed.cluster.shared::cta.b64
+  // PTX86: fence.acquire.sync_restrict::shared::cluster.cluster
+  // PTX88-LABEL: sync_restrict_barrier_handoff
+  // PTX88: fence.release.sync_restrict::shared::cta.cluster
+  // PTX88-NEXT: {{.*}}mbarrier.arrive.relaxed.cluster.shared::cluster.b64
+  // PTX88: mbarrier.try_wait.parity.relaxed.cluster.shared::cta.b64
+  // PTX88: fence.acquire.sync_restrict::shared::cluster.cluster
+  tt.func @sync_restrict_barrier_handoff(
+      %remote: !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>,
+      %local: !ttg.memdesc<1xi64, #shared0, #smem>, %phase: i32, %pred: i1) {
+    ttng.arrive_barrier %remote, 1, %pred {syncRestrict} : !ttg.memdesc<1xi64, #shared0, #ttng.shared_cluster_memory>
+    ttng.wait_barrier %local, %phase, %pred {syncRestrict} : !ttg.memdesc<1xi64, #shared0, #smem>
+    tt.return
+  }
+}
+
+// -----
+
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32} {

--- a/test/Hopper/TwoCTA/insert_2cta_sync.mlir
+++ b/test/Hopper/TwoCTA/insert_2cta_sync.mlir
@@ -23,7 +23,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // CHECK: scf.for
     // CHECK:   nvg.cluster_id
     // CHECK:   ttng.map_to_remote_buffer
-    // CHECK:   ttng.arrive_barrier
+    // CHECK:   ttng.arrive_barrier {{.*}} {relaxed}
     // CHECK:   ttng.wait_barrier
     // CHECK:   ttng.tc_gen5_mma
     scf.for %iv = %c0 to %c4 step %c1 {

--- a/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
+++ b/test/Hopper/WarpSpecialization/blackwell_ws_matmul_tma.mlir
@@ -12,8 +12,10 @@
 // CHECK: default
 // CHECK: ttng.wait_barrier {{.*}}channelGraph = array<i32: {{.*}}direction = "forward"{{.*}}dstTask = {{[0-9]+}} : i32{{.*}}parentId = {{[0-9]+}} : i32
 // Each consumer CTA relays completion to its peer after consuming the load.
-// CHECK: ttng.arrive_barrier {{.*}}shared_cluster_memory
-// CHECK: ttng.arrive_barrier {{.*}}shared_cluster_memory
+// CHECK: ttng.arrive_barrier {{.*}}syncRestrict{{.*}}shared_cluster_memory
+// CHECK: ttng.wait_barrier {{.*}}syncRestrict
+// CHECK: ttng.arrive_barrier {{.*}}syncRestrict{{.*}}shared_cluster_memory
+// CHECK: ttng.wait_barrier {{.*}}syncRestrict
 // CHECK: ttng.tc_gen5_mma
 // Group 0: Descriptor load operations (producer)
 // CHECK: partition0

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1058,6 +1058,47 @@ module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#sync_restrict_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#sync_restrict_smem = #ttg.shared_memory
+#sync_restrict_blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CGALayout = [[0]]}>
+#sync_restrict_tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, CGALayout = [[1, 0]]>
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 72 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 64 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // A sync-restrict handoff publishes and acquires the shared/proxy frontier,
+  // but not the unrelated tensor-memory frontier. The single calls below are
+  // the shared-memory lane; an ordinary release/acquire barrier emits two.
+  // CHECK-LABEL: @sync_restrict_arrive_is_shared_only
+  tt.func public @sync_restrict_arrive_is_shared_only() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<16xi32, #sync_restrict_shared, #sync_restrict_smem, mutable>
+    %tmem = ttng.tmem_alloc {tensor_memory_col_offset = 0 : i32, tensor_memory_row_offset = 0 : i32} : () -> !ttg.memdesc<256x64xf32, #sync_restrict_tmem, #ttng.tensor_memory, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 64 : i32} : () -> !ttg.memdesc<1xi64, #sync_restrict_shared, #sync_restrict_smem, mutable>
+    %remote = ttng.map_to_remote_buffer %bar, %c1_i32 : !ttg.memdesc<1xi64, #sync_restrict_shared, #sync_restrict_smem, mutable> -> !ttg.memdesc<1xi64, #sync_restrict_shared, #ttng.shared_cluster_memory, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #sync_restrict_shared, #sync_restrict_smem, mutable>
+    %before = ttg.local_load %buf : !ttg.memdesc<16xi32, #sync_restrict_shared, #sync_restrict_smem, mutable> -> tensor<16xi32, #sync_restrict_blocked>
+    %t_before = ttng.tmem_load %tmem : !ttg.memdesc<256x64xf32, #sync_restrict_tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32>
+    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_visible_reads
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
+    // CHECK: ttng.arrive_barrier {{.*}}syncRestrict
+    ttng.arrive_barrier %remote, 1, %true {syncRestrict} : !ttg.memdesc<1xi64, #sync_restrict_shared, #ttng.shared_cluster_memory, mutable>
+    // CHECK: ttng.wait_barrier {{.*}}syncRestrict
+    ttng.wait_barrier %bar, %c0_i32, %true {syncRestrict} : !ttg.memdesc<1xi64, #sync_restrict_shared, #sync_restrict_smem, mutable>
+    // CHECK: tt.call @__triton_consan_transfer_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_transfer_visible_writes
+    // CHECK: tt.call @__triton_consan_transfer_visible_reads
+    // CHECK-NOT: tt.call @__triton_consan_transfer_visible_reads
+    // CHECK: tt.call @__triton_consan_clear_waiting
+    %after = ttg.local_load %buf : !ttg.memdesc<16xi32, #sync_restrict_shared, #sync_restrict_smem, mutable> -> tensor<16xi32, #sync_restrict_blocked>
+    %t_after = ttng.tmem_load %tmem : !ttg.memdesc<256x64xf32, #sync_restrict_tmem, #ttng.tensor_memory, mutable> -> tensor<256x64xf32>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -1013,6 +1013,51 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 
 // -----
 
+#relaxed_data = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[0, 1]]}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#smem = #ttg.shared_memory
+#relaxed_writer = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1]]}>
+#relaxed_reader = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[1, 0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:100", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 4 : i32} {
+  // A relaxed arrive remains a real barrier arrival, but must not make any
+  // preceding access visible to the peer CTA. This preserves the runtime
+  // visibility check that reports a race if relaxed is misused for publishing.
+  // CHECK-LABEL: @relaxed_arrive_is_count_only
+  tt.func public @relaxed_arrive_is_count_only() {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %values = arith.constant dense<1> : tensor<8x32xi32, #relaxed_writer>
+    %buf = ttg.local_alloc %values {allocation.offset = 0 : i32} : (tensor<8x32xi32, #relaxed_writer>) -> !ttg.memdesc<8x32xi32, #relaxed_data, #smem, mutable>
+    %bar = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: ttng.init_barrier
+    // CHECK: tti.experimental_lock_acquire
+    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
+    // CHECK-NOT: tt.call @__triton_consan_track_proxy_accesses
+    // CHECK: tt.call @__triton_consan_verify_barrier_arrive
+    // CHECK: tt.call @__triton_consan_update_barrier_state
+    // CHECK: tti.experimental_lock_release
+    // CHECK: ttng.arrive_barrier {{.*}} {relaxed}
+    ttng.arrive_barrier %bar, 1, %true {relaxed} : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // The matching wait still completes, but transfers an empty frontier.
+    ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    // CHECK: ttng.wait_barrier
+    // CHECK: tt.call @__triton_consan_transfer_visible_writes
+    // CHECK: tt.call @__triton_consan_transfer_visible_reads
+    // The reader layout reaches both CTA rows. The retained visibility check
+    // reports the missing peer publication at runtime.
+    // CHECK: %[[READ_CTAS:.*]] = arith.constant 3 : i32
+    // CHECK: tt.call @__triton_consan_verify_write_visibility{{.*}}%[[READ_CTAS]]
+    // CHECK: ttg.local_load
+    %value = ttg.local_load %buf : !ttg.memdesc<8x32xi32, #relaxed_data, #smem, mutable> -> tensor<8x32xi32, #relaxed_reader>
+    tt.return
+  }
+}
+
+// -----
+
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65544 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {

--- a/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Insert2CTASync.cpp
@@ -203,7 +203,12 @@ static void insertSyncBeforeMMA(ttng::TCGen5MMAOp mma, Value barrierAlloc,
       builder, loc, remoteBarType, barrierView, leaderRank);
 
   // Both CTAs arrive on leader's barrier (count=1 each, total=2).
-  ttng::ArriveBarrierOp::create(builder, loc, remoteBar, /*count=*/1u);
+  auto arrive =
+      ttng::ArriveBarrierOp::create(builder, loc, remoteBar, /*count=*/1u);
+  // This barrier only rendezvous the two CTAs before issuing a 2-CTA MMA. The
+  // operands have their own completion barriers, so there is no memory to
+  // publish here. A release.cluster arrive serializes the inner K loop.
+  arrive.setRelaxed(true);
 
   // Compute phase from iterations within the barrier's lifetime.
   // WaitBarrierOp expects I32 for the phase parameter.

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -440,11 +440,13 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     // handoff, while cluster barriers require participation from every warp.
     builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
         loc, /*bCluster=*/false);
-    builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
+    auto publish = builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
         loc, peerBarrier, /*count=*/1, waitPred);
-    builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
+    publish.setSyncRestrict(true);
+    auto acquire = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
         loc, consBarrier, phase, followerWaitPred, /*deps=*/ValueRange{},
         consumerWaitConstraints);
+    acquire.setSyncRestrict(true);
   }
   for (int extraTaskId : additionalConsumerTaskIds) {
     builder.setAsynTaskIdsFromArray({extraTaskId});
@@ -454,11 +456,13 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
     if (twoCTA) {
       builder.createWithAsyncTaskIds<ttng::FenceAsyncSharedOp>(
           loc, /*bCluster=*/false);
-      builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
+      auto publish = builder.createWithAsyncTaskIds<ttng::ArriveBarrierOp>(
           loc, peerBarrier, /*count=*/1, waitPred);
-      builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
+      publish.setSyncRestrict(true);
+      auto acquire = builder.createWithAsyncTaskIds<ttng::WaitBarrierOp>(
           loc, consBarrier, phase, followerWaitPred, /*deps=*/ValueRange{},
           consumerWaitConstraints);
+      acquire.setSyncRestrict(true);
     }
   }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -310,8 +310,13 @@ struct WaitBarrierOpConversion
 
     bool isCrossClusterBarrier =
         LLVM::NVIDIA::getCGABroadcastMask(barrierTy) != 0;
+    bool useSyncRestrict =
+        op.getSyncRestrict() && targetInfo->getPtxVersion() >= 86;
     std::string acquire =
-        isCrossCluster || isCrossClusterBarrier ? ".acquire.cluster" : "";
+        useSyncRestrict
+            ? ".relaxed.cluster"
+            : (isCrossCluster || isCrossClusterBarrier ? ".acquire.cluster"
+                                                       : "");
     bool predicated = pred && !matchPattern(pred, m_NonZero());
     int suspendNs = 0;
     if (targetInfo->getComputeCapability() >= 100) {
@@ -390,6 +395,18 @@ struct WaitBarrierOpConversion
 
     waitLoop(operands, /*onlyAttachMLIRArgs=*/true);
     ptxBuilder.launch(rewriter, loc, void_ty(ctx));
+    if (useSyncRestrict) {
+      PTXBuilder fenceBuilder;
+      std::string fence = predicated ? "@$0 " : "";
+      fence += "fence.acquire.sync_restrict::shared::cluster.cluster;";
+      auto &fenceOp = *fenceBuilder.create(fence);
+      if (predicated)
+        fenceOp({fenceBuilder.newOperand(pred, "b")},
+                /*onlyAttachMLIRArgs=*/true);
+      else
+        fenceOp({}, /*onlyAttachMLIRArgs=*/true);
+      fenceBuilder.launch(rewriter, loc, void_ty(ctx));
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -485,12 +502,23 @@ struct ArriveBarrierOpConversion
         pred = b.and_(pred, adaptor.getPred());
 
       auto emitArrive = [&](Value targetBarrier, Value multicastMask = {}) {
+        bool useSyncRestrict =
+            op.getSyncRestrict() && targetInfo->getPtxVersion() >= 86;
+        if (useSyncRestrict) {
+          PTXBuilder fenceBuilder;
+          auto &fence = *fenceBuilder.create(
+              "@$0 fence.release.sync_restrict::shared::cta.cluster;");
+          fence({fenceBuilder.newOperand(pred, "b")},
+                /*onlyAttachMLIRArgs=*/true);
+          fenceBuilder.launch(rewriter, loc, void_ty(getContext()));
+        }
         std::stringstream ptxAsm;
         ptxAsm << "@$0 mbarrier.arrive.";
         bool needsClusterScope = isCrossCluster || isCrossClusterBarrier ||
                                  isRemoteBarrier || op.isMulticast();
         if (needsClusterScope)
-          ptxAsm << (op.getRelaxed() && targetInfo->getPtxVersion() >= 86
+          ptxAsm << ((op.getRelaxed() || useSyncRestrict) &&
+                             targetInfo->getPtxVersion() >= 86
                          ? "relaxed.cluster."
                          : "release.cluster.");
         ptxAsm << (isRemoteBarrier || isCrossClusterBarrier || op.isMulticast()

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -487,9 +487,12 @@ struct ArriveBarrierOpConversion
       auto emitArrive = [&](Value targetBarrier, Value multicastMask = {}) {
         std::stringstream ptxAsm;
         ptxAsm << "@$0 mbarrier.arrive.";
-        if (isCrossCluster || isCrossClusterBarrier || isRemoteBarrier ||
-            op.isMulticast())
-          ptxAsm << "release.cluster.";
+        bool needsClusterScope = isCrossCluster || isCrossClusterBarrier ||
+                                 isRemoteBarrier || op.isMulticast();
+        if (needsClusterScope)
+          ptxAsm << (op.getRelaxed() && targetInfo->getPtxVersion() >= 86
+                         ? "relaxed.cluster."
+                         : "release.cluster.");
         ptxAsm << (isRemoteBarrier || isCrossClusterBarrier || op.isMulticast()
                        ? "shared::cluster"
                        : "shared::cta");


### PR DESCRIPTION
## Summary

- split 2CTA TMA shared-memory publication into PTX 8.6+ sync-restrict release/acquire fences and a relaxed remote mbarrier handshake
- retain the existing release-barrier fallback for older PTX versions
- model the shared/proxy-only frontier in ConSan and validate the new IR mode

This is stacked on #3497. Unlike its pure control rendezvous, the A/B TMA
handoffs do publish shared data and cannot use a plain relaxed barrier. The
replacement follows the split protocol documented by PTX.

On the production decompose-K shape `(256, 939505) @ (939505, 424)`, the full
Triton partial-plus-reduction plan improves from 0.775 ms to 0.576 ms (-25.6%).
Three moderate-K controls improve by 13-26%.

This remains a draft because runtime ConSan for the complete generated kernel
currently encounters a pre-existing buffer-region registry failure. Focused
ConSan/lowering tests and 2,000 changing-input stress launches pass.


## Current-main status

The 13–26% measurements above are an old-base comparison and are not evidence of an incremental win over current main. Merged #3492 already removes the expensive physical-cluster release sequence, and current production kernels report zero membar-stall samples. This branch is also merge-conflicted atop now-closed #3497.

The remaining unique question is memory-ordering semantics: whether the current `fence_async_shared` plus plain peer arrive/wait is sufficient for TMA shared-data publication, or whether the explicit PTX 8.6 sync-restrict release/acquire pair is required. Keep this draft parked until it is rebased directly on current main, compared A/B at PTX/SASS and runtime level, reviewed by a compiler memory-model owner, and the pre-existing full-kernel ConSan buffer-region registry failure is resolved or clearly isolated.