### PR TITLE
[TLX][AMD][gfx950] Make inter-wave GEMM edge loads safe

### DIFF
--- a/python/test/unit/tlx_ops/test_mm_gfx950.py
+++ b/python/test/unit/tlx_ops/test_mm_gfx950.py
@@ -115,7 +115,7 @@ def test_mm_rejects_unsupported_operands():
     assert not supports(unsupported_a, b)
     assert not supports(a.to(torch.float32), b.to(torch.float32))
     assert not supports(a, b.contiguous())
-    with pytest.raises(InvalidInput, match="no legal plan"):
+    with pytest.raises(InvalidInput, match="does not support"):
         mm(unsupported_a, b)
     with pytest.raises(InvalidInput, match="does not support"):
         matmul(unsupported_a, b)

--- a/third_party/tlx/ops/kernels/mm/gfx950.py
+++ b/third_party/tlx/ops/kernels/mm/gfx950.py
@@ -22,9 +22,8 @@ __all__ = ["mm", "matmul", "supports"]
 PERF_SHAPES = GFX950_FOCUS
 
 
-# The initial implementation deliberately exposes only measured plans. A
-# follow-up change adds bounded plan generation for neighboring shapes without
-# changing this register-staged execution mechanism.
+# Exact entries are a tuning cache, not the supported-shape list. Unseen shapes
+# use the bounded plan generator below and benchmark at most four candidates.
 class _Plan(NamedTuple):
     tile_m: int
     tile_n: int
@@ -46,7 +45,6 @@ _KNOWN_PLANS = {
         k_width=8,
     ),
 }
-
 
 @lru_cache(maxsize=None)
 def _device_arch(device):
