### PR TITLE
[Performance-Fix] [Triton] [3.8] Transparent ops aren't walls

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -614,6 +614,18 @@ static int64_t tensorBytes(Value v) {
   return (elems * getElementBitWidth(ty) + 7) / 8;
 }
 
+// Does `op` carry no layout preference of its own -- i.e. will it accept
+// whatever encoding its neighbours settle on? Same op set
+// `canPropagateSrcEncodingThroughUsers` propagates through.
+static bool isLayoutTransparent(Operation *op) {
+  if (!op)
+    return false;
+  return op->hasTrait<OpTrait::Elementwise>() ||
+         isa<arith::ExtFOp, arith::TruncFOp, arith::ExtUIOp, arith::ExtSIOp,
+             arith::TruncIOp, arith::SIToFPOp, arith::FPToSIOp,
+             arith::BitcastOp>(op);
+}
+
 // Estimate the relayout traffic from committing `value` to `encoding`: every
 // neighbour that cannot supply `encoding` needs a convert_layout.
 //
@@ -637,8 +649,17 @@ static std::pair<int64_t, int64_t> estimateRelayout(
         &candidates) {
   auto canSupply = [&](Value v) {
     auto it = candidates.find(v);
-    if (it != candidates.end())
-      return it->second.contains(encoding);
+    if (it != candidates.end()) {
+      if (it->second.contains(encoding))
+        return true;
+      // A single-candidate neighbour holds one encoding only because
+      // propagation reached it once, not because it needs that one. If it is
+      // layout-transparent it will follow whatever its neighbours settle on, so
+      // charging it is a convert that never materializes -- and, worse, it
+      // walls the chain off at an arbitrary point. An anchor (a load, a
+      // tmem_load, a dot) genuinely is fixed and must still be charged.
+      return it->second.size() == 1 && isLayoutTransparent(v.getDefiningOp());
+    }
     auto ty = dyn_cast<RankedTensorType>(v.getType());
     return ty && ty.getEncoding() == encoding;
   };

--- a/test/TritonGPU/remove-layout-conversions-relayout-cost.mlir
+++ b/test/TritonGPU/remove-layout-conversions-relayout-cost.mlir
@@ -1,0 +1,44 @@
+// RUN: triton-opt %s -split-input-file -tritongpu-remove-layout-conversions | FileCheck %s
+
+// A single-candidate neighbour is not automatically a fixed one. `%res0`/`%res1`
+// reach `arith.extf` with one encoding only because that is the one propagation
+// carried to them, not because extf needs it -- extf has no layout preference at
+// all and will follow whatever the chain settles on. Charging a relayout against
+// it walls the chain off and drags it down to the neighbour's incidental layout.
+//
+// Both choices move the same 8192 bytes here: staying in #linear converts the two
+// bf16 operands (2 x 4096), dropping to #blocked converts the f32 tmem_load result
+// (1 x 8192). Equal cost, so the vectorization score decides, and #linear is twice
+// as wide. Note the convert *count* goes up while the answer gets better -- count
+// is not the objective.
+
+// CHECK-LABEL: @transparent_neighbour_is_not_a_wall
+// CHECK:         %[[T:.*]] = ttng.tmem_load
+// CHECK-NOT:     ttg.convert_layout %[[T]]
+// CHECK:         arith.mulf {{.*}} tensor<64x32xf32, #linear>
+// CHECK:         arith.addf {{.*}} tensor<64x32xf32, #linear>
+// CHECK:         arith.truncf {{.*}} tensor<64x32xf32, #linear> to tensor<64x32xbf16, #linear>
+// CHECK:         ttg.local_store
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#linear = #ttg.linear<{register = [[0, 1], [0, 2], [0, 4], [0, 8]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 16]], warp = [[16, 0], [32, 0]], block = []}>
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32, ttg.target = "cuda:100"} {
+  tt.func @transparent_neighbour_is_not_a_wall(
+      %acc: !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x128>,
+      %res0: tensor<64x32xbf16, #blocked>,
+      %res1: tensor<64x32xbf16, #blocked>,
+      %out: !ttg.memdesc<64x32xbf16, #shared, #smem, mutable>) {
+    %t = ttng.tmem_load %acc : !ttg.memdesc<64x32xf32, #tmem, #ttng.tensor_memory, mutable, 64x128> -> tensor<64x32xf32, #linear>
+    %tb = ttg.convert_layout %t : tensor<64x32xf32, #linear> -> tensor<64x32xf32, #blocked>
+    %e0 = arith.extf %res0 : tensor<64x32xbf16, #blocked> to tensor<64x32xf32, #blocked>
+    %e1 = arith.extf %res1 : tensor<64x32xbf16, #blocked> to tensor<64x32xf32, #blocked>
+    %a1 = arith.mulf %tb, %e0 : tensor<64x32xf32, #blocked>
+    %a2 = arith.addf %a1, %e1 : tensor<64x32xf32, #blocked>
+    %r = arith.truncf %a2 : tensor<64x32xf32, #blocked> to tensor<64x32xbf16, #blocked>
+    ttg.local_store %r, %out : tensor<64x32xbf16, #blocked> -> !ttg.memdesc<64x32xbf16, #shared, #smem, mutable>
+    tt.return
+  }
+}


