### PR TITLE
[triton][TLX.ops] Port historical 2-CTA Flash Attention kernel

### DIFF
--- a/python/test/tlx_benchmark/README.md
+++ b/python/test/tlx_benchmark/README.md
@@ -11,22 +11,60 @@ One shot command with extreme simplicity
 
 python python/test/tlx_benchmark/bench_{op}.py
 
+`{op}` is one of `mm`, `flash_attn`, `hstu_attn`, `kda`.
+
 ```
 options:
   -h, --help            show this help message and exit
   --device DEVICE       GPU index, or 'auto' (default) for the least-used one
   --space {heuristic,full,smoke}
-                        autotune search space; 'heuristic' is what tlx.ops.mm uses by default, and measuring anything
+                        autotune search space; the default is each op's own, and measuring anything
                         else measures a path users do not take
-  --head N              only the first N cases, for a quick look
+  --head N              only the first N cases PER DIRECTION, for a quick look; on an op with a
+                        backward, --head 10 is 10 fwd and 10 bwd
   --synthetic           run the correctness shapes instead of this arch's focus list; they are
                         mostly too small to time, so this is for looking, not for gating
-  --json JSON           machine-readable artifact (default /tmp/tlx_benchmark/mm.<arch>.json)
+  --fwd-only            skip the backward cases
+  --bwd-only            skip the forward cases
+  --latency-measure-mode {wallclock,gpu_events}
+                        'wallclock' (default) times each call as a caller sees it; 'gpu_events'
+                        pre-enqueues the batch behind a blocked stream to isolate device time
+  --cold-compile {all,first,none}
+                        how often to time a first call on a fresh cache; the default is each
+                        op's own (mm: all, everything else: first)
+  --json JSON           machine-readable artifact (default /tmp/tlx_benchmark/<op>.<arch>.json)
 ```
 
 - built in (default on) denoise (freq-lock)
 - built in (default on) GPU selection (least used)
 - built in (default on) kernel selection by gpu arch
+
+## Ops
+
+| op | reference | gate | default space |
+|----|-----------|------|---------------|
+| `mm` | `torch.matmul` | speedup >= 0.9x | heuristic |
+| `flash_attn` | `F.scaled_dot_product_attention` | speedup >= 0.9x | full |
+| `hstu_attn` | `_reference.py::triton_hstu_mha` (production Triton) | speedup >= 0.9x | full |
+| `kda` | none | absolute floor, currently unset -> reports only | full |
+
+Only `mm` has a `heuristic_config`, so it is the only op whose default is a
+single analytically chosen config. The rest autotune a full space on their first
+call, which is minutes rather than seconds; they raise `cap_s` accordingly rather
+than measure a `smoke` space no user takes. Writing a `heuristic_config` for each
+is the real fix and is tracked in the `tlx.ops` module docstring.
+
+There is no vendor library for SiLU-scaled ragged attention, so `hstu_attn`
+races the Triton kernel that ships today. The two are not tuned symmetrically --
+the reference autotunes its full space regardless of `--space` -- which is
+recorded per case as `ref_autotuned` rather than corrected for.
+
+Ops with a backward (`flash_attn`, `hstu_attn`, `kda`) produce two cases per
+shape. The backward is a different kernel at 2.5x the FLOPs, so folding it into
+the forward's number would hide it. Both run by default and are reported as two
+tables, `[fwd]` then `[bwd]`, under one summary and one artifact -- two
+different amounts of work do not belong in one TFLOP/s column. `--fwd-only` /
+`--bwd-only` skip a half.
 
 ## Metric report
 
@@ -34,12 +72,72 @@ options:
    `((), {'dtype': 'bf16', 'strides': '[[32768, 1], [12800, 1]]', 'M': '2304', 'N': '12800', 'K': '32768'})`
 2. Core metrics: ref (TFLOP/s), TLX (TFLOP/s), speedup, compile time
 3. Additional stats: samples, CV%, p50, p95, p99 (all based on TFLOP/s)
-4. status: ok/pip/noisy/error/...
+4. Op-specific columns, if the op declared any (see below)
+5. status: ok/pip/noisy/error/...
+
+### Common vs op-specific metrics
+
+Everything in 2 and 3 is common and identical for every op: an op is normalised
+onto them by supplying a `flop_count`, which is what makes a `speedup` or a `CV`
+comparable across `mm` and `flash_attn`.
+
+Anything else is one of two things, and which one decides where it goes:
+
+- **What the run was asked for** -- shape, dtype, `causal`, direction, the
+  seqlen distribution. These are inputs you chose, so they belong in `Case`:
+  in `shape`, rendered by the op's own `label()`, which is the `input` column.
+  `direction` is the one that is a real `Case` field, because it changes the
+  FLOP count and has to reach the artifact key.
+- **What the run found out** -- which SDPA backend torch dispatched, how many
+  tokens a ragged batch actually carried, a rate that needs the measured mean.
+  These go in `Result.extra`, a free-form JSON dict. They are artifact-only by
+  default; an op puts one in the table by naming it in `EXTRA_COLUMNS`.
+
+Today: `flash_attn` shows `ref_backend` (a 1.4x over `math` is a broken
+benchmark, a 1.4x over cuDNN is a result), `hstu_attn` shows observed `tokens`,
+`kda` shows `mtokens_per_s`, `mm` has none.
 
 error: break, accuracy error
-pip: speedup < 0.9 or compile time > 2 min
+pip: speedup < 0.9, or TFLOP/s under an op's absolute floor when it has no
+     reference, or compile time over that op's cap (2 min default; the ops with
+     no heuristic raise it, see above)
 noisy: CV% > 3%
 ok: everything else
+
+## How a call is timed
+
+`wallclock`, the default, is `triton.testing.do_bench`: CUDA events around each
+`fn()`, dispatched from the host one call at a time. It is the authoritative
+mode here for two reasons. It measures what a caller actually gets -- if the
+host cannot keep the GPU fed, that is a real cost of using the op, and
+`tlx_host_us` sits in the artifact to say how much of the number it is. And it
+is what every existing figure in this suite was taken with, so switching the
+default would silently invalidate comparisons against them.
+
+`gpu_events` is tritonbench's `--latency-measure-mode=gpu_events`: the whole
+batch is enqueued behind a blocked stream so the host runs far ahead, and the
+measured interval contains no dispatch gaps. Use it when the question is about
+the kernels rather than the end-to-end path -- most usefully on the
+multi-kernel backward passes (`flash_attn`, `hstu_attn`, `kda`), where a
+wallclock reading folds in several launches' worth of host work. It flatters
+both providers, so `speedup` moves much less than either absolute number; a
+large gap between the two modes for one case is itself the finding, and it will
+agree with a large `tlx_host_us`.
+
+Neither mode is a profiler. There is no per-kernel breakdown here; use
+`ir-debugging` or nsys for that.
+
+## Compile time
+
+The compile column is a real first call: a fresh Triton cache, so nothing is
+reused. For `mm` that is under a second and every case pays it. For the ops with
+no heuristic it compiles their whole autotune space -- `hstu_attn` is 48 forward
+configs -- which per case is most of the suite's runtime, spent re-answering a
+question that is not per-shape. Those ops sample it instead: one case per
+direction, the rest report `-` and are not gated on compile.
+
+`--cold-compile {all,first,none}` overrides. `all` is the honest per-case
+reading and what to use when compile time is what you are investigating.
 
 Stats are computed on per-iteration TFLOP/s, not converted from latency. So the
 percentiles ascend: p99 is the best case, `min` (artifact only) the worst.
@@ -67,3 +165,34 @@ Latency is not reported: it is `flop_count / TFLOP/s`, both in the artifact.
 Each entry carries its own strides and dtype, so there is no dtype
 cross-product. Strides, not a row/col flag: a leading stride wider than the row
 is a padded slice, and 0 is a broadcast.
+
+Shape lists live beside the kernel, in `tlx/ops/kernels/<op>/_shapes.py`, with
+each arch module re-exporting its own as `PERF_SHAPES`. Not in this directory,
+because the L1 correctness suites import the same lists -- one list, two
+consumers, no drift. Only `mm`'s focus lists come from production captures;
+the rest are hand-picked and marked provisional.
+
+## Adding an op
+
+Write `tlx/ops/kernels/<op>/_shapes.py` (`SYNTHETIC`, `<ARCH>_FOCUS`, `inputs()`,
+`flops()`, `label()`), re-export `PERF_SHAPES` from each arch module, then a
+`bench_<op>.py` with five names and one line of wiring:
+
+```python
+OP = "<op>"                    # catalog op name
+REF_NAME = "..."               # what ref_fn is; "" when there is none
+EXTRA_COLUMNS = ()             # ((header, Result.extra key), ...)
+
+def cases(synthetic=False) -> list[Case]: ...
+def prepare(case, space) -> Prepared: ...   # operands + closures + flop_count
+
+supported, default_json, run, main = driver.bind(sys.modules[__name__])
+```
+
+Optional: `DEFAULT_SPACE` (defaults to `"heuristic"`), `COLD_COMPILE` (defaults
+to `"all"`), and `annotate(result)`, a post-measurement hook for a metric that
+needs the measured mean.
+
+`Prepared.tlx_fn`/`ref_fn` must not allocate -- they are called hundreds of times
+inside the measured window. Build the tensors in `prepare` and capture them.
+`test_ops_perf.py` picks the new file up automatically.

--- a/python/test/tlx_benchmark/_harness/__init__.py
+++ b/python/test/tlx_benchmark/_harness/__init__.py
@@ -5,9 +5,10 @@ from .contract import SCHEMA_VERSION, Case, Result, Stat, Status, artifact
 from .denoise import (MAX_CLOCK_IDR, DEGRADING_REASONS, EVENT_REASONS, ClockTrace, GpuState, capture_env, check,
                       decode_event_reasons, foreign_processes, gpu_state, numa_bound, numa_node, nvml, parse_cpulist,
                       stable)
-from .measure import (DEFAULT_REPLICATES, DEFAULT_WARMUP_ITERS, MAX_REPLICATE_DEVIATION, MIN_REP_MS, MIN_TOTAL_SAMPLES,
-                      estimate_runtime_ms, host_overhead_us, measure, percentiles, relative_interdecile_range,
-                      reject_outliers_iqr, resolve_warmup_and_rep, summarize, to_tflops, window_for)
+from .measure import (DEFAULT_REPLICATES, DEFAULT_WARMUP_ITERS, LATENCY_MODES, MAX_REPLICATE_DEVIATION, MIN_REP_MS,
+                      MIN_TOTAL_SAMPLES, estimate_runtime_ms, host_overhead_us, measure, percentiles,
+                      relative_interdecile_range, reject_outliers_iqr, resolve_warmup_and_rep, summarize, to_tflops,
+                      window_for)
 
 __all__ = [
     "report",
@@ -43,6 +44,7 @@ __all__ = [
     "relative_interdecile_range",
     "stable",
     "DEFAULT_REPLICATES",
+    "LATENCY_MODES",
     "DEFAULT_WARMUP_ITERS",
     "MAX_REPLICATE_DEVIATION",
     "MIN_REP_MS",
@@ -56,4 +58,13 @@ __all__ = [
     "resolve_warmup_and_rep",
     "summarize",
     "to_tflops",
+    "driver",
+    "Prepared",
+    "bind",
+    "close_enough",
 ]
+
+# Last: `driver` imports the modules above, so it can only be pulled in once
+# they are bound on the package.
+from . import driver  # noqa: E402
+from .driver import Prepared, bind, close_enough  # noqa: E402

--- a/python/test/tlx_benchmark/_harness/contract.py
+++ b/python/test/tlx_benchmark/_harness/contract.py
@@ -7,7 +7,10 @@ from typing import Any, Optional, Sequence
 #: 2: ``Stat`` is TFLOP/s rather than milliseconds, and the redundant
 #: ``Result.tlx_tflops`` / ``ref_tflops`` are gone -- they were
 #: ``flop_count / mean_latency``, which ``Stat.mean`` now is.
-SCHEMA_VERSION = 2
+#: 3: multi-op. ``Case.direction`` (an op with a backward has two cases per
+#: shape), ``Result.extra`` (op-specific derived metrics), and ``env["ref"]``
+#: (which reference was raced -- not every op races torch).
+SCHEMA_VERSION = 3
 
 
 class Status(str, enum.Enum):
@@ -30,13 +33,22 @@ class Case:
     #: says nothing; "8192x8192x8192 A:row B:col" says what was measured. Falls
     #: back to the raw tuple so a new op need not provide one.
     label: str = ""
+    #: "fwd" or "bwd". A real field rather than an entry in ``Result.extra``
+    #: because it changes the FLOP count, changes which reference is fair, and
+    #: has to reach ``key`` -- otherwise an op's forward and backward cases
+    #: collide in the artifact and the second silently wins.
+    direction: str = "fwd"
 
     @property
     def key(self) -> str:
         # Flattened, because a shape element may be a tuple (mm carries operand
         # strides) and str() on one puts parens and spaces in the artifact key.
         parts = ("_".join(str(x) for x in s) if isinstance(s, (tuple, list)) else str(s) for s in self.shape)
-        return f"{self.op}/{self.arch}/{self.dtype}/{'x'.join(parts)}"
+        key = f"{self.op}/{self.arch}/{self.dtype}/{'x'.join(parts)}"
+        # Appended only when there is something to disambiguate, so every key an
+        # op with no backward has ever written stays byte-identical and old
+        # artifacts remain diffable against new ones.
+        return key if self.direction == "fwd" else f"{key}/{self.direction}"
 
     @property
     def input(self) -> str:
@@ -48,6 +60,7 @@ class Case:
             "arch": self.arch,
             "dtype": self.dtype,
             "shape": list(self.shape),
+            "direction": self.direction,
             "input": self.input,
             "key": self.key,
         }
@@ -126,6 +139,13 @@ class Result:
     n_configs: Optional[int] = None
     #: Free-text, carried into the failure message and the artifact.
     notes: list = dataclasses.field(default_factory=list)
+    #: Op-specific derived metrics, JSON-serializable. The dividing line against
+    #: ``Case``: ``Case`` holds what the run was ASKED for (shape, dtype, causal,
+    #: direction -- inputs you chose), ``extra`` holds what the run FOUND OUT
+    #: (which SDPA backend torch dispatched, how many tokens a ragged batch
+    #: actually carried). An op declares which of these earn a table column via
+    #: its ``EXTRA_COLUMNS``; the rest ride along in the artifact.
+    extra: dict = dataclasses.field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -141,6 +161,7 @@ class Result:
             "t_compile_single_s": self.t_compile_single_s,
             "n_configs": self.n_configs,
             "notes": list(self.notes),
+            "extra": dict(self.extra),
         }
 
 

