### PR TITLE
[TLX][AMD][gfx950] Add LocalSplitU GEMM for small-M workloads

### DIFF
--- a/python/test/unit/tlx_ops/test_mm_gfx950.py
+++ b/python/test/unit/tlx_ops/test_mm_gfx950.py
@@ -1,0 +1,195 @@
+"""gfx950 correctness coverage for ``tlx.ops.mm`` LocalSplitU GEMM."""
+
+import time
+
+import pytest
+import torch
+from triton._internal_testing import is_hip_cdna4
+from triton.tlx.ops import InvalidInput, UnsupportedOp
+from triton.tlx.ops.kernels.mm._shapes import GFX950_FOCUS, operand
+
+
+pytestmark = pytest.mark.skipif(
+    not is_hip_cdna4(), reason="Requires gfx950"
+)
+
+MAX_SECONDS_PER_CASE = 60
+
+
+def _assert_strides(tensor, wanted):
+    for dim, (got, expected) in enumerate(zip(tensor.stride(), wanted)):
+        if tensor.shape[dim] != 1:
+            assert got == expected, (
+                f"dim {dim}: stride {got}, recorded {expected}"
+            )
+
+
+@pytest.mark.parametrize(
+    "m,n,k,a_strides,b_strides,dtype_name", GFX950_FOCUS
+)
+def test_mm(m, n, k, a_strides, b_strides, dtype_name):
+    dtype = {"fp16": torch.float16}[dtype_name]
+    from triton.tlx.ops import mm as tlx_mm
+
+    a = operand(m, k, a_strides, dtype)
+    b = operand(k, n, b_strides, dtype)
+    _assert_strides(a, a_strides)
+    _assert_strides(b, b_strides)
+
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    try:
+        out = tlx_mm(a, b, arch="gfx950", space="heuristic")
+    except (InvalidInput, UnsupportedOp) as declined:
+        pytest.fail(f"gfx950 declines its focus shape: {declined}")
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - started
+    assert elapsed < MAX_SECONDS_PER_CASE, (
+        f"mm({m}x{n}x{k}, {dtype}) took {elapsed:.1f}s, "
+        f"over the {MAX_SECONDS_PER_CASE}s budget"
+    )
+
+    expected = torch.matmul(a, b)
+    torch.testing.assert_close(
+        out,
+        expected,
+        atol=1e-3 * expected.abs().max().item(),
+        rtol=1e-3,
+    )
+
+
+def test_mm_rejects_invalid_rank():
+    from triton.tlx.ops import mm as tlx_mm
+
+    a = torch.randn((16,), device="cuda", dtype=torch.float16)
+    b = torch.randn((16, 16), device="cuda", dtype=torch.float16)
+    with pytest.raises(InvalidInput, match="rank-2"):
+        tlx_mm(a, b, arch="gfx950")
+
+
+def test_mm_rejects_mismatched_reduction_dimensions():
+    from triton.tlx.ops import mm as tlx_mm
+
+    a = torch.randn((8, 16), device="cuda", dtype=torch.float16)
+    b = torch.randn((17, 8), device="cuda", dtype=torch.float16)
+    with pytest.raises(InvalidInput, match="reduction dimensions"):
+        tlx_mm(a, b, arch="gfx950")
+
+
+def test_mm_rejects_mismatched_dtype():
+    from triton.tlx.ops import mm as tlx_mm
+
+    a = torch.randn((8, 16), device="cuda", dtype=torch.float16)
+    b = torch.randn((16, 8), device="cuda", dtype=torch.float32)
+    with pytest.raises(InvalidInput, match="same dtype and device"):
+        tlx_mm(a, b, arch="gfx950")
+
+
+def test_mm_rejects_mismatched_device():
+    from triton.tlx.ops import mm as tlx_mm
+
+    a = torch.randn((8, 16), device="cuda", dtype=torch.float16)
+    b = torch.randn((16, 8), device="cpu", dtype=torch.float16)
+    with pytest.raises(InvalidInput, match="same dtype and device"):
+        tlx_mm(a, b, arch="gfx950")
+
+
+def test_mm_rejects_invalid_space():
+    from triton.tlx.ops.kernels.mm.gfx950 import mm
+
+    a = torch.randn((7, 2048), device="cuda", dtype=torch.float16)
+    b = torch.randn((8192, 2048), device="cuda", dtype=torch.float16).T
+    with pytest.raises(InvalidInput, match="space='heuristic'"):
+        mm(a, b, space="full")
+
+
+def test_mm_rejects_unsupported_operands():
+    from triton.tlx.ops.kernels.mm.gfx950 import matmul, mm, supports
+
+    a = torch.randn((7, 2048), device="cuda", dtype=torch.float16)
+    b = torch.randn((8192, 2048), device="cuda", dtype=torch.float16).T
+    unsupported_a = torch.randn(
+        (17, 2048), device="cuda", dtype=torch.float16
+    )
+    assert supports(a, b)
+    assert not supports(unsupported_a, b)
+    assert not supports(a.to(torch.float32), b.to(torch.float32))
+    assert not supports(a, b.contiguous())
+    with pytest.raises(InvalidInput, match="no legal plan"):
+        mm(unsupported_a, b)
+    with pytest.raises(InvalidInput, match="does not support"):
+        matmul(unsupported_a, b)
+
+
+@pytest.mark.parametrize("failure", ["type", "shape", "dtype", "device"])
+def test_mm_rejects_invalid_output(failure):
+    from triton.tlx.ops.kernels.mm.gfx950 import matmul
+
+    a = torch.randn((7, 2048), device="cuda", dtype=torch.float16)
+    b = torch.randn((8192, 2048), device="cuda", dtype=torch.float16).T
+    if failure == "type":
+        out, match = object(), "torch.Tensor"
+    elif failure == "shape":
+        out = torch.empty((7, 8191), device="cuda", dtype=torch.float16)
+        match = "output shape"
+    elif failure == "dtype":
+        out = torch.empty((7, 8192), device="cuda", dtype=torch.float32)
+        match = "output dtype"
+    else:
+        out = torch.empty((7, 8192), device="cpu", dtype=torch.float16)
+        match = "output device"
+    with pytest.raises(InvalidInput, match=match):
+        matmul(a, b, out=out)
+
+
+def test_mm_rejects_plan_that_does_not_cover_m(monkeypatch):
+    import triton.tlx.ops.kernels.mm.gfx950 as gfx950
+
+    a = torch.randn((17, 32), device="cuda", dtype=torch.float16)
+    b = torch.randn((16, 32), device="cuda", dtype=torch.float16).T
+    monkeypatch.setitem(
+        gfx950._KNOWN_PLANS,
+        (17, 16, 32),
+        gfx950._Plan(16, 16, 2, 16, 4),
+    )
+    with pytest.raises(InvalidInput, match="at most 16 rows"):
+        gfx950.matmul(a, b)
+
+
+def test_mm_supports_unaligned_contiguous_k_views():
+    from triton.tlx.ops.kernels.mm.gfx950 import matmul
+
+    a = torch.randn((7, 2049), device="cuda", dtype=torch.float16)[:, 1:]
+    b = torch.randn((8192, 2049), device="cuda", dtype=torch.float16)[:, 1:].T
+    actual = matmul(a, b)
+    expected = torch.matmul(a, b)
+    torch.testing.assert_close(
+        actual,
+        expected,
+        atol=1e-3 * expected.abs().max().item(),
+        rtol=1e-3,
+    )
+
+
+@pytest.mark.parametrize(
+    "n,k,pattern_period,segment_k",
+    [(8192, 2048, 512, 128), (2048, 4096, 1024, 256)],
+)
+def test_mm_matches_aten_for_cancellation(
+    n, k, pattern_period, segment_k
+):
+    """Exercise cancellation-sensitive ordered partial reduction."""
+    from triton.tlx.ops.kernels.mm.gfx950 import matmul
+
+    values = torch.zeros(k, device="cuda", dtype=torch.float16)
+    for base in range(0, k, pattern_period):
+        values[base:base + segment_k] = 65504.0
+        values[base + segment_k:base + 2 * segment_k] = 0.001
+        values[base + 2 * segment_k:base + 3 * segment_k] = -65504.0
+        values[base + 3 * segment_k:base + 4 * segment_k] = 0.001
+    a = torch.ones((7, k), device="cuda", dtype=torch.float16)
+    b = values[None, :].repeat(n, 1).contiguous().T
+
+    actual = matmul(a, b)
+    expected = torch.matmul(a, b)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/third_party/tlx/ops/__init__.py
+++ b/third_party/tlx/ops/__init__.py
@@ -9,15 +9,18 @@ per (op, arch), so there is no `variant=` argument, and architecture never
 appears in caller code.
 
 Two keyword-only overrides exist for testing and benchmarking: `arch=` pins an
