### PR TITLE
[triton][tlx] Round-trip elementwise inline asm attributes in TTGIR-to-TLX

### DIFF
--- a/test/TLX/print-ttgir-to-tlx-assert.mlir
+++ b/test/TLX/print-ttgir-to-tlx-assert.mlir
@@ -1,0 +1,41 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that tt.assert round-trips to tl.device_assert with its message.
+//
+// Unmapped, this prints as `tt.assert(cond)`, and `assert` being a Python keyword
+// makes that a syntax error that takes the whole file down, not one bad name.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def assert_scalar(
+  // CHECK: tl.device_assert([[C:[a-zA-Z_0-9]+]], "index out of range")
+  // CHECK-NOT: tt.assert
+  tt.func public @assert_scalar(%arg0: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %cond = arith.cmpi sge, %arg0, %c0_i32 : i32
+    tt.assert %cond, "index out of range" : i1
+    tt.return
+  }
+
+  // A message carrying characters that are not legal inside a Python string
+  // literal has to be escaped, not passed through. DEL is a control character
+  // above the C0 range, so it needs escaping too.
+  // CHECK-LABEL: def assert_quoted_message(
+  // CHECK: tl.device_assert({{[a-zA-Z_0-9]+}}, "bad \"x\":\\y\nz\x7f")
+  tt.func public @assert_quoted_message(%arg0: i32) attributes {noinline = false} {
+    %c0_i32 = arith.constant 0 : i32
+    %cond = arith.cmpi sge, %arg0, %c0_i32 : i32
+    tt.assert %cond, "bad \22x\22:\5Cy\0Az\7F" : i1
+    tt.return
+  }
+
+  // The condition is commonly a tensor rather than a scalar.
+  // CHECK-LABEL: def assert_tensor(
+  // CHECK: tl.device_assert({{[a-zA-Z_0-9]+}}, "mask must hold")
+  tt.func public @assert_tensor() attributes {noinline = false} {
+    %cst = arith.constant dense<0> : tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    %cond = arith.cmpi sge, %cst, %cst : tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    tt.assert %cond, "mask must hold" : tensor<128xi1, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-ballot.mlir
+++ b/test/TLX/print-ttgir-to-tlx-ballot.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that ttng.vote_ballot_sync round-trips to its TLX spelling.
+//
+// Operands match, so only the name needs mapping -- and it has to be the name the
+// DSL exports, not the MLIR op name with the dialect prefix swapped.
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // CHECK-LABEL: def ballot_scalar(
+  // CHECK: {{[a-zA-Z_0-9]+}} = tlx.vote_ballot_sync(-1, {{[a-zA-Z_0-9]+}})
+  tt.func public @ballot_scalar(%arg0: f32) attributes {noinline = false} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %mask = arith.constant -1 : i32
+    %pred = arith.cmpf olt, %arg0, %cst : f32
+    %0 = ttng.vote_ballot_sync %mask, %pred : i1 -> i32
+    tt.return
+  }
+
+  // The mask is an ordinary operand, so a narrower one is carried through rather
+  // than assumed to be all-lanes.
+  // CHECK-LABEL: def ballot_partial_mask(
+  // CHECK: tlx.vote_ballot_sync(255, {{[a-zA-Z_0-9]+}})
+  tt.func public @ballot_partial_mask(%arg0: f32) attributes {noinline = false} {
+    %cst = arith.constant 1.000000e+00 : f32
+    %mask = arith.constant 255 : i32
+    %pred = arith.cmpf olt, %arg0, %cst : f32
+    %0 = ttng.vote_ballot_sync %mask, %pred : i1 -> i32
+    tt.return
+  }
+
+  // The predicate may be a tensor, in which case the result is one too.
+  // CHECK-LABEL: def ballot_tensor(
+  // CHECK: {{[a-zA-Z_0-9]+}} = tlx.vote_ballot_sync(-1, {{[a-zA-Z_0-9]+}})
+  tt.func public @ballot_tensor() attributes {noinline = false} {
+    %mask = arith.constant -1 : i32
+    %cst = arith.constant dense<0> : tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    %pred = arith.cmpi slt, %cst, %cst : tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    %0 = ttng.vote_ballot_sync %mask, %pred : tensor<128xi1, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>> -> tensor<128xi32, #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-inline-asm.mlir
+++ b/test/TLX/print-ttgir-to-tlx-inline-asm.mlir
@@ -1,0 +1,50 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that tt.elementwise_inline_asm round-trips with its attributes.
+//
+// Four of the six arguments tl.inline_asm_elementwise takes are attributes on the
+// op, so the generic printer emits only the operands and produces a call that
+// looks mapped but cannot compile.
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // The operands become one `args` list, and asm text, constraints, purity and
+  // packing are recovered from the attributes.
+  // CHECK-LABEL: def asm_single(
+  // CHECK: {{[a-zA-Z_0-9]+}} = tl.inline_asm_elementwise("mov.b32 $0, $1;", "=r,r", [{{[a-zA-Z_0-9]+}}], tl.float32, True, 1)
+  tt.func public @asm_single() attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32, #blocked>
+    %0 = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %cst : tensor<128xf32, #blocked> -> tensor<128xf32, #blocked>
+    tt.return
+  }
+
+  // Multiple results bind as a tuple and dtype becomes a list.
+  // CHECK-LABEL: def asm_multi(
+  // CHECK: {{[a-zA-Z_0-9]+}}, {{[a-zA-Z_0-9]+}} = tl.inline_asm_elementwise({{.*}}, [tl.float32, tl.int32], True, 2)
+  tt.func public @asm_multi() attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32, #blocked>
+    %0:2 = tt.elementwise_inline_asm "mov.b32 $0, $2;" {constraints = "=r,=r,r", packed_element = 2 : i32, pure = true} %cst : tensor<128xf32, #blocked> -> tensor<128xf32, #blocked>, tensor<128xi32, #blocked>
+    tt.return
+  }
+
+  // Impure asm has to stay impure, or the round-tripped kernel is free to have it
+  // hoisted or eliminated.
+  // CHECK-LABEL: def asm_impure(
+  // CHECK: tl.inline_asm_elementwise({{.*}}, tl.float32, False, 1)
+  tt.func public @asm_impure() attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32, #blocked>
+    %0 = tt.elementwise_inline_asm "mov.b32 $0, $1;" {constraints = "=r,r", packed_element = 1 : i32, pure = false} %cst : tensor<128xf32, #blocked> -> tensor<128xf32, #blocked>
+    tt.return
+  }
+
+  // Real PTX is multi-line and quoted, so the asm text has to be escaped rather
+  // than pasted into the string literal.
+  // CHECK-LABEL: def asm_multiline(
+  // CHECK: tl.inline_asm_elementwise("\n  .reg .b32 r;\n  mov.b32 $0, \"x\";\n", "=r,r", {{.*}})
+  tt.func public @asm_multiline() attributes {noinline = false} {
+    %cst = arith.constant dense<1.000000e+00> : tensor<128xf32, #blocked>
+    %0 = tt.elementwise_inline_asm "\0A  .reg .b32 r;\0A  mov.b32 $0, \22x\22;\0A" {constraints = "=r,r", packed_element = 1 : i32, pure = true} %cst : tensor<128xf32, #blocked> -> tensor<128xf32, #blocked>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx-tmem.mlir
+++ b/test/TLX/print-ttgir-to-tlx-tmem.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-opt --tlx-print-ttgir-to-tlx %s | FileCheck %s
+
+// Test that tensor-memory allocations round-trip with a two-dimensional tile shape.
+//
+// local_alloc takes one buffer's shape plus a count. A buffer is up to 2-D, so only
+// a rank above that is multi-buffering: a rank-2 TMEM memdesc is one 2-D tile, not a
+// count and a 1-D tile.
+
+#tmem_wide = #ttng.tensor_memory_encoding<blockM = 128, blockN = 256, colStride = 1>
+#tmem_tile = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+
+  // A rank-2 TMEM memdesc is one tile: both dimensions belong to the shape and
+  // the count is 1.
+  // CHECK-LABEL: def tmem_rank2(
+  // CHECK: tlx.local_alloc((128, 256), tl.int32, 1, tlx.storage_kind.tmem)
+  tt.func public @tmem_rank2() attributes {noinline = false} {
+    %0 = ttng.tmem_alloc : () -> !ttg.memdesc<128x256xi32, #tmem_wide, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // A rank-3 TMEM memdesc keeps the existing split: the leading dimension is the
+  // buffer count and the trailing two are the tile.
+  // CHECK-LABEL: def tmem_rank3(
+  // CHECK: tlx.local_alloc((128, 128), tl.float32, 2, tlx.storage_kind.tmem)
+  tt.func public @tmem_rank3() attributes {noinline = false} {
+    %0 = ttng.tmem_alloc : () -> !ttg.memdesc<2x128x128xf32, #tmem_tile, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // The storage-alias path (memdesc_reinterpret) applies the same rule, and is
+  // where the rank-2 base allocation of an aliased buffer shows up.
+  // CHECK-LABEL: def tmem_alias(
+  // CHECK: [[BASE:[a-zA-Z_0-9]+]] = tlx.local_alloc((128, 256), tl.int32, 1, tlx.storage_kind.tmem)
+  // CHECK: tlx.local_alloc((128, 128), tl.float32, 2, tlx.storage_kind.tmem, reuse=[[BASE]])
+  tt.func public @tmem_alias() attributes {noinline = false} {
+    %0 = ttng.tmem_alloc : () -> !ttg.memdesc<128x256xi32, #tmem_wide, #ttng.tensor_memory, mutable>
+    %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<128x256xi32, #tmem_wide, #ttng.tensor_memory, mutable> -> !ttg.memdesc<2x128x128xf32, #tmem_tile, #ttng.tensor_memory, mutable>
+    tt.return
+  }
+
+  // memdesc_reinterpret is legal on shared memory too. The alias must use the
+  // same buffer-count rule as the base allocation, or the two describe different
+  // buffer counts over the same storage, and the storage kind is the default.
+  // CHECK-LABEL: def smem_alias(
+  // CHECK: [[SBASE:[a-zA-Z_0-9]+]] = tlx.local_alloc((2, 256), tl.int32, 1)
+  // CHECK: tlx.local_alloc((2, 128), tl.float32, 1, reuse=[[SBASE]])
+  // CHECK-NOT: storage_kind.tmem
+  tt.func public @smem_alias() attributes {noinline = false} {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<2x256xi32, #shared, #smem, mutable>
+    %1 = ttg.memdesc_reinterpret %0 : !ttg.memdesc<2x256xi32, #shared, #smem, mutable> -> !ttg.memdesc<2x128xf32, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1248,3 +1248,47 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// The async-copy group ops take their tokens as a list, and async_wait carries
+// its outstanding-group count in the `num` attribute rather than an operand.
+// Printed positionally, the second token binds to async_load_commit_group's
+// `_semantic` and async_load_wait_group loses its required `pendings` argument,
+// so neither survives recompilation.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: def async_copy_groups(
+  // CHECK: [[T0:[a-z0-9_]+]] = tlx.async_load(
+  // CHECK: [[T1:[a-z0-9_]+]] = tlx.async_load(
+  // Capture the commit result so the wait is pinned to the token that commit
+  // actually produced, not merely to some identifier.
+  // CHECK: [[G:[a-z0-9_]+]] = tlx.async_load_commit_group([[[T0]], [[T1]]])
+  // The leading pendings count comes from the `num` attribute, not an operand.
+  // CHECK: tlx.async_load_wait_group(1, [[[G]]])
+  tt.func public @async_copy_groups(%ptr: !tt.ptr<f16>, %offs: tensor<64x64xi32, #blocked>,
+                                    %mask: tensor<64x64xi1, #blocked>) attributes {noinline = false} {
+    %d0 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %d1 = ttg.local_alloc : () -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
+    %t0 = amdg.buffer_load_to_local %ptr[%offs] mask = %mask into %d0 : <f16>[tensor<64x64xi32, #blocked>] tensor<64x64xf16, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+    %t1 = amdg.buffer_load_to_local %ptr[%offs] mask = %mask into %d1 : <f16>[tensor<64x64xi32, #blocked>] tensor<64x64xf16, #blocked> -> <64x64xf16, #shared, #smem, mutable>
+    %g = ttg.async_commit_group tokens %t0, %t1
+    %w = ttg.async_wait %g {num = 1 : i32}
+    tt.return
+  }
+
+  // A token-less commit group is valid IR -- the assembly format makes the
+  // token list optional -- so the empty-list and omitted-list branches are
+  // both reachable.
+  // CHECK-LABEL: def async_groups_no_tokens(
+  // CHECK: tlx.async_load_commit_group([])
+  // CHECK: tlx.async_load_wait_group(0)
+  tt.func public @async_groups_no_tokens() attributes {noinline = false} {
+    %g = ttg.async_commit_group
+    %w = ttg.async_wait {num = 0 : i32}
+    tt.return
+  }
+}

--- a/test/TLX/print-ttgir-to-tlx.mlir
+++ b/test/TLX/print-ttgir-to-tlx.mlir
@@ -1292,3 +1292,114 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// An element-type cast is what the source kernel wrote as `x.to(dtype)`. The
+// printer erases layout- and shape-only casts as transparent; erasing this one
+// too leaves a later tl.dot seeing mismatched operand dtypes, which is a hard
+// error on recompile rather than a silent difference.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: def element_type_cast(
+  // The truncf must survive as .to(), or its consumer sees an f32 operand.
+  // CHECK: arg0.to(tl.bfloat16) * arg1
+  tt.func public @element_type_cast(%p: tensor<64x64xf32, #blocked>,
+                                    %v: tensor<64x64xbf16, #blocked>) attributes {noinline = false} {
+    %pt = arith.truncf %p : tensor<64x64xf32, #blocked> to tensor<64x64xbf16, #blocked>
+    %r = arith.mulf %pt, %v : tensor<64x64xbf16, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+// Edge cases of re-emitting a cast: `.to` binds to the operand text, the dtype
+// has to be one TLX can name, and a store must not append a second cast on top
+// of one the operand name already carries.
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // `.to` is a tensor method, so an inlined constant cannot carry it --
+  // `(0).to(tl.float32)` raises AttributeError at kernel compile time. tl.cast
+  // accepts the same value as a plain call.
+  // CHECK-LABEL: def cast_of_constant(
+  // CHECK: tl.cast(0, tl.float32)
+  // CHECK-NOT: 0.to(
+  tt.func public @cast_of_constant() attributes {noinline = false} {
+    %c = arith.constant 0 : i32
+    %f = arith.sitofp %c : i32 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // fp8 does have a TLX spelling, so the cast survives rather than being erased.
+  // CHECK-LABEL: def cast_to_fp8(
+  // CHECK: arg0.to(tl.float8e4nv) * arg0.to(tl.float8e4nv)
+  tt.func public @cast_to_fp8(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3FN, #blocked>
+    %m = arith.mulf %t, %t : tensor<64x64xf8E4M3FN, #blocked>
+    tt.return
+  }
+
+  // Keyword literals lex as identifiers but are not tensors, so they take the
+  // tl.cast path; ub.poison prints as `None`, which tl.cast rejects, so its
+  // cast is erased instead.
+  // CHECK-LABEL: def cast_of_keyword_literals(
+  // CHECK: tl.cast(True, tl.float32)
+  // CHECK-NOT: True.to(
+  tt.func public @cast_of_keyword_literals() attributes {noinline = false} {
+    %c = arith.constant true
+    %f = arith.uitofp %c : i1 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // CHECK-LABEL: def cast_of_poison(
+  // CHECK-NOT: None.to(
+  // CHECK-NOT: tl.cast(None
+  tt.func public @cast_of_poison() attributes {noinline = false} {
+    %p = ub.poison : i64
+    %f = arith.sitofp %p : i64 to f32
+    %m = arith.mulf %f, %f : f32
+    tt.return
+  }
+
+  // A float type TLX cannot name still falls back to erasing the cast, rather
+  // than emitting a dtype that will not compile.
+  // CHECK-LABEL: def cast_to_unnameable_dtype(
+  // CHECK: arg0 * arg0
+  // CHECK-NOT: .to(f8
+  tt.func public @cast_to_unnameable_dtype(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3B11FNUZ, #blocked>
+    %m = arith.mulf %t, %t : tensor<64x64xf8E4M3B11FNUZ, #blocked>
+    tt.return
+  }
+
+  // The store must not re-cast a source whose name already spells the cast.
+  // CHECK-LABEL: def store_of_cast(
+  // CHECK: tlx.local_store({{.*}}, arg0.to(tl.bfloat16))
+  // CHECK-NOT: .to(tl.bfloat16).to(tl.bfloat16)
+  tt.func public @store_of_cast(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xbf16, #shared, #smem, mutable>
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xbf16, #blocked>
+    ttg.local_store %t, %buf : tensor<64x64xbf16, #blocked> -> !ttg.memdesc<64x64xbf16, #shared, #smem, mutable>
+    tt.return
+  }
+
+  // Same for a dtype whose cast the name already carries: exactly one
+  // conversion, and it must not be dropped just because the store path and
+  // getValueName disagree about where the cast lives.
+  // CHECK-LABEL: def store_of_fp8_cast(
+  // CHECK: tlx.local_store({{.*}}, arg0.to(tl.float8e4nv))
+  // CHECK-NOT: tlx.local_store({{.*}}, arg0)
+  tt.func public @store_of_fp8_cast(%x: tensor<64x64xf32, #blocked>) attributes {noinline = false} {
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x64xf8E4M3FN, #shared, #smem, mutable>
+    %t = arith.truncf %x : tensor<64x64xf32, #blocked> to tensor<64x64xf8E4M3FN, #blocked>
+    ttg.local_store %t, %buf : tensor<64x64xf8E4M3FN, #blocked> -> !ttg.memdesc<64x64xf8E4M3FN, #shared, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -2060,6 +2060,35 @@ void printSimplifiedOp(
     return;
   }
 
+  // Both take their tokens as a list, and async_wait carries its outstanding-
+  // group count in the `num` attribute rather than as an operand.
+  if (opName == "ttg.async_commit_group" || opName == "ttg.async_wait") {
+    if (op->getNumResults() > 0)
+      os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
+    bool isWait = opName == "ttg.async_wait";
+    os << (isWait ? "tlx.async_load_wait_group("
+                  : "tlx.async_load_commit_group(");
+    if (isWait) {
+      auto num = op->getAttrOfType<IntegerAttr>("num");
+      os << (num ? num.getInt() : 0);
+      // The tokens list is optional; omit it entirely when there are none.
+      if (op->getNumOperands() > 0)
+        os << ", ";
+    }
+    if (!isWait || op->getNumOperands() > 0) {
+      os << "[";
+      for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+        if (i > 0)
+          os << ", ";
+        os << getValueName(op->getOperand(i), argSubstitutionMap);
+      }
+      os << "]";
+    }
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
+
   // llvm.intr.assume is a tl.assume from the source kernel.
   if (opName == "llvm.intr.assume" && op->getNumOperands() == 1) {
     os << "tl.assume(" << getValueName(op->getOperand(0), argSubstitutionMap)

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -113,6 +113,10 @@ static const TTGIRToTLXMapping opMappings[] = {
     {"ttng.arrive_barrier_named", "tlx.named_barrier_arrive",
      "Arrive at named hardware barrier"},
 
+    // Takes (mask, pred) in both spellings, so the generic operand order holds.
+    {"ttng.vote_ballot_sync", "tlx.vote_ballot_sync",
+     "Warp-level vote ballot"},
+
     // Memory allocation operations - local_alloc is handled specially
     // ttng.tmem_alloc: handled specially in printSimplifiedOp
 

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -440,6 +440,46 @@ static DenseMap<Value, std::string> buildValueNameCache(Operation *rootOp) {
   return cache;
 }
 
+std::string getElementTypeName(Type type);
+
+// Casts that change a value's element type. These are user-visible in TLX --
+// the kernel wrote `x.to(dtype)` -- unlike the width/index casts below.
+static const llvm::StringSet<> elementTypeCastOps = {
+    "arith.extf",   "arith.truncf", "arith.sitofp",
+    "arith.uitofp", "arith.fptosi", "arith.fptoui",
+};
+
+
+// Element types getElementTypeName can spell as a TLX dtype. Anything else it
+// renders as raw MLIR, which is not usable in emitted Python.
+static bool isNameableElementType(Type type) {
+  return type.isF32() || type.isF16() || type.isBF16() || type.isF64() ||
+         type.isInteger(1) || type.isInteger(8) || type.isInteger(16) ||
+         type.isInteger(32) || type.isInteger(64) ||
+         isa<Float8E4M3FNType, Float8E4M3FNUZType, Float8E5M2Type,
+             Float8E5M2FNUZType>(type);
+}
+
+// Element type of a tensor, or the type itself for a scalar.
+static Type getElementType(Type type) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type))
+    return tensorType.getElementType();
+  return type;
+}
+
+// Whether an emitted expression names a value `.to(...)` can be called on.
+// The keyword literals lex as identifiers but are not tensors, so they take
+// the tl.cast path with the other inlined constants.
+static bool isPythonIdentifier(StringRef s) {
+  if (s.empty() || isdigit(static_cast<unsigned char>(s[0])))
+    return false;
+  if (s == "True" || s == "False" || s == "None")
+    return false;
+  return llvm::all_of(s, [](char c) {
+    return isalnum(static_cast<unsigned char>(c)) || c == '_';
+  });
+}
+
 // Get simplified name for a value (just the SSA name)
 // If argSubstitutionMap is provided, substitute block args with their mapped
 // values
@@ -487,6 +527,41 @@ getValueName(Value v,
       return "None";
     }
 
+    // An element-type cast is user-visible -- the kernel wrote `x.to(dtype)` --
+    // so unlike the layout-only casts below it is re-emitted, inline at each use.
+    if (elementTypeCastOps.contains(defOp->getName().getStringRef()) &&
+        defOp->getNumOperands() > 0) {
+      Type resultType = v.getType();
+      if (auto tensorType = dyn_cast<RankedTensorType>(resultType))
+        resultType = tensorType.getElementType();
+      // Only spell the cast when the dtype has a TLX name. getElementTypeName
+      // otherwise falls back to raw MLIR (`f8E4M3FN`), which is not a Triton
+      // dtype; leave those to the transparent list below rather than emit a
+      // call that cannot compile.
+      if (isNameableElementType(resultType)) {
+        std::string operand = getValueName(defOp->getOperand(0),
+                                           argSubstitutionMap, inlineConstants);
+        std::string dtype = getElementTypeName(resultType);
+        // `.to` is a method on a tensor, so it only works when the operand
+        // names one: an inlined constant reaches here as a Python literal and
+        // `(0).to(tl.float32)` raises AttributeError at kernel compile time.
+        // tl.cast accepts those, with one exception -- ub.poison prints as
+        // `None`, which tl.cast rejects outright. That value is undefined, so
+        // erasing its cast (below) costs nothing.
+        if (operand == "None") {
+          // fall through to the transparent list
+        } else if (!isPythonIdentifier(operand)) {
+          return "tl.cast(" + operand + ", " + dtype + ")";
+        } else {
+          return operand + ".to(" + dtype + ")";
+        }
+      }
+    }
+
+    // Layout- and shape-only ops, plus the width/index casts Triton leaves
+    // implicit. The float element-type casts are still listed: the block above
+    // intercepts them whenever their dtype is nameable, so reaching one here
+    // means it is not, and erasing it beats emitting an uncompilable dtype.
     static const llvm::StringSet<> transparentOps = {
         "ttg.convert_layout", "arith.extui",   "arith.extsi",
         "arith.extf",         "arith.trunci",  "arith.truncf",
@@ -639,6 +714,15 @@ void printConstantValue(Attribute attr, llvm::raw_ostream &os) {
 
 // Get element type name as a simple string
 std::string getElementTypeName(Type type) {
+  // Mirrors the builder types in python/src/ir.cc (get_fp8e4nv_ty etc).
+  if (isa<Float8E4M3FNType>(type))
+    return "tl.float8e4nv";
+  if (isa<Float8E4M3FNUZType>(type))
+    return "tl.float8e4b8";
+  if (isa<Float8E5M2Type>(type))
+    return "tl.float8e5";
+  if (isa<Float8E5M2FNUZType>(type))
+    return "tl.float8e5b16";
   if (type.isF32())
     return "tl.float32";
   if (type.isF16())
@@ -868,6 +952,26 @@ static Value resolveThroughCasts(Value v) {
       v = op->getOperand(0);
     else
       break;
+  }
+  return v;
+}
+
+// As above, but stops at an element-type cast. The store paths use this to
+// decide whether to append a dtype cast: getValueName already spells those
+// casts, so walking past one reports the pre-cast dtype and the store appends
+// a second, redundant `.to(...)`.
+static Value resolveThroughNonElementCasts(Value v) {
+  while (auto *op = v.getDefiningOp()) {
+    StringRef name = op->getName().getStringRef();
+    if (!castOpsSet.contains(name) || op->getNumOperands() == 0)
+      break;
+    // Stop only where getValueName actually spells the cast. An element cast
+    // to a dtype TLX cannot name is erased there, so walking past it here
+    // keeps the two in agreement and lets the store re-add the conversion.
+    if (elementTypeCastOps.contains(name) &&
+        isNameableElementType(getElementType(v.getType())))
+      break;
+    v = op->getOperand(0);
   }
   return v;
 }
@@ -1575,7 +1679,7 @@ void printSimplifiedOp(
 
     // Check if transparent ops resolve the source name to a different-dtype
     // value. Resolve through casts to find the actual Python-level type.
-    Value resolvedSrc = resolveThroughCasts(src);
+    Value resolvedSrc = resolveThroughNonElementCasts(src);
     Type dstElemType;
     Type resolvedSrcElemType;
     if (auto dstMemType = dyn_cast<ttg::MemDescType>(dst.getType()))
@@ -1600,7 +1704,7 @@ void printSimplifiedOp(
     Value src = op->getOperand(1);
     std::string srcName = getValueName(src, argSubstitutionMap);
 
-    Value resolvedSrc = resolveThroughCasts(src);
+    Value resolvedSrc = resolveThroughNonElementCasts(src);
     Type dstElemType;
     Type resolvedSrcElemType;
     if (auto dstMemType = dyn_cast<ttg::MemDescType>(dst.getType()))

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1431,6 +1431,40 @@ void printLocComment(Operation *op, llvm::raw_ostream &os) {
   os << "\n";
 }
 
+// Emit `s` as a double-quoted Python string literal. Assertion messages carry
+// source text, so they can contain quotes, backslashes and newlines.
+static void printPythonStringLiteral(StringRef s, llvm::raw_ostream &os) {
+  os << '"';
+  for (char c : s) {
+    switch (c) {
+    case '"':
+      os << "\\\"";
+      break;
+    case '\\':
+      os << "\\\\";
+      break;
+    case '\n':
+      os << "\\n";
+      break;
+    case '\r':
+      os << "\\r";
+      break;
+    case '\t':
+      os << "\\t";
+      break;
+    default:
+      // Bytes >= 0x80 are left alone: they are UTF-8 continuation bytes, and
+      // escaping them individually would turn one character into several.
+      unsigned char b = static_cast<unsigned char>(c);
+      if (b < 0x20 || b == 0x7f)
+        os << llvm::format("\\x%02x", b);
+      else
+        os << c;
+    }
+  }
+  os << '"';
+}
+
 // Resolve an operand of an AttrSizedOperandSegments op by declared position.
 // Absent optional groups have size 0, so positional reads shift.
 static Value getSegmentOperand(Operation *op, unsigned segmentIdx) {
@@ -1597,6 +1631,20 @@ void printSimplifiedOp(
   }
 
   // === Special-case handlers for ops needing custom printing ===
+
+  // `assert` is a Python keyword, so the generic `tt.assert(cond)` spelling is a
+  // syntax error rather than an undefined name, and it drops the message.
+  if (opName == "tt.assert") {
+    os << "tl.device_assert("
+       << getValueName(op->getOperand(0), argSubstitutionMap);
+    if (auto msgAttr = op->getAttrOfType<StringAttr>("message")) {
+      os << ", ";
+      printPythonStringLiteral(msgAttr.getValue(), os);
+    }
+    os << ")";
+    printLocComment(op, os);
+    return;
+  }
 
   // tt.get_program_id: emit tl.program_id(axis=N)
   if (opName == "tt.get_program_id") {

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -381,6 +381,21 @@ bool isConstantTrue(Value v) {
   return false;
 }
 
+// Split a memdesc shape into the `num` and `shape` arguments of tlx.local_alloc.
+// A buffer is up to 2-D, so only a rank above that is multi-buffering; this is the
+// same rule analyzeLocalAlloc applies, and the two must agree or an alias and its
+// base describe different buffer counts.
+static void splitAllocShape(ArrayRef<int64_t> shape, int64_t &count,
+                            SmallVectorImpl<int64_t> &tileShape) {
+  if (shape.size() > 2) {
+    count = shape[0];
+    tileShape.assign(shape.begin() + 1, shape.end());
+    return;
+  }
+  count = 1;
+  tileShape.assign(shape.begin(), shape.end());
+}
+
 // Build a lookup map for fast operation name lookup
 llvm::StringMap<StringRef> buildOpNameMap() {
   llvm::StringMap<StringRef> map;
@@ -2030,17 +2045,14 @@ void printSimplifiedOp(
       bool dtypeDiffers = srcType.getElementType() != dstType.getElementType();
       bool shapeDiffers = srcType.getShape() != dstType.getShape();
       if (dtypeDiffers || shapeDiffers) {
-        ArrayRef<int64_t> shape = dstType.getShape();
         Type elemType = dstType.getElementType();
         int64_t count = 1;
         SmallVector<int64_t> actualShape;
-        if (shape.size() >= 2) {
-          count = shape[0];
-          for (size_t i = 1; i < shape.size(); ++i)
-            actualShape.push_back(shape[i]);
-        } else if (shape.size() == 1) {
-          actualShape.push_back(shape[0]);
-        }
+        // This op is legal on shared memory too, so name the storage kind from the
+        // memory space rather than assuming tensor memory.
+        bool isTmem = isa_and_nonnull<ttng::TensorMemorySpaceAttr>(
+            dstType.getMemorySpace());
+        splitAllocShape(dstType.getShape(), count, actualShape);
         // Emit local_alloc with reuse= for dtype or shape changes
         os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
         os << "tlx.local_alloc((";
@@ -2051,9 +2063,11 @@ void printSimplifiedOp(
         }
         if (actualShape.size() == 1)
           os << ","; // trailing comma for single-element tuple
-        os << "), " << getElementTypeName(elemType) << ", " << count
-           << ", tlx.storage_kind.tmem, reuse="
-           << getValueName(op->getOperand(0), argSubstitutionMap) << ")";
+        os << "), " << getElementTypeName(elemType) << ", " << count;
+        if (isTmem)
+          os << ", tlx.storage_kind.tmem";
+        os << ", reuse=" << getValueName(op->getOperand(0), argSubstitutionMap)
+           << ")";
       } else {
         // Same dtype and shape: emit as alias
         os << getValueName(op->getResult(0), argSubstitutionMap) << " = "
@@ -2070,17 +2084,10 @@ void printSimplifiedOp(
       os << getValueName(op->getResult(0), argSubstitutionMap) << " = ";
     if (auto memDescType =
             dyn_cast<ttg::MemDescType>(op->getResult(0).getType())) {
-      ArrayRef<int64_t> shape = memDescType.getShape();
       Type elemType = memDescType.getElementType();
       int64_t count = 1;
       SmallVector<int64_t> actualShape;
-      if (shape.size() >= 2) {
-        count = shape[0];
-        for (size_t i = 1; i < shape.size(); ++i)
-          actualShape.push_back(shape[i]);
-      } else if (shape.size() == 1) {
-        actualShape.push_back(shape[0]);
-      }
+      splitAllocShape(memDescType.getShape(), count, actualShape);
       os << "tlx.local_alloc((";
       for (size_t i = 0; i < actualShape.size(); ++i) {
         if (i > 0)

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -1651,6 +1651,53 @@ void printSimplifiedOp(
 
   // === Special-case handlers for ops needing custom printing ===
 
+  // tt.elementwise_inline_asm carries the asm text, constraints, purity and
+  // packing as attributes, so the generic printer emits only the operands and the
+  // call is missing four of its six arguments.
+  if (opName == "tt.elementwise_inline_asm") {
+    unsigned nres = op->getNumResults();
+    for (unsigned i = 0; i < nres; ++i)
+      os << (i ? ", " : "")
+         << getValueName(op->getResult(i), argSubstitutionMap);
+    if (nres > 0)
+      os << " = ";
+    os << "tl.inline_asm_elementwise(";
+    auto asmAttr = op->getAttrOfType<StringAttr>("asm_string");
+    printPythonStringLiteral(asmAttr ? asmAttr.getValue() : "", os);
+    os << ", ";
+    auto consAttr = op->getAttrOfType<StringAttr>("constraints");
+    printPythonStringLiteral(consAttr ? consAttr.getValue() : "", os);
+    // `args` is a sequence parameter, not varargs.
+    os << ", [";
+    for (unsigned i = 0; i < op->getNumOperands(); ++i)
+      os << (i ? ", " : "")
+         << getValueName(op->getOperand(i), argSubstitutionMap);
+    os << "], ";
+    // dtype is the result element type, and a list of them when the asm returns
+    // more than one value.
+    auto elemName = [&](Type t) {
+      if (auto rt = dyn_cast<RankedTensorType>(t))
+        return getElementTypeName(rt.getElementType());
+      return getElementTypeName(t);
+    };
+    if (nres == 1) {
+      os << elemName(op->getResult(0).getType());
+    } else {
+      os << "[";
+      for (unsigned i = 0; i < nres; ++i)
+        os << (i ? ", " : "") << elemName(op->getResult(i).getType());
+      os << "]";
+    }
+    // Default to impure when the attribute is missing: marking side-effecting
+    // asm pure would let the recompiled kernel hoist or delete it.
+    auto pureAttr = op->getAttrOfType<BoolAttr>("pure");
+    auto packAttr = op->getAttrOfType<IntegerAttr>("packed_element");
+    os << ", " << ((pureAttr && pureAttr.getValue()) ? "True" : "False") << ", "
+       << (packAttr ? packAttr.getInt() : 1) << ")";
+    printLocComment(op, os);
+    return;
+  }
+
   // `assert` is a Python keyword, so the generic `tt.assert(cond)` spelling is a
   // syntax error rather than an undefined name, and it drops the message.
   if (opName == "tt.assert") {

--- a/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
+++ b/third_party/tlx/dialect/lib/Transforms/PrintTTGIRToTLX.cpp
@@ -480,6 +480,17 @@ static bool isPythonIdentifier(StringRef s) {
   });
 }
 
+// Whether getValueName spells an element-type cast or erases it: erased when
+// TLX cannot name the dtype, or the operand is `None`. Shared with the resolver.
+static bool spellsElementTypeCast(Operation *castOp, StringRef operandName) {
+  return castOp && castOp->getNumOperands() > 0 &&
+         castOp->getNumResults() > 0 &&
+         elementTypeCastOps.contains(castOp->getName().getStringRef()) &&
+         isNameableElementType(
+             getElementType(castOp->getResult(0).getType())) &&
+         operandName != "None";
+}
+
 // Get simplified name for a value (just the SSA name)
 // If argSubstitutionMap is provided, substitute block args with their mapped
 // values
@@ -531,31 +542,18 @@ getValueName(Value v,
     // so unlike the layout-only casts below it is re-emitted, inline at each use.
     if (elementTypeCastOps.contains(defOp->getName().getStringRef()) &&
         defOp->getNumOperands() > 0) {
-      Type resultType = v.getType();
-      if (auto tensorType = dyn_cast<RankedTensorType>(resultType))
-        resultType = tensorType.getElementType();
-      // Only spell the cast when the dtype has a TLX name. getElementTypeName
-      // otherwise falls back to raw MLIR (`f8E4M3FN`), which is not a Triton
-      // dtype; leave those to the transparent list below rather than emit a
-      // call that cannot compile.
-      if (isNameableElementType(resultType)) {
-        std::string operand = getValueName(defOp->getOperand(0),
-                                           argSubstitutionMap, inlineConstants);
-        std::string dtype = getElementTypeName(resultType);
+      std::string operand = getValueName(defOp->getOperand(0),
+                                         argSubstitutionMap, inlineConstants);
+      if (spellsElementTypeCast(defOp, operand)) {
+        std::string dtype = getElementTypeName(getElementType(v.getType()));
         // `.to` is a method on a tensor, so it only works when the operand
         // names one: an inlined constant reaches here as a Python literal and
         // `(0).to(tl.float32)` raises AttributeError at kernel compile time.
-        // tl.cast accepts those, with one exception -- ub.poison prints as
-        // `None`, which tl.cast rejects outright. That value is undefined, so
-        // erasing its cast (below) costs nothing.
-        if (operand == "None") {
-          // fall through to the transparent list
-        } else if (!isPythonIdentifier(operand)) {
+        if (!isPythonIdentifier(operand))
           return "tl.cast(" + operand + ", " + dtype + ")";
-        } else {
-          return operand + ".to(" + dtype + ")";
-        }
+        return operand + ".to(" + dtype + ")";
       }
+      // Otherwise the cast is erased: fall through to the transparent list.
     }
 
     // Layout- and shape-only ops, plus the width/index casts Triton leaves
@@ -965,11 +963,9 @@ static Value resolveThroughNonElementCasts(Value v) {
     StringRef name = op->getName().getStringRef();
     if (!castOpsSet.contains(name) || op->getNumOperands() == 0)
       break;
-    // Stop only where getValueName actually spells the cast. An element cast
-    // to a dtype TLX cannot name is erased there, so walking past it here
-    // keeps the two in agreement and lets the store re-add the conversion.
-    if (elementTypeCastOps.contains(name) &&
-        isNameableElementType(getElementType(v.getType())))
+    // Stop where getValueName spells the cast; walking past one it erased would
+    // report a dtype the emitted name does not carry.
+    if (spellsElementTypeCast(op, getValueName(op->getOperand(0))))
       break;
     v = op->getOperand(0);
   }
@@ -1688,6 +1684,8 @@ void printSimplifiedOp(
       resolvedSrcElemType = resolvedType.getElementType();
 
     os << "tlx.local_store(" << dstName << ", " << srcName;
+    // dstElemType is always nameable: local_store requires src and dst element
+    // types to match, and TT_Float is exactly what isNameableElementType covers.
     if (dstElemType && resolvedSrcElemType &&
         resolvedSrcElemType != dstElemType) {
       os << ".to(" << getElementTypeName(dstElemType) << ")";
@@ -1714,6 +1712,7 @@ void printSimplifiedOp(
 
     os << "tlx.local_store(" << getValueName(dst, argSubstitutionMap) << ", "
        << srcName;
+    // dstElemType is always nameable here, as in ttg.local_store above.
     if (dstElemType && resolvedSrcElemType &&
         resolvedSrcElemType != dstElemType) {
       os << ".to(" << getElementTypeName(dstElemType) << ")";


### PR DESCRIPTION
Summary:
`tl.inline_asm_elementwise` takes six arguments and four of them live in
attributes on `tt.elementwise_inline_asm`, not operands. The generic printer emits
operands only, so the call came out with two of the six:

```counterexample
  acc_102 = tl.inline_asm_elementwise(acc_100, acc_92)
```

against the required
`inline_asm_elementwise(asm, constraints, args, dtype, is_pure, pack)`.

This is the failure mode that static checks miss. The emitted name is a real
`tl.` symbol, so a scan for unmapped dialect prefixes passes it, and the kernel
dies only when the generated TLX is compiled.

Four recoveries, in argument order: `asm_string` and `constraints` are string
attributes and go through the same Python string-literal escaper the assert
mapping added -- real PTX is multi-line and contains quotes, so pasting it in raw
would not survive; the operands become the `args` sequence rather than varargs;
`dtype` is the result element type, or a list of them when the asm returns more
than one value; and `pure` / `packed_element` supply `is_pure` and `pack`.
Impurity in particular has to survive, or the recompiled kernel is free to hoist
or eliminate asm that has side effects.

Authored with Claude.

Differential Revision: D119555601