--- a/python/test/tlx_benchmark/_harness/driver.py
+++ b/python/test/tlx_benchmark/_harness/driver.py
@@ -1,0 +1,364 @@
+"""The part of a benchmark that is the same for every op.
+
+`bench_<op>.py` supplies what only it can know -- the shapes, how to build the
+operands, what to race against, how many FLOPs that is -- and nothing else.
+Device selection, clock governing, the cold-compile pass, the measurement
+window, the verdict, the table and the artifact all live here, so adding an op
+does not mean copying a CLI.
+
+The adapter is the bench module itself, duck-typed, because `test_ops_perf.py`
+already discovers and calls bench modules that way. Five names:
+
+    OP              str                       -- catalog op name
+    REF_NAME        str                       -- what `ref_fn` is; lands in env["ref"]
+    EXTRA_COLUMNS   ((header, key), ...)      -- which Result.extra keys get a column
+    cases(synthetic)            -> list[Case]
+    prepare(case, space)        -> Prepared
+
+and one line of wiring:
+
+    supported, default_json, run, main = driver.bind(sys.modules[__name__])
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import functools
+import os
+from typing import Any, Callable, Iterable, Optional
+
+from . import report as report_mod
+from . import verdict
+from .compile import COLD_COMPILE_CAP_S, cold_compile
+from .contract import Case, Result, Status
+from .denoise import Governor, capture_env, list_devices, select_device, stable
+from .measure import DEFAULT_REPLICATES, LATENCY_MODES, host_overhead_us, measure
+
+
+@dataclasses.dataclass
+class Prepared:
+    """One case's operands, closures and cost model, from `bench.prepare`.
+
+    The closures must not allocate: they are called several hundred times inside
+    the measured window, and an allocation there is timed as if it were the
+    kernel. Build the tensors in `prepare` and capture them.
+    """
+
+    #: Called in the measured window. For a backward case this is the
+    #: `.backward()` call, not the forward.
+    tlx_fn: Callable[[], Any]
+    #: What TLX is raced against, or None when the op has no runnable reference
+    #: -- then `speedup` is not reported and `floor_tflops` is the only perf gate.
+    ref_fn: Optional[Callable[[], Any]] = None
+    #: Useful FLOPs for one call of `tlx_fn`. What makes every op's numbers
+    #: commensurable, since the suite reports throughput rather than latency.
+    flop_count: int = 0
+    #: Tensors whose `.grad` must be cleared between timed iterations. Required
+    #: for a backward case, where otherwise each iteration accumulates into the
+    #: previous one's gradients.
+    grad_to_none: Optional[Iterable] = None
+    #: Absolute TFLOP/s gate, for an op with no reference. See `verdict.judge`.
+    floor_tflops: Optional[float] = None
+    #: `() -> (ok, note)`. The op owns this because only it knows what its output
+    #: is and what tolerance applies; see `close_enough`. None skips the check --
+    #: appropriate for a backward case, whose numerics L1 already covers.
+    check: Optional[Callable[[], tuple]] = None
+    #: Op-specific derived metrics. See `Result.extra`.
+    extra: dict = dataclasses.field(default_factory=dict)
+    #: Cold-compile ceiling for this case. Overridable per op because an op with
+    #: no `heuristic_config` autotunes a full space on its first call and will
+    #: legitimately exceed the default; see the suite README.
+    cap_s: float = COLD_COMPILE_CAP_S
+
+
+#: The GPU this run is about. Everything downstream -- which `PERF_SHAPES` are
+#: imported, which `arch=` the op is pinned to, which device's clocks are
+#: captured, what the artifact is named -- has to agree with it.
+#:
+#: Set once by `select`, from `main`'s `--device`. Absent that (the pytest
+#: entry point, which does no selection) it falls back to the first device,
+#: matching what torch will call `cuda:0`. It cannot be derived from
+#: `list_devices()[0]` unconditionally: `main` may pin GPU N and set the
+#: visibility variable, and `nvidia-smi` enumerates physical devices regardless
+#: of that, so on a heterogeneous host GPU 0's arch is simply the wrong answer.
+_SELECTED: list = []  # a one-slot box, so "unset" and "no GPU" stay distinct
+
+
+def select(device) -> None:
+    _SELECTED[:] = [device]
+
+
+def selected_device():
+    if not _SELECTED:
+        devices = list_devices()
+        _SELECTED.append(devices[0] if devices else None)
+    return _SELECTED[0]
+
+
+def arch() -> Optional[str]:
+    device = selected_device()
+    return device.arch if device else None
+
+
+def device_index() -> int:
+    """Physical index, for the `nvidia-smi`-backed denoise helpers.
+
+    Physical rather than CUDA-visible: those helpers shell out to `nvidia-smi`,
+    which enumerates every GPU and does not honour the visibility variable.
+    """
+    device = selected_device()
+    return device.index if device else 0
+
+
+def close_enough(out, ref, rel: float) -> tuple:
+    """`(ok, note)` for the common "one tensor against one tensor" check.
+
+    atol tracks the magnitude of the whole result rather than of the element
+    being compared, which is what the L1 suites do, so a case cannot pass there
+    and fail here.
+    """
+    import torch
+
+    try:
+        torch.testing.assert_close(out, ref, atol=rel * ref.abs().max().item(), rtol=rel)
+    except AssertionError as mismatch:
+        return False, f"output does not match the reference: {str(mismatch).splitlines()[0]}"
+    return True, ""
+
+
+def supported(bench) -> bool:
+    # Both halves matter. No GPU means no arch; an arch the catalog has no entry
+    # for means every case would raise UnsupportedOp, and N error rows read like
+    # a failure when the honest answer is "not implemented here".
+    from triton.tlx.ops._catalog import has_impl
+
+    return arch() is not None and has_impl(bench.OP, arch())
+
+
+def default_json(bench) -> str:
+    return f"/tmp/tlx_benchmark/{bench.OP}.{arch()}.json"
+
+
+def run_case(bench, case: Case, *, space: str, cold: bool = True, latency_mode: str = "wallclock") -> Result:
+    import torch
+
+    prep = bench.prepare(case, space)
+
+    # Cold pass first, on its own fresh Triton cache. For a backward case
+    # `prepare` has already run the forward, so what this times is the backward
+    # compile alone -- which is the number that matters, the forward's being
+    # attributed to its own case.
+    #
+    # `cold=False` skips it and the case reports no compile time. See
+    # `resolve_cold_compile` for why that is the default on some ops.
+    compile_stat = cold_compile(prep.tlx_fn, cap_s=prep.cap_s) if cold else None
+
+    prep.tlx_fn()  # tune and compile outside the measured window
+    if prep.ref_fn is not None:
+        prep.ref_fn()
+    torch.cuda.synchronize()
+    correct, accuracy_note = prep.check() if prep.check is not None else (None, "")
+
+    # `measure` converts every timed iteration through flop_count, so both
+    # providers come back in TFLOP/s with the dispersion measured on that
+    # quantity rather than on latency.
+    tlx = measure(prep.tlx_fn, flop_count=prep.flop_count, replicates=DEFAULT_REPLICATES,
+                  grad_to_none=prep.grad_to_none, mode=latency_mode)
+    ref = None
+    if prep.ref_fn is not None:
+        ref = measure(prep.ref_fn, flop_count=prep.flop_count, replicates=DEFAULT_REPLICATES,
+                      grad_to_none=prep.grad_to_none, mode=latency_mode)
+    host_us = host_overhead_us(prep.tlx_fn)
+
+    result = verdict.judge(case, tlx, ref, tlx_host_us=host_us, compile_stat=compile_stat, correct=correct,
+                           accuracy_note=accuracy_note, floor_tflops=prep.floor_tflops)
+    result.flop_count = prep.flop_count
+    result.extra = dict(prep.extra)
+
+    # Optional adapter hook, for an op-specific metric that can only be computed
+    # from the measurement -- `prepare` runs before there is one. Mutates in
+    # place; a returned value is ignored.
+    annotate = getattr(bench, "annotate", None)
+    if annotate is not None:
+        annotate(result)
+
+    # `prep` and everything it closes over dies with this frame; empty_cache then
+    # returns the blocks to the driver so the next case can be allocated.
+    del prep
+    torch.cuda.empty_cache()
+    return result
+
+
+def _errored(case: Case, exc: Exception) -> Result:
+    result = Result(case=case, status=Status.ERROR)
+    result.notes.append(f"{type(exc).__name__}: {exc}")
+    return result
+
+
+def resolve_space(bench, space: Optional[str]) -> str:
+    """`None` means "whatever this op's own default is".
+
+    Ops do not share one: `mm` has a `heuristic_config` and defaults to it,
+    while `flash_attn`/`hstu_attn_dev`/`kimi_delta_attention` have none and
+    their kernels accept only "full" or "smoke" -- passing a global default of
+    "heuristic" to those is a KeyError, not a slow path.
+    """
+    return space or getattr(bench, "DEFAULT_SPACE", "heuristic")
+
+
+#: How often to pay the cold-compile pass.
+#:
+#: "all" is one fresh-cache first call per case. That is the honest reading, and
+#: it is what an op with a heuristic should do -- mm's cold pass is under a
+#: second. For an op that autotunes a full space it is the whole runtime:
+#: hstu_attn compiles 48 forward configs per pass, and running it per case pays
+#: that five times to answer a question that is not per-shape ("does a first
+#: call take too long"). "first" samples one case per direction; the rest report
+#: no compile time and are not gated on it. "none" skips it entirely.
+COLD_COMPILE_MODES = ("all", "first", "none")
+
+
+def resolve_cold_compile(bench, mode: Optional[str]) -> str:
+    mode = mode or getattr(bench, "COLD_COMPILE", "all")
+    if mode not in COLD_COMPILE_MODES:
+        raise ValueError(f"cold_compile must be one of {COLD_COMPILE_MODES}, got {mode!r}")
+    return mode
+
+
+def _head_per_direction(cases, head: int):
+    """The first `head` cases of EACH direction, in the original order.
+
+    Per direction rather than overall because `cases()` interleaves them: a flat
+    slice of an fwd/bwd list gives `head/2` of each, so `--head 10` on an op with
+    a backward would quietly measure five shapes. It also keeps `--head N`
+    meaning the same thing whether or not the op has a backward.
+    """
+    counts: dict = {}
+    kept = []
+    for case in cases:
+        seen = counts.get(case.direction, 0)
+        if seen < head:
+            counts[case.direction] = seen + 1
+            kept.append(case)
+    return kept
+
+
+def run(bench, *, space=None, head=None, synthetic=False, governor=None, cold_compile_mode=None, directions=None,
+        latency_mode="wallclock"):
+    space = resolve_space(bench, space)
+    cold_mode = resolve_cold_compile(bench, cold_compile_mode)
+    env = capture_env(device_index())
+    if governor is not None:
+        env["governed"] = governor.to_dict()
+    cases = bench.cases(synthetic)
+    if directions:
+        cases = [c for c in cases if c.direction in directions]
+    if head:
+        cases = _head_per_direction(cases, head)
+    results = []
+    sampled = set()
+    with stable(device_index()) as info:
+        for case in cases:
+            cold = cold_mode == "all" or (cold_mode == "first" and case.direction not in sampled)
+            if cold:
+                sampled.add(case.direction)
+            try:
+                results.append(run_case(bench, case, space=space, cold=cold, latency_mode=latency_mode))
+            except Exception as exc:  # a broken case must not hide the others
+                results.append(_errored(case, exc))
+    # The autotune space is part of what a number means: a heuristic-space
+    # latency and a full-space latency for the same shape differ by 4x, so two
+    # artifacts are only comparable when this matches. Same for the reference --
+    # not every op races torch, and a ratio against a Triton kernel is not the
+    # same claim as a ratio against a vendor library.
+    env["space"] = space
+    env["ref"] = getattr(bench, "REF_NAME", "")
+    env["cold_compile"] = cold_mode
+    env["latency_mode"] = latency_mode
+    if directions:
+        env["directions"] = sorted(directions)
+    env["replicates"] = DEFAULT_REPLICATES
+    if head:
+        env["head"] = head
+    env["shapes"] = "synthetic" if synthetic else "focus"
+    env["run"] = {k: info[k] for k in ("problems", "clock_trace", "elapsed_s") if k in info}
+    return results, env
+
+
+def main(bench, argv=None) -> int:
+    parser = argparse.ArgumentParser(description=bench.__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--device", default="auto", help="GPU index, or 'auto' (default) for the least-used one")
+    parser.add_argument(
+        "--space", choices=("heuristic", "full", "smoke"), default=None,
+        help=f"autotune search space (default {resolve_space(bench, None)}); the default is what this op "
+        "uses by default, and measuring anything else measures a path users do not take")
+    parser.add_argument("--head", type=int, default=None, metavar="N",
+                        help="only the first N cases per direction, for a quick look")
+    parser.add_argument(
+        "--synthetic", action="store_true",
+        help="run the correctness shapes instead of this arch's focus list; they are "
+        "mostly too small to time, so this is for looking, not for gating")
+    # An op with a backward reports both by default, in two tables.
+    only = parser.add_mutually_exclusive_group()
+    only.add_argument("--fwd-only", action="store_true", help="skip the backward cases")
+    only.add_argument("--bwd-only", action="store_true", help="skip the forward cases")
+    parser.add_argument(
+        "--latency-measure-mode", choices=LATENCY_MODES, default="wallclock", dest="latency_mode",
+        help="'wallclock' (default) times each call as a caller would see it, host dispatch "
+        "included; 'gpu_events' pre-enqueues the batch behind a blocked stream to isolate "
+        "device time, which matters most on the multi-kernel backward passes")
+    parser.add_argument(
+        "--cold-compile", choices=COLD_COMPILE_MODES, default=None, dest="cold_compile",
+        help=f"how often to time a first call on a fresh cache (default {resolve_cold_compile(bench, None)}); "
+        "'all' is per case, 'first' samples one case per direction, 'none' skips it")
+    parser.add_argument("--json", default=None,
+                        help="machine-readable artifact (default /tmp/tlx_benchmark/<op>.<arch>.json)")
+    args = parser.parse_args(argv)
+    directions = ("fwd", ) if args.fwd_only else ("bwd", ) if args.bwd_only else None
+
+    # Pick and pin the GPU before torch touches CUDA. Selection has to happen
+    # here rather than in a wrapper script so that the suite is one command,
+    # and it has to happen before the first CUDA call because the visibility
+    # variable is read once at context creation.
+    device = select_device(args.device)
+    # Pin it before anything reads `arch()`: the shape import, the `arch=` the
+    # op is dispatched on, the denoise capture and the artifact name all come
+    # from this one object.
+    select(device)
+    if device is not None:
+        os.environ[device.visibility_env] = str(device.index)
+        print(f"device: gpu{device.index} {device.name} "
+              f"({'least used' if args.device == 'auto' else 'requested'}, "
+              f"{device.memory_used_mib:.0f} MiB in use)")
+
+    # Governing is unconditional: a number taken on an ungoverned machine is not
+    # comparable to anything, so there is no switch to take one.
+    with Governor(device) as governor:
+        for step in governor.applied:
+            print(f"  denoise: {step}")
+        for step in governor.skipped:
+            print(f"  denoise: SKIPPED {step}")
+        results, env = run(bench, space=args.space, head=args.head, synthetic=args.synthetic, governor=governor,
+                           cold_compile_mode=args.cold_compile, directions=directions, latency_mode=args.latency_mode)
+    if not results:
+        # An empty focus list is legitimate -- an arch may have no capture yet --
+        # but a silent zero-row table reads like a pass. Say what was empty.
+        what = f"no {'synthetic' if args.synthetic else 'focus'} shapes for {arch()}"
+        if directions:
+            what += f" with direction in {sorted(directions)}"
+        print(f"{what}; nothing measured")
+        return 0
+    print(report_mod.render(results, env, args.json or default_json(bench), getattr(bench, "EXTRA_COLUMNS", ())))
+
+    return 1 if report_mod.failures(results) else 0
+
+
+def bind(module):
+    """The four entry points `test_ops_perf.py` and the CLI look for."""
+    return (
+        functools.partial(supported, module),
+        functools.partial(default_json, module),
+        functools.partial(run, module),
+        functools.partial(main, module),
+    )

--- a/python/test/tlx_benchmark/_harness/measure.py
+++ b/python/test/tlx_benchmark/_harness/measure.py
@@ -213,16 +213,81 @@ def host_overhead_us(fn: Callable, iters: int = 300) -> float:
     return statistics.median(samples)
 
 
+#: The two ways to time a call.
+#:
+#: "wallclock" is `triton.testing.do_bench`: CUDA events around each `fn()`,
+#: dispatched normally from the host. That is the authoritative mode here,
+#: because what it reports is what a caller gets -- if the host cannot keep the
+#: GPU fed, that is a real cost of using the op, and `tlx_host_us` says so
+#: alongside. It is also what every existing number in this suite was taken
+#: with.
+#:
+#: "gpu_events" is tritonbench's `--latency-measure-mode=gpu_events`: the whole
+#: batch is enqueued behind a blocked stream, so the host runs far ahead and
+#: the measured interval contains no dispatch gaps. That isolates device time,
+#: which is the right question when comparing two kernels rather than two
+#: end-to-end paths -- most useful on the multi-kernel backward passes
+#: (attention, KDA), where a wallclock reading folds in several launches' worth
+#: of host work. It flatters both providers equally, so a speedup ratio moves
+#: less than either absolute number.
+LATENCY_MODES = ("wallclock", "gpu_events")
+
+#: GPU cycles to hold the stream while the host enqueues the batch. Only the
+#: ramp needs covering -- once the first iteration runs there is always queued
+#: work behind it -- so this is sized for the enqueue, not for the measurement.
+#: ~20ms at 1GHz, against a few microseconds of Python per iteration.
+_GATE_CYCLES = 20_000_000
+
+
+def _gpu_event_samples(fn: Callable, iters: int, grad_to_none: Optional[Iterable] = None) -> list[float]:
+    """Per-iteration ms, with the host held off until the batch is queued."""
+    import torch
+
+    di = triton.runtime.driver.active.get_device_interface()
+    cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
+    starts = [di.Event(enable_timing=True) for _ in range(iters)]
+    ends = [di.Event(enable_timing=True) for _ in range(iters)]
+
+    di.synchronize()
+    # Everything below is enqueued behind this sleep, so the host reaches the
+    # end of the loop before the GPU reaches the start of it.
+    torch.cuda._sleep(_GATE_CYCLES)
+    for i in range(iters):
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+        triton.runtime.driver.active.clear_cache(cache)
+        starts[i].record()
+        fn()
+        ends[i].record()
+    di.synchronize()
+    return [s.elapsed_time(e) for s, e in zip(starts, ends)]
+
+
 def measure(fn: Callable, *, flop_count: Optional[float] = None, warmup: Optional[int] = None,
             rep: Optional[int] = None, auto_window: bool = False, replicates: int = DEFAULT_REPLICATES,
-            grad_to_none: Optional[Iterable] = None, remove_outliers: bool = True) -> Stat:
+            grad_to_none: Optional[Iterable] = None, remove_outliers: bool = True, mode: str = "wallclock") -> Stat:
     # replicates>1 re-warms each time and measures drift BETWEEN runs
     # (rel_max_deviation); that is no longer the gate, hence the default of 1.
     # Window sizing is inherently temporal -- `do_bench` derives its iteration
     # count from a duration -- so this half of the function stays in ms no
     # matter what the caller wants reported.
+    if mode not in LATENCY_MODES:
+        raise ValueError(f"mode must be one of {LATENCY_MODES}, got {mode!r}")
     estimate_ms = estimate_runtime_ms(fn, grad_to_none=grad_to_none)
     replicates = max(1, replicates)
+
+    if mode == "gpu_events":
+        # Same sample quota as the wallclock path, so the tail columns mean the
+        # same thing; the window is a count here rather than a duration.
+        iters = max(1, math.ceil(MIN_TOTAL_SAMPLES / replicates))
+        for _ in range(DEFAULT_WARMUP_ITERS):
+            fn()
+        runs = [_gpu_event_samples(fn, iters, grad_to_none) for _ in range(replicates)]
+        if flop_count:
+            return summarize([to_tflops(r, flop_count) for r in runs], remove_outliers=remove_outliers, unit="tflops")
+        return summarize(runs, remove_outliers=remove_outliers, unit="ms")
+
     if auto_window:
         warmup_ms, rep_ms = resolve_warmup_and_rep(warmup, rep, estimate_ms)
     else:

--- a/python/test/tlx_benchmark/_harness/report.py
+++ b/python/test/tlx_benchmark/_harness/report.py
@@ -44,14 +44,31 @@ def _fmt_compile(result) -> str:
     return f"{result.t_cold_s:.2f}s" if result.t_cold_s < 10 else f"{result.t_cold_s:.0f}s"
 
 
-def table(results: Sequence[Result]) -> str:
+def _fmt_extra(result, key: str) -> str:
+    value = result.extra.get(key)
+    if value is None:
+        return "-"
+    return f"{value:.3g}" if isinstance(value, float) else str(value)
+
+
+def table(results: Sequence[Result], extra_columns: Sequence[tuple] = ()) -> str:
+    """The common columns, then whichever op-specific ones the op asked for.
+
+    ``extra_columns`` is a sequence of ``(header, key)`` where ``key`` indexes
+    ``Result.extra``. Nothing here knows what any of them mean -- an op that
+    wants one of its derived metrics in the table declares it and the width is
+    taken from the data.
+    """
     width = max([len(r.case.input) for r in results] + [len("input")])
+    extra_widths = [max([len(head)] + [len(_fmt_extra(r, key)) for r in results]) for head, key in extra_columns]
+    heads = "".join(f" {head:>{w}}" for (head, _), w in zip(extra_columns, extra_widths))
     lines = [
         f"{'input':<{width}} {'ref TF/s':>9} {'tlx TF/s':>9} {'speedup':>8} {'compile':>8} "
-        f"{'samples':>8} {'CV%':>6} {'p50 TF/s':>9} {'p95 TF/s':>9} {'p99 TF/s':>9}  status",
-        "-" * (width + 84),
+        f"{'samples':>8} {'CV%':>6} {'p50 TF/s':>9} {'p95 TF/s':>9} {'p99 TF/s':>9}{heads}  status",
+        "-" * (width + 84 + sum(w + 1 for w in extra_widths)),
     ]
     for r in results:
+        cells = "".join(f" {_fmt_extra(r, key):>{w}}" for (_, key), w in zip(extra_columns, extra_widths))
         lines.append(f"{r.case.input:<{width}} "
                      f"{_tf(_stat(r.ref, 'mean'))} {_tf(_stat(r.tlx, 'mean'))} "
                      f"{(f'{r.speedup:.3f}x' if r.speedup else '-'):>8} "
@@ -60,7 +77,7 @@ def table(results: Sequence[Result]) -> str:
                      f"{_fmt_cv(r):>6} "
                      f"{_tf(_stat(r.tlx, 'p50'))} "
                      f"{_tf(_stat(r.tlx, 'p95'))} "
-                     f"{_tf(_stat(r.tlx, 'p99'))}  {_MARK[r.status]}")
+                     f"{_tf(_stat(r.tlx, 'p99'))}{cells}  {_MARK[r.status]}")
     return "\n".join(lines)
 
 
@@ -88,8 +105,30 @@ def _details(results: Sequence[Result], statuses: tuple[Status, ...]) -> list[st
     return [f"  {r.case.key}: {'; '.join(r.notes) or _MARK[r.status]}" for r in results if r.status in statuses]
 
 
-def render(results: Sequence[Result], env: dict, json_path: Optional[str] = None) -> str:
-    out = [table(results), ""]
+def by_direction(results: Sequence[Result]) -> dict:
+    """Results grouped by `Case.direction`, in the order the directions appear."""
+    groups: dict = {}
+    for r in results:
+        groups.setdefault(r.case.direction, []).append(r)
+    return groups
+
+
+def tables(results: Sequence[Result], extra_columns: Sequence[tuple] = ()) -> str:
+    """One table per direction, or just the one when the op has a single one.
+
+    Split because forward and backward are different kernels doing different
+    amounts of work: interleaving them puts two unrelated TFLOP/s scales in one
+    column, and the eye reads down a column.
+    """
+    groups = by_direction(results)
+    if len(groups) <= 1:
+        return table(results, extra_columns)
+    return "\n\n".join(f"[{direction}]\n{table(group, extra_columns)}" for direction, group in groups.items())
+
+
+def render(results: Sequence[Result], env: dict, json_path: Optional[str] = None,
+           extra_columns: Sequence[tuple] = ()) -> str:
+    out = [tables(results, extra_columns), ""]
     if json_path:
         out.append(f"artifact: {write_json(results, env, json_path)}")
     out.append(summary(results))

--- a/python/test/tlx_benchmark/_harness/verdict.py
+++ b/python/test/tlx_benchmark/_harness/verdict.py
@@ -31,6 +31,7 @@ def judge(
     compile_stat: Optional[CompileStat] = None,
     correct: Optional[bool] = None,
     accuracy_note: str = "",
+    floor_tflops: Optional[float] = None,
 ) -> Result:
     # Precedence is the README's order: error, pip, noisy, ok. pip ahead of noisy is
     # deliberate -- a shape that is slow AND jittery is the one most worth seeing, and
@@ -64,6 +65,17 @@ def judge(
         result.status = Status.PIP
         result.notes.append(f"speedup {result.speedup:.3f}x is under the {MIN_SPEEDUP:g}x floor")
         if tlx.cv > MAX_CV:  # still worth saying the number is soft
+            result.notes.append(f"CV {tlx.cv * 100:.1f}% is also over the {MAX_CV * 100:.0f}% limit")
+        return result
+
+    # The gate for an op with no runnable reference. Without it such an op can
+    # only fail on ERROR or the compile cap, so a 3x regression passes silently.
+    # Absolute and op-supplied rather than derived from history: this suite reads
+    # nothing from disk, so "slower than last week" is not a question it can ask.
+    if ref is None and floor_tflops and tlx.mean < floor_tflops:
+        result.status = Status.PIP
+        result.notes.append(f"{tlx.mean:.0f} TFLOP/s is under the {floor_tflops:.0f} TFLOP/s floor")
+        if tlx.cv > MAX_CV:
             result.notes.append(f"CV {tlx.cv * 100:.1f}% is also over the {MAX_CV * 100:.0f}% limit")
         return result
 

--- a/python/test/tlx_benchmark/bench_flash_attn.py
+++ b/python/test/tlx_benchmark/bench_flash_attn.py
@@ -1,0 +1,136 @@
+"""Perf and compile-time guardrail for `tlx.ops.flash_attn`, against SDPA.
+
+Forward and backward are separate cases: the backward is 2.5x the FLOPs, is a
+different kernel, and is where most of the recent work went, so folding it into
+the forward's number would hide it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import torch
+import torch.nn.functional as F
+
+from triton.tlx.ops.kernels.flash_attn._shapes import flops, label, qkv
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from _harness import Case, Prepared, close_enough, driver  # noqa: E402
+
+OP = "flash_attn"
+REF_NAME = "torch.nn.functional.scaled_dot_product_attention"
+#: No `heuristic_config` yet, so the op's own default is a full autotune -- see
+#: the `tlx.ops` module docstring. Measuring "smoke" instead would measure a
+#: path no user takes, so the suite pays the compile time and raises the cap.
+DEFAULT_SPACE = "full"
+#: Which SDPA kernel torch would dispatch. Earns a column because the headline
+#: speedup is unreadable without it: 1.4x over `math` is a broken benchmark,
+#: 1.4x over cuDNN is a result.
+EXTRA_COLUMNS = (("ref bknd", "ref_backend"), )
+
+#: One fresh-cache first call per direction, not per case: the cold pass
+#: compiles this op's whole autotune space, and "does a first call take too
+#: long" is not a per-shape question.
+COLD_COMPILE = "first"
+
+#: A full autotune on a cold cache is minutes, not seconds. The default 120s cap
+#: is calibrated for mm's heuristic path and would fail every case here on
+#: compile alone, which says nothing about the kernel.
+COMPILE_CAP_S = 900.0
+
+DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16}
+DIRECTIONS = ("fwd", "bwd")
+
+#: atol tracks the magnitude of the result, not of the element compared. Same
+#: values as `test_flash_attn.py`, so a case cannot pass there and fail here.
+REL_PRECISION = {"float16": 1e-3, "bfloat16": 8e-3}
+
+
+def shapes(synthetic: bool = False) -> list[list]:
+    if synthetic:
+        from triton.tlx.ops.kernels.flash_attn._shapes import SYNTHETIC
+
+        return list(SYNTHETIC)
+    return list(importlib.import_module(f"triton.tlx.ops.kernels.flash_attn.{driver.arch()}").PERF_SHAPES)
+
+
+def cases(synthetic: bool = False) -> list[Case]:
+    return [
+        Case(op=OP, arch=driver.arch(), dtype=str(DTYPES[entry[5]]).removeprefix("torch."), shape=tuple(entry[:5]),
+             direction=direction, label=label(*entry, direction))
+        for entry in shapes(synthetic)
+        for direction in DIRECTIONS
+    ]
+
+
+def _ref_backend(q, k, v, causal) -> str:
+    """Which kernel `scaled_dot_product_attention` would pick for these inputs.
+
+    A capability probe in the dispatcher's own preference order, not a trace of
+    the call -- torch exposes no "which one did you just run". Good enough for
+    the question it answers, which is whether the ratio is against a real
+    attention kernel or against the math fallback.
+    """
+    from torch.backends.cuda import (SDPAParams, can_use_cudnn_attention, can_use_efficient_attention,
+                                     can_use_flash_attention)
+
+    params = SDPAParams(q, k, v, None, 0.0, causal, False)
+    for name, usable, enabled in (
+        ("cudnn", can_use_cudnn_attention, torch.backends.cuda.cudnn_sdp_enabled),
+        ("flash", can_use_flash_attention, torch.backends.cuda.flash_sdp_enabled),
+        ("efficient", can_use_efficient_attention, torch.backends.cuda.mem_efficient_sdp_enabled),
+    ):
+        try:
+            if enabled() and usable(params, False):
+                return name
+        except RuntimeError:  # a probe may reject the params outright
+            continue
+    return "math"
+
+
+def prepare(case: Case, space: str) -> Prepared:
+    from triton.tlx.ops import flash_attn as tlx_flash_attn
+
+    Z, H, N_CTX, HEAD_DIM, causal = case.shape
+    backward = case.direction == "bwd"
+    dtype = getattr(torch, case.dtype)
+    q, k, v = qkv(Z, H, N_CTX, HEAD_DIM, dtype, requires_grad=backward)
+
+    tlx_fwd = lambda: tlx_flash_attn(q, k, v, causal=causal, arch=driver.arch(), space=space)  # noqa: E731
+    ref_fwd = lambda: F.scaled_dot_product_attention(  # noqa: E731
+        q, k, v, is_causal=causal, scale=HEAD_DIM**-0.5)
+    extra = {"ref_backend": _ref_backend(q, k, v, causal)}
+
+    if not backward:
+        return Prepared(tlx_fn=tlx_fwd, ref_fn=ref_fwd, flop_count=flops(*case.shape, "fwd"),
+                        check=lambda: close_enough(tlx_fwd(), ref_fwd(), REL_PRECISION[case.dtype]), extra=extra,
+                        cap_s=COMPILE_CAP_S)
+
+    # Build both graphs once, here, so the measured window is the backward and
+    # nothing else. `retain_graph` because the same graph is walked several
+    # hundred times; `grad_to_none` because otherwise each iteration accumulates
+    # into the last one's gradients.
+    tlx_out, ref_out = tlx_fwd(), ref_fwd()
+    do = torch.randn_like(tlx_out)
+    return Prepared(
+        tlx_fn=lambda: tlx_out.backward(do, retain_graph=True),
+        ref_fn=lambda: ref_out.backward(do, retain_graph=True),
+        flop_count=flops(*case.shape, "bwd"),
+        grad_to_none=[q, k, v],
+        # No accuracy check: the two `.backward()` calls write to the same
+        # `.grad` tensors, so comparing them here would need a third set of
+        # operands and a second graph. `test_flash_attn.py::test_flash_attn_bwd`
+        # already covers the numerics.
+        check=None,
+        extra=extra,
+        cap_s=COMPILE_CAP_S,
+    )
+
+
+supported, default_json, run, main = driver.bind(sys.modules[__name__])
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test/tlx_benchmark/bench_hstu_attn.py
+++ b/python/test/tlx_benchmark/bench_hstu_attn.py
@@ -1,0 +1,104 @@
+"""Perf guardrail for `tlx.ops.hstu_attn_dev`, against production Triton HSTU.
+
+There is no vendor library for SiLU-scaled ragged attention, so the reference is
+`_reference.py::triton_hstu_mha` -- the kernel that ships today, vendored into
+the op package. "Faster than what production runs" is the question that matters
+here, and it is the only one that can be asked.
+
+The two are not tuned symmetrically: the reference autotunes its full space
+while TLX runs at whatever `--space` says. That is recorded per case as
+`ref_autotuned` rather than corrected for, because forcing the reference onto
+one config would measure a kernel nobody runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import torch
+
+from triton.tlx.ops.kernels.hstu_attn._shapes import flops, inputs, label
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from _harness import Case, Prepared, close_enough, driver  # noqa: E402
+
+OP = "hstu_attn_dev"
+REF_NAME = "triton.tlx.ops.kernels.hstu_attn._reference:triton_hstu_mha"
+#: No `heuristic_config` yet; see `bench_flash_attn.py`.
+DEFAULT_SPACE = "full"
+EXTRA_COLUMNS = (("tokens", "tokens"), )
+#: One fresh-cache first call per direction, not per case: the cold pass
+#: compiles this op's whole autotune space, and "does a first call take too
+#: long" is not a per-shape question.
+COLD_COMPILE = "first"
+
+COMPILE_CAP_S = 900.0
+
+DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16}
+DIRECTIONS = ("fwd", "bwd")
+
+REL_PRECISION = {"float16": 1e-3, "bfloat16": 8e-3}
+
+
+def shapes(synthetic: bool = False) -> list[list]:
+    if synthetic:
+        from triton.tlx.ops.kernels.hstu_attn._shapes import SYNTHETIC
+
+        return list(SYNTHETIC)
+    return list(importlib.import_module(f"triton.tlx.ops.kernels.hstu_attn.{driver.arch()}").PERF_SHAPES)
+
+
+def cases(synthetic: bool = False) -> list[Case]:
+    return [
+        Case(op=OP, arch=driver.arch(), dtype=str(DTYPES[entry[5]]).removeprefix("torch."), shape=tuple(entry[:5]),
+             direction=direction, label=label(*entry, direction))
+        for entry in shapes(synthetic)
+        for direction in DIRECTIONS
+    ]
+
+
+def prepare(case: Case, space: str) -> Prepared:
+    from triton.tlx.ops import hstu_attn_dev as tlx_hstu_attn
+    from triton.tlx.ops.kernels.hstu_attn._reference import triton_hstu_mha
+
+    Z, max_seq_len, H, head_dim, causal = case.shape
+    backward = case.direction == "bwd"
+    dtype = getattr(torch, case.dtype)
+    q, k, v, offsets, attn_scale = inputs(Z, max_seq_len, H, head_dim, dtype, requires_grad=backward)
+    alpha = 1.0 / head_dim
+    tokens = int(offsets[-1])
+
+    tlx_fwd = lambda: tlx_hstu_attn(  # noqa: E731
+        q, k, v, offsets, max_seq_len, attn_scale, alpha=alpha, causal=causal, arch=driver.arch(), space=space)
+    ref_fwd = lambda: triton_hstu_mha(  # noqa: E731
+        max_seq_len, alpha, q, k, v, offsets, attn_scale)
+    # `tokens` is what a ragged batch actually carried, which the label's
+    # Z x MAX_SEQ_LEN only equals under the uniform draw.
+    extra = {"tokens": tokens, "ref_autotuned": True}
+    flop_count = flops(*case.shape, case.direction, tokens=tokens)
+
+    if not backward:
+        return Prepared(tlx_fn=tlx_fwd, ref_fn=ref_fwd, flop_count=flop_count,
+                        check=lambda: close_enough(tlx_fwd(), ref_fwd(), REL_PRECISION[case.dtype]), extra=extra,
+                        cap_s=COMPILE_CAP_S)
+
+    tlx_out, ref_out = tlx_fwd(), ref_fwd()
+    do = torch.randn_like(tlx_out)
+    return Prepared(
+        tlx_fn=lambda: tlx_out.backward(do, retain_graph=True),
+        ref_fn=lambda: ref_out.backward(do, retain_graph=True),
+        flop_count=flop_count,
+        grad_to_none=[q, k, v],
+        check=None,  # see bench_flash_attn.py
+        extra=extra,
+        cap_s=COMPILE_CAP_S,
+    )
+
+
+supported, default_json, run, main = driver.bind(sys.modules[__name__])
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test/tlx_benchmark/bench_kda.py
+++ b/python/test/tlx_benchmark/bench_kda.py
@@ -1,0 +1,115 @@
+"""Perf guardrail for `tlx.ops.kimi_delta_attention`. No reference.
+
+The only KDA reference in the tree is the per-chunk python loop in
+`test_kimi_delta_attention.py`, which does a `solve_triangular` per chunk and
+cannot be timed. So there is no `speedup` column, and the perf gate is the
+absolute `FLOOR_TFLOPS` -- currently None, i.e. this op reports rather than
+gates until a clean run exists to seed the floor from.
+
+TODO: `fla` (flash-linear-attention) ships `chunk_kda`, which would be a real
+reference. It is not a dependency of this suite and the README promises torch
+and triton only, so adding it means an optional import that skips the reference
+when absent -- deliberately deferred rather than done quietly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import torch
+
+from triton.tlx.ops.kernels.kda._shapes import CHUNK, FLOOR_TFLOPS, flops, inputs, label
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from _harness import Case, Prepared, driver  # noqa: E402
+
+OP = "kimi_delta_attention"
+REF_NAME = ""  # no runnable reference; see the module docstring
+DEFAULT_SPACE = "full"
+#: TFLOP/s is a poor headline for a chunked recurrence -- see `_shapes.flops` --
+#: so the honest rate gets the column.
+EXTRA_COLUMNS = (("Mtok/s", "mtokens_per_s"), )
+#: One fresh-cache first call per direction, not per case: the cold pass
+#: compiles this op's whole autotune space, and "does a first call take too
+#: long" is not a per-shape question.
+COLD_COMPILE = "first"
+
+COMPILE_CAP_S = 900.0
+
+#: bf16 only: the catalog entry admits fp16 but the L1 suite only covers bf16,
+#: and this suite does not measure what nothing checks.
+DTYPES = {"bf16": torch.bfloat16}
+DIRECTIONS = ("fwd", "bwd")
+
+
+def shapes(synthetic: bool = False) -> list[list]:
+    if synthetic:
+        from triton.tlx.ops.kernels.kda._shapes import SYNTHETIC
+
+        return list(SYNTHETIC)
+    return list(importlib.import_module(f"triton.tlx.ops.kernels.kda.{driver.arch()}").PERF_SHAPES)
+
+
+def cases(synthetic: bool = False) -> list[Case]:
+    return [
+        Case(op=OP, arch=driver.arch(), dtype=str(DTYPES[entry[4]]).removeprefix("torch."), shape=tuple(entry[:4]),
+             direction=direction, label=label(*entry, direction))
+        for entry in shapes(synthetic)
+        for direction in DIRECTIONS
+    ]
+
+
+def prepare(case: Case, space: str) -> Prepared:
+    from triton.tlx.ops import kimi_delta_attention as tlx_kda
+
+    B, T, H, head_dim = case.shape
+    backward = case.direction == "bwd"
+    dtype = getattr(torch, case.dtype)
+    q, k, v, g, beta, cu_seqlens = inputs(B, T, H, head_dim, dtype, requires_grad=backward)
+
+    # The op returns a TritonBench-compatible `(output, None)` pair; the index
+    # is free and keeps the closure returning something differentiable.
+    tlx_fwd = lambda: tlx_kda(  # noqa: E731
+        q, k, v, g, beta, scale=1.0, cu_seqlens=cu_seqlens, arch=driver.arch(), space=space)[0]
+
+    flop_count = flops(*case.shape, case.direction)
+    extra = {"chunks": (B * T) // CHUNK, "chunk": CHUNK}
+
+    if not backward:
+        return Prepared(tlx_fn=tlx_fwd, ref_fn=None, flop_count=flop_count, floor_tflops=FLOOR_TFLOPS,
+                        check=None,  # no runnable reference to check against
+                        extra=extra, cap_s=COMPILE_CAP_S)
+
+    out = tlx_fwd()
+    do = torch.randn_like(out)
+    return Prepared(
+        tlx_fn=lambda: out.backward(do, retain_graph=True),
+        ref_fn=None,
+        flop_count=flop_count,
+        grad_to_none=[q, k, v, g, beta],
+        floor_tflops=FLOOR_TFLOPS,
+        check=None,
+        extra=extra,
+        cap_s=COMPILE_CAP_S,
+    )
+
+
+def annotate(result) -> None:
+    """The driver's post-measurement hook: this rate needs the measured mean.
+
+    Recovered from the throughput rather than timed separately, because
+    `flop_count / mean` is exactly the latency `measure` converted away.
+    """
+    if result.tlx and result.flop_count:
+        latency_s = result.flop_count / (result.tlx.mean * 1e12)
+        tokens = result.case.shape[0] * result.case.shape[1]
+        result.extra["mtokens_per_s"] = tokens / latency_s / 1e6
+
+
+supported, default_json, run, main = driver.bind(sys.modules[__name__])
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/test/tlx_benchmark/bench_mm.py
+++ b/python/test/tlx_benchmark/bench_mm.py
@@ -1,31 +1,31 @@
+"""Perf and compile-time guardrail for `tlx.ops.mm`, against `torch.matmul`."""
+
 from __future__ import annotations
 
-import argparse
-import functools
 import importlib
-import os
+import pathlib
 import sys
 
 import torch
 
 from triton.tlx.ops.kernels.mm._shapes import flops, label, operand
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from _harness import (DEFAULT_REPLICATES, Case, Status, capture_env, cold_compile,  # noqa: E402
-                      host_overhead_us, measure, stable)
-from _harness.denoise import Governor, list_devices, select_device  # noqa: E402
-from _harness import report as report_mod  # noqa: E402
-from _harness import verdict  # noqa: E402
+from _harness import Case, Prepared, close_enough, driver  # noqa: E402
 
 OP = "mm"
+REF_NAME = "torch.matmul"
+#: mm has a shape heuristic, so its default is a single analytically chosen
+#: config and a first call stays under a second.
+DEFAULT_SPACE = "heuristic"
+EXTRA_COLUMNS = ()
+
 DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16}
 
