### PR TITLE
[triton][tlx] Share one predicate for element-cast spelling

### DIFF
--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1248,3 +1248,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// The async-copy group ops take their tokens as a list, and async_wait carries
+// its outstanding-group count in the `num` attribute rather than an operand.
+// Printed positionally, the second token binds to async_load_commit_group's
+// `_semantic` and async_load_wait_group loses its required `pendings` argument,
+// so neither survives recompilation.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: def async_copy_groups(
+  // CHECK: [[T0:[a-z0-9_]+]] = tlx.async_load(
+  // CHECK: [[T1:[a-z0-9_]+]] = tlx.async_load(
+  // Capture the commit result so the wait is pinned to the token that commit
+  // actually produced, not merely to some identifier.
+  // CHECK: [[G:[a-z0-9_]+]] = tlx.async_load_commit_group([[[T0]], [[T1]]])
+  // The leading pendings count comes from the `num` attribute, not an operand.
+  // CHECK: tlx.async_load_wait_group(1, [[[G]]])
+  tt.func public @async_copy_groups(%ptr: !tt.ptr<f16>, %offs: tensor<64x64xi32, #blocked>,
+                                    %mask: tensor<64x64xi1, #blocked>) attributes {noinline = false} {
+    %d0 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %d1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %t0 = amdg.buffer_load_to_local %ptr[%offs] mask = %mask into %d0 : <f16>[tensor<64x64xi32, #blocked>] tensor<64x64xf16, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+    %t1 = amdg.buffer_load_to_local %ptr[%offs] mask = %mask into %d1 : <f16>[tensor<64x64xi32, #blocked>] tensor<64x64xf16, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+    %g = ttg.async_commit_group tokens %t0, %t1
+    %w = ttg.async_wait %g {num = 1 : i32}
+    tt.return
+  }
+
+  // A token-less commit group is valid IR -- the assembly format makes the
+  // token list optional -- so the empty-list and omitted-list branches are
+  // both reachable.
+  // CHECK-LABEL: def async_groups_no_tokens(
+  // CHECK: tlx.async_load_commit_group([])
+  // CHECK: tlx.async_load_wait_group(0)
+  tt.func public @async_groups_no_tokens() attributes {noinline = false} {
+    %g = ttg.async_commit_group
+    %w = ttg.async_wait {num = 0 : i32}
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1292,3 +1292,114 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// An element-type cast is what the source kernel wrote as `x.to(dtype)`. The
+// printer erases layout- and shape-only casts as transparent; erasing this one
+// too leaves a later tl.dot seeing mismatched operand dtypes, which is a hard
+// error on recompile rather than a silent difference.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: def element_type_cast(
+  // The truncf must survive as .to(), or its consumer sees an f32 operand.
+  // CHECK: arg0.to(tl.bfloat16) * arg1
+  tt.func public @element_type_cast(%p: tensor<64x64xf32, #blocked>,
+                                    %v: tensor<64x64xbf16, #blocked>) attributes {noinline = false} {
+    %pt = arith.truncf %p : tensor<64x64xf32, #blocked> to tensor<64x64xbf16, #blocked>
+    %r = arith.mulf %pt, %v : tensor<64x64xbf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Edge cases of re-emitting a cast: `.to` binds to the operand text, the dtype
+// has to be one TLX can name, and a store must not append a second cast on top
+// of one the operand name already carries.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // `.to` is a tensor method, so an inlined constant cannot carry it --
+  // `(0).to(tl.float32)` raises AttributeError at kernel compile time. tl.cast
+  // accepts the same value as a plain call.
+  // CHECK-LABEL: def cast_of_constant(
+  // CHECK: tl.cast(0, tl.float32)
+  // CHECK-NOT: 0.to(
+  tt.func public @cast_of_constant() attributes {noinline = false} {
+    %c = arith.constant 0 : i32
+    %f = arith.sitofp %c : i32 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // fp8 does have a TLX spelling, so the cast survives rather than being erased.
+  // CHECK-LABEL: def cast_to_fp8(
+  // CHECK: arg0.to(tl.float8e4nv) * arg0.to(tl.float8e4nv)
+  tt.func public @cast_to_fp8(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3FN, #blocked>
+    %m = arith.mulf %t, %t : tensor<64x64xf8E4M3FN, #blocked>
+    tt.return
+  }
+
+  // Keyword literals lex as identifiers but are not tensors, so they take the
+  // tl.cast path; ub.poison prints as `None`, which tl.cast rejects, so its
+  // cast is erased instead.
+  // CHECK-LABEL: def cast_of_keyword_literals(
+  // CHECK: tl.cast(True, tl.float32)
+  // CHECK-NOT: True.to(
+  tt.func public @cast_of_keyword_literals() attributes {noinline = false} {
+    %c = arith.constant true
+    %f = arith.uitofp %c : i1 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // CHECK-LABEL: def cast_of_poison(
+  // CHECK-NOT: None.to(
+  // CHECK-NOT: tl.cast(None
+  tt.func public @cast_of_poison() attributes {noinline = false} {
+    %p = ub.poison : i64
+    %f = arith.sitofp %p : i64 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // A float type TLX cannot name still falls back to erasing the cast, rather
+  // than emitting a dtype that will not compile.
+  // CHECK-LABEL: def cast_to_unnameable_dtype(
+  // CHECK: arg0 * arg0
+  // CHECK-NOT: .to(f8
+  tt.func public @cast_to_unnameable_dtype(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3B11FNUZ, #blocked>
+    %m = arith.mulf %t, %t : tensor<64x64xf8E4M3B11FNUZ, #blocked>
+    tt.return
+  }
+
+  // The store must not re-cast a source whose name already spells the cast.
+  // CHECK-LABEL: def store_of_cast(
+  // CHECK: tlx.local_store({{.*}}, arg0.to(tl.bfloat16))
+  // CHECK-NOT: .to(tl.bfloat16).to(tl.bfloat16)
+  tt.func public @store_of_cast(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xbf16, #shared, #smem, mutable>
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xbf16, #blocked>
+    ttg.local_store %t, %buf : tensor<64x64xbf16, #blocked> -> !ttg.memdesc<64x64xbf16, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // Same for a dtype whose cast the name already carries: exactly one
+  // conversion, and it must not be dropped just because the store path and
+  // getValueName disagree about where the cast lives.
+  // CHECK-LABEL: def store_of_fp8_cast(
+  // CHECK: tlx.local_store({{.*}}, arg0.to(tl.float8e4nv))
+  // CHECK-NOT: tlx.local_store({{.*}}, arg0)
+  tt.func public @store_of_fp8_cast(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xf8E4M3FN, #shared, #smem, mutable>
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3FN, #blocked>
+    ttg.local_store %t, %buf : tensor<64x64xf8E4M3FN, #blocked> -> !ttg.memdesc<64x64xf8E4M3FN, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -2060,6 +2060,35 @@ void printSimplifiedOp(
     return;
   }
 
+  // Both take their tokens as a list, and async_wait carries its outstanding-
+  // group count in the `num` attribute rather than as an operand.
+  if (opName == "ttg.async_commit_group" || opName == "ttg.async_wait") {
+    if (op->getNumResults() > 0)
+      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+    bool isWait = opName == "ttg.async_wait";
+    os << (isWait ? "tlx.async_load_wait_group("
+                  : "tlx.async_load_commit_group(");
+    if (isWait) {
+      auto num = op->getAttrOfType<IntegerAttr>("num");
+      os << (num ? num.getInt() : 0);
+      // The tokens list is optional; omit it entirely when there are none.
+      if (op->getNumOperands() > 0)
+        os << ", ";
+    }
+    if (!isWait || op->getNumOperands() > 0) {
+      os << "[";
+      for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+        if (i > 0)
+          os << ", ";
+        os << getValueName(op->getOperand(i), argSubstitutionMap);
+      }
+      os << "]";
+    }
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
   // llvm.intr.assume is a tl.assume from the source kernel.
   if (opName == "llvm.intr.assume" && op->getNumOperands() == 1) {
     os << "tl.assume(" << getValueName(op->getOperand(0), argSubstitutionMap)

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -440,6 +440,46 @@ static DenseMap<Value, std::string> buildValueNameCache(Operation *rootOp) {
   return cache;
 }
 
+std::string getElementTypeName(Type type);
+
+// Casts that change a value's element type. These are user-visible in TLX --
+// the kernel wrote `x.to(dtype)` -- unlike the width/index casts below.
+static const llvm::StringSet<> elementTypeCastOps = {
+    "arith.extf",   "arith.truncf", "arith.sitofp",
+    "arith.uitofp", "arith.fptosi", "arith.fptoui",
+};
+
+
+// Element types getElementTypeName can spell as a TLX dtype. Anything else it
+// renders as raw MLIR, which is not usable in emitted Python.
+static bool isNameableElementType(Type type) {
+  return type.isF32() || type.isF16() || type.isBF16() || type.isF64() ||
+         type.isInteger(1) || type.isInteger(8) || type.isInteger(16) ||
+         type.isInteger(32) || type.isInteger(64) ||
+         isa<Float8E4M3FNType, Float8E4M3FNUZType, Float8E5M2Type,
+             Float8E5M2FNUZType>(type);
+}
+
+// Element type of a tensor, or the type itself for a scalar.
+static Type getElementType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    return tensorType.getElementType();
+  return type;
+}
+
+// Whether an emitted expression names a value `.to(...)` can be called on.
+// The keyword literals lex as identifiers but are not tensors, so they take
+// the tl.cast path with the other inlined constants.
+static bool isPythonIdentifier(StringRef s) {
+  if (s.empty() || isdigit(static_cast<unsigned char>(s[0])))
+    return false;
+  if (s == "True" || s == "False" || s == "None")
+    return false;
+  return llvm::all_of(s, [](char c) {
+    return isalnum(static_cast<unsigned char>(c)) || c == '_';
+  });
+}
+
 // Get simplified name for a value (just the SSA name)
 // If argSubstitutionMap is provided, substitute block args with their mapped
 // values
@@ -487,6 +527,41 @@ getValueName(Value v,
       return "None";
     }
 
+    // An element-type cast is user-visible -- the kernel wrote `x.to(dtype)` --
+    // so unlike the layout-only casts below it is re-emitted, inline at each use.
+    if (elementTypeCastOps.contains(defOp->getName().getStringRef()) &&
+        defOp->getNumOperands() > 0) {
+      Type resultType = v.getType();
+      if (auto tensorType = dyn_cast<RankedTensorType>(resultType))
+        resultType = tensorType.getElementType();
+      // Only spell the cast when the dtype has a TLX name. getElementTypeName
+      // otherwise falls back to raw MLIR (`f8E4M3FN`), which is not a Triton
+      // dtype; leave those to the transparent list below rather than emit a
+      // call that cannot compile.
+      if (isNameableElementType(resultType)) {
+        std::string operand = getValueName(defOp->getOperand(0),
+                                           argSubstitutionMap, inlineConstants);
+        std::string dtype = getElementTypeName(resultType);
+        // `.to` is a method on a tensor, so it only works when the operand
+        // names one: an inlined constant reaches here as a Python literal and
+        // `(0).to(tl.float32)` raises AttributeError at kernel compile time.
+        // tl.cast accepts those, with one exception -- ub.poison prints as
+        // `None`, which tl.cast rejects outright. That value is undefined, so
+        // erasing its cast (below) costs nothing.
+        if (operand == "None") {
+          // fall through to the transparent list
+        } else if (!isPythonIdentifier(operand)) {
+          return "tl.cast(" + operand + ", " + dtype + ")";
+        } else {
+          return operand + ".to(" + dtype + ")";
+        }
+      }
+    }
+
+    // Layout- and shape-only ops, plus the width/index casts Triton leaves
+    // implicit. The float element-type casts are still listed: the block above
+    // intercepts them whenever their dtype is nameable, so reaching one here
+    // means it is not, and erasing it beats emitting an uncompilable dtype.
     static const llvm::StringSet<> transparentOps = {
         "ttg.convert_layout", "arith.extui",   "arith.extsi",
         "arith.extf",         "arith.trunci",  "arith.truncf",
@@ -639,6 +714,15 @@ void printConstantValue(Attribute attr, llvm::raw_ostream &os) {
 
 // Get element type name as a simple string
 std::string getElementTypeName(Type type) {
+  // Mirrors the builder types in python/src/ir.cc (get_fp8e4nv_ty etc).
+  if (isa<Float8E4M3FNType>(type))
+    return "tl.float8e4nv";
+  if (isa<Float8E4M3FNUZType>(type))
+    return "tl.float8e4b8";
+  if (isa<Float8E5M2Type>(type))
+    return "tl.float8e5";
+  if (isa<Float8E5M2FNUZType>(type))
+    return "tl.float8e5b16";
   if (type.isF32())
     return "tl.float32";
   if (type.isF16())
@@ -868,6 +952,26 @@ static Value resolveThroughCasts(Value v) {
       v = op->getOperand(0);
     else
       break;
+  }
+  return v;
+}
+
+// As above, but stops at an element-type cast. The store paths use this to
+// decide whether to append a dtype cast: getValueName already spells those
+// casts, so walking past one reports the pre-cast dtype and the store appends
+// a second, redundant `.to(...)`.
+static Value resolveThroughNonElementCasts(Value v) {
+  while (auto *op = v.getDefiningOp()) {
+    StringRef name = op->getName().getStringRef();
+    if (!castOpsSet.contains(name) || op->getNumOperands() == 0)
+      break;
+    // Stop only where getValueName actually spells the cast. An element cast
+    // to a dtype TLX cannot name is erased there, so walking past it here
+    // keeps the two in agreement and lets the store re-add the conversion.
+    if (elementTypeCastOps.contains(name) &&
+        isNameableElementType(getElementType(v.getType())))
+      break;
+    v = op->getOperand(0);
   }
   return v;
 }
@@ -1575,7 +1679,7 @@ void printSimplifiedOp(
 
     // Check if transparent ops resolve the source name to a different-dtype
     // value. Resolve through casts to find the actual Python-level type.
-    Value resolvedSrc = resolveThroughCasts(src);
+    Value resolvedSrc = resolveThroughNonElementCasts(src);
     Type dstElemType;
     Type resolvedSrcElemType;
     if (auto dstMemType = dyn_cast<ttg::MemDescType>(dst.getType()))
@@ -1600,7 +1704,7 @@ void printSimplifiedOp(
     Value src = op->getOperand(1);
     std::string srcName = getValueName(src, argSubstitutionMap);
 
-    Value resolvedSrc = resolveThroughCasts(src);
+    Value resolvedSrc = resolveThroughNonElementCasts(src);
     Type dstElemType;
     Type resolvedSrcElemType;
     if (auto dstMemType = dyn_cast<ttg::MemDescType>(dst.getType()))

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -480,6 +480,17 @@ static bool isPythonIdentifier(StringRef s) {
   });
 }
 
+// Whether getValueName spells an element-type cast or erases it: erased when
+// TLX cannot name the dtype, or the operand is `None`. Shared with the resolver.
+static bool spellsElementTypeCast(Operation *castOp, StringRef operandName) {
+  return castOp && castOp->getNumOperands() > 0 &&
+         castOp->getNumResults() > 0 &&
+         elementTypeCastOps.contains(castOp->getName().getStringRef()) &&
+         isNameableElementType(
+             getElementType(castOp->getResult(0).getType())) &&
+         operandName != "None";
+}
+
 // Get simplified name for a value (just the SSA name)
 // If argSubstitutionMap is provided, substitute block args with their mapped
 // values
@@ -531,31 +542,18 @@ getValueName(Value v,
     // so unlike the layout-only casts below it is re-emitted, inline at each use.
     if (elementTypeCastOps.contains(defOp->getName().getStringRef()) &&
         defOp->getNumOperands() > 0) {
-      Type resultType = v.getType();
-      if (auto tensorType = dyn_cast<RankedTensorType>(resultType))
-        resultType = tensorType.getElementType();
-      // Only spell the cast when the dtype has a TLX name. getElementTypeName
-      // otherwise falls back to raw MLIR (`f8E4M3FN`), which is not a Triton
-      // dtype; leave those to the transparent list below rather than emit a
-      // call that cannot compile.
-      if (isNameableElementType(resultType)) {
-        std::string operand = getValueName(defOp->getOperand(0),
-                                           argSubstitutionMap, inlineConstants);
-        std::string dtype = getElementTypeName(resultType);
+      std::string operand = getValueName(defOp->getOperand(0),
+                                         argSubstitutionMap, inlineConstants);
+      if (spellsElementTypeCast(defOp, operand)) {
+        std::string dtype = getElementTypeName(getElementType(v.getType()));
         // `.to` is a method on a tensor, so it only works when the operand
         // names one: an inlined constant reaches here as a Python literal and
         // `(0).to(tl.float32)` raises AttributeError at kernel compile time.
-        // tl.cast accepts those, with one exception -- ub.poison prints as
-        // `None`, which tl.cast rejects outright. That value is undefined, so
-        // erasing its cast (below) costs nothing.
-        if (operand == "None") {
-          // fall through to the transparent list
-        } else if (!isPythonIdentifier(operand)) {
+        if (!isPythonIdentifier(operand))
           return "tl.cast(" + operand + ", " + dtype + ")";
-        } else {
-          return operand + ".to(" + dtype + ")";
-        }
+        return operand + ".to(" + dtype + ")";
       }
+      // Otherwise the cast is erased: fall through to the transparent list.
     }
 
     // Layout- and shape-only ops, plus the width/index casts Triton leaves
@@ -965,11 +963,9 @@ static Value resolveThroughNonElementCasts(Value v) {
     StringRef name = op->getName().getStringRef();
     if (!castOpsSet.contains(name) || op->getNumOperands() == 0)
       break;
-    // Stop only where getValueName actually spells the cast. An element cast
-    // to a dtype TLX cannot name is erased there, so walking past it here
-    // keeps the two in agreement and lets the store re-add the conversion.
-    if (elementTypeCastOps.contains(name) &&
-        isNameableElementType(getElementType(v.getType())))
+    // Stop where getValueName spells the cast; walking past one it erased would
+    // report a dtype the emitted name does not carry.
+    if (spellsElementTypeCast(op, getValueName(op->getOperand(0))))
       break;
     v = op->getOperand(0);
   }
@@ -1688,6 +1684,8 @@ void printSimplifiedOp(
       resolvedSrcElemType = resolvedType.getElementType();
 
     os << "tlx.local_store(" << dstName << ", " << srcName;
+    // dstElemType is always nameable: local_store requires src and dst element
+    // types to match, and TT_Float is exactly what isNameableElementType covers.
     if (dstElemType && resolvedSrcElemType &&
         resolvedSrcElemType != dstElemType) {
       os << ".to(" << getElementTypeName(dstElemType) << ")";
@@ -1714,6 +1712,7 @@ void printSimplifiedOp(
 
     os << "tlx.local_store(" << getValueName(dst, argSubstitutionMap) << ", "
        << srcName;
+    // dstElemType is always nameable here, as in ttg.local_store above.
     if (dstElemType && resolvedSrcElemType &&
         resolvedSrcElemType != dstElemType) {
       os << ".to(" << getElementTypeName(dstElemType) << ")";


### PR DESCRIPTION
Summary:
`getValueName` decides whether an element-type cast is spelled as `.to(...)` /
`tl.cast(...)` or erased, and `resolveThroughNonElementCasts` has to make the
same call so the store paths compare dtypes against the name that was actually
emitted. D118840270 left those as two copies of the rule, and they had already
drifted: the resolver stops at any nameable element cast, while `getValueName`
also erases one whose operand prints as `None`.

Factor the decision into `spellsElementTypeCast` and have both ask it. Behaviour
is unchanged -- the drift is unreachable today, since the resolver feeds only
the two store paths and those require a tensor source, while a tensor
`ub.poison` prints as `tl.full(...)`, never `None`. The point is that the two
cannot drift apart again.

Also record why the store paths need no `isNameableElementType` guard on the
destination dtype: `ttg.local_store` requires the source tensor and destination
memdesc to share an element type, and `TT_Float` is exactly the float set
`isNameableElementType` covers, so `getElementTypeName` always has a TLX name
there.

Reviewed By: njriasan

Differential Revision: D119218224


