### PR TITLE
[triton][3.8] Narrow chain fusion to `convert_layout` only (#3518)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -258,14 +258,17 @@ public:
     if (!useAcc2 || *useAcc2 == false)
       return failure();
 
-    // Walk init2 back through single-use, data-preserving ops to a tmem_load.
+    // Walk init2 back through single-use layout conversions to a tmem_load.
+    // The rewrite erases this chain, so every op in it must be elementwise
+    // identity -- only `convert_layout` qualifies. The wider list used by
+    // `findZeroInitOp` preserves all-zeros, not values, and the tile-type
+    // check below does not catch a square-tile `tt.trans`.
     SmallVector<Operation *> chain;
     Value v = init2;
     while (Operation *d = v.getDefiningOp()) {
       if (isa<triton::nvidia_gpu::TMEMLoadOp>(d))
         break;
-      if (!v.hasOneUse() || !isa<ConvertLayoutOp, ReshapeOp, TransOp,
-                                 BroadcastOp, ExpandDimsOp, SplitOp>(d))
+      if (!v.hasOneUse() || !isa<ConvertLayoutOp>(d))
         return failure();
       chain.push_back(d);
       v = d->getOperand(0);

--- a/test/TritonGPU/accumulator-init-chain-fuse.mlir
+++ b/test/TritonGPU/accumulator-init-chain-fuse.mlir
@@ -11,6 +11,8 @@
 // reuse downstream (the WSCodePartition reuse-order check aborts).
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#blockedT = #ttg.blocked<{sizePerThread = [128, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#linearTMEM = #ttg.linear<{register = [[0, 1], [8, 0], [0, 8], [0, 16], [0, 32], [0, 64], [16, 0]], lane = [[0, 2], [0, 4], [1, 0], [2, 0], [4, 0]], warp = [[32, 0], [64, 0]], block = []}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
 #shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
 #smem = #ttg.shared_memory
@@ -45,6 +47,78 @@ tt.func public @chain_accumulator_in_place(
     %v1, %ld1 = ttng.tmem_load %t1[%m1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     // dot2 tile, initialized from dot1's read-out
     %t2, %tok2 = ttng.tmem_alloc %v1 : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m2 = ttng.tc_gen5_mma %a1, %b1, %t2[%tok2], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v2, %ld2 = ttng.tmem_load %t2[%m2] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    scf.yield %v2 : tensor<128x128xf32, #blocked>
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @chain_accumulator_convert_layout_fuse
+// A single-use convert_layout in the init chain is elementwise identity, so
+// the chain still fuses onto one tile and the conversion is erased.
+// CHECK:       scf.for
+// CHECK:         %[[ACCC:.*]], %[[TKC0:.*]] = ttng.tmem_alloc %arg
+// CHECK:         %[[TKC1:.*]] = ttng.tc_gen5_mma {{.*}} %[[ACCC]][%[[TKC0]]]
+// CHECK-NOT:     ttng.tmem_alloc
+// CHECK-NOT:     ttng.tmem_load
+// CHECK-NOT:     ttg.convert_layout
+// CHECK:         %[[TKC2:.*]] = ttng.tc_gen5_mma {{.*}} %[[ACCC]][%[[TKC1]]], %true
+// CHECK:         ttng.tmem_load %[[ACCC]][%[[TKC2]]]
+tt.func public @chain_accumulator_convert_layout_fuse(
+    %a0: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b0: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %a1: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b1: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %n: i32) {
+  %true = arith.constant true
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked>) : i32 {
+    %t1, %tok1 = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m1 = ttng.tc_gen5_mma %a0, %b0, %t1[%tok1], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v1, %ld1 = ttng.tmem_load %t1[%m1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %cv = ttg.convert_layout %v1 : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #linearTMEM>
+    %t2, %tok2 = ttng.tmem_alloc %cv : (tensor<128x128xf32, #linearTMEM>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m2 = ttng.tc_gen5_mma %a1, %b1, %t2[%tok2], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v2, %ld2 = ttng.tmem_load %t2[%m2] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    scf.yield %v2 : tensor<128x128xf32, #blocked>
+  }
+  tt.return
+}
+
+// CHECK-LABEL: @chain_accumulator_transpose_no_fuse
+// A square-tile transpose in the init chain changes values (both tiles share
+// the same tensor_memory_encoding), so the pattern must NOT fuse: both tiles,
+// both read-outs, the transpose, and the conversion back to a TMEM-compatible
+// layout all survive.
+// CHECK:       scf.for
+// CHECK:         ttng.tmem_alloc
+// CHECK:         ttng.tc_gen5_mma
+// CHECK:         ttng.tmem_load
+// CHECK:         tt.trans
+// CHECK:         ttg.convert_layout
+// CHECK:         ttng.tmem_alloc
+// CHECK:         ttng.tc_gen5_mma
+// CHECK:         ttng.tmem_load
+tt.func public @chain_accumulator_transpose_no_fuse(
+    %a0: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b0: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %a1: !ttg.memdesc<128x64xf16, #shared, #smem>,
+    %b1: !ttg.memdesc<64x128xf16, #shared1, #smem>,
+    %n: i32) {
+  %true = arith.constant true
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+  %r = scf.for %i = %c0 to %n step %c1 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked>) : i32 {
+    %t1, %tok1 = ttng.tmem_alloc %acc : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %m1 = ttng.tc_gen5_mma %a0, %b0, %t1[%tok1], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %v1, %ld1 = ttng.tmem_load %t1[%m1] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
+    %vt = tt.trans %v1 {order = array<i32: 1, 0>} : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blockedT>
+    %cvt = ttg.convert_layout %vt : tensor<128x128xf32, #blockedT> -> tensor<128x128xf32, #blocked>
+    %t2, %tok2 = ttng.tmem_alloc %cvt : (tensor<128x128xf32, #blocked>) -> (!ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
     %m2 = ttng.tc_gen5_mma %a1, %b1, %t2[%tok2], %true, %true : !ttg.memdesc<128x64xf16, #shared, #smem>, !ttg.memdesc<64x128xf16, #shared1, #smem>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
     %v2, %ld2 = ttng.tmem_load %t2[%m2] : !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked>
     scf.yield %v2 : tensor<128x128xf32, #blocked>


### PR DESCRIPTION
Summary:

Ports D119333235 (stacked) to triton/3.8, fixing the same hole in the
`ChainAccumulatorInPlace` pattern (facebookexperimental/triton#2015).
The init-chain allow-list was borrowed from `findZeroInitOp`, whose contract
is "preserves all-zeros", not "preserves values elementwise". A square-tile
`tt.trans` passes the `t1`/`t2` memdesc type-equality guard, so the pattern
fused and erased the transpose, making `mma2` accumulate onto un-transposed
data - a silent miscompile. Narrow the chain to `ConvertLayoutOp` only.

Ports the two lit cases (`chain_accumulator_convert_layout_fuse`,
`chain_accumulator_transpose_no_fuse`) to the 3.8 test file as well.

Reviewed By: manman-ren

Differential Revision: D119382265


