### PR TITLE
@no-commit [TEST] TESTING pre-commit comment generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,4 @@ jobs:
     uses: ./.github/workflows/pre-commit.yml
     with:
       strict: true
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,8 @@ jobs:
 
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml
+
+  pre-commit-strict:
+    uses: ./.github/workflows/pre-commit.yml
+    with:
+      strict: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,12 @@ name: Pre-Commit Check
 
 on:
   workflow_call:
+    inputs:
+      strict:
+        description: 'true: blocking check scoped to PR changed files; false: advisory check on all files'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   pre-commit:
@@ -27,8 +33,44 @@ jobs:
           path: |
             ~/.cache/pre-commit
           key: ${{ runner.os }}-${{ steps.cache-key.outputs.pre_commit_hash }}
+      - name: Get PR changed files
+        id: changed
+        if: inputs.strict
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            echo "Not a pull_request event — nothing to check." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # List files via the API so no extra git history is needed.
+          # Fail closed: an API error must fail the check, never silently
+          # produce an empty file list that would skip the blocking step.
+          if ! gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate \
+            --jq '.[] | select(.status != "removed") | .filename' > /tmp/changed_all.txt; then
+            echo "::error::Failed to list PR changed files via the GitHub API."
+            exit 1
+          fi
+          # Deleted files are excluded: pre-commit errors on paths that
+          # don't exist in the checkout.
+          : > /tmp/changed_files.txt
+          while IFS= read -r f; do
+            [ -f "$f" ] && echo "$f" >> /tmp/changed_files.txt
+          done < /tmp/changed_all.txt
+          COUNT=$(wc -l < /tmp/changed_files.txt | tr -d ' ')
+          echo "Changed files present in checkout: ${COUNT}"
+          cat /tmp/changed_files.txt
+          if [ "$COUNT" -eq 0 ]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_files=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check pre-commit
         id: precommit
+        if: inputs.strict == false
         # Formatting issues are reported as a warning, not a hard failure, so
         # they never block a PR. The "Pre-commit warning" step below is the
         # marker other workflows key off of (see pre-commit-autofix.yml).
@@ -36,6 +78,13 @@ jobs:
         run: |
           python3 -m pip install --upgrade pre-commit
           python3 -m pre_commit run --all-files --verbose
+      - name: Check pre-commit (strict)
+        id: precommit_strict
+        if: inputs.strict && steps.changed.outputs.has_files == 'true'
+        run: |
+          python3 -m pip install --upgrade pre-commit
+          mapfile -t FILES < /tmp/changed_files.txt
+          python3 -m pre_commit run --files "${FILES[@]}" --show-diff-on-failure --verbose
       - name: Pre-commit warning
         if: steps.precommit.outcome == 'failure'
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -122,6 +122,59 @@ jobs:
               echo "::error file=${f},line=${l},col=${c}::${msg} (pre-commit-strict)"
             done
           fi
