### PR TITLE
[tlx][agent] Add warp-barrier, persistent-pipeline, and commit safeguards

### DIFF
--- a/.claude/skills/tlx-api-reference/SKILL.md
+++ b/.claude/skills/tlx-api-reference/SKILL.md
@@ -36,21 +36,79 @@ with tlx.async_tasks():
 
 | Function | Description | Arch |
 |---|---|---|
-| `tlx.alloc_barriers(num_barriers, arrive_count=1)` | Allocate SMEM barriers and initialize with arrive count | Both |
+| `tlx.alloc_barriers(num_barriers, arrive_count=1)` | Allocate ordinary SMEM barriers. Software arrivals use leader-based lowering, which may synchronize participating threads before the leader arrives. | Both |
+| `tlx.alloc_warp_barrier(num_barriers, num_warps=1, num_arrivals=1)` | Allocate SMEM barriers whose software arrivals are performed independently by every participating thread. The initialized count is `num_warps * 32 * num_arrivals`. | NVIDIA |
 | `tlx.barrier_expect_bytes(bar, bytes, pred=None)` | Set expected transaction byte count on barrier | Both |
 | `tlx.barrier_wait(bar, phase, pred=None)` | Wait until barrier phase flips (LOCAL mbarrier only) | Both |
 | `tlx.barrier_arrive(bar, arrive_count=1, remote_cta_rank=None)` | Signal arrival at barrier. `remote_cta_rank` signals a barrier in a remote CTA — **only valid when ctas_per_cga > 1**, causes "Unexpected buffer remote view in 1cta mode" otherwise. Guard with `if USE_2CTA:` when kernel supports both modes. | Both |
 | `tlx.cluster_barrier()` | Full cluster-wide synchronization barrier | Both |
 
-**arrive_count rules:**
-- `arrive_count` controls how many times `barrier_expect_bytes` must be called
-  before the barrier can complete a phase. It is NOT a count of `barrier_arrive` calls.
-- For TMA barriers where only the leader CTA calls `barrier_expect_bytes`:
-  use `arrive_count=1` (default).
-- For barriers arrived by software from both CTAs (via `barrier_arrive` with
-  `remote_cta_rank`), use `arrive_count=NUM_CTAS`.
-- `barrier_arrive` inside `tlx.async_task`: `arrive_count` = number of warp groups
-- `barrier_arrive` outside `tlx.async_task`: `arrive_count=1` (only tid==0 arrives)
+**Ordinary barrier count rules:**
+- `alloc_barriers(..., arrive_count=N)` initializes the number of logical arrivals
+  required to complete a phase. Transaction bytes registered with
+  `barrier_expect_bytes` are an additional completion condition; do not infer the
+  software arrival topology from the transaction byte count.
+- For TMA full/data-ready barriers where one task registers the transaction, use
+  `arrive_count=1` unless the surrounding protocol explicitly requires additional
+  software arrivals.
+- For local software barriers shared by replicated `tlx.async_task` consumers, the
+  ordinary count is typically the number of consumer replicas that arrive once per
+  phase.
+- For cross-CTA software arrivals using `remote_cta_rank`, derive the count from the
+  exact CTA protocol. Do not assume the local-task rule applies.
+
+### Warp-barrier semantics and safe conversion
+
+`alloc_warp_barrier` changes the physical arrival protocol, not merely the spelling
+of the allocation. With an ordinary barrier, TLX selects a leader to perform the
+arrival and may synchronize the participating threads first. With a warp barrier,
+every participating thread performs its own arrival, avoiding that leader-path
+synchronization but issuing more mbarrier arrival operations.
+
+The initialized count is:
+
+```text
+expected arrivals per phase = num_warps * 32 * num_arrivals
+```
+
+Here `num_warps` is the number of warps in each participating task replica, and
+`num_arrivals` is the number of such all-thread arrival events targeting the same
+barrier in one phase. For example, two replicated four-warp consumers that each
+release one shared buffer slot use `num_warps=4, num_arrivals=2`, for 256 arrivals.
+A consumer-owned slot released by one four-warp replica uses
+`num_warps=4, num_arrivals=1`, for 128 arrivals. Keep the corresponding
+`barrier_arrive` calls at their original final-use points and normally use the
+default unit arrival count.
+
+Before converting an ordinary barrier, classify its role and arrival source:
+
+| Barrier role | Warp-barrier candidate? | Rule |
+|---|---|---|
+| Local software empty/reuse notification | Yes, after proving the topology | Every expected lane must arrive exactly once per declared arrival event, after its final read of the protected storage. |
+| Local software data-ready notification | Sometimes | Safe only when readiness is produced by the same statically known all-thread topology; benchmark because per-thread arrivals are not universally faster. |
+| TMA transaction/full barrier | No | Keep an ordinary barrier so transaction completion remains tracked through `barrier_expect_bytes` and the TMA operation. |
+| MMA/tensor-core completion barrier | No automatic conversion | Preserve the completion mechanism required by the MMA API. |
+| Named scheduling barrier | No | Preserve the named-barrier ID, participant count, direction, and phase protocol. |
+| Remote, multicast, or cross-CTA barrier | No automatic conversion | Keep the established protocol unless backend support and the complete cluster-wide arrival topology are explicitly proven. |
+| Divergently predicated arrival | No | A missing lane leaves the phase incomplete; use a warp barrier only when every counted lane is guaranteed to execute the required arrivals. |
+
+Safe-conversion checklist:
+
+1. Identify the protected buffer and confirm the barrier is signaled by explicit
+   software `barrier_arrive` calls rather than TMA, MMA, multicast, or remote
+   completion.
+2. Enumerate every task replica, warp, lane, predicate, and arrival call that targets
+   the barrier during one phase.
+3. Verify `num_warps * 32 * num_arrivals` equals the exact number of unit arrivals.
+4. Prove every counted lane reaches the arrival after its final access to the buffer,
+   including prologue, tail, and persistent-loop iterations.
+5. Preserve buffer indices, phase calculations, wait sites, and arrival sites; change
+   only the allocator for the first A/B experiment.
+6. Keep full/TMA barriers ordinary even when the paired empty/reuse barriers are
+   converted.
+7. Run correctness and benchmark both forms. Warp barriers trade additional
+   per-thread arrivals for removal of leader-path synchronization, so conversion is
+   an optimization candidate, not a universal rule.
 
 ### Named barriers (hardware-allocated, indices 0–15)
 