### PR DESCRIPTION
Summary:
## Context

D118656976, below this, made relayout cost a property of a group of values rather than of one
value. On `gdpa_norm` backward that recovered 59% of the damage D118378270 does (6.660 -> 6.165
ms) but left **+6.0%** against the same stack with no cost model at all (5.818).

All numbers here are on `D117484320 + D117484321`. Without those two the whole question is
invisible: D118582899 reads as a no-op, and every ablation of the layout heuristic lands within
noise of every other. That is the base every row below shares.

## What was left

`buildLayoutGroups` only admits *conflicted* values -- `encodings.size() > 1`. Everything else is
treated as fixed boundary. But a value holds one candidate when propagation reached it once, which
is not the same as needing that one. Dumping the group topology at the terminal pass shows what
that costs:

```
[TOPO] group 1 size=3
   elementwise_inline_asm  operands: convert_layout(g1)  arith.extf(fixed:1)
   elementwise_inline_asm  operands: tmem_load(fixed:1)  convert_layout(fixed:1)
   convert_layout          operands: elementwise_inline_asm(g1)
```

Four groups of this shape, each a 3-op fragment of one elementwise chain, each walled off by an
`arith.extf` that has a single candidate. The wall does two things at once: it severs the fragment
from the 50-value group that is the rest of the same chain, and it charges a `convert_layout`
against the extf that will never be emitted, because extf follows whatever its neighbours pick.
With that phantom charge the fragments come out at

```
blk[1,8]      total=24576  score=8x3   <- chosen
lin(c=16)     total=32768  score=16x3
```

and contradict the trunk, which chose `lin(c=16)`. Eight `elementwise_inline_asm` ops drop from
16-wide to 8-wide and four extra converts appear.

## Why this is not a weighting problem

The obvious reading is that bytes outrank the vectorization score too eagerly, and that the fix is
to make them commensurate. It is not. The same dump on `sdyt_gdpa`, where the cost model earns
-10.8%, gives

```
blk[1,8]      total=131072  score=8    <- correct
lin(c=64)     total=329728  score=64
```

Solve `total + K * groupBytes / score` for the K that gets both right and there isn't one:
`sdyt_gdpa` needs K < 2.31, `gdpa_norm` needs K > 5.33. Measured, not just derived -- ranking by
bytes-per-unit-vectorization closes `gdpa_norm` completely (5.816) and gives back the entire
`sdyt_gdpa` win (4.398, versus 4.405 for no cost model at all).

The two cases differ structurally, not numerically. `sdyt_gdpa`'s boundary is `tt.load` -- a real
anchor, whose layout drives coalescing, and charging it is exactly what D118378270 set out to do.
`gdpa_norm`'s boundary is `arith.extf` -- an op with no layout preference of its own.

## Change

One predicate and one branch in `canSupply`. A single-candidate neighbour is treated as able to
supply any encoding when it is layout-transparent -- the op set `canPropagateSrcEncodingThroughUsers`
already propagates through. Anchors keep being charged.

That is enough on its own: the fragments stop being walled off, the phantom charge disappears, and
`gdpa_norm`'s four fragments tie on cost and fall through to the score, which prefers the wider
layout. No change to grouping, ranking, or the SMEM override.

Reviewed By: htyu

Differential Revision: D119175386