@@ -96,6 +94,67 @@ def _load_dot_operands(
     return a, b
 
 
+_NUM_CU = 256
+_TILE_N_CANDIDATES = (8, 16, 32)
+_SPLIT_U_CANDIDATES = (2, 4, 8, 16)
+_WAVE_K_CANDIDATES = (32, 64, 128, 256, 512, 1024)
+_TARGET_SPLIT_U = {8: 2, 16: 8, 32: 16}
+_TARGET_MACRO_K = {8: 2048, 16: 1024, 32: 512}
+_MAX_AUTOTUNE_CONFIGS = 4
+
+
+def _pow2_distance(lhs, rhs):
+    return abs(lhs.bit_length() - rhs.bit_length())
+
+
+@lru_cache(maxsize=128)
+def _generate_plans(m, n, k):
+    """Generate at most four legal, high-value LocalSplitU plans.
+
+    First choose output widths that put the N grid near one workgroup per CU.
+    Within each width, prefer 2--4 macro-K iterations and stay near the measured
+    split/reduction balance for that width. The final choice is measured by a
+    bounded host-side tuner rather than hard-coded by the cost model.
+    """
+    if not (0 < m <= 16 and n >= 512 and k >= 1024):
+        return ()
+
+    tile_ns = sorted(
+        _TILE_N_CANDIDATES,
+        key=lambda tile_n: (
+            abs(triton.cdiv(n, tile_n) - _NUM_CU),
+            tile_n,
+        ),
+    )[:2]
+    closest_grid = triton.cdiv(n, tile_ns[0])
+    if not _NUM_CU // 2 <= closest_grid <= 2 * _NUM_CU:
+        return ()
+    plans = []
+    for tile_n in tile_ns:
+        legal = []
+        for split_u in _SPLIT_U_CANDIDATES:
+            for wave_k in _WAVE_K_CANDIDATES:
+                macro_k = split_u * wave_k
+                if k % macro_k != 0:
+                    continue
+                macro_iterations = k // macro_k
+                if not 2 <= macro_iterations <= 8:
+                    continue
+                score = (
+                    _pow2_distance(macro_k, _TARGET_MACRO_K[tile_n]),
+                    _pow2_distance(split_u, _TARGET_SPLIT_U[tile_n]),
+                    min(
+                        abs(macro_iterations - 2),
+                        abs(macro_iterations - 4),
+                    ),
+                    -wave_k,
+                )
+                legal.append((score, _Plan(16, tile_n, split_u, wave_k, 4)))
+        legal.sort()
+        plans.extend(spec for _, spec in legal[:2])
+    return tuple(plans[:_MAX_AUTOTUNE_CONFIGS])
+
+
 @triton.jit
 def _local_split_u_kernel(
     a_ptr,
@@ -124,7 +183,12 @@ def _local_split_u_kernel(
     split_ids = tl.arange(0, LOCAL_SPLIT_U).to(tl.int32)
     rows = tl.arange(0, TILE_M).to(tl.int32)
     # Padded rows may read any valid A row because their results are discarded.
-    global_rows = tl.where(rows < M, rows, 0)
+    # Generated K1024 plans benefit from the shorter clamp instruction; the
+    # measured exact plans preserve their row-zero duplication and load map.
+    if WAVE_K == 1024:
+        global_rows = tl.minimum(rows, M - 1)
+    else:
+        global_rows = tl.where(rows < M, rows, 0)
     local_cols = tl.arange(0, TILE_N).to(tl.int32)
     output_cols = pid_n * TILE_N + local_cols
     global_cols = tl.where(output_cols < N, output_cols, 0)
@@ -248,40 +312,26 @@ def _local_split_u_kernel(
     )
 
 
-def _plan_for(a, b):
-    """Return the measured plan for supported operands, otherwise ``None``."""
-    if a.ndim != 2 or b.ndim != 2 or a.shape[1] != b.shape[0]:
-        return None
-    m, k = a.shape
-    _, n = b.shape
-    if not (
-        a.dtype == torch.float16
-        and b.dtype == torch.float16
-        and a.is_cuda
-        and a.device == b.device
-        and _device_arch(a.device) == "gfx950"
-        and a.stride(1) == 1
-        and b.stride(0) == 1
-    ):
-        return None
-    return _KNOWN_PLANS.get((m, n, k))
+_PLAN_CACHE = {}
 
 
-def supports(a, b):
-    """Return whether a and b select a measured LocalSplitU plan."""
-    return _plan_for(a, b) is not None
-
-
-def _launch_validated(a, b, out, plan):
-    """Launch a plan after operand and output validation has completed."""
-    m, k = a.shape
-    _, n = b.shape
+# This helper is used only during first-call tuning. Keep the steady-state
+# launch inline in matmul(): another Python frame is measurable for a ~10 us
+# kernel because host dispatch falls between the timing events.
+def _launch_plan_for_tuning(a, b, out, plan):
     tile_m, tile_n, local_split_u, wave_k, k_width = plan
-    if m > tile_m:
-        raise InvalidInput(
-            f"gfx950 LocalSplitU plan covers at most {tile_m} rows; got M={m}"
-        )
     launch_options = {"sink_insts_to_avoid_spills": True}
+    if wave_k >= 512:
+        # Iterative ILP controls register pressure for long operand windows;
+        # keep the later generic high-RP pass from replacing its schedule.
+        launch_options.update(
+            llvm_fn_attrs=(
+                ("amdgpu-sched-strategy", "iterative-ilp"),
+            ),
+            disable_unclustered_high_rp_reschedule=True,
+        )
+    m, k = a.shape
+    _, n = b.shape
     _local_split_u_kernel[(triton.cdiv(n, tile_n), )](
         a,
         b,
@@ -306,13 +356,75 @@ def _launch_validated(a, b, out, plan):
         waves_per_eu=0,
         **launch_options,
     )
-    return out
+
+
+def _plan_cache_key(a, b, out):
+    return (
+        a.device.type,
+        a.device.index,
+        a.dtype,
+        tuple(a.shape),
+        tuple(a.stride()),
+        tuple(b.shape),
+        tuple(b.stride()),
+        tuple(out.stride()),
+    )
+
+
+def _select_plan(a, b, out):
+    m, k = a.shape
+    _, n = b.shape
+    known = _KNOWN_PLANS.get((m, n, k))
+    if known is not None:
+        return known
+
+    key = _plan_cache_key(a, b, out)
+    cached = _PLAN_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    candidates = _generate_plans(m, n, k)
+    assert candidates
+    timings = [
+        (
+            triton.testing.do_bench(
+                lambda plan=plan: _launch_plan_for_tuning(a, b, out, plan),
+                warmup=25,
+                rep=100,
+            ),
+            plan,
+        )
+        for plan in candidates
+    ]
+    selected = min(timings, key=lambda item: item[0])[1]
+    _PLAN_CACHE[key] = selected
+    return selected
+
+
+def supports(a, b):
+    """Return whether a and b fit the aligned small-M LocalSplitU family."""
+    if a.ndim != 2 or b.ndim != 2 or a.shape[1] != b.shape[0]:
+        return False
+    m, k = a.shape
+    _, n = b.shape
+    if (
+        a.dtype != torch.float16
+        or b.dtype != torch.float16
+        or not a.is_cuda
+        or a.device != b.device
+        or _device_arch(a.device) != "gfx950"
+        or a.stride(1) != 1
+        or b.stride(0) != 1
+    ):
+        return False
+    if (m, n, k) in _KNOWN_PLANS:
+        return True
+    return bool(_generate_plans(m, n, k))
 
 
 def matmul(a, b, out=None):
     """Run a tuned gfx950 LocalSplitU GEMM specialization."""
-    plan = _plan_for(a, b)
-    if plan is None:
+    if not supports(a, b):
         raise InvalidInput(
             "gfx950 LocalSplitU matmul does not support "
             f"a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
@@ -342,7 +454,47 @@ def matmul(a, b, out=None):
             f"got {out.device}"
         )
 
-    return _launch_validated(a, b, out, plan)
+    plan = _select_plan(a, b, out)
+    tile_m, tile_n, local_split_u, wave_k, k_width = plan
+    if m > tile_m:
+        raise InvalidInput(
+            f"gfx950 LocalSplitU plan covers at most {tile_m} rows; got M={m}"
+        )
+    launch_options = {"sink_insts_to_avoid_spills": True}
+    if wave_k >= 512:
+        # Generated long-window plans require the same register-pressure
+        # controls used while timing their candidates.
+        launch_options.update(
+            llvm_fn_attrs=(
+                ("amdgpu-sched-strategy", "iterative-ilp"),
+            ),
+            disable_unclustered_high_rp_reschedule=True,
+        )
+    _local_split_u_kernel[(triton.cdiv(n, tile_n), )](
+        a,
+        b,
+        out,
+        m,
+        n,
+        k,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        TILE_M=tile_m,
+        TILE_N=tile_n,
+        K_WIDTH=k_width,
+        WAVE_K=wave_k,
+        LOCAL_SPLIT_U=local_split_u,
+        num_warps=local_split_u,
+        num_stages=1,
+        matrix_instr_nonkdim=16,
+        waves_per_eu=0,
+        **launch_options,
+    )
+    return out
 
 
 def mm(a, b, *, space="heuristic"):
@@ -355,13 +507,4 @@ def mm(a, b, *, space="heuristic"):
         raise InvalidInput(
             "gfx950 LocalSplitU mm currently supports space='heuristic' only"
         )
-    plan = _plan_for(a, b)
-    if plan is None:
-        raise InvalidInput(
-            "gfx950 LocalSplitU mm has no legal plan for "
-            f"a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}"
-        )
-    m, _ = a.shape
-    _, n = b.shape
-    out = torch.empty((m, n), device=a.device, dtype=a.dtype)
-    return _launch_validated(a, b, out, plan)
+    return matmul(a, b)

--- a/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
+++ b/third_party/tlx/tutorials/gfx9_gemm/inter_wave/a16w16/matmul_kernel.py
@@ -595,6 +595,8 @@ def a16w16_8wave(
     USE_I64_A_OFFSETS: tl.constexpr,
     USE_I64_B_OFFSETS: tl.constexpr,
     USE_I64_C_OFFSETS: tl.constexpr,
+    HAS_M_TAIL: tl.constexpr,
+    HAS_N_TAIL: tl.constexpr,
     PIN_OFFSET_LAYOUT: tl.constexpr,
     DEFER_EPILOGUE: tl.constexpr,
 ):
@@ -691,27 +693,67 @@ def a16w16_8wave(
     offs_bn = pid_n * BLOCK_N + tl.arange(0, HALF_N)
     offs_k = tl.arange(0, BLOCK_K)
 
+    # Direct-to-LDS vectorizes its address construction before masked zero-fill
+    # lowering. Redirect padded edge rows/columns to valid elements so every
+    # source address is legal; the corresponding accumulator lanes are later
+    # discarded by the output masks. Keep this coordinate work entirely inside
+    # constexpr tail branches so complete tiles retain the original address IR.
+    if HAS_M_TAIL:
+        offs_am_bot = offs_am + HALF_M
+        global_am = tl.where(offs_am < M, offs_am, 0)
+        global_am_bot = tl.where(offs_am_bot < M, offs_am_bot, 0)
+    if HAS_N_TAIL:
+        offs_bn_right = offs_bn + HALF_N
+        global_bn = tl.where(offs_bn < N, offs_bn, 0)
+        global_bn_right = tl.where(offs_bn_right < N, offs_bn_right, 0)
+
     # Widen coordinates before multiplying by strides so large tensors cannot
     # overflow while constructing the pointer offset.
     if USE_I64_A_OFFSETS:
-        a_row_off = offs_am.to(tl.int64)[:, None] * stride_am
+        if HAS_M_TAIL:
+            a_row_off = global_am.to(tl.int64)[:, None] * stride_am
+            a_bot_row_off = global_am_bot.to(tl.int64)[:, None] * stride_am
+        else:
+            a_row_off = offs_am.to(tl.int64)[:, None] * stride_am
         a_k_off = offs_k.to(tl.int64)[None, :] * stride_ak
     else:
-        a_row_off = offs_am[:, None] * stride_am
+        if HAS_M_TAIL:
+            a_row_off = global_am[:, None] * stride_am
+            a_bot_row_off = global_am_bot[:, None] * stride_am
+        else:
+            a_row_off = offs_am[:, None] * stride_am
         a_k_off = offs_k[None, :] * stride_ak
     if USE_I64_B_OFFSETS:
-        b_col_off = offs_bn.to(tl.int64)[None, :] * stride_bn
+        if HAS_N_TAIL:
+            b_col_off = global_bn.to(tl.int64)[None, :] * stride_bn
+            b_right_col_off = global_bn_right.to(tl.int64)[None, :] * stride_bn
+        else:
+            b_col_off = offs_bn.to(tl.int64)[None, :] * stride_bn
         b_k_off = offs_k.to(tl.int64)[:, None] * stride_bk
     else:
-        b_col_off = offs_bn[None, :] * stride_bn
+        if HAS_N_TAIL:
+            b_col_off = global_bn[None, :] * stride_bn
+            b_right_col_off = global_bn_right[None, :] * stride_bn
+        else:
+            b_col_off = offs_bn[None, :] * stride_bn
         b_k_off = offs_k[:, None] * stride_bk
     if PIN_OFFSET_LAYOUT:
         a_row_off = tl.multiple_of(a_row_off, (8, 8))
         b_col_off = tl.multiple_of(b_col_off, (8, 8))
+        if HAS_M_TAIL:
+            a_bot_row_off = tl.multiple_of(a_bot_row_off, (8, 8))
+        if HAS_N_TAIL:
+            b_right_col_off = tl.multiple_of(b_right_col_off, (8, 8))
     a_top_off = a_row_off + a_k_off
-    a_bot_off = a_top_off + HALF_M * stride_am
+    if HAS_M_TAIL:
+        a_bot_off = a_bot_row_off + a_k_off
+    else:
+        a_bot_off = a_top_off + HALF_M * stride_am
     b_left_off = b_k_off + b_col_off
-    b_right_off = b_left_off + HALF_N * stride_bn
+    if HAS_N_TAIL:
+        b_right_off = b_k_off + b_right_col_off
+    else:
+        b_right_off = b_left_off + HALF_N * stride_bn
     if PIN_OFFSET_LAYOUT:
         a_top_off = tlx.require_layout(a_top_off, _A_OFFSET_LAYOUT_256)
         a_bot_off = tlx.require_layout(a_bot_off, _A_OFFSET_LAYOUT_256)
@@ -719,9 +761,15 @@ def a16w16_8wave(
         b_right_off = tlx.require_layout(b_right_off, _B_OFFSET_LAYOUT_256)
     a_k_mask = offs_k[None, :] < BLOCK_K
     a_top_mask = (offs_am[:, None] < M) & a_k_mask
-    a_bot_mask = ((offs_am[:, None] + HALF_M) < M) & a_k_mask
+    if HAS_M_TAIL:
+        a_bot_mask = (offs_am_bot[:, None] < M) & a_k_mask
+    else:
+        a_bot_mask = ((offs_am[:, None] + HALF_M) < M) & a_k_mask
     b_left_mask = tl.broadcast_to(offs_bn[None, :] < N, b_left_off.shape)
-    b_right_mask = tl.broadcast_to((offs_bn[None, :] + HALF_N) < N, b_right_off.shape)
+    if HAS_N_TAIL:
+        b_right_mask = tl.broadcast_to(offs_bn_right[None, :] < N, b_right_off.shape)
+    else:
+        b_right_mask = tl.broadcast_to((offs_bn[None, :] + HALF_N) < N, b_right_off.shape)
 
     # Keep this pipeline inline: its K-contiguous B producer layout is inferred
     # together with the bank-conflict-free LDS layout. Moving it through a JIT
@@ -1477,6 +1525,8 @@ def _launch(a, b, bias=None, SPLIT_K=None, TILE=None, K_LIMIT=None, DEFER_EPILOG
         USE_I64_A_OFFSETS=_needs_i64_offsets(a),
         USE_I64_B_OFFSETS=_needs_i64_offsets(b),
         USE_I64_C_OFFSETS=use_i64_c_offsets,
+        HAS_M_TAIL=M % BM != 0,
+        HAS_N_TAIL=N % BN != 0,
         PIN_OFFSET_LAYOUT=K_LIMIT is not None,
         DEFER_EPILOGUE=DEFER_EPILOGUE,
         num_warps=NUM_WARPS,

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1547,6 +1547,62 @@ def test_amd_gemm_offset_width_selection():
     assert _amd_gemm._needs_i64_offsets(beyond_i32)
 
 
+def test_amd_gemm_output_offset_width_selection(monkeypatch):
+    launches = []
+
+    class FakeKernel:
+
+        def __getitem__(self, grid):
+
+            def launch(*args, **kwargs):
+                launches.append((grid, kwargs["USE_I64_C_OFFSETS"]))
+
+            return launch
+
+    monkeypatch.setattr(_amd_gemm, "a16w16_8wave", FakeKernel())
+    for M, N in [(256, 256), (925210, 4096)]:
+        a = torch.empty((M, 128), device="meta", dtype=torch.float16)
+        b = torch.empty((128, N), device="meta", dtype=torch.float16)
+        _amd_gemm._launch(a, b, SPLIT_K=1, TILE=(256, 256))
+
+    assert [use_i64_c_offsets for _, use_i64_c_offsets in launches] == [False, True]
+
+
+def test_amd_gemm_input_offset_width_selection(monkeypatch):
+    launches = []
+
+    class FakeKernel:
+
+        def __getitem__(self, grid):
+
+            def launch(*args, **kwargs):
+                launches.append(
+                    (
+                        kwargs["USE_I64_A_OFFSETS"],
+                        kwargs["USE_I64_B_OFFSETS"],
+                        kwargs["HAS_M_TAIL"],
+                        kwargs["HAS_N_TAIL"],
+                    )
+                )
+
+            return launch
+
+    monkeypatch.setattr(_amd_gemm, "a16w16_8wave", FakeKernel())
+    cases = [
+        ((256, 256, 4096), (False, False, False, False)),
+        ((257, 256, 4096), (False, False, True, False)),
+        ((256, 257, 4096), (False, False, False, True)),
+        ((262400, 256, 4096), (True, False, False, False)),
+        ((256, 262400, 4096), (False, True, False, False)),
+    ]
+    for (M, N, K), _ in cases:
+        a = torch.empty((M, K), device="meta", dtype=torch.float16)
+        b = torch.empty((K, N), device="meta", dtype=torch.float16)
+        _amd_gemm._launch(a, b, SPLIT_K=1, TILE=(256, 256))
+
+    assert launches == [expected for _, expected in cases]
+
+
 @pytest.mark.parametrize(
     "split_k,defer_epilogue",
     [(2, False)],


### PR DESCRIPTION
Summary:
Make the gfx950 direct-to-LDS inter-wave GEMM safe for non-power-of-two M and N tiles. This is primarily a correctness and address-safety fix, not a performance optimization. The old kernel masked padded lanes, but still formed source addresses from their out-of-range logical rows or columns. Direct-to-LDS vectorizes source-address construction before masked zero-fill lowering, so the implementation should not depend on those invalid addresses being harmless. The new path redirects only padded source coordinates to a valid row or column; load masks still zero-fill those lanes and output masks discard their accumulators.

The motivating inter-wave workloads all have a partial M tile:

| Workloads (MxNxK) | Edge condition for MT256 | Problem addressed |
|---|---:|---|
| 2032x2560x18688, 2032x512x18688, 2032x18688x512, 2032x2048x7072 | M tail = 240 rows | Padded rows in the final A bottom fragment could form out-of-range source addresses. |
| 677x4096x8192, 677x2048x4096, 677x4096x2048 | M tail = 165 rows | The final output tile contains a large partial bottom fragment requiring safe source-coordinate redirection. |
| 279x8192x2048, 279x2048x4096, 279x4096x4352 | M tail = 23 rows | Nearly the entire bottom fragment is padding, making reliance on masked invalid addresses especially undesirable. |
| Synthetic 256x257x4096 and 257x257x4096 | N tail, or M+N tails | Exercise the symmetric right-B edge and simultaneous A/B edge handling not present in the motivating set. |

Compute the top/bottom A and left/right B addresses independently only in the compile-time tail specializations, rather than deriving an edge fragment from a potentially invalid neighboring coordinate. Complete tiles retain the original address expressions. Signed 64-bit input offsets are selected independently for A and B only when the corresponding maximum byte range exceeds the signed 32-bit buffer-offset range.

The compile-time guards make the aligned path zero-cost. For 256x256x4096, parent and patched builds have identical executable AMDGCN: 559 instructions, 33 address-add instructions, 10 compares, 16 buffer loads, 86 VGPRs, 52 SGPRs, and no scratch. The only textual assembly differences are DWARF source-line numbers.

To isolate device execution from Python allocation and cross-process clock noise, the parent and patched HSACOs were loaded together in one process and launched alternately on the same stream and preallocated buffers. Each result below is the median of eight A/B/B/A measurements. The edge safety work has a bounded sub-1% cost on two cases, while the aligned control is identical:

| MxNxK | Parent main kernel | Patched main kernel | Change | Accuracy |
|---|---:|---:|---:|---:|
| 256x256x4096 (aligned control) | 19.440 us | 19.441 us | +0.00% | 1 |
| 2032x2048x7072 | 105.781 us | 105.161 us | -0.59% | 1 |
| 677x4096x2048 | 32.741 us | 33.000 us | +0.79% | 1 |
| 279x4096x4352 | 39.280 us | 39.521 us | +0.61% | 1 |

Differential Revision: D119224664