-entry instead of detecting one, and `space=` selects the autotune search space.
+entry instead of detecting one, and `space=` selects an implementation-defined
+autotune search space. Passing a space that the selected implementation does
+not provide raises `InvalidInput` rather than silently choosing another space.
 
 `space=` defaults to "heuristic" -- a single config chosen analytically -- for
 any op that offers one, so that a first call stays interactive. Measured on
 B200, `mm` at `space="full"` takes 221-285s on a cold Triton cache (348 configs
 compiled and benchmarked for a 1024x1024x1024 product) and also accumulates
 tens of GB of autotune workspaces; at "heuristic" the same call is under a
-second. Pass `space="full"` explicitly to buy back the tuned configs, which are
-worth up to ~4x on small shapes.
+second. On implementations that provide it, pass `space="full"` explicitly to
+buy back the tuned configs, which are worth up to ~4x on small shapes. The
+gfx950 LocalSplitU implementation currently provides only `"heuristic"`.
 
 Ops with no heuristic yet -- flash_attn, hstu_attn, kimi_delta_attention --
 still default to "full". Their remaining space is "smoke", which selects for
@@ -40,15 +43,32 @@ def mm(a, b, *, arch=None, space="heuristic"):
     """`a @ b`, for `(M, K) @ (K, N)` fp16/bf16. Either operand may be column-major.
 
     Defaults to a single analytically chosen config so the first call stays
-    interactive; pass `space="full"` to autotune. See the module docstring.
+    interactive. Pass `space="full"` to implementations that expose a full
+    autotune space; unsupported spaces raise `InvalidInput`. See the module
+    docstring.
     """
