### PR TITLE
[triton][beta] Avoid PT2 compilation in LayerNorm tests

### DIFF
--- a/third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py
+++ b/third_party/tlx/tutorials/blackwell-multi-cta-layernorm_test.py
@@ -349,8 +349,8 @@ def test_op(M, N, dtype):
     bias = torch.randn(N, device=DEVICE, dtype=dtype)
     eps = 1e-5
 
-    # PyTorch reference
-    output_torch = torch_layernorm(x, weight, bias, eps)
+    # Keep correctness validation independent of PT2 compiler-cache availability.
+    output_torch = _torch_layernorm_impl(x, weight, bias, eps)
 
     # TLX implementation
     output_triton, _, _ = multi_cta_layernorm(x, weight, bias, eps)

--- a/third_party/tlx/tutorials/blackwell_multi_cta_layernorm_ws_test.py
+++ b/third_party/tlx/tutorials/blackwell_multi_cta_layernorm_ws_test.py
@@ -360,7 +360,6 @@ def _torch_layernorm_impl(x, weight, bias, eps=1e-5):
     return torch.nn.functional.layer_norm(x, (x.shape[-1], ), weight, bias, eps)
 
 
-torch_layernorm = torch.compile(_torch_layernorm_impl)
 @pytest.mark.parametrize("M,N", [(4, 16384), (1152, 16384), (1024, 16384), (1024, 32768)])
 @pytest.mark.parametrize("dtype", [torch.float16])
 def test_op(M, N, dtype):
@@ -370,7 +369,8 @@ def test_op(M, N, dtype):
     bias = torch.randn(N, device=DEVICE, dtype=dtype)
     eps = 1e-5
 
-    output_torch = torch_layernorm(x, weight, bias, eps)
+    # Keep correctness validation independent of PT2 compiler-cache availability.
+    output_torch = _torch_layernorm_impl(x, weight, bias, eps)
     output_triton, _, _ = multi_cta_layernorm_ws(x, weight, bias, eps)
 
     rtol = atol = 1e-2 if dtype == torch.float16 else 1e-3


### PR DESCRIPTION
Summary: Use eager `torch.nn.functional.layer_norm` as the correctness reference in both multi-CTA LayerNorm test modules. This keeps GPU correctness tests independent of PT2 compiler-cache service availability while preserving `torch.compile` for the benchmark path. Authored with Codex.

Reviewed By: minjang, wlei-llvm

Differential Revision: D119592222


