### PR TITLE
[Triton][TLX] Run fixup immediately after AST lowering (#3510)

### DIFF
--- a/python/test/unit/language/test_tlx_dot_sm90.py
+++ b/python/test/unit/language/test_tlx_dot_sm90.py
@@ -3,9 +3,84 @@ import pytest
 import torch
 import triton
 import triton.language as tl
+from triton._C.libtriton import ir
+from triton.backends.compiler import GPUTarget
+from triton.compiler import ASTSource
+from triton.compiler.compiler import make_backend
 from triton._internal_testing import is_hopper
 import triton.language.extra.tlx as tlx
 from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+@triton.jit
+def _raw_ttir_async_dot_kernel():
+    a_tiles = tlx.local_alloc((64, 32), tl.float16, 1)
+    b_tiles = tlx.local_alloc((32, 64), tl.float16, 1)
+    acc = tlx.async_dot(a_tiles[0], b_tiles[0])
+    tlx.async_dot_wait(0, acc)
+
+
+@triton.jit
+def _raw_ttir_ws_async_dot_kernel():
+    a_tiles = tlx.local_alloc((64, 32), tl.float16, 1)
+    b_tiles = tlx.local_alloc((32, 64), tl.float16, 1)
+    with tlx.async_tasks():
+        with tlx.async_task("default"):
+            _ = tl.arange(0, 1)
+        with tlx.async_task(num_warps=4):
+            acc = tlx.async_dot(a_tiles[0], b_tiles[0])
+            tlx.async_dot_wait(0, acc)
+
+
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+def test_raw_ttir_async_dot_has_num_warps():
+    target = GPUTarget("cuda", 90, 32)
+    backend = make_backend(target)
+    options = backend.parse_options({"num_warps": 8})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(fn=_raw_ttir_async_dot_kernel, signature={}, constexprs={})
+
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+
+    assert module.get_int_attr("ttg.num-warps") == 8
+    assert module.get_int_attr("ttg.threads-per-warp") == 32
+    assert module.get_int_attr("ttg.num-ctas") == 1
+    assert module.get_bool_attr("tlx.has_tlx_ops")
+    assert module.verify()
+
+
+@pytest.mark.skipif(not is_hopper(), reason="Need Hopper")
+def test_raw_ttir_async_dot_uses_partition_num_warps():
+    target = GPUTarget("cuda", 90, 32)
+    backend = make_backend(target)
+    options = backend.parse_options({"num_warps": 8})
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(fn=_raw_ttir_ws_async_dot_kernel, signature={}, constexprs={})
+
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+    module_text = str(module)
+
+    assert module.get_int_attr("ttg.num-warps") == 8
+    assert module_text.count("partition0(") == 1
+    assert module_text.count("num_warps(4)") == 1
+    assert module_text.count("warpsPerCTA = [4, 1]") == 1
+    assert module.verify()
 
 
 @pytest.mark.skipif(not is_hopper(), reason="Need Hopper")

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -90,8 +90,11 @@ class ASTSource:
 
     def make_ir(self, target: GPUTarget, options, codegen_fns, module_map, context):
         from .code_generator import ast_to_ttir
-        return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
-                           module_map=module_map)
+        module = ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
+                             module_map=module_map)
+        if post_ast_lowering := codegen_fns.get("post_ast_lowering"):
+            post_ast_lowering(module)
+        return module
 
     def parse_options(self):
         return dict()

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -231,7 +231,23 @@ class HIPBackend(BaseBackend):
         )
 
     def get_codegen_implementation(self, options):
-        return {"min_dot_size": get_min_dot_size(self.target)}
+        def post_ast_lowering(mod):
+            pm = ir.pass_manager(mod.context)
+            pm.enable_debug()
+            tlx.tlx_passes.add_triton_tlx_fixup(
+                pm,
+                f"hip:{options.arch}",
+                options.num_warps,
+                64,
+                options.num_ctas,
+                [1, 1, 1],
+            )
+            pm.run(mod, "post_ast_lowering")
+
+        return {
+            "min_dot_size": get_min_dot_size(self.target),
+            "post_ast_lowering": post_ast_lowering,
+        }
 
     def get_module_map(self) -> Dict[str, ModuleType]:
         from triton.language.extra.hip import libdevice
@@ -291,14 +307,6 @@ class HIPBackend(BaseBackend):
     def make_ttir(mod, metadata, options):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        tlx.tlx_passes.add_triton_tlx_fixup(
-            pm,
-            f"hip:{options.arch}",
-            options.num_warps,
-            64,
-            options.num_ctas,
-            list((1, 1, 1)),
-        )
         passes.common.add_inliner(pm)
         if not amd.supports_tdm(options.arch):
             passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -753,11 +753,27 @@ class CUDABackend(BaseBackend):
         import triton.language.extra.cuda as cuda
 
         capability = int(self._parse_arch(options.arch))
+
+        def post_ast_lowering(mod):
+            pm = ir.pass_manager(mod.context)
+            pm.enable_debug()
+            tlx.tlx_passes.add_triton_tlx_fixup(
+                pm,
+                f"cuda:{capability}",
+                options.num_warps,
+                32,
+                options.num_ctas,
+                list(options.cluster_dims),
+            )
+            pm.run(mod, "post_ast_lowering")
+
         codegen_fns = {
             "convert_custom_types":
             (cuda.convert_custom_float8_sm80 if capability >= 80 else cuda.convert_custom_float8_sm70),
             "min_dot_size":
             min_dot_size(self.target),
+            "post_ast_lowering":
+            post_ast_lowering,
         }
         return codegen_fns
 
@@ -782,15 +798,6 @@ class CUDABackend(BaseBackend):
 
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        # Pass cluster_dims as a list
-        tlx.tlx_passes.add_triton_tlx_fixup(
-            pm,
-            f"cuda:{capability}",
-            opt.num_warps,
-            32,
-            opt.num_ctas,
-            list(opt.cluster_dims),
-        )
         passes.common.add_inliner(pm)
         # Storage alias lowering moved to make_ttgir (after layout propagation)
         # so the backing TMEM allocation is materialized with the resolved


### PR DESCRIPTION
Summary:

Raw `ASTSource.make_ir()` output is consumed and cached before backend TTIR stages run. TLX modules therefore exposed incomplete metadata and layout reconciliation to raw-IR consumers even though the normal compilation pipeline fixed them in the first backend pass. The Hopper MMA-builder workaround repaired only `ttg.num-warps` and coupled a module-level invariant to one layout constructor.

Run the canonical `TritonTLXFixup` through an optional post-AST-lowering callback for NVIDIA and AMD, preserving its position before inlining and all later TTIR passes. This makes raw TLX TTIR self-consistent, keeps ordinary Triton modules unchanged through the fixup's existing early return, and removes the NVIDIA MMA-builder side effect. The raw Hopper regression now checks fixup-owned launch metadata and TLX classification in addition to warp-specialized module-versus-partition warp counts.

This intentionally changes TLX `.source` artifacts to contain post-fixup TTIR. It does not add launch-option recovery for callers that discard non-default autotune settings; the affected H100 kernels use the default four-warps configuration.

Reviewed By: htyu

Differential Revision: D119281673