@@ -180,18 +238,37 @@ For 2-CTA mode: set `multi_ctas=True` (uses "arrive remote, wait local" pattern)
 ### Producer-consumer with mbarrier (pipelined GEMM)
 
 ```python
-bars_full = tlx.alloc_barriers(num_stages, arrive_count=1)   # TMA arrives implicitly
-bars_empty = tlx.alloc_barriers(num_stages, arrive_count=num_consumers)
+# Full/data-ready barriers track TMA transaction completion and remain ordinary.
+bars_full = tlx.alloc_barriers(num_stages, arrive_count=1)
 
-# Producer: TMA load → signal full
+# Ordinary software-release form: one logical arrival per consumer replica.
+bars_empty = tlx.alloc_barriers(
+    num_stages,
+    arrive_count=num_consumers,
+)
+
+# Optional optimized form when each consumer replica has four warps and every lane
+# is statically guaranteed to execute one unit arrival after its final buffer read.
+bars_empty_warp = tlx.alloc_warp_barrier(
+    num_barriers=num_stages,
+    num_warps=4,
+    num_arrivals=num_consumers,
+)
+
+# Producer: wait for reuse, then start TMA load tracked by the ordinary full barrier.
+tlx.barrier_wait(bar_empty, empty_phase)
 tlx.barrier_expect_bytes(bar_full, nbytes)
 tlx.async_descriptor_load(desc, indices, barrier=bar_full)
 
-# Consumer: wait full → MMA → signal empty
-tlx.barrier_wait(bar_full, phase)
-tlx.async_dot(A, B, acc)
+# Consumer: wait for TMA completion, consume the buffer, then release it.
+tlx.barrier_wait(bar_full, full_phase)
+acc = tlx.async_dot(A, B, acc)
+acc = tlx.async_dot_wait(0, acc)  # Prove the final buffer read completed.
 tlx.barrier_arrive(bar_empty)
 ```
+
+When evaluating the optimized form, substitute `bars_empty_warp` for `bars_empty` at
+both the producer wait and consumer arrival sites. Do not convert `bars_full`.
 
 ### PingPong with named barriers
 

--- a/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/SKILL.md
+++ b/third_party/tlx/.claude/skills/tlx-kernel-optimization-agent/SKILL.md
@@ -82,9 +82,12 @@ validated.
 
 Candidate generation automatically receives trusted source-optimization skills
 owned by `third_party/tlx/tools/agents/kernel_optimization/skills/`: every target
-receives layout-conversion efficiency guidance, CUDA/NVIDIA targets additionally
-receive async TMA output publication guidance, and Blackwell targets additionally
-receive persistent CLC scheduling and persistent pipeline efficiency guidance.
+receives layout-conversion efficiency guidance, while CUDA/NVIDIA targets also
+receive async TMA output publication and warp-barrier efficiency guidance. Known
+Hopper and Blackwell targets additionally receive NVIDIA persistent pipeline
+efficiency guidance, and Blackwell targets also receive persistent CLC scheduling
+guidance. Unknown NVIDIA architectures receive the common NVIDIA guidance but
+require an explicit allowlist update before receiving persistent pipeline guidance.
 Canonical profiling workflow documentation lives under
 `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/` and is not
 injected as source guidance. Keep workload-specific
@@ -110,6 +113,31 @@ configured round budget after an unpromoted round. Reject incorrect, duplicate,
 unstable, and materially regressing candidates.
 
 ## Layer 2: Profiling Request And Artifacts
+
+The optimizer sends a profile request for the baseline (deep), every
+correctness-passing candidate (summary, escalated to deep near the promotion
+threshold), and the finalist (deep). Profiling is always on; the `--profile`
+flag is vestigial. Every request carries `tools=["proton_launch",
+"native_profiler"]`, where `native_profiler` resolves to `ncu` on CUDA/NVIDIA
+targets automatically. Pass `--diagnostic-proton-intra-kernel` to additionally
+collect warp-granularity Proton instrumentation traces for the baseline and
+final winner only (diagnostic-only: never benchmark, promote, or commit
+instrumented source or timing).
+
+These requests produce data only if the bundle's `harness.py::profile()`
+implements them. A stub that repackages endpoint timings yields
+`ncu=unavailable` and zeroed `proton.*` fields on every line, and all
+hypotheses degrade to endpoint latency plus source inspection. Before
+launching, verify the harness profile path end to end:
+
+- Proton launch attribution: follow
+  `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/proton.md`
+  and return `profile()["proton"]` with nonzero `main_kernel_us` for the
+  expected kernel launch.
+- Target counters: follow
+  `third_party/tlx/tools/agents/kernel_optimization/docs/profiling/nvidia-ncu.md`
+  (CUDA/NVIDIA) and return `profile()["ncu"]` with non-null summary duration.
+  Report unsupported counters as JSON `null` with a diagnostic, never as zero.
 
 Harnesses that implement `profile` should accept a structured request with:
 