-
-@functools.lru_cache(maxsize=1)
-def arch() -> str | None:
-    devices = list_devices()
-    return devices[0].arch if devices else None
+#: Relative tolerance for the accuracy check, per dtype. Same values the L1
+#: correctness suite uses, so a case cannot pass there and fail here.
+REL_PRECISION = {"float16": 1e-3, "bfloat16": 8e-3}
 
 
 def shapes(synthetic: bool = False) -> list[list]:
@@ -33,161 +33,36 @@ def shapes(synthetic: bool = False) -> list[list]:
         from triton.tlx.ops.kernels.mm._shapes import SYNTHETIC
 
         return list(SYNTHETIC)
-    return list(importlib.import_module(f"triton.tlx.ops.kernels.mm.{arch()}").PERF_SHAPES)
+    return list(importlib.import_module(f"triton.tlx.ops.kernels.mm.{driver.arch()}").PERF_SHAPES)
 
 
-def default_json() -> str:
-    return f"/tmp/tlx_benchmark/{OP}.{arch()}.json"
-
-
-def cases(head: int | None = None, synthetic: bool = False) -> list[Case]:
-    out = [
-        # dtype is a Case field, so it is dropped from `shape` -- carrying it in
-        # both duplicates it in the key and in the report.
-        Case(op=OP, arch=arch(), dtype=str(DTYPES[entry[5]]).removeprefix("torch."), shape=tuple(entry[:5]),
+def cases(synthetic: bool = False) -> list[Case]:
+    # dtype is a Case field, so it is dropped from `shape` -- carrying it in
+    # both duplicates it in the key and in the report.
+    return [
+        Case(op=OP, arch=driver.arch(), dtype=str(DTYPES[entry[5]]).removeprefix("torch."), shape=tuple(entry[:5]),
              label=label(*entry)) for entry in shapes(synthetic)
     ]
-    return out[:head] if head else out
 
 
-def _operands(case: Case):
-    M, N, K, a_strides, b_strides = case.shape
-    dtype = getattr(torch, case.dtype)
-    return operand(M, K, a_strides, dtype), operand(K, N, b_strides, dtype)
-
-
-#: Relative tolerance for the accuracy check, per dtype. Same values the L1
-#: correctness suite uses, so a case cannot pass there and fail here.
-REL_PRECISION = {"float16": 1e-3, "bfloat16": 8e-3}
-
-
-def _accuracy(out, ref_out, dtype: str) -> tuple[bool, str]:
-    precision = REL_PRECISION[dtype]
-    try:
-        torch.testing.assert_close(out, ref_out, atol=precision * ref_out.abs().max().item(), rtol=precision)
-    except AssertionError as mismatch:
-        return False, f"output does not match the reference: {str(mismatch).splitlines()[0]}"
-    return True, ""
-
-
-def run_case(case: Case, *, space: str):
+def prepare(case: Case, space: str) -> Prepared:
     from triton.tlx.ops import mm as tlx_mm
 
-    a, b = _operands(case)
-    tlx_fn = lambda: tlx_mm(a, b, arch=arch(), space=space)  # noqa: E731
+    M, N, K, a_strides, b_strides = case.shape
+    dtype = getattr(torch, case.dtype)
+    a, b = operand(M, K, a_strides, dtype), operand(K, N, b_strides, dtype)
+
+    tlx_fn = lambda: tlx_mm(a, b, arch=driver.arch(), space=space)  # noqa: E731
     ref_fn = lambda: torch.matmul(a, b)  # noqa: E731
-
-    compile_stat = cold_compile(tlx_fn)
-
-    out = tlx_fn()  # tune and compile outside the measured window
-    ref_out = ref_fn()
-    torch.cuda.synchronize()
-    correct, accuracy_note = _accuracy(out, ref_out, case.dtype)
-    del out, ref_out
-
-    # The FLOP count is what makes the returned Stats throughputs: `measure`
-    # converts every timed iteration, so both providers come back in TFLOP/s
-    # with the dispersion measured on that quantity rather than on latency.
-    M, N, K = case.shape[0], case.shape[1], case.shape[2]
-    flop_count = flops(M, N, K)
-    tlx = measure(tlx_fn, flop_count=flop_count, replicates=DEFAULT_REPLICATES)
-    ref = measure(ref_fn, flop_count=flop_count, replicates=DEFAULT_REPLICATES)
-    host_us = host_overhead_us(tlx_fn)
-
-    result = verdict.judge(case, tlx, ref, tlx_host_us=host_us, compile_stat=compile_stat, correct=correct,
-                           accuracy_note=accuracy_note)
-    result.flop_count = flop_count
-
-    # The operands are freed when this frame exits; empty_cache then returns the
-    # blocks to the driver so the next case (up to 2 GB at 1000000x512) can be
-    # allocated. Do not `del` them -- the closures above still name them.
-    torch.cuda.empty_cache()
-    return result
+    return Prepared(
+        tlx_fn=tlx_fn,
+        ref_fn=ref_fn,
+        flop_count=flops(M, N, K),
+        check=lambda: close_enough(tlx_fn(), ref_fn(), REL_PRECISION[case.dtype]),
+    )
 
 
-def run(*, space="heuristic", head=None, synthetic=False, governor=None):
-    env = capture_env()
-    if governor is not None:
-        env["governed"] = governor.to_dict()
-    results = []
-    with stable() as info:
-        for case in cases(head, synthetic):
-            try:
-                results.append(run_case(case, space=space))
-            except Exception as exc:  # a broken case must not hide the others
-                results.append(_errored(case, exc))
-    # The autotune space is part of what a number means: a heuristic-space
-    # latency and a full-space latency for the same shape differ by 4x, so two
-    # artifacts are only comparable when this matches.
-    env["space"] = space
-    env["replicates"] = DEFAULT_REPLICATES
-    if head:
-        env["head"] = head
-    env["shapes"] = "synthetic" if synthetic else "focus"
-    env["run"] = {k: info[k] for k in ("problems", "clock_trace", "elapsed_s") if k in info}
-    return results, env
-
-
-def _errored(case: Case, exc: Exception):
-    from _harness import Result
-
-    result = Result(case=case, status=Status.ERROR)
-    result.notes.append(f"{type(exc).__name__}: {exc}")
-    return result
-
-
-def supported() -> bool:
-    return arch() is not None
-
-
-# --------------------------------------------------------------------------
-# CLI entry point -- the deterministic command
-# --------------------------------------------------------------------------
-
-
-def main(argv=None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--device", default="auto", help="GPU index, or 'auto' (default) for the least-used one")
-    parser.add_argument(
-        "--space", choices=("heuristic", "full", "smoke"), default="heuristic",
-        help="autotune search space; 'heuristic' is what tlx.ops.mm uses by default, and "
-        "measuring anything else measures a path users do not take")
-    parser.add_argument("--head", type=int, default=None, metavar="N", help="only the first N cases, for a quick look")
-    parser.add_argument(
-        "--synthetic", action="store_true",
-        help="run the correctness shapes instead of this arch's focus list; they are "
-        "mostly too small to time, so this is for looking, not for gating")
-    parser.add_argument("--json", default=default_json(), help=f"machine-readable artifact (default {default_json()})")
-    args = parser.parse_args(argv)
-
-    # Pick and pin the GPU before torch touches CUDA. Selection has to happen
-    # here rather than in a wrapper script so that the suite is one command,
-    # and it has to happen before the first CUDA call because the visibility
-    # variable is read once at context creation.
-    device = select_device(args.device)
-    if device is not None:
-        os.environ[device.visibility_env] = str(device.index)
-        print(f"device: gpu{device.index} {device.name} "
-              f"({'least used' if args.device == 'auto' else 'requested'}, "
-              f"{device.memory_used_mib:.0f} MiB in use)")
-
-    # Governing is unconditional: a number taken on an ungoverned machine is not
-    # comparable to anything, so there is no switch to take one.
-    with Governor(device) as governor:
-        for step in governor.applied:
-            print(f"  denoise: {step}")
-        for step in governor.skipped:
-            print(f"  denoise: SKIPPED {step}")
-        results, env = run(space=args.space, head=args.head, synthetic=args.synthetic, governor=governor)
-    if not results:
-        # An empty focus list is legitimate -- an arch may have no capture yet --
-        # but a silent zero-row table reads like a pass. Say which list was empty.
-        print(f"no {'synthetic' if args.synthetic else 'focus'} shapes for {arch()}; nothing measured")
-        return 0
-    print(report_mod.render(results, env, args.json))
-
-    return 1 if report_mod.failures(results) else 0
-
+supported, default_json, run, main = driver.bind(sys.modules[__name__])
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/python/test/tlx_benchmark/conftest.py
+++ b/python/test/tlx_benchmark/conftest.py
@@ -1,10 +1,21 @@
 def pytest_addoption(parser):
     group = parser.getgroup("tlx-benchmark")
     group.addoption(
-        "--space", choices=("heuristic", "full", "smoke"), default="heuristic",
-        help="autotune search space; 'heuristic' is what tlx.ops.mm uses by default, and "
-        "measuring anything else measures a path users do not take")
-    group.addoption("--head", type=int, default=None, metavar="N", help="only the first N cases, for a quick look")
+        "--space", choices=("heuristic", "full", "smoke"), default=None,
+        help="autotune search space; the default is each op's own (mm: heuristic, everything "
+        "else: full), and measuring anything else measures a path users do not take")
+    group.addoption("--head", type=int, default=None, metavar="N",
+                    help="only the first N cases per direction, for a quick look")
     group.addoption("--synthetic", action="store_true",
                     help="run the correctness shapes instead of this arch's focus list")
+    group.addoption("--fwd-only", action="store_true", dest="fwd_only", help="skip the backward cases")
+    group.addoption("--bwd-only", action="store_true", dest="bwd_only", help="skip the forward cases")
+    group.addoption(
+        "--latency-measure-mode", choices=("wallclock", "gpu_events"), default="wallclock", dest="latency_mode",
+        help="'wallclock' (default) times each call as a caller would see it; 'gpu_events' "
+        "pre-enqueues the batch behind a blocked stream to isolate device time")
+    group.addoption(
+        "--cold-compile", choices=("all", "first", "none"), default=None, dest="cold_compile",
+        help="how often to time a first call on a fresh cache; the default is each op's own "
+        "(mm: all, everything else: first, since their cold pass compiles a full autotune space)")
     group.addoption("--json", default=None, help="machine-readable artifact (default: bench module's)")

--- a/python/test/tlx_benchmark/test_harness.py
+++ b/python/test/tlx_benchmark/test_harness.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import os
 
@@ -554,3 +555,403 @@ def test_governor_can_be_disabled():
     with Governor(Device(NVIDIA, 0, "NVIDIA B200"), enable=False) as g:
         pass
     assert g.applied == []
+
+
+# --------------------------------------------------------------------------
+# direction: the one op-specific axis that is a Case field
+# --------------------------------------------------------------------------
+
+
+def test_forward_keys_are_unchanged_by_the_direction_field():
+    # Schema 3 added `direction`. Every key an op with no backward has ever
+    # written has to survive it, or old artifacts stop being diffable.
+    case = Case(op="mm", arch="sm100", dtype="float16", shape=(1024, 2048, 512, True, False))
+    assert case.direction == "fwd"
+    assert case.key == "mm/sm100/float16/1024x2048x512xTruexFalse"
+
+
+def test_forward_and_backward_do_not_collide_in_the_artifact():
+    shape = (4, 32, 4096, 128, False)
+    fwd = Case(op="flash_attn", arch="sm100", dtype="bfloat16", shape=shape)
+    bwd = Case(op="flash_attn", arch="sm100", dtype="bfloat16", shape=shape, direction="bwd")
+    assert fwd.key != bwd.key
+    assert bwd.key.endswith("/bwd")
+    assert json.loads(json.dumps(fwd.to_dict()))["direction"] == "fwd"
+
+
+# --------------------------------------------------------------------------
+# extra: op-specific derived metrics
+# --------------------------------------------------------------------------
+
+
+def test_extra_defaults_to_empty_and_round_trips():
+    result = Result(case=_case(), status=Status.OK)
+    assert result.extra == {}
+    doc = json.loads(json.dumps(artifact([result], env={})))
+    assert doc["results"][0]["extra"] == {}
+
+
+def test_declared_extra_columns_are_rendered_and_undeclared_ones_are_not():
+    from _harness import report
+
+    result = Result(case=_case(), status=Status.OK, tlx=summarize([1.0]),
+                    extra={"ref_backend": "cudnn", "tokens": 32768})
+    without = report.table([result])
+    assert "cudnn" not in without and "32768" not in without
+
+    with_col = report.table([result], (("ref bknd", "ref_backend"), ))
+    assert "ref bknd" in with_col and "cudnn" in with_col
+    # Only what was declared: `tokens` stays in the artifact.
+    assert "32768" not in with_col
+
+
+def test_a_missing_extra_key_renders_as_absent_not_as_a_crash():
+    from _harness import report
+
+    result = Result(case=_case(), status=Status.OK, tlx=summarize([1.0]), extra={})
+    # The data row, not the dashed separator: the cell itself must be a dash.
+    row = report.table([result], (("Mtok/s", "mtokens_per_s"), )).splitlines()[2]
+    assert row.endswith("-  ok")
+
+
+# --------------------------------------------------------------------------
+# verdict: the absolute floor, for an op with no reference
+# --------------------------------------------------------------------------
+
+
+def test_floor_gates_an_op_that_has_no_reference():
+    from _harness import verdict
+
+    slow = verdict.judge(_case(), _stat(mean=40.0), None, floor_tflops=100.0)
+    assert slow.status is Status.PIP
+    assert "under the 100 TFLOP/s floor" in "; ".join(slow.notes)
+
+    fast = verdict.judge(_case(), _stat(mean=140.0), None, floor_tflops=100.0)
+    assert fast.status is Status.OK
+
+
+def test_no_floor_means_a_reference_less_op_reports_rather_than_gates():
+    from _harness import verdict
+
+    assert verdict.judge(_case(), _stat(mean=1.0), None).status is Status.OK
+    assert verdict.judge(_case(), _stat(mean=1.0), None, floor_tflops=None).status is Status.OK
+
+
+def test_the_speedup_floor_wins_when_a_reference_exists():
+    from _harness import verdict
+
+    # A floor is the substitute for a ratio, not an addition to one: with a
+    # reference present the ratio decides, so the two can never disagree.
+    result = verdict.judge(_case(), _stat(mean=100.0), _stat(mean=50.0), floor_tflops=1e6)
+    assert result.status is Status.OK
+
+
+# --------------------------------------------------------------------------
+# driver: the adapter contract
+# --------------------------------------------------------------------------
+
+BENCH_MODULES = ("bench_mm", "bench_flash_attn", "bench_hstu_attn", "bench_kda")
+
+
+@pytest.mark.parametrize("module_name", BENCH_MODULES)
+def test_every_bench_module_satisfies_the_adapter_contract(module_name):
+    import importlib
+
+    bench = importlib.import_module(module_name)
+    for name in ("OP", "REF_NAME", "EXTRA_COLUMNS", "cases", "prepare", "supported", "default_json", "run", "main"):
+        assert hasattr(bench, name), f"{module_name} is missing {name}"
+    assert all(len(col) == 2 for col in bench.EXTRA_COLUMNS)
+    # An op with no reference must say so rather than leave it implicit.
+    assert isinstance(bench.REF_NAME, str)
+
+
+@pytest.mark.parametrize("module_name", BENCH_MODULES)
+def test_synthetic_cases_are_well_formed_without_a_gpu(module_name):
+    import importlib
+
+    bench = importlib.import_module(module_name)
+    cases = bench.cases(synthetic=True)
+    assert cases, f"{module_name} has no synthetic shapes"
+    for case in cases:
+        assert case.op == bench.OP
+        assert case.direction in ("fwd", "bwd")
+        assert case.label, "an op must render its own shape tuple"
+        assert case.key.count("/") >= 3
+
+
+def test_space_resolves_to_each_ops_own_default():
+    import importlib
+
+    from _harness import driver
+
+    # mm has a heuristic_config; the attention ops do not, and their kernels
+    # accept only "full"/"smoke" -- a shared "heuristic" default is a KeyError.
+    assert driver.resolve_space(importlib.import_module("bench_mm"), None) == "heuristic"
+    assert driver.resolve_space(importlib.import_module("bench_flash_attn"), None) == "full"
+    # An explicit choice still wins.
+    assert driver.resolve_space(importlib.import_module("bench_mm"), "full") == "full"
+
+
+def test_bind_returns_the_four_entry_points_bound_to_the_module():
+    import importlib
+
+    from _harness import driver
+
+    bench = importlib.import_module("bench_mm")
+    supported, default_json, run, main = driver.bind(bench)
+    assert callable(supported) and callable(run) and callable(main)
+    assert default_json() == bench.default_json()
+
+
+# --------------------------------------------------------------------------
+# driver: how often the cold-compile pass is paid
+# --------------------------------------------------------------------------
+
+
+class _FakeBench:
+    """A bench module stand-in whose `prepare` records what it was asked for."""
+
+    OP = "fake"
+    REF_NAME = ""
+    EXTRA_COLUMNS = ()
+
+    def __init__(self, cold_compile=None, directions=("fwd", "bwd"), n=3):
+        if cold_compile is not None:
+            self.COLD_COMPILE = cold_compile
+        self._directions = directions
+        self._n = n
+
+    def cases(self, synthetic=False):
+        return [
+            Case(op=self.OP, arch="sm100", dtype="bfloat16", shape=(i, ), direction=d)
+            for i in range(self._n)
+            for d in self._directions
+        ]
+
+
+def _cold_flags(bench, monkeypatch, mode=None):
+    """Which cases the driver would pay a cold pass for."""
+    from _harness import driver
+
+    seen = []
+
+    def fake_run_case(_bench, case, *, space, cold=True, latency_mode="wallclock"):
+        seen.append((case.direction, cold))
+        return Result(case=case, status=Status.OK)
+
+    monkeypatch.setattr(driver, "run_case", fake_run_case)
+    monkeypatch.setattr(driver, "capture_env", lambda *a, **k: {})
+    monkeypatch.setattr(driver, "stable", __import__("contextlib").contextmanager(lambda *a, **k: iter([{}])))
+    driver.run(bench, space="full", cold_compile_mode=mode)
+    return seen
+
+
+def test_first_mode_samples_one_cold_pass_per_direction(monkeypatch):
+    # The whole point: hstu_attn compiles 48 forward configs per cold pass, and
+    # paying that once per case is most of the suite's runtime for a question
+    # that is not per-shape.
+    seen = _cold_flags(_FakeBench(cold_compile="first"), monkeypatch)
+    assert [c for _, c in seen].count(True) == 2  # one fwd, one bwd
+    assert {d for d, c in seen if c} == {"fwd", "bwd"}
+    # And it is the FIRST of each, so a later shape never pays it.
+    assert seen[0] == ("fwd", True) and seen[1] == ("bwd", True)
+    assert all(not c for _, c in seen[2:])
+
+
+def test_all_is_the_default_so_an_op_that_says_nothing_is_unchanged(monkeypatch):
+    seen = _cold_flags(_FakeBench(), monkeypatch)
+    assert all(cold for _, cold in seen)
+
+
+def test_none_skips_every_cold_pass(monkeypatch):
+    seen = _cold_flags(_FakeBench(cold_compile="none"), monkeypatch)
+    assert not any(cold for _, cold in seen)
+
+
+def test_an_explicit_mode_overrides_the_ops_own(monkeypatch):
+    seen = _cold_flags(_FakeBench(cold_compile="first"), monkeypatch, mode="all")
+    assert all(cold for _, cold in seen)
+
+
+def test_an_unknown_cold_compile_mode_is_rejected():
+    from _harness import driver
+
+    with pytest.raises(ValueError, match="cold_compile"):
+        driver.resolve_cold_compile(_FakeBench(), "sometimes")
+
+
+def test_mm_still_times_every_case_and_the_full_space_ops_do_not():
+    import importlib
+
+    from _harness import driver
+
+    # mm's cold pass is under a second at heuristic space, so sampling it would
+    # drop information for no saving.
+    assert driver.resolve_cold_compile(importlib.import_module("bench_mm"), None) == "all"
+    for name in ("bench_flash_attn", "bench_hstu_attn", "bench_kda"):
+        assert driver.resolve_cold_compile(importlib.import_module(name), None) == "first"
+
+
+def test_a_case_with_no_cold_pass_reports_no_compile_time_and_is_not_gated():
+    from _harness import report, verdict
+
+    result = verdict.judge(_case(), _stat(mean=100.0), _stat(mean=100.0), compile_stat=None)
+    assert result.t_cold_s is None
+    assert result.status is Status.OK
+    # input, ref, tlx, speedup, compile, ...
+    assert report.table([result]).splitlines()[2].split()[4] == "-"
+
+
+# --------------------------------------------------------------------------
+# report: one table per direction
+# --------------------------------------------------------------------------
+
+
+def _result(direction="fwd", shape=(4, 32, 4096, 128, False)):
+    case = Case(op="flash_attn", arch="sm100", dtype="bfloat16", shape=shape, direction=direction)
+    return Result(case=case, status=Status.OK, tlx=summarize([1.0]), ref=summarize([1.0]), speedup=1.0)
+
+
+def test_an_op_with_one_direction_gets_one_unlabelled_table():
+    from _harness import report
+
+    rendered = report.tables([_result(), _result(shape=(2, 32, 8192, 128, True))])
+    assert "[fwd]" not in rendered
+    assert len(rendered.splitlines()) == 4  # header, rule, two rows
+
+
+def test_forward_and_backward_are_reported_as_two_tables():
+    from _harness import report
+
+    # Interleaved on the way in, as `cases()` produces them.
+    rendered = report.tables([
+        _result("fwd"),
+        _result("bwd"),
+        _result("fwd", (2, 32, 8192, 128, True)),
+        _result("bwd", (2, 32, 8192, 128, True))
+    ])
+    assert "[fwd]" in rendered and "[bwd]" in rendered
+    assert rendered.index("[fwd]") < rendered.index("[bwd]")
+    # Each table has its own header, and each case landed under its own heading.
+    fwd_block, bwd_block = rendered.split("[bwd]")
+    assert fwd_block.count("ref TF/s") == 1 and bwd_block.count("ref TF/s") == 1
+    assert fwd_block.count("4096") == 1 and bwd_block.count("4096") == 1
+
+
+def test_the_summary_and_the_artifact_stay_whole_across_the_split(tmp_path):
+    from _harness import report
+
+    rendered = report.render([_result("fwd"), _result("bwd")], {}, tmp_path / "fa.json")
+    assert rendered.count("2 ok") == 1  # one summary over both tables
+    doc = json.loads((tmp_path / "fa.json").read_text())
+    assert {r["case"]["direction"] for r in doc["results"]} == {"fwd", "bwd"}
+
+
+def _picked(monkeypatch, bench, **kwargs):
+    """The cases the driver would actually run."""
+    from _harness import driver
+
+    picked = []
+
+    def fake_run_case(_bench, case, *, space, cold=True, latency_mode="wallclock"):
+        picked.append(case)
+        return Result(case=case, status=Status.OK)
+
+    monkeypatch.setattr(driver, "run_case", fake_run_case)
+    monkeypatch.setattr(driver, "capture_env", lambda *a, **k: {})
+    monkeypatch.setattr(driver, "stable", __import__("contextlib").contextmanager(lambda *a, **k: iter([{}])))
+    _, env = driver.run(bench, space="full", **kwargs)
+    return picked, env
+
+
+def test_head_counts_per_direction_not_overall(monkeypatch):
+    # A flat slice of the interleaved fwd/bwd list would give `head/2` shapes of
+    # each, so `--head 2` would quietly measure one shape.
+    picked, _ = _picked(monkeypatch, _FakeBench(cold_compile="none", n=5), head=2)
+    assert [(c.shape[0], c.direction) for c in picked] == [(0, "fwd"), (0, "bwd"), (1, "fwd"), (1, "bwd")]
+
+
+def test_head_is_unchanged_for_an_op_with_one_direction(monkeypatch):
+    picked, _ = _picked(monkeypatch, _FakeBench(cold_compile="none", directions=("fwd", ), n=5), head=2)
+    assert [c.shape[0] for c in picked] == [0, 1]
+
+
+def test_direction_filter_runs_before_head(monkeypatch):
+    picked, env = _picked(monkeypatch, _FakeBench(cold_compile="none"), head=2, directions=("bwd", ))
+    assert [c.direction for c in picked] == ["bwd", "bwd"]
+    assert env["directions"] == ["bwd"]
+
+
+# --------------------------------------------------------------------------
+# driver: the selected device is the single source of truth
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unpinned_driver():
+    """Restore the module-level device pin, which is process-wide."""
+    from _harness import driver
+
+    saved = list(driver._SELECTED)
+    driver._SELECTED.clear()
+    yield driver
+    driver._SELECTED[:] = saved
+
+
+def test_arch_follows_the_selected_device_not_physical_gpu_zero(unpinned_driver, monkeypatch):
+    from _harness.denoise import NVIDIA, Device
+
+    # A heterogeneous host: `--device 1` must not report GPU 0's arch, and
+    # nvidia-smi enumerates physical devices whatever the visibility variable
+    # says, so list_devices()[0] is simply the wrong answer here.
+    monkeypatch.setattr(
+        unpinned_driver, "list_devices",
+        lambda: [Device(NVIDIA, 0, "NVIDIA H100"), Device(NVIDIA, 1, "NVIDIA B200")])
+    # Unpinned falls back to the first device, i.e. what torch calls cuda:0.
+    # H100 is not in ARCH_BY_PART, so that answer is None -- and None is exactly
+    # what the old code would have reported for a run pinned to the B200.
+    assert unpinned_driver.arch() is None
+
+    unpinned_driver.select(Device(NVIDIA, 1, "NVIDIA B200"))
+    assert unpinned_driver.arch() == "sm100"
+    assert unpinned_driver.device_index() == 1
+
+
+def test_every_arch_consumer_reads_the_same_pin(unpinned_driver, monkeypatch):
+    import importlib
+
+    from _harness.denoise import NVIDIA, Device
+
+    monkeypatch.setattr(unpinned_driver, "list_devices", lambda: [Device(NVIDIA, 0, "NVIDIA H100")])
+    unpinned_driver.select(Device(NVIDIA, 3, "NVIDIA B200"))
+    bench = importlib.import_module("bench_mm")
+    # The artifact name, the support check and the cases all agree.
+    assert unpinned_driver.default_json(bench).endswith("mm.sm100.json")
+    assert unpinned_driver.supported(bench)
+    assert {c.arch for c in bench.cases(synthetic=True)} == {"sm100"}
+
+
+def test_no_gpu_stays_distinguishable_from_an_unset_pin(unpinned_driver, monkeypatch):
+    monkeypatch.setattr(unpinned_driver, "list_devices", lambda: [])
+    assert unpinned_driver.arch() is None
+    assert unpinned_driver.device_index() == 0  # the denoise helpers still need an int
+
+
+# --------------------------------------------------------------------------
+# measure: the two latency modes
+# --------------------------------------------------------------------------
+
+
+def test_wallclock_is_the_default_and_the_documented_vocabulary():
+    from _harness import LATENCY_MODES
+    from _harness.measure import measure
+
+    assert LATENCY_MODES == ("wallclock", "gpu_events")
+    assert "wallclock" == inspect.signature(measure).parameters["mode"].default
+
+
+def test_an_unknown_latency_mode_is_rejected():
+    from _harness.measure import measure
+
+    with pytest.raises(ValueError, match="mode must be one of"):
+        measure(lambda: None, mode="profiler")

--- a/python/test/tlx_benchmark/test_ops_perf.py
+++ b/python/test/tlx_benchmark/test_ops_perf.py
@@ -16,14 +16,25 @@ def test_op_perf(module_name, pytestconfig):
     if not bench.supported():
         pytest.skip(f"{bench.OP} has no implementation for this device")
 
+    fwd_only, bwd_only = pytestconfig.getoption("--fwd-only"), pytestconfig.getoption("--bwd-only")
+    if fwd_only and bwd_only:
+        raise pytest.UsageError("--fwd-only and --bwd-only are mutually exclusive")
+
     results, env = bench.run(
         space=pytestconfig.getoption("--space"),
         head=pytestconfig.getoption("--head"),
         synthetic=pytestconfig.getoption("--synthetic"),
+        cold_compile_mode=pytestconfig.getoption("--cold-compile"),
+        latency_mode=pytestconfig.getoption("--latency-measure-mode"),
+        directions=("fwd", ) if fwd_only else ("bwd", ) if bwd_only else None,
     )
+    if not results:
+        pytest.skip(f"{bench.OP} has no cases matching the current filters")
     from _harness import report as report_mod
 
-    print("\n" + report_mod.render(results, env, pytestconfig.getoption("--json") or bench.default_json()))
+    print("\n" + report_mod.render(results, env,
+                                   pytestconfig.getoption("--json") or bench.default_json(),
+                                   getattr(bench, "EXTRA_COLUMNS", ())))
 
     bad = report_mod.failures(results)
     assert not bad, "\n".join(f"{r.case.key}: {'; '.join(r.notes)}" for r in bad)

--- a/third_party/tlx/ops/_catalog.py
+++ b/third_party/tlx/ops/_catalog.py
@@ -130,6 +130,16 @@ def _arches_for(op: str) -> list[str]:
     return sorted(s.arch for s in CATALOG if s.op == op)
 
 
+def has_impl(op: str, arch: str) -> bool:
+    """Is there a catalog entry for this pair, without importing the kernel?
+
+    A table lookup, not a capability check: the benchmark suite uses it to skip
+    an op cleanly on an arch it was never written for, rather than running every
+    shape and reporting each one as an error.
+    """
+    return (op, arch) in _BY_KEY
+
+
 def impl_for(op: str, arch: Optional[str] = None) -> tuple[Callable[..., Any], OpSpec]:
     """The blessed callable for `op`, plus its spec.
 

--- a/third_party/tlx/ops/kernels/flash_attn/_shapes.py
+++ b/third_party/tlx/ops/kernels/flash_attn/_shapes.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+# Entries are [Z, H, N_CTX, HEAD_DIM, causal, dtype].
+
+#: Identical to `test_flash_attn.py::SHAPES`.
+SYNTHETIC: list[list] = [
+    [1, 1, 256, 64, False, "fp16"],
+    [1, 2, 512, 64, True, "fp16"],
+    [2, 4, 1024, 64, False, "fp16"],
+    [2, 4, 1024, 128, False, "fp16"],
+    [2, 4, 1024, 128, True, "fp16"],
+    [4, 8, 2048, 128, True, "fp16"],
+    [1, 16, 4096, 128, False, "fp16"],
+    [2, 32, 2048, 64, False, "fp16"],
+    [4, 8, 512, 64, True, "fp16"],
+    [1, 1, 8192, 128, True, "fp16"],
+]
+
+#: TODO: placeholder shapes, not a capture. Awaiting real ones.
+SM100_FOCUS: list[list] = [
+    [4, 32, 4096, 128, False, "bf16"],
+    [4, 32, 4096, 128, True, "bf16"],
+    [2, 32, 8192, 128, True, "bf16"],
+    [1, 16, 16384, 128, True, "bf16"],
+    [4, 32, 4096, 64, False, "bf16"],
+    [4, 32, 4096, 128, False, "fp16"],
+]
+
+
+def qkv(Z, H, N_CTX, HEAD_DIM, dtype, requires_grad=False, device="cuda"):
+    import torch
+
+    return [
+        torch.randn((Z, H, N_CTX, HEAD_DIM), device=device, dtype=dtype).requires_grad_(requires_grad) for _ in range(3)
+    ]
+
+
+def flops(Z, H, N_CTX, HEAD_DIM, causal, direction="fwd"):
+    """The tutorials' and tritonbench's count, so the numbers are comparable.
+
+    `tutorials/fused_attention_ws_auto_tma.py`: 2.5x on the backward is 2.0 plus
+    0.5 to recompute the scores.
+    """
+    total = 2 * (2.0 * Z * H * N_CTX * N_CTX * HEAD_DIM)
+    if causal:
+        total *= 0.5
+    if direction == "bwd":
+        total *= 2.5
+    return int(total)
+
+
+def label(Z, H, N_CTX, HEAD_DIM, causal, dtype, direction="fwd") -> str:
+    """The report's input column."""
+    return (f"((), {{'dtype': '{dtype}', 'causal': '{causal}', 'dir': '{direction}', "
+            f"'Z': '{Z}', 'H': '{H}', 'N_CTX': '{N_CTX}', 'HEAD_DIM': '{HEAD_DIM}'}})")

--- a/third_party/tlx/ops/kernels/flash_attn/sm100.py
+++ b/third_party/tlx/ops/kernels/flash_attn/sm100.py
@@ -19,6 +19,11 @@ from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _s
 from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+from ._shapes import SM100_FOCUS
+
+#: The shapes `bench_flash_attn.py` gates on for this arch.
+PERF_SHAPES = SM100_FOCUS
+
 
 class Policy(IntEnum):
     DENSE = 0
@@ -4139,6 +4144,21 @@ def _select_forward_plan(q, k, v, causal):
         max(int(Policy.CAUSAL_64K),
             n_ctx.bit_length() - CAUSAL_POLICY_BIT_OFFSET),
     )
+    # TODO: this num_ctas=2 branch is a ~4.8x PESSIMIZATION on GB200
+    # (devgpu036.nao2). At Z=4 H=32 N_CTX=4096 HEAD_DIM=128 bf16 non-causal it
+    # reads 246 TF/s against 1186 with num_ctas forced to 1. The cause is the
+    # 2-CTA path itself, not the dtype: forcing num_ctas=2 on the same shape in
+    # fp16 also gives exactly 246, and forcing 1 recovers full speed in both.
+    # Config-independent (smoke and full spaces agree) and numerically correct,
+    # so it is slow rather than wrong. Landing on the same 246 for both dtypes
+    # looks more like serialization than mistuning, and the fp16 backward at the
+    # same shape fails outright with cluster misconfiguration (912) -- likely
+    # the same 2-CTA fault.
+    #
+    # NOT changed here: this was only measured on GB200, and the branch was
+    # presumably tuned on B200, which shares sm100. Run
+    # `python/test/tlx_benchmark/bench_flash_attn.py --fwd-only` on a B200 to
+    # decide between narrowing this to B200 and dropping it.
     return ForwardPlan(
         stage=3 if causal else 1,
         pipelined=pipelined,

--- a/third_party/tlx/ops/kernels/flash_attn/sm100.py
+++ b/third_party/tlx/ops/kernels/flash_attn/sm100.py
@@ -1,48 +1,17 @@
-"""Blackwell (sm100) flash attention -- the `tlx.ops.flash_attn` implementation.
-
-Promoted from `tutorials/blackwell_fa_ws_pipelined_persistent.py`, now frozen.
-
-Carries the full backward path even though the catalog defers a public backward
-op. Both autotuners are applied lazily so the search space can vary per caller.
-"""
-from enum import IntEnum
-from typing import NamedTuple
 import functools
 
 import torch
 import triton
 import triton.language as tl
 import triton.language.extra.tlx as tlx
-from triton.language import core
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 from triton.language.extra.cuda.inline_ptx_lib import _mul_f32x2, _fma_f32x2, _sub_f32x2
-from triton.language.extra.subtile_ops import _join_n_2D, _split_n_2D
+from triton.language.extra.subtile_ops import _split_n_2D
 from triton.tools.tensor_descriptor import TensorDescriptor
 
 from ._shapes import SM100_FOCUS
 
-#: The shapes `bench_flash_attn.py` gates on for this arch.
 PERF_SHAPES = SM100_FOCUS
-
-
-class Policy(IntEnum):
-    DENSE = 0
-    CAUSAL_64K = 1
-    CAUSAL_128K = 2
-    CAUSAL_256K = 3
-    CAUSAL_512K = 4
-
-
-class ForwardPlan(NamedTuple):
-    stage: int
-    pipelined: bool
-    policy: int
-    num_ctas: int
-
-
-POLICY_DENSE = tl.constexpr(int(Policy.DENSE))
-CAUSAL_POLICY_BIT_OFFSET = 16
-FWD_BLOCK_M = tl.constexpr(256)
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 
@@ -79,17 +48,15 @@ configs = [
             "RESCALE_OPT": rescale_opt,
             "USE_WHERE": where,  # used when RESCALE_OPT is True
             "USE_WARP_BARRIER": uwb,
-            "FAST_FIXED": fast_fixed,
         },
         num_stages=1,
         num_warps=4,
         pre_hook=_host_descriptor_pre_hook,
-    ) for kv in [3, 6] for grp_n in [1, 4] for (rescale_opt, where, fast_fixed) in [
-        (False, False, True),
-        (False, False, False),
-        (True, False, False),
-        (True, True, False),
-    ] for uwb in [False, True]
+    )
+    for kv in [3, 6]
+    for grp_n in [1, 4]
+    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
+    for uwb in [False, True]
 ] + [
     triton.Config(
         {
@@ -105,24 +72,20 @@ configs = [
             "USE_WHERE": where,
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
-            "FAST_FIXED": fast_fixed,
         },
         num_stages=1,
         num_warps=4,
         pre_hook=_host_descriptor_pre_hook,
         ctas_per_cga=(2, 1, 1),
-    ) for kv in [3, 6] for grp_n in [1] for (rescale_opt, where, fast_fixed) in [
-        (False, False, True),
-        (False, False, False),
-        (True, False, False),
-        (True, True, False),
-    ]
+    )
+    for kv in [4, 5, 6, 7, 8, 9]
+    for grp_n in [1]
+    for (rescale_opt, where) in [(False, False), (True, False), (True, True)]
 ]
 
 
 def prune_configs_by_hdim(configs, named_args, **kwargs):
     HEAD_DIM = kwargs["HEAD_DIM"]
