### PR TITLE
[Triton] Reset autotuner launch options across cache keys (#3514)

### DIFF
--- a/python/test/unit/runtime/test_fast_cache_edge_cases.py
+++ b/python/test/unit/runtime/test_fast_cache_edge_cases.py
@@ -853,3 +853,92 @@ class TestCtasPerCgaAutotunerSteadyState(TestCase):
         add_kernel_2cta[grid](x2, y2, o2, n)
         torch.cuda.synchronize()
         self.assertTrue(torch.allclose(o2, x2 + y2))
+
+    def _run_new_key_cluster_config_sequence(self, check_best_config):
+        def select_cta_count(configs, named_args, **kwargs):
+            if named_args["n_elements"] == 256:
+                return [config for config in configs if config.kwargs["USE_2CTA"]]
+            return configs
+
+        benchmark_index = 0
+
+        def do_bench(fn, quantiles):
+            nonlocal benchmark_index
+            fn()
+            benchmark_index += 1
+            return [float(benchmark_index)] * len(quantiles)
+
+        @triton.autotune(
+            configs=[
+                triton.Config(
+                    {"BLOCK_SIZE": 128, "USE_2CTA": False},
+                    num_warps=4,
+                    num_stages=1,
+                ),
+                triton.Config(
+                    {"BLOCK_SIZE": 128, "USE_2CTA": False},
+                    num_warps=8,
+                    num_stages=1,
+                ),
+                triton.Config(
+                    {"BLOCK_SIZE": 128, "USE_2CTA": True},
+                    num_warps=4,
+                    num_stages=1,
+                    ctas_per_cga=(2, 1, 1),
+                ),
+            ],
+            key=["n_elements"],
+            prune_configs_by={"early_config_prune": select_cta_count},
+            do_bench=do_bench,
+        )
+        @triton.jit
+        def add_kernel_switching_ctas(
+            x_ptr,
+            y_ptr,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: tl.constexpr,
+            USE_2CTA: tl.constexpr,
+            DEFAULT_VALUE: tl.constexpr = 0,
+        ):
+            scale = _CLUSTER_SCALE
+            pid = tl.program_id(0)
+            offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+            mask = offs < n_elements
+            x = tl.load(x_ptr + offs, mask=mask)
+            y = tl.load(y_ptr + offs, mask=mask)
+            tl.store(
+                out_ptr + offs,
+                ((x + y) * scale).to(tl.float32),
+                mask=mask,
+            )
+
+        device = _get_device()
+        # The final 256 revisits an already-seeded key after the 1-CTA key has
+        # replaced the active fast-cache metadata. The defaulted constexpr
+        # forces _try_fast_path to use its Python fallback.
+        for n in (256, 384, 256):
+            x = torch.randn(n, device=device, dtype=torch.float32)
+            y = torch.randn(n, device=device, dtype=torch.float32)
+            out = torch.empty(n, device=device, dtype=torch.float32)
+            def grid(meta):
+                num_ctas = 2 if meta["USE_2CTA"] else 1
+                num_blocks = triton.cdiv(n, 128)
+                return (triton.cdiv(num_blocks, num_ctas) * num_ctas, )
+
+            add_kernel_switching_ctas[grid](x, y, out, n)
+            torch.cuda.synchronize()
+            if check_best_config:
+                self.assertEqual(add_kernel_switching_ctas.best_config.kwargs["USE_2CTA"], n == 256)
+            self.assertTrue(torch.allclose(out, x + y))
+
+    @unittest.skipUnless(is_hopper_or_newer(), "ctas_per_cga is NVIDIA-only and requires Hopper (sm90) or newer")
+    @patch.dict(os.environ, {"TRITON_AUTOTUNE_USE_C_CACHE": "1"})
+    def test_new_key_dispatches_correct_cluster_config_with_c_proxy(self):
+        # Native proxy hits bypass Autotuner.run(), so output is the behavioral oracle.
+        self._run_new_key_cluster_config_sequence(check_best_config=False)
+
+    @unittest.skipUnless(is_hopper_or_newer(), "ctas_per_cga is NVIDIA-only and requires Hopper (sm90) or newer")
+    @patch.dict(os.environ, {"TRITON_AUTOTUNE_USE_C_CACHE": "0"})
+    def test_new_key_replaces_previous_cluster_config(self):
+        self._run_new_key_cluster_config_sequence(check_best_config=True)

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -517,7 +517,9 @@ class Autotuner(KernelInterface):
             raise ValueError(f"Conflicting meta-parameters: {', '.join(conflicts)}."
                              " Make sure that you don't re-define auto-tuned symbols.")
         # augment meta-parameters with tunable ones
-        current = dict(meta, **config.all_kwargs())
+        config_kwargs = config.all_kwargs()
+        current = dict(meta, **config_kwargs)
+        self._set_fast_cache_meta(config_kwargs)
         full_nargs = {**self.nargs, **current}
 
         # Capture the CompiledKernel the launch returns (run(...) returns it even on a normal
@@ -709,6 +711,18 @@ class Autotuner(KernelInterface):
         native_autotune_proxy_insert(proxy, key_vals, constexpr_vals, constexpr_positions, options_hash,
                                      config.pre_hook)
 
+    def _set_fast_cache_meta(self, config_kwargs):
+        """Install one config's compilation options before launching it."""
+        if not getattr(self.fn, 'c_cache', False):
+            return
+        meta = {k: v for k, v in config_kwargs.items() if k not in getattr(self.fn, '_param_name_to_idx', {})}
+        if getattr(self.fn, '_fc_meta_kwargs', None) == meta:
+            return
+        options_hash = _hash_fc_opts(meta) if meta else 0
+        self.fn._fc_options_hash = options_hash
+        self.fn._fc_meta_kwargs = meta
+        self.fn._jit_proxy_cache = {}
+
     def _try_fast_path(self, args, kwargs, config):
         """Attempt C fast cache dispatch; return kernel or None to fall back.
 
@@ -770,18 +784,6 @@ class Autotuner(KernelInterface):
             except (ImportError, AttributeError):
                 native_fast_dispatch_insert = None
             kernel = self.fn.run(*full_args, grid=evaluated_grid, warmup=False, **_meta)
-            # Update _fc_options_hash so C proxy and JIT.run fast path lookups
-            # use the same hash that JIT.run's insertion used (includes meta-params
-            # like ctas_per_cga that affect compilation options).
-            if _meta:
-                _meta_opts = {k: v for k, v in _meta.items() if k not in getattr(self.fn, '_param_name_to_idx', {})}
-                if _meta_opts:
-                    self.fn._fc_options_hash = _hash_fc_opts(_meta_opts)
-                # Store meta kwargs for C proxy fallback forwarding.
-                self.fn._fc_meta_kwargs = _meta
-                # Invalidate proxy cache so next __getitem__ creates a new proxy
-                # with the updated options_hash and meta_kwargs.
-                self.fn._jit_proxy_cache = {}
             if native_fast_dispatch_insert is not None:
                 _disp = getattr(kernel, '_dispatcher', None)
                 if _disp is not None:
@@ -922,6 +924,9 @@ class Autotuner(KernelInterface):
                 self._at_proxy_seeded.add(key)
         else:
             config = self.configs[0]
+        # Restore the winner before every launch path, including Python
+        # fallbacks and dump_best_config_ir recompilation.
+        self._set_fast_cache_meta(config.all_kwargs())
         self.best_config = config
         if knobs.autotuning.print and not used_cached_result:
             print(f"Triton autotuning for function {self.base_fn.__name__},\nwith key as {key},\n"


### PR DESCRIPTION
Summary:

The B200 TLX correctness shard fails in `test_blackwell_fa_ws_pipelined_persistent_backward_public_paths[dtype5-768-False]` with `cuLaunchKernelEx failed: a kernel launch error has occurred due to cluster misconfiguration (912)`.

The preceding N_CTX=512 autotune key can select a 2-CTA configuration. N_CTX=768 prunes that configuration and selects 1-CTA. During candidate benchmarking, however, `JITFunction.run` merges the previous key’s `_fc_meta_kwargs`, so the 1-CTA candidate inherits stale `ctas_per_cga=(2, 1, 1)` and launches an incompatible grid.

Install each candidate’s launch options and options hash before every benchmark launch, as well as before final C-cache seeding, and invalidate the proxy cache when switching configuration metadata.

Reviewed By: htyu

Differential Revision: D119355733


