### PR TITLE
[ci] setup cublas library to the CI path

### DIFF
--- a/.ci/tritonbench/setup-ld-library.sh
+++ b/.ci/tritonbench/setup-ld-library.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Source this script so LD_LIBRARY_PATH is available to subsequent commands.
+set -euo pipefail
+
+TORCH_NVIDIA_LIB_DIR=$(python -c 'from pathlib import Path; import torch; print(Path(torch.__file__).parent.parent / "nvidia")')
+
+if [ ! -f "${TORCH_NVIDIA_LIB_DIR}/libcublas.so" ]; then
+  for cublas_library in "${TORCH_NVIDIA_LIB_DIR}"/libcublas.so.*; do
+    if [ -f "${cublas_library}" ]; then
+      ln -s "${cublas_library}" "${TORCH_NVIDIA_LIB_DIR}/libcublas.so"
+      break
+    fi
+  done
+fi
+
+if [ ! -f "${TORCH_NVIDIA_LIB_DIR}/libcublas.so" ]; then
+  echo "ERROR: Neither libcublas.so nor libcublas.so.* exists in ${TORCH_NVIDIA_LIB_DIR}" >&2
+  exit 1
+fi
+
+export LD_LIBRARY_PATH="${TORCH_NVIDIA_LIB_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"

--- a/.ci/tritonbench/setup-ld-library.sh
+++ b/.ci/tritonbench/setup-ld-library.sh
@@ -2,12 +2,18 @@
 # Source this script so LD_LIBRARY_PATH is available to subsequent commands.
 set -euo pipefail
 
-TORCH_NVIDIA_LIB_DIR=$(python -c 'from pathlib import Path; import torch; print(Path(torch.__file__).parent.parent / "nvidia")')
+TORCH_NVIDIA_LIB_DIR=$(python -c 'from pathlib import Path; import torch; print(Path(torch.__file__).parent.parent / "nvidia" / "cu13" / "lib" )')
 
 if [ ! -f "${TORCH_NVIDIA_LIB_DIR}/libcublas.so" ]; then
   for cublas_library in "${TORCH_NVIDIA_LIB_DIR}"/libcublas.so.*; do
     if [ -f "${cublas_library}" ]; then
-      ln -s "${cublas_library}" "${TORCH_NVIDIA_LIB_DIR}/libcublas.so"
+      ln -sf "${cublas_library}" "${TORCH_NVIDIA_LIB_DIR}/libcublas.so"
+      break
+    fi
+  done
+  for cublas_library in "${TORCH_NVIDIA_LIB_DIR}"/libcublasLt.so.*; do
+    if [ -f "${cublas_library}" ]; then
+      ln -sf "${cublas_library}" "${TORCH_NVIDIA_LIB_DIR}/libcublasLt.so"
       break
     fi
   done
@@ -15,6 +21,11 @@ fi
 
 if [ ! -f "${TORCH_NVIDIA_LIB_DIR}/libcublas.so" ]; then
   echo "ERROR: Neither libcublas.so nor libcublas.so.* exists in ${TORCH_NVIDIA_LIB_DIR}" >&2
+  exit 1
+fi
+
+if [ ! -f "${TORCH_NVIDIA_LIB_DIR}/libcublasLt.so" ]; then
+  echo "ERROR: Neither libcublasLt.so nor libcublasLt.so.* exists in ${TORCH_NVIDIA_LIB_DIR}" >&2
   exit 1
 fi
 

--- a/.github/workflows/h100.yml
+++ b/.github/workflows/h100.yml
@@ -300,6 +300,7 @@ jobs:
         timeout-minutes: 30
         run: |
           . "${SETUP_SCRIPT}"
+          . ./.ci/tritonbench/setup-ld-library.sh
           python -m pytest python/test/unit/runtime/ -v --junitxml=/tmp/runtime-unit.xml
       - name: Collect nightly failures (runtime)
         id: parse


### PR DESCRIPTION
As titled. This is to handle errors in the newly added h100 runtime tests.

There will be a follow-up PR to add the ENV setup to Tritonbench Docker image.

Test Plan:

```
python/test/unit/runtime/test_blaslt.py::test_blaslt[float8_e4m3fn-16-16-16] PASSED [ 15%]
```