### PR TITLE
[TLX] Use persistent scheduling for Hopper attention forward

### DIFF
--- a/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
+++ b/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
@@ -3,6 +3,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
+from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
@@ -31,6 +32,21 @@ configs = [
 ]
 
 
+@triton.jit
+def _compute_offsets(tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M: tl.constexpr):
+    group_id = tile_idx // num_pid_in_group
+    first_pid_n = group_id
+    start_m = tile_idx % num_pid_in_group
+    off_hz = first_pid_n
+    off_z = off_hz // H
+    off_h = off_hz % H
+    offset_y = off_z * (N_CTX * H) + off_h * N_CTX
+    qo_offset_y = offset_y + start_m * BLOCK_M
+    lo, hi = 0, N_CTX
+    kv_offset_y = offset_y + lo
+    return start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y
+
+
 @triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
 @triton.jit
 def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
@@ -46,6 +62,24 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
     tl.static_assert(BLOCK_N <= HEAD_DIM)
     BLOCK_M_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
 
+    Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
+    K_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_k))
+    V_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_v))
+
+    # Persistent kernel setup
+    prog_id = tl.program_id(0)
+    num_progs = tl.num_programs(0)
+    num_pid_m = tl.cdiv(N_CTX, BLOCK_M)
+    num_pid_n = Z * H
+    num_pid_in_group = num_pid_m
+    total_tiles = num_pid_m * Z * H
+
+    tiles_per_prog = total_tiles // num_progs
+    if prog_id < total_tiles % num_progs:
+        tiles_per_prog += 1
+
+    tile_idx = prog_id
+
     # allocate buffers
     q_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_q), NUM_MMA_GROUPS)
     k_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS)
@@ -53,126 +87,114 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
 
     # allocate barriers
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=1)
-    k_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    q_empties = tlx.alloc_warp_barrier(
+        num_barriers=NUM_MMA_GROUPS,
+        num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+        num_arrivals=1,
+    )
+    k_empties = tlx.alloc_warp_barrier(
+        num_barriers=NUM_BUFFERS,
+        num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+        num_arrivals=NUM_MMA_GROUPS,
+    )
     k_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
-    v_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=NUM_MMA_GROUPS)
+    v_empties = tlx.alloc_warp_barrier(
+        num_barriers=NUM_BUFFERS,
+        num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+        num_arrivals=NUM_MMA_GROUPS,
+    )
     v_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS, arrive_count=1)
 
     with tlx.async_tasks(exclusive=True):
         # producer group
         with tlx.async_task("default"):
-            # initialize offsets
-            start_m = tl.program_id(0)
-            off_hz = tl.program_id(1)
-            off_z = off_hz // H
-            off_h = off_hz % H
-            offset_y = off_z * (N_CTX * H) + off_h * N_CTX
-            qo_offset_y = offset_y + start_m * BLOCK_M
-            lo, hi = 0, N_CTX
-            kv_offset_y = offset_y + lo
+            accum_cnt_kv = 0
 
-            # load q: it will stay in SRAM throughout
-            for cid in tl.range(0, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
-                tlx.barrier_expect_bytes(q_fulls[cid], 2 * BLOCK_M_SPLIT * HEAD_DIM)  # float16
-                qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                tlx.async_descriptor_load(desc_q, q_tiles[cid], [qo_offset_y_split, 0], q_fulls[cid])
+            for i in range(0, tiles_per_prog):
+                # initialize offsets
+                start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M)
 