+      - name: Generate GitHub App token
+        id: app-token
+        if: failure() && steps.precommit_strict.outcome == 'failure'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Post inline review comments
+        if: failure() && steps.precommit_strict.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
+            echo "No PR context; skipping review comments."
+            exit 0
+          fi
+          # Inline review comments (unlike issue comments or check
+          # annotations) are imported onto the linked internal diff, so post
+          # each diagnostic where reviewers on both sides will see it.
+          MATCHES=$(grep -E -o -m 10 '[^:[:space:]]+\.pyi?:[0-9]+:[0-9]+: .+$' /tmp/precommit-strict.log || true)
+          if [ -z "$MATCHES" ]; then
+            echo "No file diagnostics to post."
+            exit 0
+          fi
+          # Already-posted bot comments (sha path:line), so re-runs on the
+          # same head don't spam duplicates. Best-effort: proceed without
+          # dedup rather than fail the report.
+          if ! gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- precommit-strict-lint -->")) | "\(.commit_id) \(.path):\(.line // empty)"' \
+            > /tmp/existing.txt; then
+            echo "::warning::Could not list existing review comments; proceeding without dedup."
+            : > /tmp/existing.txt
+          fi
+          echo "$MATCHES" | while IFS= read -r line; do
+            f="${line%%:*}"
+            rest="${line#*:}"
+            l="${rest%%:*}"
+            rest="${rest#*:}"
+            c="${rest%%:*}"
+            msg="${rest#*: }"
+            [ -f "$f" ] || continue
+            grep -qxF "${HEAD_SHA} ${f}:${l}" /tmp/existing.txt && continue
+            BODY=$(printf '<!-- precommit-strict-lint -->\n**pre-commit-strict** (blocking): %s\n`%s:%s:%s`' "$msg" "$f" "$l" "$c")
+            # Per-comment posts: a diagnostic on a line outside the PR diff
+            # 422s for that comment only instead of failing the whole batch.
+            if ! gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
+              -f body="$BODY" -f commit_id="$HEAD_SHA" -f path="$f" -F line="$l" -f side="RIGHT" --silent; then
+              echo "::warning::Could not post inline comment for ${f}:${l} (line may be outside the PR diff)."
+            fi
+          done
       - name: Pre-commit warning
         if: steps.precommit.outcome == 'failure'
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -84,7 +84,44 @@ jobs:
         run: |
           python3 -m pip install --upgrade pre-commit
           mapfile -t FILES < /tmp/changed_files.txt
-          python3 -m pre_commit run --files "${FILES[@]}" --show-diff-on-failure --verbose
+          set -o pipefail
+          python3 -m pre_commit run --files "${FILES[@]}" --show-diff-on-failure --verbose 2>&1 | tee /tmp/precommit-strict.log
+      - name: Report strict failures
+        if: failure() && steps.precommit_strict.outcome == 'failure'
+        run: |
+          set -euo pipefail
+          {
+            echo "### :x: Pre-commit strict — issues in PR changed files (blocking)"
+            echo ""
+            echo "Only files changed in this PR were checked. Fix locally and push, or comment \`/fix-precommit\` for autofixable hooks (ruff, yapf, clang-format)."
+            echo ""
+            echo "<details><summary>Diff of required changes</summary>"
+            echo ""
+            echo '```diff'
+            git diff
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Emit file-level annotations from ruff-style diagnostics
+          # (path:line:col: message) so failures show inline on the PR.
+          # Capped at 10: the per-step annotation limit.
+          MATCHES=$(grep -E -o -m 10 '[^:[:space:]]+\.pyi?:[0-9]+:[0-9]+: .+$' /tmp/precommit-strict.log || true)
+          if [ -n "$MATCHES" ]; then
+            echo "$MATCHES" | while IFS= read -r line; do
+              f="${line%%:*}"
+              rest="${line#*:}"
+              l="${rest%%:*}"
+              rest="${rest#*:}"
+              c="${rest%%:*}"
+              msg="${rest#*: }"
+              f="${f//%/\%25}"
+              f="${f//,/%2C}"
+              msg="${msg//%/\%25}"
+              [ -f "$f" ] || continue
+              echo "::error file=${f},line=${l},col=${c}::${msg} (pre-commit-strict)"
+            done
+          fi
       - name: Pre-commit warning
         if: steps.precommit.outcome == 'failure'
         run: |

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -744,3 +744,9 @@ def refresh_knobs():
     runtime.debug = env_bool("TRITON_DEBUG").get()
     runtime.sanitize_overflow = env_bool("TRITON_SANITIZE_OVERFLOW").get()
     compilation.instrumentation_mode = env_str("TRITON_INSTRUMENTATION_MODE", "").get()
+
+
+# TEST-ONLY (@no-commit): intentional pre-commit violations to exercise the strict workflow.
+def _test_precommit_violation():
+    unused_test_variable = 1  
+    return None


### PR DESCRIPTION
Summary:
TEST-ONLY. DO NOT LAND. Intentional pre-commit violations in `python/triton/knobs.py` to exercise the strict workflow end-to-end after export to GitHub: an unused local variable (ruff F841, persistent diagnostic for annotations + inline review comments) and trailing whitespace (formatter rewrite for the summary diff).

To test: export this stack to GitHub and confirm the strict check fails red, the bot posts inline review comments on the PR, and those comments sync back onto the internal diff changesets. Abandon afterwards.

Differential Revision: D119413898