+    if a.ndim != 2 or b.ndim != 2:
+        raise InvalidInput(
+            "tlx.ops.mm expects two rank-2 tensors; "
+            f"got a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
+        )
+    if a.shape[1] != b.shape[0]:
+        raise InvalidInput(
+            "tlx.ops.mm reduction dimensions must match; "
+            f"got a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
+        )
+    if a.dtype != b.dtype or a.device != b.device:
+        raise InvalidInput(
+            "tlx.ops.mm operands must have the same dtype and device; "
+            f"got a=({a.dtype}, {a.device}), b=({b.dtype}, {b.device})"
+        )
     fn, spec = impl_for("mm", arch)
     # Mirror the kernel's operand prep: a non-contiguous operand is fed to its
     # descriptor transposed, so that is the stride TMA must find aligned.
     a_src = a if a.is_contiguous() else a.T
     b_src = b if b.is_contiguous() else b.T
-    check_inputs(spec, dtype=a.dtype, row_strides=(a_src.stride(0), b_src.stride(0), b.shape[1]),
-                 elem_bytes=a.element_size())
+    check_inputs(spec, dtype=a.dtype, M=a.shape[0], N=b.shape[1], K=a.shape[1],
+                 row_strides=(a_src.stride(0), b_src.stride(0), b.shape[1]), elem_bytes=a.element_size())
     return fn(a, b, space=space)
 
 