--- a/third_party/tlx/tools/agents/kernel_optimization/providers.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/providers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import ast
+import hashlib
 import json
+import re
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -16,13 +19,18 @@ _SKILLS_ROOT = Path(__file__).resolve().parent / "skills"
 _LAYOUT_CONVERSION_SKILL = _SKILLS_ROOT / "common/layout-conversion-efficiency.md"
 _NVIDIA_TARGET_SKILLS = _SKILLS_ROOT / "targets/nvidia"
 _ASYNC_TMA_OUTPUT_SKILL = _NVIDIA_TARGET_SKILLS / "async-tma-output-publication.md"
+_NVIDIA_WARP_BARRIER_SKILL = (
+    _NVIDIA_TARGET_SKILLS / "nvidia-warp-barrier-efficiency.md"
+)
 _BLACKWELL_CLC_SKILL = _NVIDIA_TARGET_SKILLS / "blackwell-persistent-clc-scheduling.md"
-_BLACKWELL_PIPELINE_SKILL = (
-    _NVIDIA_TARGET_SKILLS / "blackwell-persistent-pipeline-efficiency.md"
+_NVIDIA_PERSISTENT_PIPELINE_SKILL = (
+    _NVIDIA_TARGET_SKILLS / "nvidia-persistent-pipeline-efficiency.md"
 )
 _BLACKWELL_ARCHITECTURES = frozenset(
     {"blackwell", "sm100", "sm_100", "b200", "b200a", "gb200", "gb300"}
 )
+_HOPPER_ARCHITECTURES = frozenset({"hopper", "h100", "sm90", "sm_90"})
+_PERSISTENT_PIPELINE_ARCHITECTURES = _BLACKWELL_ARCHITECTURES | _HOPPER_ARCHITECTURES
 
 
 TLX_PROMPT_PREAMBLE = """You are optimizing one Triton or TLX kernel against an external deterministic harness.
@@ -53,17 +61,23 @@ TLX API guidance:
 
 The complete current source is available as `candidate.py` in your writable working
 directory. Edit that file directly and leave it as the complete replacement source. Also
-write `candidate_metadata.json` with integer `schema_version` set to 1 and these string
+write `candidate_metadata.json` with integer `schema_version` set to 2 and these string
 fields: `hypothesis`, `evidence`, `change`, `expected_effect`, `risk`, `commit_title`,
-and `commit_summary`. The first five fields must each be one line and under 240 characters.
-`commit_title` must be an imperative, one-line title under 80 characters that describes the
-actual source change, without performance claims or attribution. `commit_summary` must be
-under 4000 characters and contain exactly two clearly labeled
-sections: `Change summary:` explains what changed, its affected scope, and preserved
-invariants or fallback paths; `Why:` explains the measured evidence and optimization
-rationale. Do not include a commit subject, a `Performance:` section, `TLX agent authored`,
-or any unverified performance or correctness claim. The external harness adds a formatted
-`Performance:` section with authoritative numbers after final revalidation.
+`commit_summary`, and `source_sha256`. `original.py` is an immutable copy of the source you
+started from. After the final edit, inspect the final unified diff from `original.py` to `candidate.py`
+and base all metadata only on that diff. Set `source_sha256` to the lowercase SHA-256 digest
+of the final `candidate.py` bytes so stale metadata from an earlier edit is rejected.
+The first five fields must each be one line and under 240 characters. `commit_title` must be
+an imperative, one-line title under 80 characters that precisely describes the actual
+source change, without performance claims, vague labels such as "Optimize kernel", or
+attribution. `commit_summary` must be under 4000 characters and contain exactly two clearly
+labeled sections: `Change summary:` explains what changed, names at least one changed
+top-level function, class, or module variable exactly as spelled in the source, and states
+preserved invariants or fallback paths; `Why:` explains the measured evidence and
+optimization rationale. Do not describe edits absent from the final diff. Do not include a
+commit subject, a `Performance:` section, `TLX agent authored`, or any unverified
+performance or correctness claim. The external harness adds a formatted `Performance:`
+section with authoritative numbers after final revalidation.
 Do not modify any other file. Keep the final response to one short plain-text summary;
 do not print source code or a patch.
 """
@@ -136,6 +150,36 @@ class MockLLMProvider:
         return CandidateProposal(source=context.current_source, summary="mock-echo")
 
 
+_METADATA_SCHEMA_VERSION = 2
+_COMMIT_SUMMARY_RE = re.compile(
+    r"\AChange summary:[ \t]*\n?(?P<change>.+?)\n\nWhy:[ \t]*\n?(?P<why>.+)\Z",
+    re.DOTALL,
+)
+_GENERIC_COMMIT_TITLES = frozenset(
+    {
+        "improve performance",
+        "optimize candidate",
+        "optimize kernel",
+        "optimize performance",
+        "update kernel",
+    }
+)
+_COMMIT_METADATA_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "for",
+        "in",
+        "of",
+        "on",
+        "the",
+        "to",
+        "use",
+        "with",
+    }
+)
+
 _SHORT_METADATA_FIELDS = (
     "hypothesis",
     "evidence",
@@ -156,54 +200,119 @@ def _clean_commit_title(value: object) -> str:
 def _clean_commit_summary(value: object) -> str:
     text = str(value or "").replace("\x00", "")
     paragraphs = [" ".join(part.split()) for part in text.split("\n\n")]
-    return "\n\n".join(part for part in paragraphs if part)[:4000].strip()
+    return "\n\n".join(part for part in paragraphs if part).strip()
 
 
-def _fallback_commit_summary(metadata: dict[str, str]) -> str:
-    change = metadata.get("change", "") or (
-        "Apply the source change selected by TLX Agent against the frozen harness."
-    )
-    risk = metadata.get("risk", "")
-    if risk:
-        change = f"{change} Preserved behavior and risk: {risk}"
-    why = " ".join(
-        part
-        for part in (
-            metadata.get("hypothesis", ""),
-            f"Evidence: {metadata['evidence']}" if metadata.get("evidence") else "",
-            (
-                f"Expected effect: {metadata['expected_effect']}"
-                if metadata.get("expected_effect")
-                else ""
-            ),
+def _top_level_nodes(source: str) -> dict[str, ast.AST]:
+    nodes: dict[str, ast.AST] = {}
+    for node in ast.parse(source).body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            nodes[node.name] = node
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    nodes[target.id] = node
+    return nodes
+
+
+def _commit_words(text: str) -> frozenset[str]:
+    words = set()
+    for token in re.findall(
+        r"[A-Za-z][A-Za-z0-9]*", text.casefold().replace("_", " ")
+    ):
+        word = token[:-1] if token.endswith("s") and len(token) > 4 else token
+        if word not in _COMMIT_METADATA_STOP_WORDS:
+            words.add(word)
+    return frozenset(words)
+
+
+def _changed_top_level_names(before: str, after: str) -> tuple[str, ...]:
+    before_nodes = _top_level_nodes(before)
+    after_nodes = _top_level_nodes(after)
+    names = set(before_nodes) | set(after_nodes)
+
+    def node_dump(node: ast.AST | None) -> str | None:
+        return ast.dump(node, include_attributes=False) if node is not None else None
+
+    return tuple(
+        sorted(
+            name
+            for name in names
+            if node_dump(before_nodes.get(name)) != node_dump(after_nodes.get(name))
         )
-        if part
-    ) or "TLX Agent selected this candidate for external correctness and performance evaluation."
-    return _clean_commit_summary(f"Change summary:\n{change}\n\nWhy:\n{why}")
+    )
 
 
-def _read_candidate_metadata(path: Path) -> dict[str, str]:
-    metadata = {field: "" for field in _SHORT_METADATA_FIELDS}
-    metadata["commit_title"] = ""
-    metadata["commit_summary"] = ""
-    if path.exists():
-        try:
-            payload = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError):
-            payload = {}
-        if isinstance(payload, dict):
-            for field in _SHORT_METADATA_FIELDS:
-                metadata[field] = _clean_short_metadata(payload.get(field, ""))
-            metadata["commit_title"] = _clean_commit_title(
-                payload.get("commit_title", "")
-            )
-            metadata["commit_summary"] = _clean_commit_summary(
-                payload.get("commit_summary", "")
-            )
-    if not metadata["commit_title"]:
-        metadata["commit_title"] = _clean_commit_title(metadata.get("change", ""))
-    if not metadata["commit_summary"]:
-        metadata["commit_summary"] = _fallback_commit_summary(metadata)
+def _read_candidate_metadata(
+    path: Path,
+    *,
+    source: str,
+    original_source: str,
+) -> dict[str, str]:
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError as error:
+        raise ValueError("candidate_metadata.json was not created") from error
+    except (json.JSONDecodeError, OSError) as error:
+        raise ValueError(f"candidate metadata is not valid JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("candidate metadata must be a JSON object")
+    if payload.get("schema_version") != _METADATA_SCHEMA_VERSION:
+        raise ValueError(
+            f"candidate metadata schema_version must be {_METADATA_SCHEMA_VERSION}"
+        )
+
+    metadata: dict[str, str] = {}
+    for field in (*_SHORT_METADATA_FIELDS, "commit_title", "commit_summary"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"candidate metadata field {field!r} must be non-empty")
+        metadata[field] = value.strip()
+    for field in _SHORT_METADATA_FIELDS:
+        if "\n" in metadata[field] or len(metadata[field]) > 240:
+            raise ValueError(f"candidate metadata field {field!r} must be one line under 240 characters")
+        metadata[field] = _clean_short_metadata(metadata[field])
+
+    title = metadata["commit_title"]
+    if "\n" in title or len(title) >= 80:
+        raise ValueError("commit_title must be one line under 80 characters")
+    title = _clean_commit_title(title)
+    if title.casefold() in _GENERIC_COMMIT_TITLES:
+        raise ValueError("commit_title is too generic to describe the candidate diff")
+    metadata["commit_title"] = title
+
+    summary = metadata["commit_summary"]
+    if len(summary) >= 4000:
+        raise ValueError("commit_summary must be under 4000 characters")
+    match = _COMMIT_SUMMARY_RE.fullmatch(summary)
+    if match is None:
+        raise ValueError(
+            "commit_summary must contain exactly 'Change summary:' and 'Why:' sections"
+        )
+    if "Performance:" in summary or "tlx agent authored" in summary.casefold():
+        raise ValueError("commit_summary contains content reserved for the external harness")
+    changed_names = _changed_top_level_names(original_source, source)
+    if not changed_names:
+        raise ValueError("candidate source does not change a top-level scope")
+    if not any(name in match.group("change") for name in changed_names):
+        names = ", ".join(changed_names[:8])
+        raise ValueError(
+            "commit_summary must name at least one changed top-level scope: " + names
+        )
+    if not (_commit_words(title) & _commit_words(match.group("change"))):
+        raise ValueError("commit_title does not describe the commit_summary change")
+    change_summary = " ".join(match.group("change").split())
+    why = " ".join(match.group("why").split())
+    metadata["commit_summary"] = (
+        f"Change summary:\n{change_summary}\n\nWhy:\n{why}"
+    )
+
+    digest = payload.get("source_sha256")
+    expected_digest = hashlib.sha256(source.encode()).hexdigest()
+    if digest != expected_digest:
+        raise ValueError("candidate metadata source_sha256 does not match candidate.py")
+    metadata["source_sha256"] = expected_digest
     return metadata
 
 
@@ -225,9 +334,11 @@ class CodexCandidateProvider:
             with tempfile.TemporaryDirectory(prefix="tlx-agent-candidate-") as directory:
                 workspace = Path(directory)
                 candidate_path = workspace / "candidate.py"
+                original_path = workspace / "original.py"
                 output_path = workspace / "last-message.txt"
                 metadata_path = workspace / "candidate_metadata.json"
                 candidate_path.write_text(context.current_source)
+                original_path.write_text(context.current_source)
                 command = [
                     "codex",
                     "exec",
@@ -257,7 +368,13 @@ class CodexCandidateProvider:
                         + " | ".join(diagnostics[-8:])
                     )
                 source = candidate_path.read_text()
-                metadata = _read_candidate_metadata(metadata_path)
+                if original_path.read_text() != context.current_source:
+                    raise RuntimeError("candidate generator modified immutable original.py")
+                metadata = _read_candidate_metadata(
+                    metadata_path,
+                    source=source,
+                    original_source=context.current_source,
+                )
         except FileNotFoundError as error:
             raise RuntimeError(
                 "codex binary not found; install it or use --provider mock"
@@ -291,9 +408,11 @@ def _target_skill_paths(target: KernelTarget) -> tuple[Path, ...]:
     if backend not in {"cuda", "nvidia"}:
         return tuple(skills)
     architecture = target.architecture.strip().lower()
-    skills.append(_ASYNC_TMA_OUTPUT_SKILL)
+    skills.extend((_ASYNC_TMA_OUTPUT_SKILL, _NVIDIA_WARP_BARRIER_SKILL))
     if architecture in _BLACKWELL_ARCHITECTURES:
-        skills.extend((_BLACKWELL_CLC_SKILL, _BLACKWELL_PIPELINE_SKILL))
+        skills.append(_BLACKWELL_CLC_SKILL)
+    if architecture in _PERSISTENT_PIPELINE_ARCHITECTURES:
+        skills.append(_NVIDIA_PERSISTENT_PIPELINE_SKILL)
     return tuple(skills)
 
 

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/nvidia-persistent-pipeline-efficiency.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/nvidia-persistent-pipeline-efficiency.md
@@ -1,6 +1,6 @@
-# Blackwell Persistent Pipeline Efficiency
+# NVIDIA Persistent Pipeline Efficiency
 
-Apply this guidance to NVIDIA Blackwell kernels with persistent workers, preprocessing launches, asynchronous task pipelines, or staged output publication. Preserve the kernel's numerical and synchronization contracts; optimize data movement and scheduling without assuming a particular algorithm.
+Apply this guidance to NVIDIA Hopper and Blackwell kernels with persistent workers, preprocessing launches, asynchronous task pipelines, or staged output publication. Preserve the kernel's numerical and synchronization contracts; optimize data movement and scheduling without assuming a particular algorithm.
 
 ## Amortize Launch And Scheduling Overhead
 
@@ -28,7 +28,7 @@ Packed native arithmetic can reduce conversions and instruction count when opera
 
 Order pipeline stages by producer/consumer readiness rather than source order. Defer a load or barrier wait until immediately before first use when doing so creates useful overlap, but never move it past a dependency.
 
-TMEM and SMEM reuse require explicit lifetime proofs. Before aliasing storage:
+Reusable storage and synchronization state require explicit lifetime proofs. Before aliasing storage:
 
 - prove every compute operation and local load completed its final read;
 - prove every asynchronous store drained before its staging slot is overwritten;

--- a/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/nvidia-warp-barrier-efficiency.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/skills/targets/nvidia/nvidia-warp-barrier-efficiency.md
@@ -1,0 +1,48 @@
+# NVIDIA Warp Barrier Efficiency
+
+Apply this guidance to NVIDIA kernels that use TLX mbarriers. Treat barrier changes as synchronization protocol changes, not mechanical API substitutions. Preserve correctness first and promote only with stable end-to-end benchmark evidence.
+
+## Build A Barrier Ledger
+
+Before proposing a barrier optimization, inventory every relevant barrier and record:
+
+- its role: full/data-ready, empty/reuse, completion, scheduling, or handoff;
+- its signal source: explicit software arrival, TMA transaction, MMA completion, named barrier, remote arrival, or multicast;
+- the producer, consumer, and owner of the protected storage;
+- every task replica, warp, lane, predicate, arrive site, and wait site;
+- the expected arrival count and phase progression;
+- the final access that must complete before the protected storage is reused.
+
+Do not change a barrier whose role, participants, ownership, or phase cannot be proven from the complete kernel. Include prologue, steady-state, tail, boundary, and persistent outer-loop paths in the ledger.
+
+## Distinguish Arrival Protocols
+
+`tlx.alloc_barriers` uses ordinary leader-based software arrival lowering and may synchronize participating threads before the selected leader arrives. `tlx.alloc_warp_barrier` makes every participating thread arrive independently. Its initialized arrival count is:
+
+```text
+num_warps * 32 * num_arrivals
+```
+
+`num_warps` is the number of warps in one arriving task replica. `num_arrivals` is the number of all-thread arrival events targeting the same barrier in one phase, including replicated consumer tasks when each replica arrives once. Derive both values from the ledger; do not copy an ordinary barrier's logical arrival count into a warp-barrier allocation.
+
+Consult `.claude/skills/tlx-api-reference/SKILL.md` and nearby same-architecture kernels before using `tlx.alloc_warp_barrier`. Reuse a demonstrated topology rather than inventing an arrival protocol.
+
+## Select Only Safe Candidates
+
+Local barriers signaled by explicit software `tlx.barrier_arrive` calls are the primary candidates. Empty/reuse notifications are especially useful to evaluate when all consumer lanes release a shared-memory slot after their final read.
+
+Do not automatically convert:
+
+- TMA full/data-ready or transaction-completion barriers;
+- MMA or tensor-core completion barriers;
+- named scheduling barriers;
+- remote, multicast, or cross-CTA barriers;
+- predicated or divergent arrivals where any counted lane can skip an arrival.
+
+A warp barrier is safe only when every counted lane performs exactly the declared arrivals in every phase. For persistent kernels, prove the same topology across initial phases, ring wraparound, logical-task transitions, and the final tail.
+
+## Isolate And Measure The Change
+
+For the first A/B candidate, change only the allocator. Preserve the barrier's wait and arrive sites, ownership, protected buffer, buffer indices, and phase calculations. Keep paired TMA full barriers ordinary when evaluating warp barriers for software empty/reuse notifications.
+
+Warp barriers may remove leader-path synchronization, but they issue more per-thread mbarrier arrivals. They are not universally faster. Verify all protected correctness cases, then use stable end-to-end benchmark and profile evidence to decide whether the reduced synchronization cost outweighs the additional arrival instructions. Revert the candidate when the topology proof fails or the measured result is noisy, neutral, or slower.

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import tempfile
@@ -151,8 +152,11 @@ class ScoringTest(unittest.TestCase):
         self.assertIn("do not print source code or a patch", prompt)
         self.assertIn("candidate_metadata.json", prompt)
         self.assertIn("schema_version", prompt)
+        self.assertIn("source_sha256", prompt)
+        self.assertIn("original.py", prompt)
+        self.assertIn("final unified diff", prompt)
         self.assertIn("commit_title", prompt)
-        self.assertIn("actual source change", prompt)
+        self.assertIn("precisely describes the actual", prompt)
         self.assertIn("commit_summary", prompt)
         self.assertIn("Change summary:", prompt)
         self.assertIn("Why:", prompt)
@@ -162,8 +166,12 @@ class ScoringTest(unittest.TestCase):
         self.assertIn("Trusted built-in target optimization skills", prompt)
         self.assertIn("# TLX Layout Conversion Efficiency", prompt)
         self.assertIn("# NVIDIA Async TMA Output Publication", prompt)
+        self.assertIn("# NVIDIA Warp Barrier Efficiency", prompt)
+        self.assertIn("## Build A Barrier Ledger", prompt)
+        self.assertIn("tlx.alloc_warp_barrier", prompt)
+        self.assertIn("num_warps * 32 * num_arrivals", prompt)
         self.assertIn("# Blackwell Persistent CLC Scheduling", prompt)
-        self.assertIn("# Blackwell Persistent Pipeline Efficiency", prompt)
+        self.assertIn("# NVIDIA Persistent Pipeline Efficiency", prompt)
         self.assertIn("optimize data movement and scheduling", prompt)
         self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
         self.assertLess(
@@ -171,16 +179,70 @@ class ScoringTest(unittest.TestCase):
             prompt.index("# NVIDIA Async TMA Output Publication"),
         )
         self.assertLess(
+            prompt.index("# NVIDIA Async TMA Output Publication"),
+            prompt.index("# NVIDIA Warp Barrier Efficiency"),
+        )
+        self.assertLess(
+            prompt.index("# NVIDIA Warp Barrier Efficiency"),
+            prompt.index("# Blackwell Persistent CLC Scheduling"),
+        )
+        self.assertLess(
+            prompt.index("# Blackwell Persistent CLC Scheduling"),
+            prompt.index("# NVIDIA Persistent Pipeline Efficiency"),
+        )
+        self.assertLess(
             prompt.index("Trusted built-in target optimization skills"),
             prompt.index("Frozen target-specific optimization guidance"),
         )
 
-    def test_codex_prompt_selects_nvidia_non_blackwell_skill(self) -> None:
+    def test_codex_prompt_selects_hopper_persistent_pipeline_without_clc(self) -> None:
+        for architecture in ("hopper", "h100", "sm90", "sm_90"):
+            with self.subTest(architecture=architecture):
+                request = KernelOptimizationRequest(
+                    kernel_source="VALUE = 1\n",
+                    harness_path=Path(__file__),
+                    cases=(InputCase("target", {}),),
+                    target=KernelTarget("nvidia", architecture),
+                    output_dir=Path("/tmp/tlx-agent-test"),
+                )
+                prompt = _build_prompt(
+                    request,
+                    CandidateContext(
+                        1,
+                        0,
+                        request.kernel_source,
+                        _performance(("target", 100.0)),
+                        (),
+                    ),
+                )
+                self.assertIn("# TLX Layout Conversion Efficiency", prompt)
+                self.assertIn("# NVIDIA Async TMA Output Publication", prompt)
+                self.assertIn("# NVIDIA Warp Barrier Efficiency", prompt)
+                self.assertIn("## Build A Barrier Ledger", prompt)
+                self.assertIn("tlx.alloc_warp_barrier", prompt)
+                self.assertIn("num_warps * 32 * num_arrivals", prompt)
+                self.assertIn("# NVIDIA Persistent Pipeline Efficiency", prompt)
+                self.assertLess(
+                    prompt.index("# TLX Layout Conversion Efficiency"),
+                    prompt.index("# NVIDIA Async TMA Output Publication"),
+                )
+                self.assertLess(
+                    prompt.index("# NVIDIA Async TMA Output Publication"),
+                    prompt.index("# NVIDIA Warp Barrier Efficiency"),
+                )
+                self.assertLess(
+                    prompt.index("# NVIDIA Warp Barrier Efficiency"),
+                    prompt.index("# NVIDIA Persistent Pipeline Efficiency"),
+                )
+                self.assertNotIn("# Blackwell Persistent CLC Scheduling", prompt)
+                self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
+
+    def test_codex_prompt_does_not_inject_persistence_for_unknown_nvidia(self) -> None:
         request = KernelOptimizationRequest(
             kernel_source="VALUE = 1\n",
             harness_path=Path(__file__),
             cases=(InputCase("target", {}),),
-            target=KernelTarget("nvidia", "hopper"),
+            target=KernelTarget("nvidia", "sm89"),
             output_dir=Path("/tmp/tlx-agent-test"),
         )
         prompt = _build_prompt(
@@ -195,13 +257,12 @@ class ScoringTest(unittest.TestCase):
         )
         self.assertIn("# TLX Layout Conversion Efficiency", prompt)
         self.assertIn("# NVIDIA Async TMA Output Publication", prompt)
-        self.assertLess(
-            prompt.index("# TLX Layout Conversion Efficiency"),
-            prompt.index("# NVIDIA Async TMA Output Publication"),
-        )
+        self.assertIn("# NVIDIA Warp Barrier Efficiency", prompt)
+        self.assertIn("## Build A Barrier Ledger", prompt)
+        self.assertIn("tlx.alloc_warp_barrier", prompt)
+        self.assertIn("num_warps * 32 * num_arrivals", prompt)
+        self.assertNotIn("# NVIDIA Persistent Pipeline Efficiency", prompt)
         self.assertNotIn("# Blackwell Persistent CLC Scheduling", prompt)
-        self.assertNotIn("# Blackwell Persistent Pipeline Efficiency", prompt)
-        self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
 
     def test_codex_prompt_selects_common_skill_only_for_amd(self) -> None:
         guidance = "Preserve runtime scale behavior."
@@ -230,8 +291,11 @@ class ScoringTest(unittest.TestCase):
         self.assertIn("Trusted built-in target optimization skills", prompt)
         self.assertIn("# TLX Layout Conversion Efficiency", prompt)
         self.assertNotIn("# NVIDIA Async TMA Output Publication", prompt)
+        self.assertNotIn("# NVIDIA Warp Barrier Efficiency", prompt)
+        self.assertNotIn("## Build A Barrier Ledger", prompt)
+        self.assertNotIn("tlx.alloc_warp_barrier", prompt)
         self.assertNotIn("# Blackwell Persistent CLC Scheduling", prompt)
-        self.assertNotIn("# Blackwell Persistent Pipeline Efficiency", prompt)
+        self.assertNotIn("# NVIDIA Persistent Pipeline Efficiency", prompt)
         self.assertNotIn("# NVIDIA Target Profiling With NCU", prompt)
         self.assertLess(
             prompt.index("# TLX Layout Conversion Efficiency"),
@@ -278,32 +342,89 @@ class ScoringTest(unittest.TestCase):
         self.assertIn("speedup=0.9500x", prompt)
         self.assertNotIn(prior_source.strip(), prompt)
 
-    def test_candidate_metadata_reads_summary_and_builds_fallback(self) -> None:
+    def test_candidate_metadata_is_bound_to_changed_source_scope(self) -> None:
+        original = "def kernel():\n    return 1\n"
+        source = "def kernel():\n    return 2\n"
+        payload = {
+            "schema_version": 2,
+            "hypothesis": "Reduce repeated work.",
+            "evidence": "The profile attributes time to the repeated operation.",
+            "change": "Fold the repeated operation in kernel.",
+            "expected_effect": "Reduce instruction count.",
+            "risk": "Preserve the existing return type.",
+            "commit_title": "Fold repeated work in kernel",
+            "commit_summary": (
+                "Change summary:\nUpdate kernel to fold the repeated operation while "
+                "preserving its return contract.\n\nWhy:\nThe profile attributes time "
+                "to the repeated operation."
+            ),
+            "source_sha256": hashlib.sha256(source.encode()).hexdigest(),
+        }
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "candidate_metadata.json"
-            path.write_text(
-                json.dumps(
-                    {
-                        "schema_version": 1,
-                        "hypothesis": "  reduce   work ",
-                        "change": "Fold a constant scale.",
-                        "commit_title": "Fold half scale into dS encoding",
-                        "commit_summary": "Change summary:\nFold the scale into the encoded exponent.\n\nWhy:\nReduce repeated arithmetic while preserving the generic fallback.",
-                    }
-                )
+            path.write_text(json.dumps(payload))
+            metadata = _read_candidate_metadata(
+                path,
+                source=source,
+                original_source=original,
             )
-            metadata = _read_candidate_metadata(path)
-            self.assertEqual(metadata["hypothesis"], "reduce work")
-            self.assertEqual(metadata["commit_title"], "Fold half scale into dS encoding")
-            self.assertIn("encoded exponent", metadata["commit_summary"])
-            self.assertIn("generic fallback", metadata["commit_summary"])
+            self.assertEqual(metadata["hypothesis"], "Reduce repeated work.")
+            self.assertEqual(metadata["commit_title"], "Fold repeated work in kernel")
+            self.assertIn("Update kernel", metadata["commit_summary"])
 
-            path.write_text(json.dumps({"change": "Fold a constant scale."}))
-            fallback = _read_candidate_metadata(path)
-            self.assertEqual(fallback["commit_title"], "Fold a constant scale")
-            self.assertIn("Change summary:", fallback["commit_summary"])
-            self.assertIn("Fold a constant scale.", fallback["commit_summary"])
-            self.assertIn("Why:", fallback["commit_summary"])
+            stale = dict(payload, source_sha256="0" * 64)
+            path.write_text(json.dumps(stale))
+            with self.assertRaisesRegex(ValueError, "source_sha256"):
+                _read_candidate_metadata(
+                    path,
+                    source=source,
+                    original_source=original,
+                )
+
+            unrelated = dict(
+                payload,
+                commit_summary=(
+                    "Change summary:\nUpdate helper behavior.\n\n"
+                    "Why:\nReduce repeated work."
+                ),
+            )
+            path.write_text(json.dumps(unrelated))
+            with self.assertRaisesRegex(ValueError, "changed top-level scope: kernel"):
+                _read_candidate_metadata(
+                    path,
+                    source=source,
+                    original_source=original,
+                )
+
+            generic = dict(payload, commit_title="Optimize kernel")
+            path.write_text(json.dumps(generic))
+            with self.assertRaisesRegex(ValueError, "too generic"):
+                _read_candidate_metadata(
+                    path,
+                    source=source,
+                    original_source=original,
+                )
+
+            unrelated_title = dict(payload, commit_title="Pipeline descriptor stores")
+            path.write_text(json.dumps(unrelated_title))
+            with self.assertRaisesRegex(ValueError, "does not describe"):
+                _read_candidate_metadata(
+                    path,
+                    source=source,
+                    original_source=original,
+                )
+
+            malformed = dict(
+                payload,
+                commit_summary="Change summary:\nUpdate kernel without a rationale.",
+            )
+            path.write_text(json.dumps(malformed))
+            with self.assertRaisesRegex(ValueError, "exactly.*sections"):
+                _read_candidate_metadata(
+                    path,
+                    source=source,
+                    original_source=original,
+                )
 
     def test_codex_prompt_compacts_profile_and_preserves_scope_boundaries(self) -> None:
         request = KernelOptimizationRequest(


### PR DESCRIPTION
Summary:
Teach kernel optimization agents to evaluate NVIDIA warp barriers with an explicit synchronization proof, while preventing stale or unrelated agent metadata from reaching auto-created commits. Candidate metadata is bound to the final source and checked for structural and semantic consistency before promotion.

Add evidence-driven persistent-pipeline guidance for known Hopper and Blackwell targets. Require candidates to justify persistent worker counts from logical work and profiling, maintain one outer-task and ring-phase convention across asynchronous tasks, prove reusable-storage lifetimes across persistent iterations, and retain fallbacks for small or unsupported workloads. Keep Blackwell Cluster Launch Control guidance Blackwell-only and preserve existing behavior for unknown NVIDIA and non-NVIDIA architectures.

Update the TLX optimization workflow skill to document target-guidance selection and the profiling contract. Require real Proton launch attribution and native-profiler evidence from the target harness, explain baseline/candidate/finalist profile levels, and reject stub profiling that reports unavailable or zeroed evidence.

Differential Revision: D119228131
