### PR TITLE
[triton-beta] Size entropy n_repeat from wall-clock cost

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -27,6 +27,80 @@ def test_entropy_warmup_sample_budget(probe_ms, expected):
     assert _autotuner._entropy_warmup_sample_limit(probe_ms, 250) == expected
 
 
+@pytest.mark.parametrize(
+    "rep_ms, sampling_wall_s, n_sampling_launches, kernel_avg_ms, expected",
+    [
+        # Wall-clock denominator: 0.06s over 550 sampling launches ~= 0.109ms/iter.
+        # The kernel average (0.027ms) must NOT be used here: the old formula
+        # sized 100/0.027 = 3703 repeats, overshooting the rep budget ~4x.
+        (100, 0.06, 550, 0.027, 916),
+        # No sampling launches: fall back to the kernel average.
+        (100, 0.0, 0, 0.027, 3703),
+        # Non-positive denominator: fixed fallback count.
+        (100, 0.0, 10, 0.0, 100),
+        # Floor of 10 repeats for slow kernels.
+        (100, 2.0, 10, 50.0, 10),
+        # Ceiling of 10000 repeats for tiny per-iteration costs (bounds the
+        # 2*n_repeat event pre-allocation in _timed_measurement).
+        (100, 0.001, 1000, 0.027, 10000),
+    ],
+)
+def test_entropy_repeat_uses_wall_clock_denominator(
+    rep_ms, sampling_wall_s, n_sampling_launches, kernel_avg_ms, expected
+):
+    assert (
+        _autotuner._entropy_repeat_count(
+            rep_ms, sampling_wall_s, n_sampling_launches, kernel_avg_ms
+        )
+        == expected
+    )
+
+
+def test_entropy_sampling_syncs_tail_on_early_convergence(monkeypatch):
+    # Fast convergence stops consuming partway through a 50-launch batch, but
+    # all 50 launches were issued and count toward the repeat denominator, so
+    # the final event must be synchronized before returning: otherwise the
+    # caller's wall-clock span excludes the tail's GPU time while the
+    # denominator includes it, underestimating per-iteration cost.
+    created = []
+    synced = []
+
+    class FakeEvent:
+
+        def __init__(self, enable_timing=True):
+            created.append(self)
+
+        def record(self):
+            pass
+
+        def synchronize(self):
+            synced.append(self)
+
+        def elapsed_time(self, other):
+            return 0.027
+
+    class FakeCuda:
+        Event = FakeEvent
+
+    class FakeTorch:
+        cuda = FakeCuda
+
+    monkeypatch.setattr(
+        _autotuner._EntropyCriterion, "is_finished",
+        lambda self: self.total_samples >= 20)
+
+    counter, avg_ms, launched = _autotuner._entropy_sampling(
+        lambda: None, lambda: None, FakeTorch)
+
+    assert counter == 20
+    assert launched == 50
+    assert avg_ms == pytest.approx(0.027)
+    # 20 in-loop syncs plus the final tail event; the skipped middle events
+    # need no sync since the last event orders the whole batch on the stream.
+    assert len(synced) == 21
+    assert synced[-1] is created[-1]
+
+
 def test_cpu_backend_skips_cuda_entropy_benchmark(monkeypatch, fresh_knobs):
     expected = [1.0, 0.5, 1.5]
     calls = []

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -184,8 +184,39 @@ def _entropy_warmup_sample_limit(probe_ms: float, budget_ms: int) -> int:
     return max(1, min(10000, int(budget_ms / probe_ms)))
 
 