--- a/third_party/tlx/ops/_catalog.py
+++ b/third_party/tlx/ops/_catalog.py
@@ -62,6 +62,17 @@ CATALOG: tuple[OpSpec, ...] = (
         requires=frozenset(),
     ),
     OpSpec(
+        op="mm",
+        arch="gfx950",
+        variant="local_split_u",
+        impl="kernels.mm.gfx950:mm",
+        # Deliberately not `_FP16`: that shared set also contains bfloat16,
+        # while this first gfx950 implementation has only been validated for
+        # IEEE fp16 operands.
+        dtypes=frozenset({"float16"}),
+        requires=frozenset(),
+    ),
+    OpSpec(
         op="flash_attn",
         arch="sm100",
         variant="ws_pipelined_persistent",

--- a/third_party/tlx/ops/kernels/mm/_shapes.py
+++ b/third_party/tlx/ops/kernels/mm/_shapes.py
@@ -72,7 +72,14 @@ GFX942_FOCUS: list[list] = [
     [1024, 6144, 4096, (4096, 1), (6144, 1), "fp16"],
 ]
 
-ALL: list[list] = _union(SYNTHETIC, SM100_FOCUS, GFX942_FOCUS)
+GFX950_FOCUS: list[list] = [
+    [7, 8192, 2048, (2048, 1), (1, 2048), "fp16"],
+    [7, 2048, 4096, (4096, 1), (1, 4096), "fp16"],
+]
+
+ALL: list[list] = _union(
+    SYNTHETIC, SM100_FOCUS, GFX942_FOCUS, GFX950_FOCUS
+)
 
 
 def operand(rows, cols, strides, dtype, device="cuda"):

--- a/third_party/tlx/ops/kernels/mm/gfx950.py
+++ b/third_party/tlx/ops/kernels/mm/gfx950.py
@@ -1,0 +1,367 @@
+"""gfx950 small-M GEMM implementation for :func:`triton.tlx.ops.mm`.
+
+The logical M dimension is too small to expose enough output tiles. Each wave
+therefore computes one block-cyclic K partition of the same output tile. The
+FP32 partials are reduced in wave order inside the workgroup before the logical
+result is stored.
+"""
+
+from functools import lru_cache
+from typing import NamedTuple
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx
+
+from ..._catalog import InvalidInput
+from ._shapes import GFX950_FOCUS
+
+__all__ = ["mm", "matmul", "supports"]
+
+PERF_SHAPES = GFX950_FOCUS
+
+
+# The initial implementation deliberately exposes only measured plans. A
+# follow-up change adds bounded plan generation for neighboring shapes without
+# changing this register-staged execution mechanism.
+class _Plan(NamedTuple):
+    tile_m: int
+    tile_n: int
+    local_split_u: int
+    wave_k: int
+    k_width: int
+
+
+_KNOWN_PLANS = {
+    # Sixteen short K32 chains maximize wave-level latency hiding. N32 keeps
+    # one workgroup per CU and gives every A load two independent MFMA users.
+    (7, 8192, 2048): _Plan(
+        tile_m=16, tile_n=32, local_split_u=16, wave_k=32, k_width=8
+    ),
+    # N16 gives two output tiles per CU. Four K256 partitions provide enough
+    # wave-level latency hiding without the long-lived K1024 operands.
+    (7, 2048, 4096): _Plan(
+        tile_m=16, tile_n=16, local_split_u=4, wave_k=256,
+        k_width=8,
+    ),
+}
+
+
+@lru_cache(maxsize=None)
+def _device_arch(device):
+    """Return the AMD architecture for a CUDA device, or an empty string."""
+    properties = torch.cuda.get_device_properties(device)
+    return getattr(properties, "gcnArchName", "").split(":", 1)[0]
+
+
+@triton.jit
+def _load_dot_operands(
+    a_ptr,
+    b_ptr,
+    global_rows,
+    global_cols,
+    split_ids,
+    rk,
+    macro_k_base,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_bn: tl.constexpr,
+    WAVE_K: tl.constexpr,
+    K_WIDTH: tl.constexpr,
+    dot_a: tl.constexpr,
+    dot_b: tl.constexpr,
+):
+    """Load one macro-K slice directly into the two MFMA operand layouts."""
+    split_k = macro_k_base + split_ids[:, None, None] * WAVE_K
+    a_offsets = (
+        global_rows[None, :, None] * stride_am
+        + (split_k + rk[None, None, :]) * stride_ak
+    )
+    b_offsets = (
+        (split_k + rk[None, :, None]) * stride_bk
+        + global_cols[None, None, :] * stride_bn
+    )
+    # The offsets already have their dot-operand layouts, so the loaded values
+    # reach MFMA registers without an intervening conversion through LDS.
+    # K_WIDTH is also the largest contiguous run owned by one lane; claiming a
+    # wider buffer vector would cross the lane's two disjoint K runs.
+    a_offsets = tlx.require_layout(a_offsets, dot_a)
+    b_offsets = tlx.require_layout(b_offsets, dot_b)
+    a = tlx.buffer_load(a_ptr, a_offsets, contiguity=K_WIDTH)
+    b = tlx.buffer_load(
+        b_ptr, b_offsets, cache=".cg", contiguity=K_WIDTH
+    )
+    return a, b
+
+
+@triton.jit
+def _local_split_u_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_cm: tl.constexpr,
+    stride_cn: tl.constexpr,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    K_WIDTH: tl.constexpr,
+    WAVE_K: tl.constexpr,
+    LOCAL_SPLIT_U: tl.constexpr,
+):
+    """Compute one MxN tile by partitioning K across the CTA's waves."""
+    MACRO_K: tl.constexpr = WAVE_K * LOCAL_SPLIT_U
+    tl.static_assert(M <= TILE_M)
+
+    pid_n = tl.program_id(0).to(tl.int32)
+    split_ids = tl.arange(0, LOCAL_SPLIT_U).to(tl.int32)
+    rows = tl.arange(0, TILE_M).to(tl.int32)
+    # Padded rows may read any valid A row because their results are discarded.
+    global_rows = tl.where(rows < M, rows, 0)
+    local_cols = tl.arange(0, TILE_N).to(tl.int32)
+    output_cols = pid_n * TILE_N + local_cols
+    global_cols = tl.where(output_cols < N, output_cols, 0)
+    rk = tl.arange(0, WAVE_K).to(tl.int32)
+
+    # The leading batch axis is the LocalSplitU partition. Mapping that axis
+    # one-to-one onto waves keeps the wave-specific K coordinate explicit.
+    mma: tl.constexpr = tlx.amd_mfma_layout(
+        version=4,
+        instr_shape=[16, 16, 32],
+        transposed=True,
+        warps_per_cta=[LOCAL_SPLIT_U, 1, 1],
+    )
+    dot_a: tl.constexpr = tlx.dot_operand_layout(
+        0, mma, k_width=K_WIDTH
+    )
+    dot_b: tl.constexpr = tlx.dot_operand_layout(
+        1, mma, k_width=K_WIDTH
+    )
+
+    tl.static_assert(K % MACRO_K == 0)
+    acc = tlx.zeros(
+        (LOCAL_SPLIT_U, TILE_M, TILE_N),
+        tl.float32,
+        layout=mma,
+    )
+
+    current_a, current_b = _load_dot_operands(
+        a_ptr, b_ptr, global_rows, global_cols, split_ids, rk, 0,
+        stride_am, stride_ak, stride_bk, stride_bn,
+        WAVE_K, K_WIDTH, dot_a, dot_b,
+    )
+
+    # One-stage register pipeline: issue K(t+1)'s global loads before K(t)'s
+    # dot. The chosen WAVE_K controls the prefetch lifetime and register cost.
+    for macro in tl.range(0, K // MACRO_K - 1, num_stages=1):
+        next_k = (macro + 1) * MACRO_K
+        next_a, next_b = _load_dot_operands(
+            a_ptr, b_ptr, global_rows, global_cols, split_ids, rk, next_k,
+            stride_am, stride_ak, stride_bk, stride_bn,
+            WAVE_K, K_WIDTH, dot_a, dot_b,
+        )
+        acc = tl.dot(
+            current_a,
+            current_b,
+            acc,
+            allow_tf32=False,
+            out_dtype=tl.float32,
+        )
+        current_a = next_a
+        current_b = next_b
+
+    acc = tl.dot(
+        current_a,
+        current_b,
+        acc,
+        allow_tf32=False,
+        out_dtype=tl.float32,
+    )
+
+    if LOCAL_SPLIT_U == 16 and TILE_N == 32:
+        # This swizzle is tuned for the dense U16/N32 partial tile. Its encoding
+        # depends on TILE_N, so other U16 widths deliberately use the default
+        # layout instead of silently inheriting different swizzle parameters.
+        partial_layout: tl.constexpr = tlx.swizzled_layout(
+            2, 2, 3, order=[2, 1, 0]
+        )
+        partial_buffer = tlx.local_alloc(
+            (LOCAL_SPLIT_U, TILE_M, TILE_N),
+            tl.float32,
+            1,
+            layout=partial_layout,
+        )
+    else:
+        partial_buffer = tlx.local_alloc(
+            (LOCAL_SPLIT_U, TILE_M, TILE_N), tl.float32, 1
+        )
+    partial_view = tlx.local_view(partial_buffer, 0)
+    tlx.local_store(partial_view, acc)
+    tl.debug_barrier()
+
+    tl.static_assert(
+        LOCAL_SPLIT_U == 2
+        or LOCAL_SPLIT_U == 4
+        or LOCAL_SPLIT_U == 8
+        or LOCAL_SPLIT_U == 16
+    )
+    result = tl.reshape(
+        tlx.local_load(
+            tlx.local_slice(
+                partial_view,
+                [0, 0, 0],
+                [1, TILE_M, TILE_N],
+            )
+        ),
+        (TILE_M, TILE_N),
+    )
+    # Load and immediately consume each subsequent partial. This preserves
+    # increasing split-id association without keeping every partial live.
+    for split in tl.static_range(1, LOCAL_SPLIT_U):
+        partial = tlx.local_load(
+            tlx.local_slice(
+                partial_view,
+                [split, 0, 0],
+                [1, TILE_M, TILE_N],
+            )
+        )
+        result += tl.reshape(partial, (TILE_M, TILE_N))
+
+    output_rows = tl.arange(0, TILE_M).to(tl.int32)
+    output_ptrs = (
+        c_ptr
+        + output_rows[:, None] * stride_cm
+        + output_cols[None, :] * stride_cn
+    )
+    tl.store(
+        output_ptrs,
+        result.to(c_ptr.dtype.element_ty),
+        mask=(output_rows[:, None] < M)
+        & (output_cols[None, :] < N),
+    )
+
+
+def _plan_for(a, b):
+    """Return the measured plan for supported operands, otherwise ``None``."""
+    if a.ndim != 2 or b.ndim != 2 or a.shape[1] != b.shape[0]:
+        return None
+    m, k = a.shape
+    _, n = b.shape
+    if not (
+        a.dtype == torch.float16
+        and b.dtype == torch.float16
+        and a.is_cuda
+        and a.device == b.device
+        and _device_arch(a.device) == "gfx950"
+        and a.stride(1) == 1
+        and b.stride(0) == 1
+    ):
+        return None
+    return _KNOWN_PLANS.get((m, n, k))
+
+
+def supports(a, b):
+    """Return whether a and b select a measured LocalSplitU plan."""
+    return _plan_for(a, b) is not None
+
+
+def _launch_validated(a, b, out, plan):
+    """Launch a plan after operand and output validation has completed."""
+    m, k = a.shape
+    _, n = b.shape
+    tile_m, tile_n, local_split_u, wave_k, k_width = plan
+    if m > tile_m:
+        raise InvalidInput(
+            f"gfx950 LocalSplitU plan covers at most {tile_m} rows; got M={m}"
+        )
+    launch_options = {"sink_insts_to_avoid_spills": True}
+    _local_split_u_kernel[(triton.cdiv(n, tile_n), )](
+        a,
+        b,
+        out,
+        m,
+        n,
+        k,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        TILE_M=tile_m,
+        TILE_N=tile_n,
+        K_WIDTH=k_width,
+        WAVE_K=wave_k,
+        LOCAL_SPLIT_U=local_split_u,
+        num_warps=local_split_u,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        waves_per_eu=0,
+        **launch_options,
+    )
+    return out
+
+
+def matmul(a, b, out=None):
+    """Run a tuned gfx950 LocalSplitU GEMM specialization."""
+    plan = _plan_for(a, b)
+    if plan is None:
+        raise InvalidInput(
+            "gfx950 LocalSplitU matmul does not support "
+            f"a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
+        )
+    m, k = a.shape
+    _, n = b.shape
+    if out is None:
+        out = torch.empty((m, n), device=a.device, dtype=a.dtype)
+    elif not isinstance(out, torch.Tensor):
+        raise InvalidInput(
+            "gfx950 LocalSplitU output must be a torch.Tensor; "
+            f"got {type(out).__name__}"
+        )
+    elif out.shape != (m, n):
+        raise InvalidInput(
+            f"gfx950 LocalSplitU output shape must be {(m, n)}; "
+            f"got {tuple(out.shape)}"
+        )
+    elif out.dtype != a.dtype:
+        raise InvalidInput(
+            f"gfx950 LocalSplitU output dtype must be {a.dtype}; "
+            f"got {out.dtype}"
+        )
+    elif out.device != a.device:
+        raise InvalidInput(
+            f"gfx950 LocalSplitU output device must be {a.device}; "
+            f"got {out.device}"
+        )
+
+    return _launch_validated(a, b, out, plan)
+
+
+def mm(a, b, *, space="heuristic"):
+    """Run the gfx950 implementation selected by ``tlx.ops.mm``.
+
+    The initial implementation has one measured plan per supported shape;
+    the next stack revision broadens this into a bounded plan generator.
+    """
+    if space != "heuristic":
+        raise InvalidInput(
+            "gfx950 LocalSplitU mm currently supports space='heuristic' only"
+        )
+    plan = _plan_for(a, b)
+    if plan is None:
+        raise InvalidInput(
+            "gfx950 LocalSplitU mm has no legal plan for "
+            f"a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
+        )
+    m, _ = a.shape
+    _, n = b.shape
+    out = torch.empty((m, n), device=a.device, dtype=a.dtype)
+    return _launch_validated(a, b, out, plan)

--- a/third_party/tlx/tutorials/gfx9_gemm/a16w16_matmul.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/a16w16_matmul.py
@@ -1,9 +1,10 @@
 """Family-level gfx950 a16w16 GEMM dispatcher.
 
 This module intentionally sits above the implementation directories: it
-selects between an exact-shape persistent kernel and the general inter-wave
-fallback.  Keeping dispatch policy here avoids making either implementation
-depend on the other and gives clients one stable a16w16 entry point.
+selects an exact-shape persistent kernel, a skinny LocalSplitU kernel, or the
+general inter-wave fallback. Keeping dispatch policy here avoids making the
+implementations depend on one another and gives clients one stable a16w16
+entry point.
 """
 
 from .a16w16.matmul_kernel_persistent import (
@@ -11,10 +12,19 @@ from .a16w16.matmul_kernel_persistent import (
     supports as _persistent_supports,
 )
 from .inter_wave.a16w16.matmul_kernel import matmul as _inter_wave_matmul
+# This in-tree compatibility dispatcher intentionally uses the implementation
+# fast path. Routing every ~12-us launch back through the public catalog adds
+# measurable Python dispatch overhead; external callers should use tlx.ops.mm.
+from triton.tlx.ops.kernels.mm.gfx950 import (
+    matmul as _skinny_matmul,
+    supports as _skinny_supports,
+)
 
 
 def matmul(a, b):
-    """Dispatch to a specialized persistent kernel or the general fallback."""
+    """Dispatch to a specialized kernel or the general fallback."""
     if _persistent_supports(a, b):
         return _persistent_matmul(a, b)
+    if _skinny_supports(a, b):
+        return _skinny_matmul(a, b)
     return _inter_wave_matmul(a, b)


### PR DESCRIPTION
Summary:
Add a LocalSplitU FP16 GEMM for small-M, deep-K workloads on gfx950 and expose it through the `tlx.ops.mm` implementation catalog.

The two motivating shapes have only seven output rows. A conventional GEMM mapping cannot partition M below the native 16-row MFMA tile: nine of the sixteen physical rows are padding, and large N tiles leave too few independent output workgroups to occupy the device. Simply shrinking N creates more workgroups but also gives each workgroup too little independent MFMA work to hide global-memory and instruction latency. In contrast, both shapes have substantial reduction work in K.

LocalSplitU converts that deep K dimension into useful intra-workgroup parallelism. Each wave computes one FP32 partial for the same logical MxN output tile over a block-cyclic K partition. The workgroup publishes those partials to LDS, combines them in increasing split-id order, and stores the result once. Unlike global Split-K, this requires neither atomics nor a global workspace and keeps all coordination inside the CTA.

The hot loop uses a one-stage register pipeline that issues K(t+1)'s A/B global loads before consuming K(t)'s operands with MFMA. The `7x8192x2048` plan uses N32 and sixteen K32 wave partitions, producing 256 output workgroups--one per CU--while exposing sixteen short independent MFMA chains inside each workgroup. The `7x2048x4096` plan uses N16 and four K256 partitions, balancing 128 output workgroups with lower local-reduction and register-residency costs.

Floating-point association is part of the numerical contract. Different LocalSplitU factors necessarily group FP32 additions differently and therefore cannot promise bitwise equality with one another. When TLX uses the same LocalSplitU and block-cyclic K mapping as hipBLASLt, it also preserves the vendor's increasing split-id reduction order. The U16 plan retains its independently tuned split factor but uses the same deterministic ordered-reduction rule. Each LDS partial is loaded and immediately accumulated to avoid extending every partial's register lifetime. Cancellation-sensitive tests mix large positive, small, and large negative contributions and check exact agreement with ATen for both motivating shapes.

The load contract is deliberately fail-closed. The implementation accepts only validated FP16 row-major-A/column-major-B inputs on gfx950, and `contiguity` is exactly the K width owned by each lane. Unsupported inputs and invalid caller-provided outputs raise `InvalidInput` through explicit checks that remain active under `python -O`. The selected plans use a legal K width of eight; random-input tests are required because the previous constant/easy accuracy workload did not expose an invalid over-wide load declaration during development.

MI350X TritonBench, TN layout, 200 warmup iterations and 1000 repetitions. "Parent TLX" is the general inter-wave implementation selected at this diff's parent; both columns report accuracy 1, and the LocalSplitU results were separately checked against `torch.matmul` with random and cancellation-sensitive FP16 inputs.

| MxNxK | Parent TLX | LocalSplitU | TLX latency reduction | ATen | ATen / LocalSplitU | Accuracy |
|---|---:|---:|---:|---:|---:|---:|
| 7x8192x2048 | 70.32 us | 12.12 us | 82.8% | 12.60 us | 1.040x | 1 |
| 7x2048x4096 | 74.00 us | 11.92 us | 83.9% | 11.60 us | 0.973x | 1 |

Keep the existing tutorial-level a16w16 entry as a compatibility wrapper, package `triton.tlx.ops` in the fbsource Buck Python target, and add the two motivating shapes to the shared op test data. A follow-up diff can broaden dispatch with bounded heuristic generation without changing the correctness contract of this standalone diff.

Reviewed By: htyu

Differential Revision: D119224662