-    N_CTX = kwargs["N_CTX"]
     STAGE = kwargs["STAGE"]
     target_kv_buffers = 6 if HEAD_DIM == 64 else 3
     target_group_size_n = 4 if STAGE == 3 else 1
@@ -134,86 +97,13 @@ def prune_configs_by_hdim(configs, named_args, **kwargs):
         if grp_n != target_group_size_n:
             continue
         if is_2cta:
-            num_ctas = conf.kwargs["NUM_CTAS"]
-            if N_CTX % (conf.kwargs["BLOCK_M"] * num_ctas) != 0:
-                continue
-            if kv != target_kv_buffers:
+            if kv not in (4, 5, 6, 7):
                 continue
         else:
             if kv != target_kv_buffers:
                 continue
         pruned.append(conf)
     return pruned
-
-
-_S2_F16_GAUGE = tl.constexpr(0.055517269)
-
-
-@core.builtin
-def _s2_exp2_f16(x, a2, b2m, _semantic=None):
-    return core.inline_asm_elementwise(
-        """
-        {
-            .reg .b64 ra, rb, rc, rd;
-            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
-            mov.b64 ra, { $1, $2 };
-            mov.b64 rb, { $3, $4 };
-            mov.b64 rc, { $5, $6 };
-            fma.rn.f32x2 rd, ra, rb, rc;
-            mov.b64 { v0, v1 }, rd;
-            prmt.b32 pk, v0, v1, 0x5410;
-            mov.b32 zz, 0;
-            mov.b32 mk, 0x02000200;
-            add.s16x2 uu, pk, mk;
-            mov.b32 c0, 0x39AB39AB;
-            fma.rn.f16x2 pk, uu, c0, pk;
-            max.f16x2 pk, pk, zz;
-            mov.b32 $0, pk;
-        }
-        """,
-        "=r,r,r,r,r,r,r",
-        [x, a2, b2m],
-        dtype=core.float16,
-        is_pure=True,
-        pack=2,
-        _semantic=_semantic,
-    )
-
-
-@core.builtin
-def _s2_exp2_bf16(x, a2, b2m, _semantic=None):
-    return core.inline_asm_elementwise(
-        """
-        {
-            .reg .b64 ra, rb, rc, rd;
-            .reg .b32 v0, v1, pk, zz, uu, mk, c0;
-            mov.b64 ra, { $1, $2 };
-            mov.b64 rb, { $3, $4 };
-            mov.b64 rc, { $5, $6 };
-            fma.rn.f32x2 rd, ra, rb, rc;
-            mov.b64 { v0, v1 }, rd;
-            prmt.b32 pk, v0, v1, 0x5410;
-            mov.b32 zz, 0;
-            mov.b32 mk, 0x00400040;
-            add.s16x2 uu, pk, mk;
-            mov.b32 c0, 0x3f3b3f3b;
-            fma.rn.bf16x2 pk, uu, c0, pk;
-            max.bf16x2 pk, pk, zz;
-            mov.b32 $0, pk;
-        }
-        """,
-        "=r,r,r,r,r,r,r",
-        [x, a2, b2m],
-        dtype=core.bfloat16,
-        is_pure=True,
-        pack=2,
-        _semantic=_semantic,
-    )
-
-
-@triton.jit
-def _reduce_bf16(a, b):
-    return (a + b).to(tl.bfloat16)
 
 
 @triton.jit