-def _entropy_warmup(kernel_call, clear_cache, torch, entropy_window_size=500, regr_window_size=299, max_samples=10000):
-    """Adaptive warmup using entropy convergence. Returns (n_samples, avg_ms)."""
+def _entropy_repeat_count(
+    rep_ms: float,
+    sampling_wall_s: float,
+    n_sampling_launches: int,
+    kernel_avg_ms: float,
+) -> int:
+    """Number of timed measurement iterations for the entropy benchmarker.
+
+    Sized from the measured wall-clock cost per iteration (cache clear + kernel
+    + events, as observed across sampling launches) so the timed phase lasts
+    ~rep_ms of wall time. kernel_avg_ms covers the kernel only, so it would
+    overshoot the budget whenever the clear dominates (fast kernels); it is
+    only a fallback when no sampling launches were recorded. Mirrors do_bench,
+    whose runtime estimate includes the cache clear.
+
+    The denominator conservatively includes the sampling phase's per-sample
+    sync/analysis overhead (event synchronize + elapsed_time + entropy
+    bookkeeping), which the back-to-back timed phase does not pay, so the
+    timed phase may undershoot rep_ms rather than overshoot it. Bounded to
+    [10, 10000]: the floor keeps slow kernels measurable, the ceiling bounds
+    the 2*n_repeat event pre-allocation in _timed_measurement.
+    """
+    if n_sampling_launches > 0:
+        per_iter_ms = sampling_wall_s / n_sampling_launches * 1000.0
+    else:
+        per_iter_ms = kernel_avg_ms
+    if per_iter_ms > 0:
+        return max(10, min(10000, int(rep_ms / per_iter_ms)))
+    return 100
+
+
+def _entropy_sampling(kernel_call, clear_cache, torch, entropy_window_size=500, regr_window_size=299, max_samples=10000):
+    """Adaptive sampling using entropy convergence. Returns (n_samples, avg_ms, n_launched). n_launched counts all issued launches, including any trailing batch whose measurements were skipped after early convergence."""
     crit = _EntropyCriterion(
         max_angle=0.048,
         min_r2=0.36,
@@ -197,6 +228,7 @@ def _entropy_warmup(kernel_call, clear_cache, torch, entropy_window_size=500, re
     last_batch = [0.0] * BATCH_SIZE
     n_written = 0
     counter = 0
+    launched = 0
     converged = False
     precision_increase = False
 
@@ -209,6 +241,7 @@ def _entropy_warmup(kernel_call, clear_cache, torch, entropy_window_size=500, re
             start_ev[i].record()
             kernel_call()
             end_ev[i].record()
+        launched += batch_size
         n_written = 0
         for i in range(batch_size):
             end_ev[i].synchronize()
@@ -230,8 +263,14 @@ def _entropy_warmup(kernel_call, clear_cache, torch, entropy_window_size=500, re
                 crit.reset()
                 precision_increase = True
 
+    # On early convergence the trailing launches of the final batch were issued
+    # but never synchronized; wait for the last one so the caller's wall-clock
+    # span covers exactly the launched count used as the repeat denominator.
+    if converged and n_written < batch_size:
+        end_ev[batch_size - 1].synchronize()
+
     avg_ms = statistics.fmean(last_batch[:n_written]) if n_written > 0 else 0.0
-    return counter, avg_ms
+    return counter, avg_ms, launched
 
 
 def _timed_measurement(kernel_call, clear_cache, n_repeat, torch):
@@ -473,7 +512,8 @@ class Autotuner(KernelInterface):
             entropy_window = min(500, max(50, int(_WARMUP_BUDGET_MS / probe_ms)))
             regr_window = max(20, int(entropy_window * 0.6))
 
-            n_warmup = _entropy_warmup(
+            t0 = time.perf_counter()
+            sampling = _entropy_sampling(
                 kernel_call,
                 clear,
                 torch,
@@ -481,8 +521,13 @@ class Autotuner(KernelInterface):
                 regr_window_size=regr_window,
                 max_samples=max_samples,
             )
-            avg_ms = n_warmup[1]
-            n_repeat = max(10, int(rep / avg_ms)) if avg_ms > 0 else 100
+            sampling_wall_s = time.perf_counter() - t0
+            avg_ms = sampling[1]
+            # Divide by launched (not consumed) samples: every launch pays a
+            # clear+kernel even when early convergence skips consuming the
+            # trailing batch, so the launched count is the unbiased
+            # per-iteration cost basis.
+            n_repeat = _entropy_repeat_count(rep, sampling_wall_s, sampling[2], avg_ms)
             times = _timed_measurement(kernel_call, clear, n_repeat, torch)
 
             if quantiles is not None:


### PR DESCRIPTION
Summary:
The entropy autotuner sizes measurement repeats as `n_repeat = rep / avg_ms`, where `avg_ms` is kernel-only time. But every timed iteration also pays a 256MB L2-cache clear plus events, so for kernels faster than the clear (~65us on H100-class) this overshoots the `rep` budget ~4x (100/0.027 = 3703 repeats instead of ~950). Standard `do_bench` does not have this bug: its runtime estimate includes the clear.

This diff sizes entropy repeats from measured wall-clock cost per iteration (warmup wall / warmup samples) via a new `_entropy_repeat_count()` helper, matching `do_bench` accounting. Fallbacks preserved: kernel average with no warmup samples, fixed 100 on non-positive denominator, 10-repeat floor. No change to the standard path, which was verified already correct.

Measured on `fp8_gemm_rowwise` (m=1,n=1024,k=2768, 100 configs, GH200): autotune `bench_time` 66.89s -> 36.61s (standard: 31.31s), same best config and identical kernel-time distributions before/after.

Differential Revision: D119397931