-            # loop over loading k, v
-            kv_phase = 0
-            acc_cnt = 0
-            for _ in tl.range(lo, hi, BLOCK_N):
-                buf_id = acc_cnt % NUM_BUFFERS
-                # buffers in a row share the same phase
-                kv_phase = kv_phase ^ (buf_id == 0)
+                # Interleave the first K load between the two Q loads so consumer 0
+                # can begin its first QK while the producer finishes startup.
+                _, q_phase = get_bufidx_phase(i, 1)
+                q_cid: tl.constexpr = 0
+                tlx.barrier_wait(q_empties[q_cid], q_phase ^ 1)
+                tlx.barrier_expect_bytes(q_fulls[q_cid], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
+                qo_offset_y_split = qo_offset_y + q_cid * BLOCK_M_SPLIT
+                tlx.async_descriptor_load(desc_q, q_tiles[q_cid], [qo_offset_y_split, 0], q_fulls[q_cid])
 
-                # wait for the K buffer to be released by the consumer
-                tlx.barrier_wait(k_empties[buf_id], kv_phase)
-                # load K
-                tlx.barrier_expect_bytes(k_fulls[buf_id], 2 * BLOCK_N * HEAD_DIM)  # float16
-                tlx.async_descriptor_load(desc_k, k_tiles[buf_id], [kv_offset_y, 0], k_fulls[buf_id])
+                kv_buf_id, kv_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
+                kv_offset = kv_offset_y + lo
+                tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
+                tlx.barrier_expect_bytes(k_fulls[kv_buf_id], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                tlx.async_descriptor_load(desc_k, k_tiles[kv_buf_id], [kv_offset, 0], k_fulls[kv_buf_id])
 
-                # wait for the V buffer to be released by the consumer
-                tlx.barrier_wait(v_empties[buf_id], kv_phase)
-                # load V
-                tlx.barrier_expect_bytes(v_fulls[buf_id], 2 * BLOCK_N * HEAD_DIM)  # float16
-                tlx.async_descriptor_load(desc_v, v_tiles[buf_id], [kv_offset_y, 0], v_fulls[buf_id])
+                for cid in tl.range(1, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
+                    tlx.barrier_wait(q_empties[cid], q_phase ^ 1)
+                    tlx.barrier_expect_bytes(q_fulls[cid], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
+                    qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
+                    tlx.async_descriptor_load(desc_q, q_tiles[cid], [qo_offset_y_split, 0], q_fulls[cid])
 
-                kv_offset_y += BLOCK_N
-                acc_cnt += 1
+                tlx.barrier_wait(v_empties[kv_buf_id], kv_phase ^ 1)
+                tlx.barrier_expect_bytes(v_fulls[kv_buf_id], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                tlx.async_descriptor_load(desc_v, v_tiles[kv_buf_id], [kv_offset, 0], v_fulls[kv_buf_id])
+                accum_cnt_kv += 1
+
+                # Keep the established K-then-V order for the steady-state ring.
+                for kv_idx in tl.range(lo + BLOCK_N, hi, BLOCK_N, loop_unroll_factor=2):
+                    kv_buf_id, kv_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
+                    kv_offset = kv_offset_y + kv_idx
+
+                    # wait for the K buffer to be released by both consumers
+                    tlx.barrier_wait(k_empties[kv_buf_id], kv_phase ^ 1)
+                    # load K
+                    tlx.barrier_expect_bytes(k_fulls[kv_buf_id], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                    tlx.async_descriptor_load(desc_k, k_tiles[kv_buf_id], [kv_offset, 0], k_fulls[kv_buf_id])
+
+                    # wait for the V buffer to be released by both consumers
+                    tlx.barrier_wait(v_empties[kv_buf_id], kv_phase ^ 1)
+                    # load V
+                    tlx.barrier_expect_bytes(v_fulls[kv_buf_id], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                    tlx.async_descriptor_load(desc_v, v_tiles[kv_buf_id], [kv_offset, 0], v_fulls[kv_buf_id])
+
+                    accum_cnt_kv += 1
+
+                tile_idx += num_progs
 
         # consumer group
         with tlx.async_task(num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS, registers=232, replicate=NUM_MMA_GROUPS):
-            # initialize pointer to m and l
-            m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
-            l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
-            acc = tl.zeros([BLOCK_M_SPLIT, HEAD_DIM], dtype=tl.float32)
-
-            # load scales
-            qk_scale = sm_scale
-            qk_scale *= 1.44269504  # 1/log(2)
-
-            # wait for the Q buffer to be populated by the producer
+            accum_cnt_kv = 0
             cid: tl.constexpr = tlx.async_task_replica_id()
-            tlx.barrier_wait(q_fulls[cid], 0)
 
-            lo, hi = 0, N_CTX
-            k_phase = 0
-            v_phase = 1
-            k_buf_id = 0
-            v_buf_id = 0
-
-            # wait for the K[0] buffer to be populated by the producer
-            tlx.barrier_wait(k_fulls[k_buf_id], k_phase)
-
-            # -- compute qk[0] ----
-            k_tile = tlx.local_trans(k_tiles[k_buf_id])
-
-            if cid == 0:
-                # Consumer 0 waits for Consumer 1 to reach synchronization point at barrier 9.
-                tlx.named_barrier_wait(9, 256)
-            else:
-                # Consumer 1 signals its arrival at barrier 9.
-                tlx.named_barrier_arrive(9, 256)
-                # Then waits at barrier 10 until Consumer 0 finishes issuing its async_dot.
-                tlx.named_barrier_wait(10, 256)
-
-            qk = tlx.async_dot(q_tiles[cid], k_tile)
-
-            if cid == 0:
-                # After issuing async_dot, Consumer 0 signals barrier 10 to unblock Consumer 1.
-                tlx.named_barrier_arrive(10, 256)
-            else:
-                # Consumer 1 signals barrier 9 to unblock Consumer 0.
+            # Bootstrap the pingpong sequence once before the persistent tile loop.
+            if cid == 1:
                 tlx.named_barrier_arrive(9, 256)
 
-            # wait for the MMA to complete
-            qk = tlx.async_dot_wait(0, qk)
-            # release the K buffer
-            tlx.barrier_arrive(k_empties[k_buf_id], 1)
+            for i in range(0, tiles_per_prog):
+                # initialize offsets
+                start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M)
 
-            # -- compute m_i and l_i ----
-            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
-            qk = qk * qk_scale - m_ij[:, None]
-            p = tl.math.exp2(qk)
-            # -- compute correction factor
-            alpha = tl.math.exp2(m_i - m_ij)
-            # -- update output accumulator[0] --
-            acc = acc * alpha[:, None]
-            l_ij = tl.sum(p, 1)
-            l_i = l_i * alpha + l_ij
-            m_i = m_ij
-            acc_cnt = 1
+                # initialize pointer to m and l
+                m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
+                l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
+                acc = tl.zeros([BLOCK_M_SPLIT, HEAD_DIM], dtype=tl.float32)
 
-            # loop over k, v and update accumulator
-            for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N):
-                k_buf_id = acc_cnt % NUM_BUFFERS
-                # buffers in a row share the same phase
-                k_phase = k_phase ^ (k_buf_id == 0)
+                # load scales
+                qk_scale = sm_scale
+                qk_scale *= 1.44269504  # 1/log(2)
 
-                # wait for the K buffer to be populated by the producer
+                # wait for the Q buffer to be populated by the producer
+                _, q_phase = get_bufidx_phase(i, 1)
+                tlx.barrier_wait(q_fulls[cid], q_phase)
+
+                k_buf_id, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
+
+                # wait for the K[0] buffer to be populated by the producer
                 tlx.barrier_wait(k_fulls[k_buf_id], k_phase)
 
-                # compute qk for the current iteration
+                # -- compute qk[0] ----
                 k_tile = tlx.local_trans(k_tiles[k_buf_id])
 
                 if cid == 0:
@@ -191,17 +213,8 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                     # Consumer 1 signals barrier 9 to unblock Consumer 0.
                     tlx.named_barrier_arrive(9, 256)
 
-                # compute pv from the previous iteration
-                # wait for the previous V buffer to be populated by the producer
-                v_buf_id = (acc_cnt - 1) % NUM_BUFFERS
-                v_phase = v_phase ^ (v_buf_id == 0)
-                tlx.barrier_wait(v_fulls[v_buf_id], v_phase)
-                # prepare p and v for the dot
-                p = p.to(tlx.dtype_of(desc_k))
-                acc = tlx.async_dot(p, v_tiles[v_buf_id], acc)
-
-                # wait for the current qk MMA to complete
-                qk = tlx.async_dot_wait(1, qk)
+                # wait for the MMA to complete
+                qk = tlx.async_dot_wait(0, qk)
                 # release the K buffer
                 tlx.barrier_arrive(k_empties[k_buf_id], 1)
 
@@ -211,46 +224,95 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 p = tl.math.exp2(qk)
                 # -- compute correction factor
                 alpha = tl.math.exp2(m_i - m_ij)
+                # -- update output accumulator[0] --
+                acc = acc * alpha[:, None]
                 l_ij = tl.sum(p, 1)
-                # update m_i and l_i
                 l_i = l_i * alpha + l_ij
                 m_i = m_ij
+                accum_cnt_kv += 1
 
-                # -- update output accumulator --
-                # wait for the previous pv MMA to complete
+                # loop over k, v and update accumulator
+                for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N, loop_unroll_factor=2):
+                    k_buf_id, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
+
+                    # wait for the K buffer to be populated by the producer
+                    tlx.barrier_wait(k_fulls[k_buf_id], k_phase)
+
+                    # compute qk for the current iteration
+                    k_tile = tlx.local_trans(k_tiles[k_buf_id])
+
+                    if cid == 0:
+                        # Consumer 0 waits for Consumer 1 to reach synchronization point at barrier 9.
+                        tlx.named_barrier_wait(9, 256)
+                    else:
+                        # Then waits at barrier 10 until Consumer 0 finishes issuing its async_dot.
+                        tlx.named_barrier_wait(10, 256)
+
+                    qk = tlx.async_dot(q_tiles[cid], k_tile)
+
+                    if cid == 0:
+                        # After issuing async_dot, Consumer 0 signals barrier 10 to unblock Consumer 1.
+                        tlx.named_barrier_arrive(10, 256)
+                    else:
+                        # Consumer 1 signals barrier 9 to unblock Consumer 0.
+                        tlx.named_barrier_arrive(9, 256)
+
+                    # compute pv from the previous iteration
+                    # wait for the previous V buffer to be populated by the producer
+                    v_buf_id, v_phase = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS)
+                    tlx.barrier_wait(v_fulls[v_buf_id], v_phase)
+                    # prepare p and v for the dot
+                    p = p.to(tlx.dtype_of(desc_k))
+                    acc = tlx.async_dot(p, v_tiles[v_buf_id], acc)
+
+                    # wait for the current qk MMA to complete
+                    qk = tlx.async_dot_wait(1, qk)
+                    # release the K buffer
+                    tlx.barrier_arrive(k_empties[k_buf_id], 1)
+
+                    # -- compute m_i and l_i ----
+                    m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+                    qk = qk * qk_scale - m_ij[:, None]
+                    p = tl.math.exp2(qk)
+                    # -- compute correction factor
+                    alpha = tl.math.exp2(m_i - m_ij)
+                    l_ij = tl.sum(p, 1)
+                    # update m_i and l_i
+                    l_i = l_i * alpha + l_ij
+                    m_i = m_ij
+
+                    # -- update output accumulator --
+                    # wait for the previous pv MMA to complete
+                    acc = tlx.async_dot_wait(0, acc)
+                    # release the V buffer
+                    tlx.barrier_arrive(v_empties[v_buf_id], 1)
+                    acc = acc * alpha[:, None]
+                    accum_cnt_kv += 1
+
+                # compute pv from the last iteration
+                # wait for the V buffer to be populated by the producer
+                v_buf_id, v_phase = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS)
+                tlx.barrier_wait(v_fulls[v_buf_id], v_phase)
+                # prepare p and v for the dot
+                p = p.to(tlx.dtype_of(desc_k))
+                acc = tlx.async_dot(p, v_tiles[v_buf_id], acc)
+                # Q is no longer live once the final PV has been issued.
+                acc = tlx.async_dot_wait(1, acc)
+                tlx.barrier_arrive(q_empties[cid], 1)
+                # wait for the final PV to complete before releasing V
                 acc = tlx.async_dot_wait(0, acc)
-                # release the V buffer
                 tlx.barrier_arrive(v_empties[v_buf_id], 1)
-                acc = acc * alpha[:, None]
-                acc_cnt += 1
 
-            # compute pv from the last iteration
-            # wait for the V buffer to be populated by the producer
-            v_buf_id = (acc_cnt - 1) % NUM_BUFFERS
-            v_phase = v_phase ^ (v_buf_id == 0)
-            tlx.barrier_wait(v_fulls[v_buf_id], v_phase)
-            # prepare p and v for the dot
-            p = p.to(tlx.dtype_of(desc_k))
-            acc = tlx.async_dot(p, v_tiles[v_buf_id], acc)
-            # wait for the MMA to complete
-            acc = tlx.async_dot_wait(0, acc)
-            # release the V buffer
-            tlx.barrier_arrive(v_empties[v_buf_id], 1)
+                # epilogue
+                qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
+                m_i += tl.math.log2(l_i)
+                acc = acc / l_i[:, None]
+                offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                m_ptrs = M + off_hz * N_CTX + offs_m
+                tl.store(m_ptrs, m_i)
+                desc_o.store([qo_offset_y_split, 0], acc.to(tlx.dtype_of(desc_o)))
 
-            # epilogue
-            start_m = tl.program_id(0)
-            off_hz = tl.program_id(1)
-            off_z = off_hz // H
-            off_h = off_hz % H
-            offset_y = off_z * (N_CTX * H) + off_h * N_CTX
-            qo_offset_y = offset_y + start_m * BLOCK_M
-            qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-            m_i += tl.math.log2(l_i)
-            acc = acc / l_i[:, None]
-            offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
-            m_ptrs = M + off_hz * N_CTX + offs_m
-            tl.store(m_ptrs, m_i)
-            desc_o.store([qo_offset_y_split, 0], acc.to(tlx.dtype_of(desc_o)))
+                tile_idx += num_progs
 
 
 @triton.jit
@@ -599,8 +661,11 @@ class _attention(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
 
+        NUM_SMS = torch.cuda.get_device_properties(q.device).multi_processor_count
+
         def grid(META):
-            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+            total_tiles = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+            return (min(NUM_SMS, total_tiles), 1, 1)
 
         ctx.grid = grid
         _attn_fwd_ws_pipelined_pingpong[grid](
@@ -700,7 +765,9 @@ def attention(q, k, v, sm_scale, config=None):
 
     triton.set_allocator(alloc_fn)
 
-    grid = (triton.cdiv(q.shape[2], config["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+    NUM_SMS = torch.cuda.get_device_properties(q.device).multi_processor_count
+    total_tiles = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
+    grid = (min(NUM_SMS, total_tiles), 1, 1)
     _attn_fwd_ws_pipelined_pingpong.fn[grid](
         sm_scale,
         M,


### PR DESCRIPTION
Summary:
Optimize `_attn_fwd_ws_pipelined_pingpong` for Hopper BF16 forward attention by introducing an SM-capped persistent scheduler and improving the resulting producer/consumer pipeline.

The kernel flattens query-tile, batch, and head work, lets each CTA advance by the persistent grid size, and carries K/V ring phases across tiles. On top of that baseline, it unrolls the consumer QK/PV loop by two, publishes startup data in Q0-K0-Q1-V0 order, unrolls producer K/V publication by two, and uses warp barriers for Q/K/V empty notifications while retaining ordinary TMA completion barriers for full notifications.

Preserve the two-slot K/V ring, descriptor geometry, named barriers 9/10 with 256 participants, Q/K/V ownership and phases, public attention API, autograd behavior, and backward kernels.

Performance:
H100 GPU 6, BF16, non-causal forward, B=4, H=48, D=128, GPU-event timing. The baseline is the parent revision; every baseline/final shape ran in an independent Tritonbench process with an independent fresh Triton cache and paired alternating revision order.

| SeqLen | Baseline TFLOP/s | Final TFLOP/s | Speedup | Latency reduction | Baseline latency | Final latency |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 67.198 | 70.198 | 1.0446x | 4.27% | 0.0240 ms | 0.0229 ms |
| 256 | 162.229 | 170.183 | 1.0490x | 4.67% | 0.0397 ms | 0.0379 ms |
| 512 | 330.179 | 360.155 | 1.0908x | 8.32% | 0.0780 ms | 0.0716 ms |
| 1024 | 524.972 | 544.034 | 1.0363x | 3.50% | 0.1964 ms | 0.1895 ms |
| 2048 | 610.919 | 652.136 | 1.0675x | 6.32% | 0.6749 ms | 0.6323 ms |
| 4096 | 657.351 | 646.613 | 0.9837x | -1.66% | 2.5090 ms | 2.5506 ms |
| 8192 | 650.151 | 691.538 | 1.0637x | 5.98% | 10.1470 ms | 9.5397 ms |
| Average | 429.000 | 447.837 | 1.0439x | - | - | - |

The implementation improves arithmetic-average throughput by 4.39%. At S8192 it improves throughput by 6.37%, reducing latency from 10.1470 ms to 9.5397 ms. S4096 regresses by 1.66% in this measurement.

Final TLX versus FlashAttention-3 using the same H100/BF16 shape family and GPU-event timing:

| SeqLen | FA3 TFLOP/s | Final TLX TFLOP/s | TLX / FA3 | TLX latency delta |
| ---: | ---: | ---: | ---: | ---: |
| 128 | 85.020 | 70.198 | 82.57% | 21.11% slower |
| 256 | 169.610 | 170.183 | 100.34% | 0.34% faster |
| 512 | 367.049 | 360.155 | 98.12% | 1.91% slower |
| 1024 | 570.836 | 544.034 | 95.30% | 4.93% slower |
| 2048 | 642.158 | 652.136 | 101.55% | 1.53% faster |
| 4096 | 667.456 | 646.613 | 96.88% | 3.22% slower |
| 8192 | 679.140 | 691.538 | 101.83% | 1.79% faster |
| Average | 454.467 | 447.837 | 98.54% | - |

TLX exceeds FA3 at S256, S2048, and S8192. Tritonbench preprocessing, including FA3 input transposition, is excluded from the timed kernel region.

Profiling:
The protected S8192 promotion retained 168 registers/thread and 18.75% achieved occupancy while improving NCU duration from 12330 us to 12070 us. SM busy increased from 78.58% to 81.27%, issue slots busy from 39.97% to 41.01%, eligible warps per scheduler from 0.59 to 0.62, and no-eligible cycles decreased from 59.60% to 58.49%. Proton attributed exactly one `_attn_fwd_ws_pipelined_pingpong` launch with zero non-main-kernel GPU time.

Differential Revision: D119239332