@@ -336,7 +226,7 @@ def _apply_causal_mask(qk, col_limit, BLOCK: tl.constexpr, keep_ge: tl.constexpr
 
 
 @triton.jit
-def _fwd_softmax_tile_1cta(
+def _softmax_inner_loop(
     qk_fulls,
     qk_tiles,
     p_fulls,
@@ -346,7 +236,6 @@ def _fwd_softmax_tile_1cta(
     alpha_tiles,
     cid,
     accum_cnt_qk,
-    gauge_cnt,
     qk_scale,
     offs_m,
     m_i,
@@ -360,72 +249,10 @@ def _fwd_softmax_tile_1cta(
     STAGE: tl.constexpr,
     RESCALE_OPT: tl.constexpr,
     SCALAR_N: tl.constexpr,
-    FAST_FIXED: tl.constexpr,
+    USE_2CTA: tl.constexpr = False,
 ):
-    FAST_BF16: tl.constexpr = FAST_FIXED and out_dtype == tl.bfloat16
-    FAST_F16: tl.constexpr = FAST_FIXED and out_dtype == tl.float16
-    NUM_P_SLICES: tl.constexpr = 2 if FAST_F16 else NUM_MMA_SLICES
-    if FAST_FIXED:
-        lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-        for start_n in tl.range(lo, hi, BLOCK_N):
-            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-            tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
-            if gauge_cnt == 0:
-                for fragment_id in tl.static_range(0, 4):
-                    qk_fragment = tlx.local_load(tlx.subslice(
-                        tlx.local_view(qk_tiles, cid),
-                        fragment_id * 32,
-                        32,
-                    ))
-                    if STAGE == 2:
-                        col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
-                        qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
-                    m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-                m_i = tl.ceil(m_i) + _S2_F16_GAUGE
-            l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
-            p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
-            for fragment_id in tl.static_range(0, 4):
-                qk_fragment = tlx.local_load(tlx.subslice(
-                    tlx.local_view(qk_tiles, cid),
-                    fragment_id * 32,
-                    32,
-                ))
-                if STAGE == 2:
-                    col_limit_right = (offs_m - (start_n + fragment_id * 32) + 1)[:, None]
-                    qk_fragment = _apply_causal_mask(qk_fragment, col_limit_right, 32)
-                if FAST_BF16:
-                    p_h = _s2_exp2_bf16(
-                        qk_fragment,
-                        qk_scale * 128.0,
-                        12582912.0 + 128.0 * (126.0 - m_i[:, None]),
-                    )
-                elif STAGE == 2:
-                    p_i = tl.math.exp2(_fma_f32x2(qk_fragment, qk_scale, -m_i[:, None]))
-                    p_h = p_i.to(out_dtype)
-                else:
-                    p_h = _s2_exp2_f16(
-                        qk_fragment,
-                        qk_scale * 1024.0,
-                        12582912.0 + 1024.0 * (14.0 - m_i[:, None]),
-                    )
-                if (FAST_BF16 or FAST_F16) and fragment_id % 2 == 0:
-                    p_pending = p_h
-                elif FAST_BF16 or FAST_F16:
-                    p_bufIdx = cid * 2 + fragment_id // 2
-                    tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), _join_n_2D([p_pending, p_h]))
-                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
-                if FAST_BF16:
-                    l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
-                elif STAGE == 2:
-                    l_ij += tl.sum(p_i, 1)
-                else:
-                    l_ij += tl.sum(p_h, 1).to(tl.float32)
-            l_i += l_ij
-            accum_cnt_qk += 1
-            gauge_cnt += 1
-        return m_i, l_i, accum_cnt_qk, gauge_cnt
-
     lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
+
     for start_n in tl.range(lo, hi, BLOCK_N):
         qk_buf = cid
         qk_buf_phase = accum_cnt_qk & 1
@@ -482,466 +309,32 @@ def _fwd_softmax_tile_1cta(
         # the loop is unrolled twice likely for vectorization
         qks = _split_n_2D(qk, NUM_MMA_SLICES)
         l_ij = tl.zeros_like(l_i)
-        p_pending = tl.zeros([BLOCK_M // 2, BLOCK_N // NUM_MMA_SLICES], dtype=out_dtype)
         for slice_id in tl.static_range(0, NUM_MMA_SLICES):
             # prepare p for the v dot
+            p_bufIdx = qk_buf * NUM_MMA_SLICES + slice_id
             p_i = tl.math.exp2(qks[slice_id])
-            p_h = p_i.to(out_dtype)
-            if FAST_F16:
-                if slice_id % 2 == 0:
-                    p_pending = p_h
-                else:
-                    p_bufIdx = qk_buf * NUM_P_SLICES + slice_id // 2
-                    tlx.local_store(
-                        tlx.local_view(p_tiles, p_bufIdx),
-                        _join_n_2D([p_pending, p_h]),
-                    )
-                    tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
+            tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_i.to(out_dtype))
+            if USE_2CTA:
+                # The TMEM store completes before this readiness token; it does
+                # not publish ordinary SMEM to the peer CTA.
+                tlx.barrier_arrive(
+                    tlx.local_view(p_fulls, p_bufIdx),
+                    1,
+                    remote_cta_rank=0,
+                )
             else:
-                p_bufIdx = qk_buf * NUM_P_SLICES + slice_id
-                tlx.local_store(tlx.local_view(p_tiles, p_bufIdx), p_h)
                 tlx.barrier_arrive(tlx.local_view(p_fulls, p_bufIdx))
             l_ij += tl.sum(p_i, 1)
 
         l_i += l_ij
         m_i = m_ij
         accum_cnt_qk += 1
-    return m_i, l_i, accum_cnt_qk, gauge_cnt
+
+    return m_i, l_i, accum_cnt_qk
 
 
 @triton.jit
-def _fwd_softmax_tile_2cta(
-    qk_fulls,
-    qk_tiles,
-    p_fulls,
-    p_tiles,
-    cid,
-    accum_cnt_qk,
-    gauge_cnt,
-    qk_scale,
-    m_i,
-    l_i,
-    start_m,
-    N_CTX,
-    out_dtype,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    STAGE: tl.constexpr,
-):
-    tl.static_assert(NUM_MMA_SLICES == 2)
-    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-    for start_n in tl.range(lo, hi, BLOCK_N):
-        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
-        if gauge_cnt == 0:
-            for fragment_id in tl.static_range(0, 4):
-                qk_fragment = tlx.local_load(tlx.subslice(
-                    tlx.local_view(qk_tiles, cid),
-                    fragment_id * 32,
-                    32,
-                ))
-                m_i = tl.maximum(m_i, tl.max(qk_fragment, 1) * qk_scale)
-            m_i = tl.ceil(m_i) + 0.055517269
-        l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
-        p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
-        for fragment_id in tl.static_range(0, 4):
-            qk_fragment = tlx.local_load(tlx.subslice(
-                tlx.local_view(qk_tiles, cid),
-                fragment_id * 32,
-                32,
-            ))
-            p_h = _s2_exp2_bf16(
-                qk_fragment,
-                qk_scale * 128.0,
-                12582912.0 + 128.0 * (126.0 - m_i[:, None]),
-            )
-            if fragment_id < 2:
-                p_fragment = tlx.local_slice(
-                    tlx.local_view(p_tiles, cid * 2),
-                    [0, fragment_id * 32],
-                    [BLOCK_M // 2, 32],
-                )
-                tlx.local_store(p_fragment, p_h)
-                tlx.barrier_arrive(
-                    tlx.local_view(p_fulls, cid * 3 + fragment_id),
-                    1,
-                    remote_cta_rank=0,
-                )
-            elif fragment_id == 2:
-                p_pending = p_h
-            else:
-                tlx.local_store(
-                    tlx.local_view(p_tiles, cid * 2 + 1),
-                    _join_n_2D([p_pending, p_h]),
-                )
-                tlx.barrier_arrive(
-                    tlx.local_view(p_fulls, cid * 3 + 2),
-                    1,
-                    remote_cta_rank=0,
-                )
-            l_ij += tl.reduce(p_h, axis=1, combine_fn=_reduce_bf16).to(tl.float32)
-        l_i += l_ij
-        accum_cnt_qk += 1
-        gauge_cnt += 1
-    return m_i, l_i, accum_cnt_qk, gauge_cnt
-
-
-@triton.jit
-def _fwd_softmax_tile_2cta_online(
-    qk_fulls,
-    qk_tiles,
-    p_fulls,
-    p_tiles,
-    acc_fulls,
-    acc_tiles,
-    cid,
-    accum_cnt_qk,
-    gauge_cnt,
-    qk_scale,
-    m_i,
-    l_i,
-    start_m,
-    N_CTX,
-    out_dtype,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    STAGE: tl.constexpr,
-    RESCALE_OPT: tl.constexpr,
-):
-    tl.static_assert(NUM_MMA_SLICES == 2)
-    lo, hi = _get_unfused_loop_bounds(start_m, N_CTX, BLOCK_M, STAGE)
-    for start_n in tl.range(lo, hi, BLOCK_N):
-        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
-        tlx.barrier_wait(tlx.local_view(qk_fulls, cid), qk_phase)
-        qk = tlx.local_load(tlx.local_view(qk_tiles, cid))
-        if RESCALE_OPT:
-            m_ij = tl.maximum(m_i, tl.max(qk, 1))
-            alpha_ = (m_i - m_ij) * qk_scale
-            alpha = tl.math.exp2(alpha_)
-            rescale_mask = alpha_ >= -8.0
-            alpha = tl.where(rescale_mask, 1.0, alpha)
-            m_ij = tl.where(rescale_mask, m_i, m_ij)
-        else:
-            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
-            alpha = tl.math.exp2(m_i - m_ij)
-        if gauge_cnt > 0:
-            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                acc_slice = tlx.subslice(
-                    tlx.local_view(acc_tiles, cid),
-                    HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                    HEAD_DIM // NUM_MMA_SLICES,
-                )
-                acc = tlx.local_load(acc_slice)
-                tlx.local_store(acc_slice, _mul_f32x2(acc, alpha[:, None]))
-        tlx.barrier_arrive(
-            tlx.local_view(acc_fulls, cid),
-            1,
-            remote_cta_rank=0,
-        )
-        l_i *= alpha
-        if RESCALE_OPT:
-            qk = _fma_f32x2(qk, qk_scale, -(m_ij * qk_scale)[:, None])
-        else:
-            qk = _fma_f32x2(qk, qk_scale, -m_ij[:, None])
-        qk_fragments = _split_n_2D(qk, 4)
-        l_ij = tl.zeros([BLOCK_M // 2], dtype=tl.float32)
-        p_pending = tl.zeros([BLOCK_M // 2, 32], dtype=out_dtype)
-        for fragment_id in tl.static_range(0, 4):
-            p_i = tl.math.exp2(qk_fragments[fragment_id])
-            p_h = p_i.to(out_dtype)
-            if fragment_id < 2:
-                p_fragment = tlx.local_slice(
-                    tlx.local_view(p_tiles, cid * 2),
-                    [0, fragment_id * 32],
-                    [BLOCK_M // 2, 32],
-                )
-                tlx.local_store(p_fragment, p_h)
-                tlx.barrier_arrive(
-                    tlx.local_view(p_fulls, cid * 3 + fragment_id),
-                    1,
-                    remote_cta_rank=0,
-                )
-            elif fragment_id == 2:
-                p_pending = p_h
-            else:
-                tlx.local_store(
-                    tlx.local_view(p_tiles, cid * 2 + 1),
-                    _join_n_2D([p_pending, p_h]),
-                )
-                tlx.barrier_arrive(
-                    tlx.local_view(p_fulls, cid * 3 + 2),
-                    1,
-                    remote_cta_rank=0,
-                )
-            l_ij += tl.sum(p_i, 1)
-        l_i += l_ij
-        m_i = m_ij
-        accum_cnt_qk += 1
-        gauge_cnt += 1
-    return m_i, l_i, accum_cnt_qk, gauge_cnt
-
-
-@triton.jit
-def _fwd_softmax_tile(
-    qk_fulls,
-    qk_tiles,
-    p_fulls,
-    p_tiles,
-    alpha_empties,
-    alpha_fulls,
-    alpha_tiles,
-    acc_fulls,
-    acc_tiles,
-    cid,
-    accum_cnt_qk,
-    gauge_cnt,
-    qk_scale,
-    offs_m,
-    m_i,
-    l_i,
-    start_m,
-    N_CTX,
-    out_dtype,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    STAGE: tl.constexpr,
-    RESCALE_OPT: tl.constexpr,
-    SCALAR_N: tl.constexpr,
-    USE_2CTA: tl.constexpr,
-    FAST_FIXED: tl.constexpr,
-):
-    if USE_2CTA:
-        if FAST_FIXED:
-            return _fwd_softmax_tile_2cta(
-                qk_fulls,
-                qk_tiles,
-                p_fulls,
-                p_tiles,
-                cid,
-                accum_cnt_qk,
-                gauge_cnt,
-                qk_scale,
-                m_i,
-                l_i,
-                start_m,
-                N_CTX,
-                out_dtype,
-                BLOCK_M,
-                BLOCK_N,
-                NUM_MMA_SLICES,
-                STAGE,
-            )
-        return _fwd_softmax_tile_2cta_online(
-            qk_fulls,
-            qk_tiles,
-            p_fulls,
-            p_tiles,
-            acc_fulls,
-            acc_tiles,
-            cid,
-            accum_cnt_qk,
-            gauge_cnt,
-            qk_scale,
-            m_i,
-            l_i,
-            start_m,
-            N_CTX,
-            out_dtype,
-            BLOCK_M,
-            BLOCK_N,
-            HEAD_DIM,
-            NUM_MMA_SLICES,
-            STAGE,
-            RESCALE_OPT,
-        )
-    return _fwd_softmax_tile_1cta(
-        qk_fulls,
-        qk_tiles,
-        p_fulls,
-        p_tiles,
-        alpha_empties,
-        alpha_fulls,
-        alpha_tiles,
-        cid,
-        accum_cnt_qk,
-        gauge_cnt,
-        qk_scale,
-        offs_m,
-        m_i,
-        l_i,
-        start_m,
-        N_CTX,
-        out_dtype,
-        BLOCK_M,
-        BLOCK_N,
-        NUM_MMA_SLICES,
-        STAGE,
-        RESCALE_OPT,
-        SCALAR_N,
-        FAST_FIXED,
-    )
-
-
-@triton.jit
-def _fwd_control_tile(
-    tile_id,
-    tile_count,
-    accum_cnt,
-    sm_scale,
-    M,
-    H,
-    num_pid_n,
-    num_pid_in_group,
-    N_CTX,
-    desc_o,
-    alpha_empties,
-    alpha_fulls,
-    alpha_tiles,
-    acc_empties,
-    acc_fulls,
-    acc_tiles,
-    l_fulls,
-    l_tiles,
-    m_tiles,
-    qk_empties,
-    o_empties,
-    o_fulls,
-    o_tiles,
-    cluster_cta_rank,
-    BLOCK_M_SPLIT: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    EFFECTIVE_BLOCK_M: tl.constexpr,
-    GROUP_SIZE_N: tl.constexpr,
-    HEAD_DIM: tl.constexpr,
-    NUM_CTAS: tl.constexpr,
-    NUM_GROUPS_PER_CTA: tl.constexpr,
-    NUM_MMA_SLICES: tl.constexpr,
-    RESCALE_OPT: tl.constexpr,
-    SCALAR_N: tl.constexpr,
-    STAGE: tl.constexpr,
-    USE_2CTA: tl.constexpr,
-    USE_WHERE: tl.constexpr,
-    SKIP_RESCALE,
-    FUSE_EPILOG,
-):
-    start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-        tile_id // NUM_CTAS,
-        H,
-        num_pid_n,
-        num_pid_in_group,
-        N_CTX,
-        EFFECTIVE_BLOCK_M,
-        STAGE,
-        GROUP_SIZE_N,
-    )
-    control_lo = hi if SKIP_RESCALE else lo
-    # Rescale the live output accumulator when the online-softmax gauge changes.
-    for _ in tl.range(control_lo, hi, BLOCK_N):
-        _, phase = get_bufidx_phase(accum_cnt, 1)
-        for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-            tlx.barrier_wait(alpha_fulls[cid], phase)
-            alpha_loaded = tlx.local_load(alpha_tiles[cid])
-            alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
-            tlx.barrier_arrive(alpha_empties[cid])
-            if RESCALE_OPT:
-                # One warp vote skips the whole accumulator update when no lane
-                # changed its online-softmax gauge.
-                pred = alpha_1 < 1.0
-                ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
-                should_rescale = ballot_result != 0
-
-            if USE_WHERE:
-                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                    subslice = tlx.subslice(
-                        acc_tiles[cid],
-                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                        HEAD_DIM // NUM_MMA_SLICES,
-                    )
-                    acc = tlx.local_load(subslice)
-                    if RESCALE_OPT:
-                        scaled_acc = _mul_f32x2(acc, alpha_1)
-                        acc = tl.where(should_rescale, scaled_acc, acc)
-                    else:
-                        acc = _mul_f32x2(acc, alpha_1)
-                    tlx.local_store(subslice, acc)
-            else:
-                if RESCALE_OPT:
-                    should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
-                    should_rescale_scalar = tl.reshape(should_rescale_red, ())
-                if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
-                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        subslice = tlx.subslice(
-                            acc_tiles[cid],
-                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                            HEAD_DIM // NUM_MMA_SLICES,
-                        )
-                        acc = tlx.local_load(subslice)
-                        acc = _mul_f32x2(acc, alpha_1)
-                        tlx.local_store(subslice, acc)
-            if USE_2CTA:
-                tlx.barrier_arrive(acc_fulls[cid], 1, remote_cta_rank=0)
-            else:
-                tlx.barrier_arrive(acc_fulls[cid])
-        accum_cnt += 1
-
-    _, phase = get_bufidx_phase(tile_count, 1)
-    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-        group_id = cid * NUM_CTAS + cluster_cta_rank
-        # l and m share a synchronization group, so release QK only after both loads.
-        tlx.barrier_wait(l_fulls[cid], phase)
-        l_loaded = tlx.local_load(l_tiles[cid])
-        m_loaded = tlx.local_load(m_tiles[cid])
-        l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
-        m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
-        if USE_2CTA:
-            tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
-        else:
-            tlx.barrier_arrive(qk_empties[cid])
-        if RESCALE_OPT:
-            m = m * sm_scale * 1.44269504
-        m += tl.math.log2(l)
-        offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
-        m_ptrs = M + off_hz * N_CTX + offs_m
-        tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
-
-        # Normalize the completed accumulator into the output staging tile;
-        # the epilog task owns publication to global memory.
-        tlx.barrier_wait(acc_empties[cid], phase)
-        tlx.barrier_wait(o_empties[cid], phase ^ 1)
-        scale = 1 / l
-        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-            subslice = tlx.subslice(
-                acc_tiles[cid],
-                HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                HEAD_DIM // NUM_MMA_SLICES,
-            )
-            acc = tlx.local_load(subslice)
-            acc = _mul_f32x2(acc, scale)
-            acc = acc.to(tlx.dtype_of(desc_o))
-            subslice_o = tlx.local_slice(
-                o_tiles[cid],
-                [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
-                [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
-            )
-            tlx.local_store(subslice_o, acc)
-        tlx.fence("async_shared")
-        if FUSE_EPILOG:
-            qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-            tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
-            tlx.async_descriptor_store_wait(0)
-            tlx.barrier_arrive(o_empties[cid])
-        else:
-            tlx.barrier_arrive(o_fulls[cid])
-    return accum_cnt
-
-
-@triton.jit
-def _fwd_load_tile(
+def _fwd_load_1cta(
     tile_count,
     accum_cnt_kv,
     lo,
@@ -965,53 +358,8 @@ def _fwd_load_tile(
     HEAD_DIM: tl.constexpr,
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
-    cluster_cta_rank=0,
-    v_tiles=None,
-    v_fulls=None,
-    v_empties=None,
-    NUM_GROUPS_PER_CTA: tl.constexpr = 2,
-    NUM_CTAS: tl.constexpr = 1,
 ):
-    USE_2CTA: tl.constexpr = NUM_CTAS == 2
     # load q0
-    if USE_2CTA:
-        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
-        for group_id in tl.static_range(0, NUM_GROUPS_PER_CTA):
-            q_id = q_bufIdx + group_id * NUM_BUFFERS_Q
-            tlx.barrier_wait(q_empties[q_id], q_phase ^ 1)
-            if cluster_cta_rank == 0:
-                tlx.barrier_expect_bytes(q_fulls[q_id], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
-            tlx.async_descriptor_load(
-                desc_q,
-                q_tiles[q_id],
-                [qo_offset_y + (group_id * NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
-                q_fulls[q_id],
-                two_ctas=True,
-            )
-        for _ in tl.range(lo, hi, BLOCK_N):
-            buf, phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-            tlx.barrier_wait(kv_empties[buf], phase ^ 1)
-            tlx.barrier_wait(v_empties[buf], phase ^ 1)
-            if cluster_cta_rank == 0:
-                tlx.barrier_expect_bytes(kv_fulls[buf], K_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-                tlx.barrier_expect_bytes(v_fulls[buf], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
-            tlx.async_descriptor_load(
-                desc_k,
-                kv_tiles[buf],
-                [kv_offset_y + cluster_cta_rank * (BLOCK_N // NUM_CTAS), 0],
-                kv_fulls[buf],
-                two_ctas=True,
-            )
-            tlx.async_descriptor_load(
-                desc_v,
-                v_tiles[buf],
-                [kv_offset_y, cluster_cta_rank * (HEAD_DIM // NUM_CTAS)],
-                v_fulls[buf],
-                two_ctas=True,
-            )
-            kv_offset_y += BLOCK_N
-            accum_cnt_kv += 1
-        return accum_cnt_kv
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
     tlx.barrier_expect_bytes(q_fulls[q_bufIdx], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
@@ -1074,20 +422,7 @@ def _fwd_load_tile(
 
 
 @triton.jit
-def _fwd_pv_32_32_64(p0, p1, b0, b1, b2, phase, v, acc, use_acc, done, HEAD_DIM: tl.constexpr):
-    tlx.barrier_wait(b0, phase)
-    tlx.async_dot(tlx.local_slice(p0, [0, 0], [128, 32]), tlx.local_slice(v, [0, 0], [32, HEAD_DIM // 2]), acc,
-                  use_acc=use_acc, force_async=True, two_ctas=True)
-    tlx.barrier_wait(b1, phase)
-    tlx.async_dot(tlx.local_slice(p0, [0, 32], [128, 32]), tlx.local_slice(v, [32, 0], [32, HEAD_DIM // 2]), acc,
-                  use_acc=True, force_async=True, two_ctas=True)
-    tlx.barrier_wait(b2, phase)
-    tlx.async_dot(p1, tlx.local_slice(v, [64, 0], [64, HEAD_DIM // 2]), acc, use_acc=True, mBarriers=done,
-                  force_async=True, two_ctas=True)
-
-
-@triton.jit
-def _fwd_mma_tile(
+def _fwd_mma_dots_1cta(
     tile_count,
     accum_cnt_kv,
     accum_cnt_qk,
@@ -1111,19 +446,11 @@ def _fwd_mma_tile(
     HEAD_DIM_KV: tl.constexpr,
     NUM_BUFFERS_Q: tl.constexpr,
     NUM_BUFFERS_KV: tl.constexpr,
-    NUM_P_SLICES: tl.constexpr,
-    v_tiles=None,
-    v_fulls=None,
-    v_empties=None,
-    USE_2CTA: tl.constexpr = False,
-    SKIP_RESCALE: tl.constexpr = False,
+    NUM_MMA_SLICES: tl.constexpr,
 ):
-    v_tiles = v_tiles if USE_2CTA else kv_tiles
-    v_fulls = v_fulls if USE_2CTA else kv_fulls
-    v_empties = v_empties if USE_2CTA else kv_empties
     q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
     k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
+    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
     # wait for the K buffer to be populated by the producer
     tlx.barrier_wait(kv_fulls[k_bufIdx], k_phase)
@@ -1140,7 +467,6 @@ def _fwd_mma_tile(
         qk_tiles[0],
         use_acc=False,
         mBarriers=[qk_fulls[0]],
-        two_ctas=USE_2CTA,
     )
 
     # -- compute q1 @ k ----
@@ -1152,49 +478,29 @@ def _fwd_mma_tile(
         qk_tiles[1],
         use_acc=False,
         mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
-        two_ctas=USE_2CTA,
     )
 
     _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
 
     # -- compute p0 @ v ----
     # wait for the V buffer to be populated by the producer
-    tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
-    if USE_2CTA:
-        if not SKIP_RESCALE:
-            tlx.barrier_wait(acc_fulls[0], qk_phase)
-        _fwd_pv_32_32_64(
-            p_tiles[0],
-            p_tiles[1],
-            p_fulls[0],
-            p_fulls[1],
-            p_fulls[2],
-            qk_phase,
-            v_tiles[v_bufIdx],
-            acc_tiles[0],
-            False,
-            [],
-            HEAD_DIM_KV * 2,
+    tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
+    tlx.barrier_wait(acc_fulls[0], qk_phase)
+    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+        p_bufIdx = slice_id
+        tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+        kv_slice = tlx.local_slice(
+            kv_tiles[v_bufIdx],
+            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+            [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
         )
-    else:
-        if not SKIP_RESCALE:
-            tlx.barrier_wait(acc_fulls[0], qk_phase)
-        for slice_id in tl.static_range(0, NUM_P_SLICES):
-            p_bufIdx = slice_id
-            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-            kv_slice = tlx.local_slice(
-                v_tiles[v_bufIdx],
-                [BLOCK_N * slice_id // NUM_P_SLICES, 0],
-                [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
-            )
-            tlx.async_dot(
-                p_tiles[p_bufIdx],
-                kv_slice,
-                acc_tiles[0],
-                use_acc=slice_id > 0,
-                force_async=True,
-                two_ctas=USE_2CTA,
-            )
+        tlx.async_dot(
+            p_tiles[p_bufIdx],
+            kv_slice,
+            acc_tiles[0],
+            use_acc=slice_id > 0,
+            force_async=True,
+        )
 
     acc1_init = False
 
@@ -1203,9 +509,9 @@ def _fwd_mma_tile(
         qk_phase_prev = qk_phase
 
         accum_cnt_qk += 1
-        accum_cnt_kv += 1 if USE_2CTA else 2
+        accum_cnt_kv += 2
         k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
-        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv if USE_2CTA else accum_cnt_kv + 1, NUM_BUFFERS_KV)
+        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv + 1, NUM_BUFFERS_KV)
 
         # -- compute q0 @ k ----
         # wait for the K buffer to be populated by the producer
@@ -1219,48 +525,27 @@ def _fwd_mma_tile(
             qk_tiles[0],
             use_acc=False,
             mBarriers=[qk_fulls[0]],
-            two_ctas=USE_2CTA,
         )
 
         # -- compute p1 @ v from the previous iteration----
-        if USE_2CTA:
-            if not SKIP_RESCALE:
-                tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-            _fwd_pv_32_32_64(
-                p_tiles[2],
-                p_tiles[3],
-                p_fulls[3],
-                p_fulls[4],
-                p_fulls[5],
-                qk_phase_prev,
-                v_tiles[v_bufIdx_prev],
-                acc_tiles[1],
-                acc1_init,
-                [v_empties[v_bufIdx_prev]],
-                HEAD_DIM_KV * 2,
+        tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            p_bufIdx = slice_id + NUM_MMA_SLICES
+            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
+            kv_slice = tlx.local_slice(
+                kv_tiles[v_bufIdx_prev],
+                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
-        else:
-            if not SKIP_RESCALE:
-                tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
-            for slice_id in tl.static_range(0, NUM_P_SLICES):
-                p_bufIdx = slice_id + NUM_P_SLICES
-                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
-                kv_slice = tlx.local_slice(
-                    v_tiles[v_bufIdx_prev],
-                    [BLOCK_N * slice_id // NUM_P_SLICES, 0],
-                    [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
-                )
-                use_acc = acc1_init if slice_id == 0 else True
-                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_P_SLICES - 1 else []
-                tlx.async_dot(
-                    p_tiles[p_bufIdx],
-                    kv_slice,
-                    acc_tiles[1],
-                    use_acc=use_acc,
-                    mBarriers=mBarriers,
-                    force_async=SKIP_RESCALE,
-                    two_ctas=USE_2CTA,
-                )
+            use_acc = acc1_init if slice_id == 0 else True
+            mBarriers = [kv_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+            tlx.async_dot(
+                p_tiles[p_bufIdx],
+                kv_slice,
+                acc_tiles[1],
+                use_acc=use_acc,
+                mBarriers=mBarriers,
+            )
 
         acc1_init = True
 
@@ -1271,175 +556,104 @@ def _fwd_mma_tile(
             qk_tiles[1],
             use_acc=False,
             mBarriers=[qk_fulls[1], kv_empties[k_bufIdx]],
-            two_ctas=USE_2CTA,
         )
 
         # -- compute p0 @ v ----
         # wait for the V buffer to be populated by the producer
-        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+        tlx.barrier_wait(kv_fulls[v_bufIdx], v_phase)
 
-        if USE_2CTA:
-            if not SKIP_RESCALE:
-                tlx.barrier_wait(acc_fulls[0], qk_phase)
-            _fwd_pv_32_32_64(
-                p_tiles[0],
-                p_tiles[1],
-                p_fulls[0],
-                p_fulls[1],
-                p_fulls[2],
-                qk_phase,
-                v_tiles[v_bufIdx],
-                acc_tiles[0],
-                True,
-                [],
-                HEAD_DIM_KV * 2,
-            )
-        else:
-            if not SKIP_RESCALE:
-                tlx.barrier_wait(acc_fulls[0], qk_phase)
-            for slice_id in tl.static_range(0, NUM_P_SLICES):
-                p_bufIdx = slice_id
-                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
-                kv_slice = tlx.local_slice(
-                    v_tiles[v_bufIdx],
-                    [BLOCK_N * slice_id // NUM_P_SLICES, 0],
-                    [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
-                )
-                tlx.async_dot(
-                    p_tiles[p_bufIdx],
-                    kv_slice,
-                    acc_tiles[0],
-                    use_acc=True,
-                    force_async=True,
-                    two_ctas=USE_2CTA,
-                )
-
-    tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=USE_2CTA)
-    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=USE_2CTA)
-    tlx.tcgen05_commit(acc_empties[0], two_ctas=USE_2CTA)
-
-    # -- compute p1 @ v ----
-    if USE_2CTA:
-        if not SKIP_RESCALE:
-            tlx.barrier_wait(acc_fulls[1], qk_phase)
-        _fwd_pv_32_32_64(
-            p_tiles[2],
-            p_tiles[3],
-            p_fulls[3],
-            p_fulls[4],
-            p_fulls[5],
-            qk_phase,
-            v_tiles[v_bufIdx],
-            acc_tiles[1],
-            acc1_init,
-            [acc_empties[1], v_empties[v_bufIdx]],
-            HEAD_DIM_KV * 2,
-        )
-    else:
-        if not SKIP_RESCALE:
-            tlx.barrier_wait(acc_fulls[1], qk_phase)
-        for slice_id in tl.static_range(0, NUM_P_SLICES):
-            p_bufIdx = slice_id + NUM_P_SLICES
+        tlx.barrier_wait(acc_fulls[0], qk_phase)
+        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+            p_bufIdx = slice_id
             tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
             kv_slice = tlx.local_slice(
-                v_tiles[v_bufIdx],
-                [BLOCK_N * slice_id // NUM_P_SLICES, 0],
-                [BLOCK_N // NUM_P_SLICES, HEAD_DIM_KV],
+                kv_tiles[v_bufIdx],
+                [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
             )
-            use_acc = acc1_init if slice_id == 0 else True
-            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_P_SLICES - 1 else []
             tlx.async_dot(
                 p_tiles[p_bufIdx],
                 kv_slice,
-                acc_tiles[1],
-                use_acc=use_acc,
-                mBarriers=mBarriers,
-                two_ctas=USE_2CTA,
+                acc_tiles[0],
+                use_acc=True,
+                force_async=True,
             )
 
+    tlx.tcgen05_commit(q_empties[q_bufIdx])
+    tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q])
+    tlx.tcgen05_commit(acc_empties[0])
+
+    # -- compute p1 @ v ----
+    tlx.barrier_wait(acc_fulls[1], qk_phase)
+    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+        p_bufIdx = slice_id + NUM_MMA_SLICES
+        tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+        kv_slice = tlx.local_slice(
+            kv_tiles[v_bufIdx],
+            [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+            [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV],
+        )
+        use_acc = acc1_init if slice_id == 0 else True
+        mBarriers = [acc_empties[1], kv_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+        tlx.async_dot(
+            p_tiles[p_bufIdx],
+            kv_slice,
+            acc_tiles[1],
+            use_acc=use_acc,
+            mBarriers=mBarriers,
+        )
+
     accum_cnt_qk += 1
-    accum_cnt_kv += 1 if USE_2CTA else 2
+    accum_cnt_kv += 2
     return accum_cnt_kv, accum_cnt_qk
 
 
 @triton.jit
-def _attn_fwd_ws(
-    sm_scale,
-    M,  #
-    Z,
-    H,
-    desc_q,
-    desc_k,
-    desc_v,
-    desc_o,
-    N_CTX,  #
-    HEAD_DIM: tl.constexpr,  #
-    BLOCK_M: tl.constexpr,  #
-    BLOCK_N: tl.constexpr,  #
-    STAGE: tl.constexpr,  #
-    NUM_BUFFERS_Q: tl.constexpr,  #
-    NUM_BUFFERS_KV: tl.constexpr,  #
-    NUM_BUFFERS_QK: tl.constexpr,  #
-    NUM_MMA_GROUPS: tl.constexpr,  #
-    NUM_MMA_SLICES: tl.constexpr,  #
-    GROUP_SIZE_N: tl.constexpr,  #
-    RESCALE_OPT: tl.constexpr,  #
-    USE_WHERE: tl.constexpr,  #
-    USE_WARP_BARRIER: tl.constexpr,  #
-    NUM_CTAS: tl.constexpr = 1,  #
-    PIPELINED: tl.constexpr = False,
-    POLICY: tl.constexpr = POLICY_DENSE,
-    DENSE_REGS: tl.constexpr = 200,
-    FAST_FIXED: tl.constexpr = True,
-):
+def _attn_fwd_ws(sm_scale, M,  #
+                 Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
+                 HEAD_DIM: tl.constexpr,  #
+                 BLOCK_M: tl.constexpr,  #
+                 BLOCK_N: tl.constexpr,  #
+                 STAGE: tl.constexpr,  #
+                 NUM_BUFFERS_Q: tl.constexpr,  #
+                 NUM_BUFFERS_KV: tl.constexpr,  #
+                 NUM_BUFFERS_QK: tl.constexpr,  #
+                 NUM_MMA_GROUPS: tl.constexpr,  #
+                 NUM_MMA_SLICES: tl.constexpr,  #
+                 GROUP_SIZE_N: tl.constexpr,  #
+                 RESCALE_OPT: tl.constexpr,  #
+                 USE_WHERE: tl.constexpr,  #
+                 USE_WARP_BARRIER: tl.constexpr,  #
+                 NUM_CTAS: tl.constexpr = 1,  #
+                 ):
     _attn_fwd_ws_kernel(sm_scale, M, Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX, HEAD_DIM, BLOCK_M, BLOCK_N, STAGE,
                         NUM_BUFFERS_Q, NUM_BUFFERS_KV, NUM_BUFFERS_QK, NUM_MMA_GROUPS, NUM_MMA_SLICES, GROUP_SIZE_N,
-                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS, PIPELINED, POLICY, DENSE_REGS, FAST_FIXED)
+                        RESCALE_OPT, USE_WHERE, USE_WARP_BARRIER, NUM_CTAS)
 
 
 @triton.jit
-def _attn_fwd_ws_kernel(
-    sm_scale,
-    M,  #
-    Z,
-    H,
-    desc_q,
-    desc_k,
-    desc_v,
-    desc_o,
-    N_CTX,  #
-    HEAD_DIM: tl.constexpr,  #
-    BLOCK_M: tl.constexpr,  #
-    BLOCK_N: tl.constexpr,  #
-    STAGE: tl.constexpr,  #
-    NUM_BUFFERS_Q: tl.constexpr,  #
-    NUM_BUFFERS_KV: tl.constexpr,  #
-    NUM_BUFFERS_QK: tl.constexpr,  #
-    NUM_MMA_GROUPS: tl.constexpr,  #
-    NUM_MMA_SLICES: tl.constexpr,  #
-    GROUP_SIZE_N: tl.constexpr,  #
-    RESCALE_OPT: tl.constexpr,  #
-    USE_WHERE: tl.constexpr,  #
-    USE_WARP_BARRIER: tl.constexpr,  #
-    NUM_CTAS: tl.constexpr = 1,  #
-    PIPELINED: tl.constexpr = False,
-    POLICY: tl.constexpr = POLICY_DENSE,
-    DENSE_REGS: tl.constexpr = 200,
-    FAST_FIXED: tl.constexpr = True,
-):
+def _attn_fwd_ws_kernel(sm_scale, M,  #
+                        Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
+                        HEAD_DIM: tl.constexpr,  #
+                        BLOCK_M: tl.constexpr,  #
+                        BLOCK_N: tl.constexpr,  #
+                        STAGE: tl.constexpr,  #
+                        NUM_BUFFERS_Q: tl.constexpr,  #
+                        NUM_BUFFERS_KV: tl.constexpr,  #
+                        NUM_BUFFERS_QK: tl.constexpr,  #
+                        NUM_MMA_GROUPS: tl.constexpr,  #
+                        NUM_MMA_SLICES: tl.constexpr,  #
+                        GROUP_SIZE_N: tl.constexpr,  #
+                        RESCALE_OPT: tl.constexpr,  #
+                        USE_WHERE: tl.constexpr,  #
+                        USE_WARP_BARRIER: tl.constexpr,  #
+                        NUM_CTAS: tl.constexpr = 1,  #
+                        ):
     tl.static_assert(NUM_MMA_GROUPS == 2)
     tl.static_assert(NUM_BUFFERS_QK == 1)
     tl.static_assert(NUM_BUFFERS_Q == 1)
 
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
-    tl.static_assert(not USE_2CTA or BLOCK_M == 256)
-    FAST_F16_CAPABLE: tl.constexpr = (tlx.dtype_of(desc_v) == tl.float16 and NUM_MMA_SLICES == 4 and not RESCALE_OPT
-                                      and not USE_2CTA)
-    # BF16 fixed-gauge row sums are too imprecise for the softmax metadata reused by backward.
-    USE_FAST_FIXED: tl.constexpr = FAST_FIXED and FAST_F16_CAPABLE
-    USE_FAST_F16: tl.constexpr = USE_FAST_FIXED and FAST_F16_CAPABLE
-    FUSE_EPILOG: tl.constexpr = USE_FAST_FIXED and not USE_2CTA
-    DIRECT_SCHED: tl.constexpr = USE_2CTA or USE_FAST_F16
     cluster_cta_rank = tlx.cluster_cta_rank() if USE_2CTA else 0
     is_leader = (not USE_2CTA) or (cluster_cta_rank % 2 == 0)
 
@@ -1461,12 +675,10 @@ def _attn_fwd_ws_kernel(
     # original grid
     #   triton.cdiv(q.shape[2], META["BLOCK_M"]),
     #   q.shape[0] * q.shape[1],
-    start_pid = tl.program_id(0) // NUM_CTAS
+    start_pid = tl.program_id(0)
     num_pid_m = tl.cdiv(N_CTX, EFFECTIVE_BLOCK_M)
     num_pid_n = Z * H
     num_pid_in_group = num_pid_m * GROUP_SIZE_N
-    num_tiles = num_pid_m * num_pid_n
-    persistent_stride = tl.num_programs(0) // NUM_CTAS
 
     # allocate SMEM buffers and barriers
     NUM_Q_BUFS: tl.constexpr = NUM_GROUPS_PER_CTA * NUM_BUFFERS_Q
@@ -1477,7 +689,7 @@ def _attn_fwd_ws_kernel(
         # V loaded as (N, D/2).
         k_tiles = tlx.local_alloc((BLOCK_N_KV, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         v_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM_KV), tlx.dtype_of(desc_v), NUM_BUFFERS_KV)
-        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA)
+        o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_GROUPS_PER_CTA, reuse=q_tiles)
     else:
         kv_tiles = tlx.local_alloc((BLOCK_N, HEAD_DIM), tlx.dtype_of(desc_k), NUM_BUFFERS_KV)
         o_tiles = tlx.local_alloc((BLOCK_M_SPLIT, HEAD_DIM), tlx.dtype_of(desc_o), NUM_MMA_GROUPS)
@@ -1499,11 +711,10 @@ def _attn_fwd_ws_kernel(
     qk_storage_alias = tlx.storage_alias_spec(storage=tlx.storage_kind.tmem)
     qk_tiles = tlx.local_alloc((BLOCK_M_SPLIT, BLOCK_N), qk_dtype, NUM_MMA_GROUPS, tlx.storage_kind.tmem,
                                reuse=qk_storage_alias)
-    NUM_P_SLICES: tl.constexpr = 2 if USE_FAST_F16 else NUM_MMA_SLICES
     p_tiles = tlx.local_alloc(
-        (BLOCK_M_SPLIT, BLOCK_N // NUM_P_SLICES),
+        (BLOCK_M_SPLIT, BLOCK_N // NUM_MMA_SLICES),
         tlx.dtype_of(desc_v),
-        NUM_MMA_GROUPS * NUM_P_SLICES,
+        NUM_MMA_GROUPS * NUM_MMA_SLICES,
         tlx.storage_kind.tmem,
         reuse=qk_storage_alias,
     )
@@ -1545,7 +756,7 @@ def _attn_fwd_ws_kernel(
         tlx.reuse_group(
             qk_tiles,
             tlx.reuse_group(
-                tlx.reuse_group(p_tiles, group_size=NUM_P_SLICES),
+                tlx.reuse_group(p_tiles, group_size=NUM_MMA_SLICES),
                 alpha_tiles,
                 l_tiles,
                 m_tiles,
@@ -1560,33 +771,22 @@ def _attn_fwd_ws_kernel(
     acc_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS)
 
     # Cross-CTA barriers: must use mbarriers for 2-CTA (arrive_count=NUM_CTAS).
-    if USE_2CTA:
-        qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
-        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * 3, arrive_count=NUM_CTAS)
-        acc_fulls = (acc_empties
-                     if USE_FAST_FIXED else tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS))
-    elif USE_WARP_BARRIER:
+    if USE_WARP_BARRIER:
         qk_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
-        p_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS * NUM_P_SLICES, num_warps=4)
-        acc_fulls = (acc_empties
-                     if USE_FAST_FIXED else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4))
+        p_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, num_warps=4)
+        acc_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
     else:
         qk_empties = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
-        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_P_SLICES, arrive_count=NUM_CTAS)
-        acc_fulls = (acc_empties
-                     if USE_FAST_FIXED else tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS))
-    # Alpha/l stay within the compute role and use warp barriers. The 2-CTA
-    # output handoff below uses an mbarrier for the separate epilog role.
-    alpha_fulls = (qk_fulls if USE_FAST_FIXED else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4))
-    alpha_empties = (qk_empties if USE_FAST_FIXED else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4))
+        p_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS * NUM_MMA_SLICES, arrive_count=NUM_CTAS)
+        acc_fulls = tlx.alloc_barriers(num_barriers=NUM_MMA_GROUPS, arrive_count=NUM_CTAS)
+    # Intra-CTA barriers: always use fast warp barriers (no cross-CTA traffic).
+    alpha_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
+    alpha_empties = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
     l_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
-    o_fulls = (tlx.alloc_barriers(
-        num_barriers=NUM_MMA_GROUPS) if USE_2CTA else tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4))
+    o_fulls = tlx.alloc_warp_barrier(num_barriers=NUM_MMA_GROUPS, num_warps=4)
 
     # CLC consumers per CTA: correction(1) + softmax(NUM_GROUPS_PER_CTA) + mma(1) + load(1) + epilog(1).
-    if not DIRECT_SCHED:
-        clc_context = tlx.clc_create_context(num_consumers=3 + NUM_GROUPS_PER_CTA if FUSE_EPILOG else 4 +
-                                             NUM_GROUPS_PER_CTA)
+    clc_context = tlx.clc_create_context(num_consumers=(4 + NUM_GROUPS_PER_CTA) * NUM_CTAS)
 
     # In 2-CTA mode, cross-CTA barrier_arrive (to the leader's mbarriers) requires
     # the mbarrier.init to be visible cluster-wide before any remote arrive.
@@ -1598,77 +798,153 @@ def _attn_fwd_ws_kernel(
         # correction group
         with tlx.async_task("default"):
             accum_cnt = 0
+            phase = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_producer = 1
             clc_phase_consumer = 0
             while tile_id != -1:
-                # Publish this persistent tile, then finalize its M and O outputs.
-                if not USE_2CTA:
-                    if not DIRECT_SCHED:
-                        tlx.clc_producer(clc_context, clc_phase_producer)
-                        clc_phase_producer ^= 1
-                    accum_cnt = _fwd_control_tile(
-                        tile_id,
-                        tile_count,
-                        accum_cnt,
-                        sm_scale,
-                        M,
-                        H,
-                        num_pid_n,
-                        num_pid_in_group,
-                        N_CTX,
-                        desc_o,
-                        alpha_empties,
-                        alpha_fulls,
-                        alpha_tiles,
-                        acc_empties,
-                        acc_fulls,
-                        acc_tiles,
-                        l_fulls,
-                        l_tiles,
-                        m_tiles,
-                        qk_empties,
-                        o_empties,
-                        o_fulls,
-                        o_tiles,
-                        cluster_cta_rank,
-                        BLOCK_M_SPLIT,
-                        BLOCK_N,
-                        EFFECTIVE_BLOCK_M,
-                        GROUP_SIZE_N,
-                        HEAD_DIM,
-                        NUM_CTAS,
-                        NUM_GROUPS_PER_CTA,
-                        NUM_MMA_SLICES,
-                        RESCALE_OPT,
-                        SCALAR_N,
-                        STAGE,
-                        USE_2CTA,
-                        USE_WHERE,
-                        USE_FAST_FIXED,
-                        FUSE_EPILOG,
-                    )
+                # CLC producer: announce work to all consumer tasks
+                tlx.clc_producer(clc_context, clc_phase_producer, multi_ctas=USE_2CTA)
+                clc_phase_producer ^= 1
+
+                # initialize offsets
+                start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
+                    tile_id // NUM_CTAS,
+                    H,
+                    num_pid_n,
+                    num_pid_in_group,
+                    N_CTX,
+                    EFFECTIVE_BLOCK_M,
+                    STAGE,
+                    GROUP_SIZE_N,
+                )
+                for _ in tl.range(lo, hi, BLOCK_N):
+                    _, phase = get_bufidx_phase(accum_cnt, 1)
+                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                        # -- update output accumulator --
+                        tlx.barrier_wait(alpha_fulls[cid], phase)
+                        alpha_loaded = tlx.local_load(alpha_tiles[cid])
+                        alpha_1 = tl.split(alpha_loaded)[0][:, None] if SCALAR_N == 2 else alpha_loaded
+                        tlx.barrier_arrive(alpha_empties[cid])
+                        # Perform warp-level ballot vote to check if any thread needs rescaling
+                        # 0xFFFFFFFF means all 32 threads in the warp participate
+                        if RESCALE_OPT:
+                            pred = alpha_1 < 1.0
+                            # ballot_result is a tensor with the same shape as pred
+                            # All elements contain the same warp-level ballot value
+                            # Non-zero means at least one thread has alpha_1 < 1.0
+                            ballot_result = tlx.vote_ballot_sync(0xFFFFFFFF, pred)
+                            should_rescale = ballot_result != 0
+
+                        if USE_WHERE:
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                subslice = tlx.subslice(
+                                    acc_tiles[cid],
+                                    HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                                    HEAD_DIM // NUM_MMA_SLICES,
+                                )
+                                acc = tlx.local_load(subslice)
+                                # Use tl.where to conditionally apply rescaling
+                                # acc = acc * alpha_1 where should_rescale, else acc unchanged
+                                if RESCALE_OPT:
+                                    scaled_acc = _mul_f32x2(acc, alpha_1)
+                                    acc = tl.where(should_rescale, scaled_acc, acc)
+                                else:
+                                    acc = _mul_f32x2(acc, alpha_1)
+                                tlx.local_store(subslice, acc)
+                        else:
+                            # option 2: use a single scalar IfOp
+                            if RESCALE_OPT:
+                                should_rescale_red = tl.reduce(should_rescale, axis=0, combine_fn=_reduce_or)
+                                should_rescale_scalar = tl.reshape(should_rescale_red, ())
+                            if not RESCALE_OPT or (RESCALE_OPT and should_rescale_scalar):
+                                for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                    subslice = tlx.subslice(
+                                        acc_tiles[cid],
+                                        HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                                        HEAD_DIM // NUM_MMA_SLICES,
+                                    )
+                                    acc = tlx.local_load(subslice)
+                                    acc = _mul_f32x2(acc, alpha_1)
+                                    tlx.local_store(subslice, acc)
+                        if USE_2CTA:
+                            # This token reports completion of the TMEM update;
+                            # it does not publish ordinary SMEM to the peer CTA.
+                            tlx.barrier_arrive(
+                                acc_fulls[cid],
+                                1,
+                                remote_cta_rank=0,
+                            )
+                        else:
+                            tlx.barrier_arrive(acc_fulls[cid])
+                    accum_cnt += 1
+
+                _, phase = get_bufidx_phase(tile_count, 1)
+                for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
+                    # epilogue
+                    tlx.barrier_wait(l_fulls[cid], phase)
+                    l_loaded = tlx.local_load(l_tiles[cid])
+                    m_loaded = tlx.local_load(m_tiles[cid])
+                    l = tl.split(l_loaded)[0][:, None] if SCALAR_N == 2 else l_loaded
+                    m = tl.split(m_loaded)[0][:, None] if SCALAR_N == 2 else m_loaded
+                    # Signal qk_empties after both l and m loads complete,
+                    # since both tiles share the same synchronization group.
+                    if USE_2CTA:
+                        # The l/m loads are complete before this recycle token;
+                        # it does not publish ordinary SMEM to the peer CTA.
+                        tlx.barrier_arrive(
+                            qk_empties[cid],
+                            1,
+                            remote_cta_rank=0,
+                        )
+                    else:
+                        tlx.barrier_arrive(qk_empties[cid])
+                    if RESCALE_OPT:
+                        # RESCALE_OPT stores unscaled row-max in m_tiles.
+                        # The bwd kernel expects scaled values (m * qk_scale),
+                        # so we scale here before storing M.
+                        m = m * sm_scale * 1.44269504
+                    m += tl.math.log2(l)
+                    offs_m = start_m * EFFECTIVE_BLOCK_M + group_id * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                    m_ptrs = M + off_hz * N_CTX + offs_m
+                    tl.store(m_ptrs, tl.reshape(m, [BLOCK_M_SPLIT]))
+
+                    tlx.barrier_wait(acc_empties[cid], phase)
+                    tlx.barrier_wait(o_empties[cid], phase ^ 1)
+                    scale = 1 / l
+                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                        subslice = tlx.subslice(
+                            acc_tiles[cid],
+                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
+                            HEAD_DIM // NUM_MMA_SLICES,
+                        )
+                        acc = tlx.local_load(subslice)
+                        acc = _mul_f32x2(acc, scale)
+                        acc = acc.to(tlx.dtype_of(desc_o))
+                        subslice_o = tlx.local_slice(
+                            o_tiles[cid],
+                            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
+                            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
+                        )
+                        tlx.local_store(subslice_o, acc)
+                    tlx.barrier_arrive(o_fulls[cid])
+
                 tile_count += 1
-                if DIRECT_SCHED:
-                    next_tile_id = tile_id + persistent_stride
-                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
-                else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
-                    clc_phase_consumer ^= 1
+                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
+                clc_phase_consumer ^= 1
 
         # softmax groups
-        with tlx.async_task(num_warps=4, registers=DENSE_REGS if USE_2CTA else 168, replicate=NUM_GROUPS_PER_CTA):
+        with tlx.async_task(num_warps=4, registers=256 if (USE_2CTA and HEAD_DIM >= 256) else 168,
+                            replicate=NUM_GROUPS_PER_CTA):
             accum_cnt_qk = 0
-            gauge_cnt = 0
-            tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
-                gauge_cnt = 0
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id,
+                    tile_id // NUM_CTAS,
                     H,
                     num_pid_n,
                     num_pid_in_group,
@@ -1681,9 +957,8 @@ def _attn_fwd_ws_kernel(
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
                 # FA4 update_row_sum has init_val being None for the first iteration, here
                 # we use initial value of 1.0
-                l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32)
-                if not USE_FAST_FIXED:
-                    l_i += 1.0
+                l_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) + 1.0
+                acc = tl.zeros([BLOCK_M_SPLIT, HEAD_DIM], dtype=tl.float32)
                 qk_scale = sm_scale
                 qk_scale *= 1.44269504  # 1/log(2)
                 p_dtype = tlx.dtype_of(desc_v)
@@ -1696,7 +971,7 @@ def _attn_fwd_ws_kernel(
                     group_id = cid
                 offs_m = (start_m * EFFECTIVE_BLOCK_M) + ((group_id * BLOCK_M_SPLIT) + tl.arange(0, BLOCK_M_SPLIT))
                 if STAGE & 1:
-                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
+                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1704,11 +979,8 @@ def _attn_fwd_ws_kernel(
                         alpha_empties,
                         alpha_fulls,
                         alpha_tiles,
-                        acc_fulls,
-                        acc_tiles,
                         cid,
                         accum_cnt_qk,
-                        gauge_cnt,
                         qk_scale,
                         offs_m,
                         m_i,
@@ -1718,16 +990,14 @@ def _attn_fwd_ws_kernel(
                         p_dtype,
                         BLOCK_M,
                         BLOCK_N,
-                        HEAD_DIM,
                         NUM_MMA_SLICES,
                         STAGE=4 - STAGE,
                         RESCALE_OPT=RESCALE_OPT,
                         SCALAR_N=SCALAR_N,
                         USE_2CTA=USE_2CTA,
-                        FAST_FIXED=USE_FAST_FIXED,
                     )
                 if STAGE & 2:
-                    m_i, l_i, accum_cnt_qk, gauge_cnt = _fwd_softmax_tile(
+                    m_i, l_i, accum_cnt_qk = _softmax_inner_loop(
                         qk_fulls,
                         qk_tiles,
                         p_fulls,
@@ -1735,11 +1005,8 @@ def _attn_fwd_ws_kernel(
                         alpha_empties,
                         alpha_fulls,
                         alpha_tiles,
-                        acc_fulls,
-                        acc_tiles,
                         cid,
                         accum_cnt_qk,
-                        gauge_cnt,
                         qk_scale,
                         offs_m,
                         m_i,
@@ -1749,51 +1016,19 @@ def _attn_fwd_ws_kernel(
                         p_dtype,
                         BLOCK_M,
                         BLOCK_N,
-                        HEAD_DIM,
                         NUM_MMA_SLICES,
                         STAGE=2,
                         RESCALE_OPT=RESCALE_OPT,
                         SCALAR_N=SCALAR_N,
                         USE_2CTA=USE_2CTA,
-                        FAST_FIXED=USE_FAST_FIXED,
                     )
 
-                if USE_2CTA:
-                    tlx.barrier_arrive(qk_empties[cid], 1, remote_cta_rank=0)
-                    m_out = m_i * qk_scale if RESCALE_OPT else m_i
-                    tl.store(M + off_hz * N_CTX + offs_m, tl.math.log2(l_i) + m_out)
-                    _, phase = get_bufidx_phase(tile_count, 1)
-                    tlx.barrier_wait(acc_empties[cid], phase)
-                    tlx.barrier_wait(o_empties[cid], phase ^ 1)
-                    scale = (1 / l_i)[:, None]
-                    for slice_id in tl.static_range(0, NUM_MMA_SLICES):
-                        subslice = tlx.subslice(
-                            acc_tiles[cid],
-                            HEAD_DIM * slice_id // NUM_MMA_SLICES,
-                            HEAD_DIM // NUM_MMA_SLICES,
-                        )
-                        acc = _mul_f32x2(tlx.local_load(subslice), scale)
-                        acc = acc.to(tlx.dtype_of(desc_o))
-                        subslice_o = tlx.local_slice(
-                            o_tiles[cid],
-                            [0, HEAD_DIM * slice_id // NUM_MMA_SLICES],
-                            [BLOCK_M_SPLIT, HEAD_DIM // NUM_MMA_SLICES],
-                        )
-                        tlx.local_store(subslice_o, acc)
-                    tlx.fence("async_shared")
-                    tlx.barrier_arrive(o_fulls[cid])
-                else:
-                    # prepare l_i for the epilog
-                    tlx.local_store(l_tiles[cid], tl.join(l_i, l_i) if SCALAR_N == 2 else l_i[:, None])
-                    tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
-                    tlx.barrier_arrive(l_fulls[cid])
-                tile_count += 1
-                if DIRECT_SCHED:
-                    next_tile_id = tile_id + persistent_stride
-                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
-                else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
-                    clc_phase_consumer ^= 1
+                # prepare l_i for the epilog
+                tlx.local_store(l_tiles[cid], tl.join(l_i, l_i) if SCALAR_N == 2 else l_i[:, None])
+                tlx.local_store(m_tiles[cid], tl.join(m_i, m_i) if SCALAR_N == 2 else m_i[:, None])
+                tlx.barrier_arrive(l_fulls[cid])
+                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
+                clc_phase_consumer ^= 1
 
         # mma group
         with tlx.async_task(num_warps=1, registers=24):
@@ -1804,98 +1039,212 @@ def _attn_fwd_ws_kernel(
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
-                _, _, lo, hi, _, _ = _compute_offsets(
-                    tile_id,
-                    H,
-                    num_pid_n,
-                    num_pid_in_group,
-                    N_CTX,
-                    EFFECTIVE_BLOCK_M,
-                    STAGE,
-                    GROUP_SIZE_N,
-                )
                 if USE_2CTA:
                     if is_leader:
-                        accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
-                            tile_count,
-                            accum_cnt_kv,
-                            accum_cnt_qk,
-                            lo,
-                            hi,
-                            q_tiles,
-                            k_tiles,
-                            qk_tiles,
-                            p_tiles,
-                            acc_tiles,
-                            q_fulls,
-                            q_empties,
-                            k_fulls,
-                            k_empties,
-                            qk_fulls,
-                            qk_empties,
-                            p_fulls,
-                            acc_fulls,
-                            acc_empties,
-                            BLOCK_N,
-                            HEAD_DIM_KV,
-                            NUM_BUFFERS_Q,
-                            NUM_BUFFERS_KV,
-                            NUM_P_SLICES,
-                            v_tiles,
-                            v_fulls,
-                            v_empties,
-                            True,
-                            SKIP_RESCALE=USE_FAST_FIXED,
-                        )
-                else:
-                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_tile(
-                        tile_count,
-                        accum_cnt_kv,
-                        accum_cnt_qk,
-                        lo,
-                        hi,
-                        q_tiles,
-                        kv_tiles,
-                        qk_tiles,
-                        p_tiles,
-                        acc_tiles,
-                        q_fulls,
-                        q_empties,
-                        kv_fulls,
-                        kv_empties,
-                        qk_fulls,
-                        qk_empties,
-                        p_fulls,
-                        acc_fulls,
-                        acc_empties,
-                        BLOCK_N,
-                        HEAD_DIM_KV,
-                        NUM_BUFFERS_Q,
-                        NUM_BUFFERS_KV,
-                        NUM_P_SLICES,
-                        None,
-                        None,
-                        None,
-                        False,
-                        SKIP_RESCALE=USE_FAST_FIXED,
-                    )
-                tile_count += 1
-                if DIRECT_SCHED:
-                    next_tile_id = tile_id + persistent_stride
-                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
-                else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
-                    clc_phase_consumer ^= 1
+                        _, _, lo2, hi2, _, _ = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n, num_pid_in_group,
+                                                                N_CTX, EFFECTIVE_BLOCK_M, STAGE, GROUP_SIZE_N)
+                        q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
 
-        # Q/K/V loader role; output publication remains in the epilog task.
+                        tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                        tlx.barrier_wait(q_fulls[q_bufIdx], q_phase)
+
+                        k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                        tlx.barrier_wait(qk_empties[0], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                      two_ctas=True)
+
+                        tlx.barrier_wait(q_fulls[q_bufIdx + NUM_BUFFERS_Q], q_phase)
+                        tlx.barrier_wait(qk_empties[1], q_phase ^ 1)
+                        tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                      mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                        _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                        tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                        tlx.barrier_wait(acc_fulls[0], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=slice_id > 0,
+                                          force_async=True, two_ctas=True)
+
+                        acc1_init = False
+
+                        for i in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                            v_bufIdx_prev = v_bufIdx
+                            qk_phase_prev = qk_phase
+
+                            accum_cnt_qk += 1
+                            accum_cnt_kv += 1
+                            k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                            v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+
+                            tlx.barrier_wait(k_fulls[k_bufIdx], k_phase)
+                            k_tile = tlx.local_trans(k_tiles[k_bufIdx])
+                            _, qk_phase = get_bufidx_phase(accum_cnt_qk, 1)
+
+                            tlx.async_dot(q_tiles[0], k_tile, qk_tiles[0], use_acc=False, mBarriers=[qk_fulls[0]],
+                                          two_ctas=True)
+
+                            tlx.barrier_wait(acc_fulls[1], qk_phase_prev)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id + NUM_MMA_SLICES
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase_prev)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx_prev],
+                                                           [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                use_acc = acc1_init if slice_id == 0 else True
+                                mBarriers = [v_empties[v_bufIdx_prev]] if slice_id == NUM_MMA_SLICES - 1 else []
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                              mBarriers=mBarriers, two_ctas=True)
+
+                            acc1_init = True
+
+                            tlx.async_dot(q_tiles[1], k_tile, qk_tiles[1], use_acc=False,
+                                          mBarriers=[qk_fulls[1], k_empties[k_bufIdx]], two_ctas=True)
+
+                            tlx.barrier_wait(v_fulls[v_bufIdx], v_phase)
+                            tlx.barrier_wait(acc_fulls[0], qk_phase)
+                            for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                                p_bufIdx = slice_id
+                                tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                                kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                           [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                                tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[0], use_acc=True, force_async=True,
+                                              two_ctas=True)
+
+                        tlx.tcgen05_commit(q_empties[q_bufIdx], two_ctas=True)
+                        tlx.tcgen05_commit(q_empties[q_bufIdx + NUM_BUFFERS_Q], two_ctas=True)
+                        tlx.tcgen05_commit(acc_empties[0], two_ctas=True)
+
+                        tlx.barrier_wait(acc_fulls[1], qk_phase)
+                        for slice_id in tl.static_range(0, NUM_MMA_SLICES):
+                            p_bufIdx = slice_id + NUM_MMA_SLICES
+                            tlx.barrier_wait(p_fulls[p_bufIdx], qk_phase)
+                            kv_slice = tlx.local_slice(v_tiles[v_bufIdx], [BLOCK_N * slice_id // NUM_MMA_SLICES, 0],
+                                                       [BLOCK_N // NUM_MMA_SLICES, HEAD_DIM_KV])
+                            use_acc = acc1_init if slice_id == 0 else True
+                            mBarriers = [acc_empties[1], v_empties[v_bufIdx]] if slice_id == NUM_MMA_SLICES - 1 else []
+                            tlx.async_dot(p_tiles[p_bufIdx], kv_slice, acc_tiles[1], use_acc=use_acc,
+                                          mBarriers=mBarriers, two_ctas=True)
+
+                        accum_cnt_qk += 1
+                        accum_cnt_kv += 1
+                else:
+                    _, _, lo, hi, _, _ = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M,
+                                                          STAGE, GROUP_SIZE_N)
+                    accum_cnt_kv, accum_cnt_qk = _fwd_mma_dots_1cta(tile_count, accum_cnt_kv, accum_cnt_qk, lo, hi,
+                                                                    q_tiles, kv_tiles, qk_tiles, p_tiles, acc_tiles,
+                                                                    q_fulls, q_empties, kv_fulls, kv_empties, qk_fulls,
+                                                                    qk_empties, p_fulls, acc_fulls, acc_empties,
+                                                                    BLOCK_N, HEAD_DIM_KV, NUM_BUFFERS_Q, NUM_BUFFERS_KV,
+                                                                    NUM_MMA_SLICES)
+                tile_count += 1
+                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
+                clc_phase_consumer ^= 1
+
+        # load
         with tlx.async_task(num_warps=1, registers=24):
             accum_cnt_kv = 0
             tile_count = 0
             tile_id = start_pid
             clc_phase_consumer = 0
             while tile_id != -1:
-                _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_id,
+                if USE_2CTA:
+                    _, off_hz2, lo2, hi2, qo2, kv2 = _compute_offsets(tile_id // NUM_CTAS, H, num_pid_n,
+                                                                      num_pid_in_group, N_CTX, EFFECTIVE_BLOCK_M, STAGE,
+                                                                      GROUP_SIZE_N)
+
+                    q_bufIdx, q_phase = get_bufidx_phase(tile_count, NUM_BUFFERS_Q)
+                    # Q and O share SMEM (o_tiles reuses q_tiles). Wait for the
+                    # epilog to finish storing the previous tile's O before
+                    # overwriting the buffer with new Q data.
+                    _, o_phase = get_bufidx_phase(tile_count, 1)
+                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                        tlx.barrier_wait(o_empties[cid], o_phase ^ 1)
+                    # load Q0
+                    tlx.barrier_wait(q_empties[q_bufIdx], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx], [qo2 + cluster_cta_rank * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx], two_ctas=tl.constexpr(True))
+                    # load Q1
+                    q_bufIdx1 = q_bufIdx + NUM_BUFFERS_Q
+                    tlx.barrier_wait(q_empties[q_bufIdx1], q_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(q_fulls[q_bufIdx1],
+                                                 Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_q, q_tiles[q_bufIdx1],
+                                              [qo2 + (NUM_CTAS + cluster_cta_rank) * BLOCK_M_SPLIT, 0],
+                                              q_fulls[q_bufIdx1], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y = kv2
+
+                    k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(k_fulls[k_bufIdx], K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                    tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                              [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                              two_ctas=tl.constexpr(True))
+
+                    v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                    tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                    if is_leader:
+                        tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                    tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx], [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV],
+                                              v_fulls[v_bufIdx], two_ctas=tl.constexpr(True))
+
+                    kv_offset_y += BLOCK_N
+                    accum_cnt_kv += 1
+
+                    for _ in tl.range(lo2 + BLOCK_N, hi2, BLOCK_N):
+                        k_bufIdx, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(k_empties[k_bufIdx], k_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(k_fulls[k_bufIdx],
+                                                     K_BYTES_PER_ELEM * BLOCK_N_KV * HEAD_DIM * NUM_CTAS)
+                        tlx.async_descriptor_load(desc_k, k_tiles[k_bufIdx],
+                                                  [kv_offset_y + cluster_cta_rank * BLOCK_N_KV, 0], k_fulls[k_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        v_bufIdx, v_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS_KV)
+                        tlx.barrier_wait(v_empties[v_bufIdx], v_phase ^ 1)
+                        if is_leader:
+                            tlx.barrier_expect_bytes(v_fulls[v_bufIdx], V_BYTES_PER_ELEM * BLOCK_N * HEAD_DIM)
+                        tlx.async_descriptor_load(desc_v, v_tiles[v_bufIdx],
+                                                  [kv_offset_y, cluster_cta_rank * HEAD_DIM_KV], v_fulls[v_bufIdx],
+                                                  two_ctas=tl.constexpr(True))
+
+                        kv_offset_y += BLOCK_N
+                        accum_cnt_kv += 1
+                else:
+                    _, _, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(tile_id, H, num_pid_n, num_pid_in_group,
+                                                                              N_CTX, BLOCK_M, STAGE, GROUP_SIZE_N)
+                    accum_cnt_kv = _fwd_load_1cta(tile_count, accum_cnt_kv, lo, hi, qo_offset_y, kv_offset_y, desc_q,
+                                                  desc_k, desc_v, q_tiles, kv_tiles, q_fulls, q_empties, kv_fulls,
+                                                  kv_empties, Q_BYTES_PER_ELEM, K_BYTES_PER_ELEM, V_BYTES_PER_ELEM,
+                                                  BLOCK_M_SPLIT, BLOCK_N, HEAD_DIM, NUM_BUFFERS_Q, NUM_BUFFERS_KV)
+
+                tile_count += 1
+                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
+                clc_phase_consumer ^= 1
+
+        # epilog group
+        with tlx.async_task(num_warps=1, registers=24):
+            # initialize offsets
+            tile_count = 0
+            tile_id = start_pid
+            clc_phase_consumer = 0
+            while tile_id != -1:
+                # initialize offsets
+                _, _, _, _, qo_offset_y, _ = _compute_offsets(
+                    tile_id // NUM_CTAS,
                     H,
                     num_pid_n,
                     num_pid_in_group,
@@ -1904,108 +1253,18 @@ def _attn_fwd_ws_kernel(
                     STAGE,
                     GROUP_SIZE_N,
                 )
-                if USE_2CTA:
-                    accum_cnt_kv = _fwd_load_tile(
-                        tile_count,
-                        accum_cnt_kv,
-                        lo,
-                        hi,
-                        qo_offset_y,
-                        kv_offset_y,
-                        desc_q,
-                        desc_k,
-                        desc_v,
-                        q_tiles,
-                        k_tiles,
-                        q_fulls,
-                        q_empties,
-                        k_fulls,
-                        k_empties,
-                        Q_BYTES_PER_ELEM,
-                        K_BYTES_PER_ELEM,
-                        V_BYTES_PER_ELEM,
-                        BLOCK_M_SPLIT,
-                        BLOCK_N,
-                        HEAD_DIM,
-                        NUM_BUFFERS_Q,
-                        NUM_BUFFERS_KV,
-                        cluster_cta_rank,
-                        v_tiles,
-                        v_fulls,
-                        v_empties,
-                        NUM_GROUPS_PER_CTA,
-                        NUM_CTAS,
-                    )
-                else:
-                    accum_cnt_kv = _fwd_load_tile(
-                        tile_count,
-                        accum_cnt_kv,
-                        lo,
-                        hi,
-                        qo_offset_y,
-                        kv_offset_y,
-                        desc_q,
-                        desc_k,
-                        desc_v,
-                        q_tiles,
-                        kv_tiles,
-                        q_fulls,
-                        q_empties,
-                        kv_fulls,
-                        kv_empties,
-                        Q_BYTES_PER_ELEM,
-                        K_BYTES_PER_ELEM,
-                        V_BYTES_PER_ELEM,
-                        BLOCK_M_SPLIT,
-                        BLOCK_N,
-                        HEAD_DIM,
-                        NUM_BUFFERS_Q,
-                        NUM_BUFFERS_KV,
-                    )
+                _, phase = get_bufidx_phase(tile_count, 1)
+                for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
+                    group_id = cid * NUM_CTAS + cluster_cta_rank
+                    tlx.barrier_wait(o_fulls[cid], phase)
+                    qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
+                    tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
+                    tlx.async_descriptor_store_wait(0)
+                    tlx.barrier_arrive(o_empties[cid])
 
                 tile_count += 1
-                if DIRECT_SCHED:
-                    next_tile_id = tile_id + persistent_stride
-                    tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
-                else:
-                    tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
-                    clc_phase_consumer ^= 1
-
-        # epilog group
-        if USE_2CTA or not FUSE_EPILOG:
-            with tlx.async_task(num_warps=1, registers=24):
-                # initialize offsets
-                tile_count = 0
-                tile_id = start_pid
-                clc_phase_consumer = 0
-                while tile_id != -1:
-                    # initialize offsets
-                    _, _, _, _, qo_offset_y, _ = _compute_offsets(
-                        tile_id,
-                        H,
-                        num_pid_n,
-                        num_pid_in_group,
-                        N_CTX,
-                        EFFECTIVE_BLOCK_M,
-                        STAGE,
-                        GROUP_SIZE_N,
-                    )
-                    _, phase = get_bufidx_phase(tile_count, 1)
-                    for cid in tl.static_range(0, NUM_GROUPS_PER_CTA):
-                        group_id = cid * NUM_CTAS + cluster_cta_rank
-                        tlx.barrier_wait(o_fulls[cid], phase)
-                        qo_offset_y_split = qo_offset_y + group_id * BLOCK_M_SPLIT
-                        tlx.async_descriptor_store(desc_o, o_tiles[cid], [qo_offset_y_split, 0])
-                        tlx.async_descriptor_store_wait(0)
-                        tlx.barrier_arrive(o_empties[cid])
-
-                    tile_count += 1
-                    if DIRECT_SCHED:
-                        next_tile_id = tile_id + persistent_stride
-                        tile_id = tl.where(next_tile_id < num_tiles, next_tile_id, -1)
-                    else:
-                        tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer)
-                        clc_phase_consumer ^= 1
+                tile_id = tlx.clc_consumer(clc_context, clc_phase_consumer, multi_ctas=USE_2CTA)
+                clc_phase_consumer ^= 1
 
 
 @triton.jit
@@ -2047,72 +1306,93 @@ def _attn_bwd_dq_postprocess(DQ_ACCUM, DQ_OUT,  #
     tl.store(dst, val.to(DQ_OUT.dtype.element_ty))
 
 
+@triton.jit
+def bwd_calculate_offsets(
+    tile_idx,
+    n_tile_num,
+    num_pid_m,
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,
+    BLOCK_N1: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    STAGE: tl.constexpr,
+):
+    bhid = tile_idx // n_tile_num
+    pid = tile_idx % n_tile_num
+    pid, bhid = tl.swizzle2d(pid, bhid, n_tile_num, num_pid_m, GROUP_SIZE_M)
+    batch = bhid // H
+    head = bhid % H
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    start_n = pid
+    start_m = _get_start_m_bwd(start_n, BLOCK_N1, STAGE)
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+    return off_chz, batch, head, start_m, start_n, num_steps
+
+
 _bwd_selected_meta = {}
 
 
 def _bwd_host_descriptor_pre_hook_tlx(nargs):
-    block_m = nargs["BLOCK_M1"]
-    block_n = nargs["BLOCK_N1"]
-    head_dim = nargs["HEAD_DIM"]
-    num_ctas = nargs.get("NUM_CTAS", 1)
-    _bwd_selected_meta["BLOCK_M1"] = block_m
-    _bwd_selected_meta["NUM_CTAS"] = num_ctas
+    BLOCK_M1 = nargs["BLOCK_M1"]
+    BLOCK_N1 = nargs["BLOCK_N1"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    NUM_CTAS = nargs.get("NUM_CTAS", 1)
+
+    _bwd_selected_meta["BLOCK_M1"] = BLOCK_M1
+    _bwd_selected_meta["NUM_CTAS"] = NUM_CTAS
+
     # Reset dq accumulator to zeros before each autotuner warmup run.
     # dq uses TMA reduce-add, so stale values accumulate across runs.
     # dk/dv don't need zeroing — they use use_acc=False on the first iteration.
     nargs["desc_dq"].base.zero_()
-    nargs["desc_q"].block_shape = [1, 1, block_m, head_dim // num_ctas]
-    nargs["desc_do"].block_shape = [1, 1, block_m, head_dim // num_ctas]
-    nargs["desc_v"].block_shape = [1, 1, block_n, head_dim]
-    nargs["desc_k"].block_shape = [1, 1, block_n, head_dim]
-    direct_dq = nargs.get("SCALE_QK_IN_KERNEL", False) and num_ctas > 1 and head_dim == 128
-    if direct_dq:
-        dq_m = block_m // num_ctas
-        dq_slice = head_dim // nargs["EPILOGUE_SUBTILE"]
-    elif num_ctas > 1:
-        dq_m = block_m
-        dq_slice = head_dim // nargs["EPILOGUE_SUBTILE"]
+
+    nargs["desc_q"].block_shape = [1, 1, BLOCK_M1, HEAD_DIM // NUM_CTAS]
+    nargs["desc_do"].block_shape = [1, 1, BLOCK_M1, HEAD_DIM // NUM_CTAS]
+    nargs["desc_v"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
+    nargs["desc_k"].block_shape = [1, 1, BLOCK_N1, HEAD_DIM]
+    if NUM_CTAS > 1:
+        EPILOGUE_SUBTILE = nargs["EPILOGUE_SUBTILE"]
+        DQ_SLICE_N = HEAD_DIM // EPILOGUE_SUBTILE
+        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_SLICE_N]
     else:
-        dq_m = block_m
-        dq_slice = nargs["DQ_REDUCE_NCOL"]
-    nargs["desc_dq"].block_shape = [1, 1, dq_m, dq_slice]
-    dkv_slice = nargs["DKV_STORE_NCOL"]
-    nargs["desc_dv"].block_shape = [1, 1, block_n, dkv_slice]
-    nargs["desc_dk"].block_shape = [1, 1, block_n, dkv_slice]
-    if "desc_m" in nargs:
-        nargs["desc_m"].block_shape = [block_m]
-    if "desc_delta" in nargs:
-        nargs["desc_delta"].block_shape = [block_m]
+        DQ_REDUCE_NCOL = nargs["DQ_REDUCE_NCOL"]
+        nargs["desc_dq"].block_shape = [1, 1, BLOCK_M1, DQ_REDUCE_NCOL]
+    DKV_STORE_NCOL = nargs["DKV_STORE_NCOL"]
+    nargs["desc_dv"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
+    nargs["desc_dk"].block_shape = [1, 1, BLOCK_N1, DKV_STORE_NCOL]
+    nargs["desc_m"].block_shape = [BLOCK_M1]
+    nargs["desc_delta"].block_shape = [BLOCK_M1]
     # 2-CTA: separate B-operand descriptors for the transposed views.
     if "desc_kt" in nargs and "desc_qt" in nargs:
-        nargs["desc_kt"].block_shape = [1, 1, block_n * num_ctas, head_dim // num_ctas]
-        nargs["desc_qt"].block_shape = [1, 1, block_m // num_ctas, head_dim]
-        nargs["desc_dot"].block_shape = [1, 1, block_m // num_ctas, head_dim]
+        nargs["desc_kt"].block_shape = [1, 1, BLOCK_N1 * NUM_CTAS, HEAD_DIM // NUM_CTAS]
+        nargs["desc_qt"].block_shape = [1, 1, BLOCK_M1 // NUM_CTAS, HEAD_DIM]
+        nargs["desc_dot"].block_shape = [1, 1, BLOCK_M1 // NUM_CTAS, HEAD_DIM]
 
 
 configs_bwd_1cta = [
     triton.Config(
         {
-            "BLOCK_M1": 64,
+            "BLOCK_M1": bm1,
             "BLOCK_N1": 128,
             "NUM_BUFFERS_KV": 1,
             "NUM_BUFFERS_Q": 2,
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
-            "NUM_COMPUTE_SLICES": 2,
             "DKV_STORE_NCOL": 64,
+            "NUM_COMPUTE_SLICES": 2,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
             "EPILOGUE_SUBTILE": 4,
             "GROUP_SIZE_M": 1,
-            "USE_WARP_BARRIER": use_warp_barrier,
+            "USE_WARP_BARRIER": uwb,
             "NUM_CTAS": 1,
         },
         num_warps=8,
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
-    ) for use_warp_barrier in (False, True)
+    ) for bm1 in [64] for uwb in [False, True]
 ]
 
 configs_bwd_2cta = [
@@ -2126,11 +1406,11 @@ configs_bwd_2cta = [
             "NUM_BUFFERS_DO": 1,
             "NUM_BUFFERS_DS": 1,
             "NUM_BUFFERS_TMEM": 1,
-            "NUM_COMPUTE_SLICES": 2,
             "DKV_STORE_NCOL": 64,
+            "NUM_COMPUTE_SLICES": 2,
             "DQ_REDUCE_STAGES": 2,
             "DQ_REDUCE_NCOL": 32,
-            "EPILOGUE_SUBTILE": 8,
+            "EPILOGUE_SUBTILE": 4,
             "GROUP_SIZE_M": 1,
             "USE_WARP_BARRIER": False,
             "NUM_CTAS": 2,
@@ -2139,23 +1419,10 @@ configs_bwd_2cta = [
         num_stages=1,
         pre_hook=_bwd_host_descriptor_pre_hook_tlx,
         ctas_per_cga=(2, 1, 1),
-    )
+    ),
 ]
 
-BWD_CONFIGS = configs_bwd_1cta + configs_bwd_2cta
-
-
-def prune_bwd_configs(configs, named_args, **kwargs):
-    n_ctx = kwargs["N_CTX"] if "N_CTX" in kwargs else named_args["N_CTX"]
-    configs = [
-        config for config in configs if ((n_ctx + config.kwargs["BLOCK_N1"] - 1) // config.kwargs["BLOCK_N1"]) %
-        config.kwargs.get("NUM_CTAS", 1) == 0
-    ]
-    if kwargs.get("SCALE_QK_IN_KERNEL", False):
-        assert kwargs["HEAD_DIM"] == 128
-        configs = [config for config in configs if config.kwargs.get("NUM_CTAS", 1) == 2]
-        assert configs
-    return configs
+configs_bwd_tlx = configs_bwd_1cta + configs_bwd_2cta
 
 
 @triton.jit
@@ -2354,7 +1621,7 @@ def _bwd_mma_dots_1cta(
         q_tiles[q_buf_id],
         dk_tiles[kv_buf_id],
         use_acc=num_steps > 1,
-        mBarriers=[q_empties[q_buf_id], dk_fulls[kv_buf_id]],
+        mBarriers=[q_empties[q_buf_id], dk_fulls[tmem_buf_id]],
     )
 
     # Compute dq = tl.dot(tl.trans(dsT), k)
@@ -3046,7 +2313,6 @@ def _bwd_compute_inner_loop(
     step_m,
     do_out_dtype,
     q_out_dtype,
-    qk_scale,
     N_CTX,
     NUM_BUFFERS_TMEM: tl.constexpr,
     NUM_BUFFERS_DS: tl.constexpr,
@@ -3059,7 +2325,6 @@ def _bwd_compute_inner_loop(
     D_STAGE: tl.constexpr,
     # 2-CTA params (defaults for 1-CTA)
     USE_2CTA: tl.constexpr = False,
-    SCALE_QK_IN_KERNEL: tl.constexpr = False,
     NUM_CTAS: tl.constexpr = 1,
     dsT_xchg_tiles=None,
     ds_xchg_tiles=None,
@@ -3100,10 +2365,7 @@ def _bwd_compute_inner_loop(
         # causal mask to the logits via the R2P bitmask helper (keep query-cols
         # m >= key-row n), then exp2 (exp2(-inf) = 0), avoiding the per-element
         # ISETP arithmetic of `offs_m >= offs_n`.
-        if SCALE_QK_IN_KERNEL:
-            sT = _fma_f32x2(qkT, qk_scale, -m[None, :])
-        else:
-            sT = _sub_f32x2(qkT, m[None, :])
+        sT = _sub_f32x2(qkT, m[None, :])
         if STAGE == 1:
             col_limit_left = (offs_n - curr_m)[:, None]
             sT = _apply_causal_mask(sT, col_limit_left, BLOCK_M1, keep_ge=True)
@@ -3122,8 +2384,13 @@ def _bwd_compute_inner_loop(
         # local_store->TMEM lowering auto-emits tcgen05.wait::st, so p_fulls
         # already observes the completed P store; no manual wait.
         if USE_2CTA:
-            tlx.barrier_arrive(qk_empties[tmem_buf_id], 1, remote_cta_rank=0)
-            tlx.barrier_arrive(p_fulls[tmem_buf_id], 1, remote_cta_rank=0)
+            # These TMEM handshakes do not publish ordinary memory.
+            tlx.barrier_arrive(
+                qk_empties[tmem_buf_id], 1, remote_cta_rank=0
+            )
+            tlx.barrier_arrive(
+                p_fulls[tmem_buf_id], 1, remote_cta_rank=0
+            )
         else:
             tlx.barrier_arrive(qk_empties[tmem_buf_id])
             tlx.barrier_arrive(p_fulls[tmem_buf_id])
@@ -3151,7 +2418,10 @@ def _bwd_compute_inner_loop(
         # 2-CTA: exchange half of dS with peer via DSMEM, then
         # overwrite ds_tiles so it contains mixed dS from both CTAs.
         if USE_2CTA:
-            tlx.barrier_arrive(dsT_tmem_fulls[ds_buf_id], 1, remote_cta_rank=0)
+            # This token reports TMEM store completion, not SMEM publication.
+            tlx.barrier_arrive(
+                dsT_tmem_fulls[ds_buf_id], 1, remote_cta_rank=0
+            )
             _, ds_phase = get_bufidx_phase(blk_idx, NUM_BUFFERS_DS)
             # Wait for MMA Dot 5 to finish reading ds_tiles before overwriting.
             tlx.barrier_wait(ds_empties[ds_buf_id], ds_phase ^ 1)
@@ -3172,7 +2442,9 @@ def _bwd_compute_inner_loop(
             peer_data = tlx.local_load(peer_tmem)
             # Signal dp_empties right after TMEM reload is done —
             # dsT_tmem is no longer needed, MMA can overwrite dp/dq TMEM.
-            tlx.barrier_arrive(dp_empties[tmem_buf_id], 1, remote_cta_rank=0)
+            tlx.barrier_arrive(
+                dp_empties[tmem_buf_id], 1, remote_cta_rank=0
+            )
             tlx.local_store(ds_xchg_tiles[ds_buf_id], peer_data)
             tlx.fence("async_shared")
             remote_dst = own_smem
@@ -3228,14 +2500,12 @@ def _attn_bwd_ws(
     NUM_COMPUTE_SLICES: tl.constexpr,
     DQ_REDUCE_STAGES: tl.constexpr,
     DQ_REDUCE_NCOL: tl.constexpr,
-    DQ_STAGE_COUNT: tl.constexpr,
     DKV_STORE_NCOL: tl.constexpr,
     STAGE: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     USE_WARP_BARRIER: tl.constexpr = False,
     EPILOGUE_SUBTILE: tl.constexpr = 4,
     NUM_CTAS: tl.constexpr = 1,
-    SCALE_QK_IN_KERNEL: tl.constexpr = False,
 ):
     # Runtime error if NUM_BUFFERS_DO != 1
     tl.static_assert(NUM_BUFFERS_DO == 1)
@@ -3248,14 +2518,6 @@ def _attn_bwd_ws(
     REUSE_DP_FOR_DQ: tl.constexpr = (BLOCK_M1 == 128) and (HEAD_DIM == 128) and (NUM_CTAS == 1)
 
     USE_2CTA: tl.constexpr = NUM_CTAS == 2
-    tl.static_assert(
-        not SCALE_QK_IN_KERNEL or (USE_2CTA and HEAD_DIM == 128),
-        "direct dQ requires NUM_CTAS=2 and HEAD_DIM=128",
-    )
-    DIRECT_DQ_OUTPUT: tl.constexpr = SCALE_QK_IN_KERNEL
-    DQ_READ_DONE_BAR: tl.constexpr = 12
-    NUM_REDUCE_THREADS: tl.constexpr = 4 * 32
-    qk_scale = sm_scale * 1.4426950408889634
 
     # Compute bytes per element for each tensor type
     Q_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_q))
@@ -3318,12 +2580,7 @@ def _attn_bwd_ws(
         dq_empties = tlx.alloc_warp_barrier(num_barriers=NUM_BUFFERS_TMEM, num_warps=4)
     else:
         dq_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_TMEM, arrive_count=NUM_CTAS)
-    if DIRECT_DQ_OUTPUT:
-        dq_stage_fulls = tlx.alloc_warp_barrier(num_barriers=DQ_STAGE_COUNT, num_warps=4)
-        dq_stage_empties = tlx.alloc_barriers(num_barriers=DQ_STAGE_COUNT)
-    else:
-        dq_stage_fulls = None
-        dq_stage_empties = None
+
     dv_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_KV)
     if USE_WARP_BARRIER:
         dv_empties = tlx.alloc_warp_barrier(num_barriers=NUM_BUFFERS_KV, num_warps=8)
@@ -3378,8 +2635,7 @@ def _attn_bwd_ws(
     DQ_SLICE_N: tl.constexpr = HEAD_DIM // EPILOGUE_SUBTILE
     if USE_2CTA:
         DQ_STORE_STAGES: tl.constexpr = 1 if EPILOGUE_SUBTILE == 4 else 2
-        DQ_BUFFER_STAGES: tl.constexpr = DQ_STAGE_COUNT if DIRECT_DQ_OUTPUT else DQ_STORE_STAGES
-        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_BUFFER_STAGES)
+        dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_SLICE_N), tlx.dtype_of(desc_dq), DQ_STORE_STAGES)
     else:
         DQ_REDUCE_ITERS: tl.constexpr = HEAD_DIM // DQ_REDUCE_NCOL
         dq_store_buf = tlx.local_alloc((BLOCK_M1, DQ_REDUCE_NCOL), tlx.dtype_of(desc_dq), DQ_REDUCE_STAGES)
@@ -3529,10 +2785,7 @@ def _attn_bwd_ws(
         cluster_cta_rank = 0
         is_leader = True  # noqa: F841
 
-    # `less_reg_mma`: the MMA task issues many dots over the same SMEM
-    # operands, so a CSE-d operand descriptor stays live across all of them and
-    # spills. Give each MMA its own address computation instead.
-    with tlx.async_tasks(exclusive=not DIRECT_DQ_OUTPUT, less_reg_mma=True):
+    with tlx.async_tasks(exclusive=True):
         # compute
         with tlx.async_task("default"):
             blk_idx = 0
@@ -3568,7 +2821,6 @@ def _attn_bwd_ws(
                     step_m,
                     do_out_dtype,
                     q_out_dtype,
-                    qk_scale,
                     N_CTX,
                     NUM_BUFFERS_TMEM,
                     NUM_BUFFERS_DS,
@@ -3580,7 +2832,6 @@ def _attn_bwd_ws(
                     M_STAGE=M_STAGE,
                     D_STAGE=D_STAGE,
                     USE_2CTA=USE_2CTA,
-                    SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                     NUM_CTAS=NUM_CTAS,
                     dsT_xchg_tiles=None,
                     ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3618,7 +2869,6 @@ def _attn_bwd_ws(
                         step_m,
                         do_out_dtype,
                         q_out_dtype,
-                        qk_scale,
                         N_CTX,
                         NUM_BUFFERS_TMEM,
                         NUM_BUFFERS_DS,
@@ -3630,7 +2880,6 @@ def _attn_bwd_ws(
                         M_STAGE=M_STAGE,
                         D_STAGE=D_STAGE,
                         USE_2CTA=USE_2CTA,
-                        SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                         NUM_CTAS=NUM_CTAS,
                         dsT_xchg_tiles=None,
                         ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3666,7 +2915,6 @@ def _attn_bwd_ws(
                         step_m,
                         do_out_dtype,
                         q_out_dtype,
-                        qk_scale,
                         N_CTX,
                         NUM_BUFFERS_TMEM,
                         NUM_BUFFERS_DS,
@@ -3678,7 +2926,6 @@ def _attn_bwd_ws(
                         M_STAGE=M_STAGE,
                         D_STAGE=D_STAGE,
                         USE_2CTA=USE_2CTA,
-                        SCALE_QK_IN_KERNEL=SCALE_QK_IN_KERNEL,
                         NUM_CTAS=NUM_CTAS,
                         dsT_xchg_tiles=None,
                         ds_xchg_tiles=ds_xchg_tiles if USE_2CTA else None,
@@ -3708,7 +2955,10 @@ def _attn_bwd_ws(
                     [batch, head, start_block_n, slice_id * DKV_STORE_NCOL],
                 )
             if USE_2CTA:
-                tlx.barrier_arrive(dv_empties[kv_buf_id], 1, remote_cta_rank=0)
+                # The dV accumulator has been consumed; no SMEM is published.
+                tlx.barrier_arrive(
+                    dv_empties[kv_buf_id], 1, remote_cta_rank=0
+                )
             else:
                 tlx.barrier_arrive(dv_empties[kv_buf_id])
             tlx.barrier_wait(dk_fulls[kv_buf_id], kv_phase)
@@ -3741,7 +2991,10 @@ def _attn_bwd_ws(
             # the last K read, not these staging stores into the sdk/sdv aliases;
             # once the KV ring cycles, also arrive k_empties here.
             if USE_2CTA:
-                tlx.barrier_arrive(dk_empties[kv_buf_id], 1, remote_cta_rank=0)
+                # The dK accumulator and staging aliases are ready for reuse.
+                tlx.barrier_arrive(
+                    dk_empties[kv_buf_id], 1, remote_cta_rank=0
+                )
             else:
                 tlx.barrier_arrive(k_empties[kv_buf_id])
                 tlx.barrier_arrive(dk_empties[kv_buf_id])
@@ -3758,53 +3011,35 @@ def _attn_bwd_ws(
                 tlx.barrier_wait(dq_fulls[tmem_buf_id], tmem_phase)
                 if USE_2CTA:
                     dq_m_offset = cluster_cta_rank * DQ_STORE_M
+                    packed_row_base = 2 * (curr_m + dq_m_offset)
                     DQ_PACK_ITERS: tl.constexpr = (HEAD_DIM // NUM_CTAS) // DQ_SLICE_N
-                    if DIRECT_DQ_OUTPUT:
-                        dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
-                        tlx.named_barrier_wait(DQ_READ_DONE_BAR, NUM_REDUCE_THREADS)
-                        tlx.barrier_arrive(dq_empties[tmem_buf_id], 1, remote_cta_rank=0)
-                        dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
-                        for slice_id in tl.static_range(DQ_PACK_ITERS):
-                            dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
-                            dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(dq_stage_count, DQ_STAGE_COUNT)
-                            tlx.barrier_wait(
-                                dq_stage_empties[dq_stage_buf_id],
-                                dq_stage_phase ^ 1,
-                            )
-                            dq_smem = dq_store_buf[dq_stage_buf_id]
-                            tlx.local_store(
-                                dq_smem,
-                                (dq_slices[slice_id] * sm_scale).to(tlx.dtype_of(desc_dq)),
-                            )
-                            tlx.fence("async_shared")
-                            tlx.barrier_arrive(dq_stage_fulls[dq_stage_buf_id])
+                    dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
+                    if USE_WARP_BARRIER:
+                        tlx.barrier_arrive(dq_empties[tmem_buf_id])
                     else:
-                        packed_row_base = 2 * (curr_m + dq_m_offset)
-                        dq_full = tlx.local_load(dq_phys[tmem_buf_id + DQ_BUF_IDX])
-                        if USE_WARP_BARRIER:
-                            tlx.barrier_arrive(dq_empties[tmem_buf_id])
-                        else:
-                            tlx.barrier_arrive(dq_empties[tmem_buf_id], 1, remote_cta_rank=0)
-                        dq_full = dq_full * LN2
-                        dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
-                        for slice_id in tl.static_range(DQ_PACK_ITERS):
-                            dq_smem = dq_store_buf[slice_id % DQ_STORE_STAGES]
-                            tlx.async_descriptor_store_wait(DQ_STORE_STAGES - 1)
-                            tlx.local_store(
-                                dq_smem,
-                                dq_slices[slice_id].to(tlx.dtype_of(desc_dq)),
-                            )
-                            tlx.async_descriptor_store(
-                                desc_dq,
-                                dq_smem,
-                                [
-                                    batch,
-                                    head,
-                                    packed_row_base,
-                                    slice_id * DQ_SLICE_N,
-                                ],
-                                store_reduce="add",
-                            )
+                        # The dQ TMEM value has been consumed and can be reused.
+                        tlx.barrier_arrive(
+                            dq_empties[tmem_buf_id],
+                            1,
+                            remote_cta_rank=0,
+                        )
+                    dq_full = dq_full * LN2
+                    dq_slices = _split_n_2D(dq_full, DQ_PACK_ITERS)
+                    for slice_id in tl.static_range(DQ_PACK_ITERS):
+                        dq_smem = dq_store_buf[slice_id % DQ_STORE_STAGES]
+                        tlx.async_descriptor_store_wait(DQ_STORE_STAGES - 1)
+                        tlx.local_store(dq_smem, dq_slices[slice_id].to(tlx.dtype_of(desc_dq)))
+                        tlx.async_descriptor_store(
+                            desc_dq,
+                            dq_smem,
+                            [
+                                batch,
+                                head,
+                                packed_row_base,
+                                slice_id * DQ_SLICE_N,
+                            ],
+                            store_reduce="add",
+                        )
                 else:
                     HALF_HD: tl.constexpr = HEAD_DIM // 2
                     SLICES_PER_HALF: tl.constexpr = HALF_HD // DQ_REDUCE_NCOL
@@ -3816,10 +3051,7 @@ def _attn_bwd_ws(
                             [BLOCK_M1, DQ_REDUCE_NCOL],
                         )
                         dq = tlx.local_load(dq_slice)
-                        if SCALE_QK_IN_KERNEL:
-                            dq = dq * sm_scale
-                        else:
-                            dq = dq * LN2
+                        dq = dq * LN2
                         tlx.async_descriptor_store_wait(DQ_REDUCE_STAGES - 1)
                         tlx.local_store(
                             dq_store_buf[dq_smem_idx],
@@ -3846,51 +3078,6 @@ def _attn_bwd_ws(
 
             # Wait for the final tile
             tlx.async_descriptor_store_wait(0)
-
-        if USE_2CTA and DIRECT_DQ_OUTPUT:
-            with tlx.async_task(num_warps=1, registers=88):
-                curr_m = start_m
-                dq_m_offset = cluster_cta_rank * DQ_STORE_M
-                DQ_PACK_ITERS: tl.constexpr = (HEAD_DIM // NUM_CTAS // DQ_SLICE_N)
-                for blk_idx in range(num_steps):
-                    for slice_id in tl.static_range(DQ_PACK_ITERS):
-                        dq_stage_count = blk_idx * DQ_PACK_ITERS + slice_id
-                        dq_stage_buf_id, dq_stage_phase = get_bufidx_phase(dq_stage_count, DQ_STAGE_COUNT)
-                        if dq_stage_count >= DQ_STAGE_COUNT:
-                            tlx.async_descriptor_store_wait(DQ_STAGE_COUNT - 1)
-                            tlx.barrier_arrive(dq_stage_empties[dq_stage_buf_id])
-                        tlx.barrier_wait(dq_stage_fulls[dq_stage_buf_id], dq_stage_phase)
-                        dq_smem = dq_store_buf[dq_stage_buf_id]
-                        dq_smem_lo = tlx.local_slice(dq_smem, [0, 0], [DQ_STORE_M, DQ_SLICE_N])
-                        dq_smem_hi = tlx.local_slice(
-                            dq_smem,
-                            [DQ_STORE_M, 0],
-                            [DQ_STORE_M, DQ_SLICE_N],
-                        )
-                        tlx.async_descriptor_store(
-                            desc_dq,
-                            dq_smem_lo,
-                            [
-                                batch,
-                                head,
-                                curr_m + dq_m_offset,
-                                slice_id * DQ_SLICE_N,
-                            ],
-                            store_reduce="add",
-                        )
-                        tlx.async_descriptor_store(
-                            desc_dq,
-                            dq_smem_hi,
-                            [
-                                batch,
-                                head,
-                                curr_m + dq_m_offset,
-                                HEAD_DIM // NUM_CTAS + slice_id * DQ_SLICE_N,
-                            ],
-                            store_reduce="add",
-                        )
-                    curr_m += BLOCK_M1
-                tlx.async_descriptor_store_wait(0)
 
         # mma
         with tlx.async_task(num_warps=1, registers=88):
@@ -4133,41 +3320,6 @@ def _attn_bwd_ws(
         #     pass
 
 
-def _select_forward_plan(q, k, v, causal):
-    head_dim = q.shape[-1]
-    n_ctx = q.shape[2]
-    pipelined = (head_dim == 64 and q.shape == k.shape and q.shape == v.shape and n_ctx >= 32768
-                 and n_ctx % 256 == 0) or (head_dim == 128 and not causal and q.shape == k.shape and q.shape == v.shape
-                                           and n_ctx >= 1024 and n_ctx % 256 == 0)
-    policy = int(Policy.DENSE) if not causal else min(
-        int(Policy.CAUSAL_512K),
-        max(int(Policy.CAUSAL_64K),
-            n_ctx.bit_length() - CAUSAL_POLICY_BIT_OFFSET),
-    )
-    # TODO: this num_ctas=2 branch is a ~4.8x PESSIMIZATION on GB200
-    # (devgpu036.nao2). At Z=4 H=32 N_CTX=4096 HEAD_DIM=128 bf16 non-causal it
-    # reads 246 TF/s against 1186 with num_ctas forced to 1. The cause is the
-    # 2-CTA path itself, not the dtype: forcing num_ctas=2 on the same shape in
-    # fp16 also gives exactly 246, and forcing 1 recovers full speed in both.
-    # Config-independent (smoke and full spaces agree) and numerically correct,
-    # so it is slow rather than wrong. Landing on the same 246 for both dtypes
-    # looks more like serialization than mistuning, and the fp16 backward at the
-    # same shape fails outright with cluster misconfiguration (912) -- likely
-    # the same 2-CTA fault.
-    #
-    # NOT changed here: this was only measured on GB200, and the branch was
-    # presumably tuned on B200, which shares sm100. Run
-    # `python/test/tlx_benchmark/bench_flash_attn.py --fwd-only` on a B200 to
-    # decide between narrowing this to B200 and dropping it.
-    return ForwardPlan(
-        stage=3 if causal else 1,
-        pipelined=pipelined,
-        policy=policy,
-        num_ctas=(2 if head_dim == 128 and q.dtype == torch.bfloat16 and not causal and q.shape == k.shape
-                  and q.shape == v.shape and (n_ctx == 1024 or n_ctx >= 4096) else 1),
-    )
-
-
 class _attention(torch.autograd.Function):
 
     @staticmethod
@@ -4177,7 +3329,7 @@ class _attention(torch.autograd.Function):
         assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
         assert HEAD_DIM_K in {16, 32, 64, 128, 256}
 
-        plan = _select_forward_plan(q, k, v, causal)
+        stage = 3 if causal else 1
 
         o = torch.empty_like(q)
         extra_kern_args = {}
@@ -4186,8 +3338,7 @@ class _attention(torch.autograd.Function):
         # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
         y_dim = q.shape[0] * q.shape[1] * q.shape[2]
 
-        use_s1_2cta = plan.num_ctas == 2
-        dummy_block = [128, HEAD_DIM_K] if plan.pipelined else [1, 1]
+        dummy_block = [1, 1]
         desc_q = TensorDescriptor(
             q,
             shape=[y_dim, HEAD_DIM_K],
@@ -4198,13 +3349,13 @@ class _attention(torch.autograd.Function):
             v,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=[128, 64] if use_s1_2cta else dummy_block,
+            block_shape=dummy_block,
         )
         desc_k = TensorDescriptor(
             k,
             shape=[y_dim, HEAD_DIM_K],
             strides=[HEAD_DIM_K, 1],
-            block_shape=[64, 128] if use_s1_2cta else dummy_block,
+            block_shape=dummy_block,
         )
         desc_o = TensorDescriptor(
             o,
@@ -4218,71 +3369,27 @@ class _attention(torch.autograd.Function):
 
         triton.set_allocator(alloc_fn)
 
-        if plan.pipelined:
-            work_ctas = (triton.cdiv(q.shape[2], FWD_BLOCK_M.value * plan.num_ctas) * q.shape[0] * q.shape[1] *
-                         plan.num_ctas)
-            grid = (min(torch.cuda.get_device_properties(q.device).multi_processor_count, work_ctas)
-                    if use_s1_2cta else work_ctas, )
-            # Pinned config: launches the jit kernel directly. The tutorial read
-            # `.fn` to unwrap the module-scope autotuner, which is gone here.
-            _attn_fwd_ws[grid](
-                sm_scale,
-                M,  #
-                q.shape[0],
-                q.shape[1],  #
-                desc_q,
-                desc_k,
-                desc_v,
-                desc_o,  #
-                N_CTX=q.shape[2],  #
-                HEAD_DIM=HEAD_DIM_K,  #
-                BLOCK_M=256,
-                BLOCK_N=128,
-                STAGE=plan.stage,  #
-                NUM_BUFFERS_Q=1,
-                NUM_BUFFERS_KV=3 if HEAD_DIM_K == 128 else 6,
-                NUM_BUFFERS_QK=1,
-                NUM_MMA_GROUPS=2,
-                NUM_MMA_SLICES=(2 if HEAD_DIM_K == 128 or (q.dtype != torch.float16 and plan.policy in (1, 2)) else 4),
-                GROUP_SIZE_N=4 if plan.policy == 1 else 1,
-                RESCALE_OPT=False,
-                USE_WHERE=False,
-                USE_WARP_BARRIER=True,
-                NUM_CTAS=plan.num_ctas,
-                PIPELINED=True,
-                POLICY=plan.policy,
-                DENSE_REGS=176 if use_s1_2cta else 168,
-                FAST_FIXED=True,
-                num_stages=1,
-                num_warps=4,
-                **({"ctas_per_cga": (2, 1, 1)} if use_s1_2cta else {}),
-                **extra_kern_args,
-            )
-        else:
+        def grid(META):
+            num_ctas = META.get("NUM_CTAS") or 1
+            n_ctas = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
+            n_ctas = triton.cdiv(n_ctas, num_ctas) * num_ctas
+            return (n_ctas, )
 
-            def grid(META):
-                num_ctas = META.get("NUM_CTAS") or 1
-                n_clusters = triton.cdiv(q.shape[2], META["BLOCK_M"] * num_ctas) * q.shape[0] * q.shape[1]
-                return (n_clusters * num_ctas, )
-
-            _tuned_fwd(_SPACE)[grid](
-                sm_scale,
-                M,
-                q.shape[0],
-                q.shape[1],
-                desc_q,
-                desc_k,
-                desc_v,
-                desc_o,
-                N_CTX=q.shape[2],
-                HEAD_DIM=HEAD_DIM_K,
-                STAGE=plan.stage,
-                PIPELINED=False,
-                POLICY=plan.policy,
-                DENSE_REGS=168,
-                **extra_kern_args,
-            )
         ctx.grid = grid
+        _tuned_fwd(_SPACE)[grid](
+            sm_scale,
+            M,  #
+            q.shape[0],
+            q.shape[1],  #
+            desc_q,
+            desc_k,
+            desc_v,
+            desc_o,  #
+            N_CTX=q.shape[2],  #
+            HEAD_DIM=HEAD_DIM_K,  #
+            STAGE=stage,  #
+            **extra_kern_args,
+        )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
@@ -4295,28 +3402,17 @@ class _attention(torch.autograd.Function):
         q, k, v, o, M = ctx.saved_tensors
         assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous()
         assert o.is_contiguous() and do.is_contiguous()
-        assert ctx.HEAD_DIM in (64, 128), "backward requires head dimension 64 or 128"
-        BATCH, N_HEAD, N_CTX = q.shape[:3]
-        direct_dq_output = ctx.HEAD_DIM == 128 and N_CTX % 256 == 0
-        bf16_dq_output = (direct_dq_output and q.dtype == torch.bfloat16 and not ctx.causal)
-        if direct_dq_output:
-            if bf16_dq_output:
-                dq = torch.zeros(q.shape, device=q.device, dtype=torch.bfloat16)
-            else:
-                dq = torch.zeros(q.shape, device=q.device, dtype=torch.float32)
-        else:
-            dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
+        dq = torch.empty(q.shape, device=q.device, dtype=torch.float32)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
         _HALF_HD = ctx.HEAD_DIM // 2
-        if direct_dq_output:
-            dq_accum = dq
-        else:
-            dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
+        dq_accum = torch.zeros([BATCH, N_HEAD, N_CTX, ctx.HEAD_DIM], device=q.device, dtype=torch.float32)
         PRE_BLOCK = 128
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
-        arg_k = k if direct_dq_output else k * (ctx.sm_scale * RCP_LN2)
+        arg_k = k
+        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
         assert N_CTX % PRE_BLOCK == 0
         pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
         delta = torch.empty_like(M)
@@ -4355,12 +3451,8 @@ class _attention(torch.autograd.Function):
             strides=desc_strides,
             block_shape=dummy_block,
         )
-        if direct_dq_output:
-            packed_shape = desc_shape
-            packed_strides = desc_strides
-        else:
-            packed_shape = [BATCH, N_HEAD, 2 * N_CTX, _HALF_HD]
-            packed_strides = [N_HEAD * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
+        packed_shape = [BATCH, N_HEAD, 2 * N_CTX, _HALF_HD]
+        packed_strides = [N_HEAD * N_CTX * HEAD_DIM, N_CTX * HEAD_DIM, _HALF_HD, 1]
         desc_dq = TensorDescriptor(
             dq_accum,
             shape=packed_shape,
@@ -4411,124 +3503,113 @@ class _attention(torch.autograd.Function):
 
         stage = 3 if ctx.causal else 1
         _tuned_bwd(_SPACE)[grid_persistent](
-            desc_q,
-            desc_k,
-            desc_v,
-            ctx.sm_scale,
-            desc_do,
-            desc_dq,
-            desc_dk,
-            desc_dv,  #
-            desc_m,
-            desc_delta,  #
-            M,
-            delta,  #
-            N_HEAD,
-            BATCH,  #
+            desc_q, desc_k, desc_v, ctx.sm_scale, desc_do, desc_dq, desc_dk, desc_dv,  #
+            desc_m, desc_delta,  #
+            M, delta,  #
+            N_HEAD, BATCH,  #
             N_CTX,  #
-            desc_kt,
-            desc_qt,
-            desc_dot,  #
+            desc_kt, desc_qt, desc_dot,  #
             BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
             HEAD_DIM=ctx.HEAD_DIM,  #
             STAGE=stage,  #
-            DQ_STAGE_COUNT=(4 if bf16_dq_output and N_CTX >= 4096 else 2),
-            SCALE_QK_IN_KERNEL=direct_dq_output,
         )
 
-        if not direct_dq_output:
-            _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
-            post_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
-            _attn_bwd_dq_postprocess[post_grid](
-                dq_accum, dq,  #
-                N_CTX,  #
-                BLK=_blk, HALF_HD=_HALF_HD,  #
-                BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
-            )
+        _blk = _bwd_selected_meta["BLOCK_M1"] // _bwd_selected_meta["NUM_CTAS"]
+        post_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        _attn_bwd_dq_postprocess[post_grid](
+            dq_accum, dq,  #
+            N_CTX,  #
+            BLK=_blk, HALF_HD=_HALF_HD,  #
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM,  #
+        )
 
         return dq, dk, dv, None, None
 
 
-#: Full autotune search spaces. Used by the perf caller (``space="full"``).
+def attention(q, k, v, sm_scale, causal, config=None):
+    if config is None:
+        return _attention.apply(q, k, v, sm_scale, causal)
+
+    # Non-autotuned path with explicit config
+    HEAD_DIM_K = q.shape[-1]
+    stage = 3 if causal else 1
+    o = torch.empty_like(q)
+    M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
+    y_dim = q.shape[0] * q.shape[1] * q.shape[2]
+
+    dummy_block = [1, 1]
+    desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+    desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+    desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+    desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+
+    # Apply pre_hook to set block shapes
+    nargs = {**config, "HEAD_DIM": HEAD_DIM_K, "desc_q": desc_q, "desc_k": desc_k, "desc_v": desc_v, "desc_o": desc_o}
+    _host_descriptor_pre_hook(nargs)
+
+    def alloc_fn(size: int, align: int, _):
+        return torch.empty(size, dtype=torch.int8, device="cuda")
+
+    triton.set_allocator(alloc_fn)
+
+    num_ctas = config.get("NUM_CTAS", 1)
+    grid0 = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
+    grid0 = triton.cdiv(grid0, num_ctas) * num_ctas
+    grid = (grid0, 1, 1)
+    launch_kwargs = {}
+    if num_ctas > 1:
+        launch_kwargs["ctas_per_cga"] = (num_ctas, 1, 1)
+    _attn_fwd_ws[grid](
+        sm_scale,
+        M,
+        q.shape[0],
+        q.shape[1],
+        desc_q,
+        desc_k,
+        desc_v,
+        desc_o,
+        N_CTX=q.shape[2],
+        HEAD_DIM=HEAD_DIM_K,
+        STAGE=stage,
+        num_stages=1,
+        **launch_kwargs,
+        **config,
+    )
+    return o
+
+
 CONFIGS = lambda: configs  # noqa: E731
-BWD_CONFIGS_FULL = lambda: BWD_CONFIGS  # noqa: E731
+BWD_CONFIGS_FULL = lambda: configs_bwd_tlx  # noqa: E731
+# One historical config for each forward pruner path, plus the first 2-CTA config.
+SMOKE_CONFIGS = lambda: [configs[i] for i in (0, 6, 12, 18, 24)]  # noqa: E731
+BWD_CONFIGS_SMOKE = lambda: [configs_bwd_1cta[0], configs_bwd_2cta[0]]  # noqa: E731
 
-
-def _dedupe_by_path(config_list, axes):
-    """First real config per distinct combination of `axes`.
-
-    A subset of the shipped list rather than hand-authored entries: the pruners
-    reject configs that do not fit the target, so an invented combination can be
-    pruned away entirely.
-    """
-    seen, out = set(), []
-    for cfg in config_list:
-        key = tuple(cfg.kwargs.get(a) for a in axes) + (cfg.num_ctas, )
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(cfg)
-    return out
-
-
-#: Small forward space: the softmax variants, warp-barrier, 1-CTA vs 2-CTA.
-SMOKE_CONFIGS = lambda: _dedupe_by_path(  # noqa: E731
-    configs, ("RESCALE_OPT", "USE_WHERE", "FAST_FIXED", "USE_WARP_BARRIER"))
-
-#: Backward smoke space is the full one: it is only a few entries, and a subset
-#: was pruned to nothing at HEAD_DIM=128 causal.
-BWD_CONFIGS_SMOKE = lambda: BWD_CONFIGS  # noqa: E731
-
-
-def _widen_on_empty(prune, full_space):
-    """Fall back to the full space when pruning empties a reduced one.
-
-    The pruners are shape- and stage-dependent: an 8-of-40 forward subset that
-    works non-causal prunes to zero at STAGE=3.
-    """
-
-    def pruned(configs, named_args, **kwargs):
-        out = prune(configs, named_args, **kwargs)
-        if not out:
-            out = prune(full_space(), named_args, **kwargs)
-        return out
-
-    return pruned
-
-
-#: Module state, not an argument: backward runs inside autograd, long after
-#: flash_attn() returns, so there is no frame to thread it through.
 _SPACE = "full"
 
 
 @functools.lru_cache(maxsize=None)
 def _tuned_fwd(space):
-    """Autotuned forward kernel for a search space."""
     return triton.autotune(
         configs={"full": CONFIGS, "smoke": SMOKE_CONFIGS}[space](),
         key=["N_CTX", "HEAD_DIM", "STAGE"],
-        prune_configs_by={"early_config_prune": _widen_on_empty(prune_configs_by_hdim, CONFIGS)},
+        prune_configs_by={"early_config_prune": prune_configs_by_hdim},
     )(_attn_fwd_ws)
 
 
 @functools.lru_cache(maxsize=None)
 def _tuned_bwd(space):
-    """Autotuned backward kernel for a search space."""
     return triton.autotune(
         configs={"full": BWD_CONFIGS_FULL, "smoke": BWD_CONFIGS_SMOKE}[space](),
         key=["N_CTX", "HEAD_DIM"],
-        prune_configs_by={"early_config_prune": _widen_on_empty(prune_bwd_configs, BWD_CONFIGS_FULL)},
     )(_attn_bwd_ws)
 
 
 def flash_attn(q, k, v, causal=False, sm_scale=None, *, space="full"):
-    """Fused attention over `(Z, H, N_CTX, HEAD_DIM)`. Differentiable.
-
-    `sm_scale` defaults to `HEAD_DIM ** -0.5`. `space` is "full" for perf or
-    "smoke" for correctness; not exposed on `tlx.ops.flash_attn`.
-    """
+    """Fused attention over ``(Z, H, N_CTX, HEAD_DIM)``. Differentiable."""
     global _SPACE
+    if space not in ("full", "smoke"):
+        raise ValueError(f"space must be 'full' or 'smoke', got {space!r}")
     if sm_scale is None:
-        sm_scale = q.shape[-1]**-0.5
+        sm_scale = q.shape[-1] ** -0.5
     _SPACE = space
     return _attention.apply(q, k, v, sm_scale, causal)

--- a/third_party/tlx/ops/kernels/hstu_attn/_shapes.py
+++ b/third_party/tlx/ops/kernels/hstu_attn/_shapes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+# Entries are [Z, MAX_SEQ_LEN, H, HEAD_DIM, causal, dtype]. The op is
+# causal-only, so `causal` is True throughout and is carried for the label
+# rather than as a knob.
+
+#: Identical to `test_hstu_attn.py::SM100_SHAPES`.
+SYNTHETIC: list[list] = [
+    [1, 256, 4, 128, True, "bf16"],
+    [2, 512, 4, 128, True, "bf16"],
+    [2, 512, 8, 64, True, "bf16"],
+    [1, 1024, 4, 64, True, "bf16"],
+    [4, 256, 4, 128, True, "bf16"],
+    [2, 1024, 4, 128, True, "bf16"],
+    [8, 128, 4, 128, True, "bf16"],
+    [2, 256, 16, 64, True, "bf16"],
+    [1, 2048, 2, 128, True, "bf16"],
+]
+
+#: TODO: placeholder shapes, not a capture. The production shape is
+#: heads=4 seq=4096 sparsity=0.95 batch=512 (`tutorials/hstu_self_attn/bench_self.py:41`),
+#: which needs the sparse length draw below before it can be used here.
+SM100_FOCUS: list[list] = [
+    [32, 1024, 4, 128, True, "bf16"],
+    [64, 512, 4, 128, True, "bf16"],
+    [16, 2048, 4, 128, True, "bf16"],
+    [32, 1024, 8, 128, True, "bf16"],
+    [32, 1024, 4, 128, True, "fp16"],
+]
+
+#: Empty: the AMD entry is forward-only and the reference is unvalidated there.
+GFX950_FOCUS: list[list] = []
+
+#: How sequence lengths are drawn. The distribution dominates ragged-attention
+#: performance, so a number taken under one is not comparable to one taken under
+#: another -- hence it is in the label.
+#: TODO: only "uniform" exists; production is sparsity 0.95, see
+#: `generate_sparse_seq_len` in `tutorials/hstu_self_attn/bench_self.py`.
+RAGGED = "uniform"
+
+
+def inputs(Z, max_seq_len, H, head_dim, dtype, requires_grad=False, device="cuda"):
+    """A uniform-length ragged batch: every sequence is exactly max_seq_len."""
+    import torch
+
+    offsets = torch.arange(0, (Z + 1) * max_seq_len, max_seq_len, device=device, dtype=torch.int64)
+    total = int(offsets[-1])
+    q, k, v = (torch.randn(total, H, head_dim, device=device, dtype=dtype).requires_grad_(requires_grad)
+               for _ in range(3))
+    attn_scale = torch.tensor(1.0 / max_seq_len, device=device, dtype=torch.float32)
+    return q, k, v, offsets, attn_scale
+
+
+def flops(Z, MAX_SEQ_LEN, H, HEAD_DIM, causal, direction="fwd", tokens=None):
+    """Same convention as `flash_attn`, so the two ops' TFLOP/s read alike.
+
+    `tokens` is the OBSERVED total. Under the uniform draw it equals
+    `Z * MAX_SEQ_LEN`; under any other draw the nominal product overstates the
+    work by the padding factor, so the mean actual length is used instead.
+    """
+    seq = (tokens / Z) if tokens else MAX_SEQ_LEN
+    total = 2 * (2.0 * Z * H * seq * seq * HEAD_DIM)
+    if causal:
+        total *= 0.5
+    if direction == "bwd":
+        total *= 2.5
+    return int(total)
+
+
+def label(Z, MAX_SEQ_LEN, H, HEAD_DIM, causal, dtype, direction="fwd") -> str:
+    """The report's input column."""
+    return (f"((), {{'dtype': '{dtype}', 'ragged': '{RAGGED}', 'dir': '{direction}', "
+            f"'Z': '{Z}', 'MAX_SEQ_LEN': '{MAX_SEQ_LEN}', 'H': '{H}', 'HEAD_DIM': '{HEAD_DIM}'}})")

--- a/third_party/tlx/ops/kernels/hstu_attn/gfx950.py
+++ b/third_party/tlx/ops/kernels/hstu_attn/gfx950.py
@@ -8,6 +8,12 @@ import triton.language.extra.tlx as tlx
 import torch
 import torch.nn.functional as F
 
+from ._shapes import GFX950_FOCUS
+
+#: The shapes `bench_hstu_attn.py` gates on for this arch -- empty today, see
+#: `_shapes.py`.
+PERF_SHAPES = GFX950_FOCUS
+
 try:
     from triton.language.extra.libdevice import (
         fast_dividef,

--- a/third_party/tlx/ops/kernels/hstu_attn/sm100.py
+++ b/third_party/tlx/ops/kernels/hstu_attn/sm100.py
@@ -50,6 +50,10 @@ from ._reference import (
     forward_valid_mask,
     target_common_preprocess,
 )
+from ._shapes import SM100_FOCUS
+
+#: The shapes `bench_hstu_attn.py` gates on for this arch.
+PERF_SHAPES = SM100_FOCUS
 
 try:
     # @manual=//triton:triton

--- a/third_party/tlx/ops/kernels/kda/_shapes.py
+++ b/third_party/tlx/ops/kernels/kda/_shapes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+# Entries are [B, T, H, HEAD_DIM, dtype], where B is the number of packed
+# sequences and T the tokens in each; the op takes them as one `[1, B*T, H, D]`
+# tensor plus `cu_seqlens`. HEAD_DIM is 128 throughout -- the catalog entry
+# accepts nothing else.
+
+#: The L1 shape, from `test_kimi_delta_attention.py::_inputs`.
+SYNTHETIC: list[list] = [
+    [2, 64, 2, 128, "bf16"],
+]
+
+#: TODO: placeholder shapes, not a capture. Awaiting real ones.
+SM100_FOCUS: list[list] = [
+    [4, 4096, 8, 128, "bf16"],
+    [4, 4096, 16, 128, "bf16"],
+    [2, 8192, 8, 128, "bf16"],
+    [8, 2048, 8, 128, "bf16"],
+]
+
+#: Chunk length the kernel works in. Used only by `flops`.
+CHUNK = 64
+
+#: Absolute TFLOP/s gate -- the only perf gate available, since KDA has no
+#: runnable reference. None = report only, until a clean run exists to seed it.
+FLOOR_TFLOPS = None
+
+
+def inputs(B, T, H, head_dim, dtype, requires_grad=False, device="cuda"):
+    """Packed `[1, B*T, H, D]` inputs plus `cu_seqlens`, as the op wants them.
+
+    Mirrors `test_kimi_delta_attention.py::_inputs`. The normalization and the
+    negative softplus are load-bearing: the delta rule diverges on plain random
+    inputs, which would time arithmetic no real caller produces.
+    """
+    import torch
+    import torch.nn.functional as F
+
+    gen = torch.Generator(device=device).manual_seed(0)
+
+    def rn(*shape):
+        return torch.randn(*shape, generator=gen, device=device, dtype=torch.float32)
+
+    total = B * T
+    q = F.normalize(rn(1, total, H, head_dim), dim=-1).to(dtype).requires_grad_(requires_grad)
+    k = F.normalize(rn(1, total, H, head_dim), dim=-1).to(dtype).requires_grad_(requires_grad)
+    v = rn(1, total, H, head_dim).to(dtype).requires_grad_(requires_grad)
+    g = (-F.softplus(rn(1, total, H, head_dim))).requires_grad_(requires_grad)
+    beta = torch.sigmoid(rn(1, total, H)).requires_grad_(requires_grad)
+    cu_seqlens = torch.arange(0, (B + 1) * T, T, device=device, dtype=torch.int64)
+    return q, k, v, g, beta, cu_seqlens
+
+
+def flops(B, T, H, HEAD_DIM, direction="fwd", chunk=CHUNK):
+    """Approximate: NOT comparable to mm or attention, only to other KDA runs.
+
+    Per chunk per (sequence, head), the matmuls in `sm100.py`'s docstring are
+    four of `2*C*C*D` and three of `2*C*D*D`; the triangular inverse is not
+    counted and the backward is taken as 2x for its two passes. The uncounted
+    work is a real fraction of the runtime, so `mtokens_per_s` in
+    `Result.extra` is the honest rate.
+    """
+    per_seq_head = 8 * T * chunk * HEAD_DIM + 6 * T * HEAD_DIM * HEAD_DIM
+    total = B * H * per_seq_head
+    if direction == "bwd":
+        total *= 2.0
+    return int(total)
+
+
+def label(B, T, H, HEAD_DIM, dtype, direction="fwd") -> str:
+    """The report's input column."""
+    return (f"((), {{'dtype': '{dtype}', 'dir': '{direction}', "
+            f"'B': '{B}', 'T': '{T}', 'H': '{H}', 'HEAD_DIM': '{HEAD_DIM}'}})")

--- a/third_party/tlx/ops/kernels/kda/sm100.py
+++ b/third_party/tlx/ops/kernels/kda/sm100.py
@@ -24,6 +24,11 @@ import triton.language as tl
 import triton.language.extra.tlx as tlx
 from triton.language.extra.tlx.warp_spec import get_bufidx_phase
 
+from ._shapes import SM100_FOCUS
+
+#: The shapes `bench_kda.py` reports on for this arch.
+PERF_SHAPES = SM100_FOCUS
+
 
 @triton.jit
 def _add_f32x2(a, b):


### PR DESCRIPTION
Summary: Replace the sm100 tlx.ops Flash Attention backend with the historical implementation restored by D119124691. Preserve the tlx.ops public API, lazy full/smoke search spaces, and autotuning across both 1-CTA and 2-CTA backward configurations.

Differential Revision: D119263863
