### PR TITLE
[triton][beta] Preserve scratch reads after leading barriers

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -402,7 +402,6 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   if (barrierStages.beforeMemoryEffects) {
     // Model a leading local barrier before handling the operation's effects.
     blockInfo->sync();
-    return;
   }
 
   // If the current op is an (async) memory wait and there is no later sync

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -799,6 +799,41 @@ tt.func @atomic_release_loop(%ptr: !tt.ptr<i32>) -> i32 {
   tt.return %result : i32
 }
 
+// The scan reuses scratch read by the scalar atomic after its internal barrier.
+// CHECK-LABEL: atomic_release_then_scan
+tt.func @atomic_release_then_scan(%ptr: !tt.ptr<i32>, %x: tensor<8x16xf32, #AL>) -> (i32, tensor<8x16xf32, #AL>) {
+  %one = arith.constant 1 : i32
+  %true = arith.constant true
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: tt.atomic_rmw add, release
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: %{{.*}} = "tt.scan"
+  %old = tt.atomic_rmw add, release, gpu, %ptr, %one, %true : (!tt.ptr<i32>, i32, i1) -> i32
+  %scan = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}>({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %sum = arith.addf %lhs, %rhs : f32
+    tt.scan.return %sum : f32
+  }) : (tensor<8x16xf32, #AL>) -> tensor<8x16xf32, #AL>
+  tt.return %old, %scan : i32, tensor<8x16xf32, #AL>
+}
+
+// CHECK-LABEL: atomic_acq_rel_then_scan
+tt.func @atomic_acq_rel_then_scan(%ptr: !tt.ptr<i32>, %x: tensor<8x16xf32, #AL>) -> (i32, tensor<8x16xf32, #AL>) {
+  %one = arith.constant 1 : i32
+  %true = arith.constant true
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: tt.atomic_rmw add, acq_rel
+  // CHECK-NEXT: ttg.barrier local
+  // CHECK-NEXT: %{{.*}} = "tt.scan"
+  %old = tt.atomic_rmw add, acq_rel, gpu, %ptr, %one, %true : (!tt.ptr<i32>, i32, i1) -> i32
+  %scan = "tt.scan"(%x) <{axis = 0 : i32, reverse = false}>({
+  ^bb0(%lhs: f32, %rhs: f32):
+    %sum = arith.addf %lhs, %rhs : f32
+    tt.scan.return %sum : f32
+  }) : (tensor<8x16xf32, #AL>) -> tensor<8x16xf32, #AL>
+  tt.return %old, %scan : i32, tensor<8x16xf32, #AL>
+}
+
 // A timed poll also uses shared memory to broadcast its result.
 // CHECK-LABEL: atomic_poll_acquire_loop
 tt.func @atomic_poll_acquire_loop(%ptr: !tt.ptr<i32>, %expected: i32, %timeout: i64) -> i1 {


### PR DESCRIPTION
Summary:
Scalar `release`/`acq_rel` atomics can be followed by a scan that reuses the shared scratch used to broadcast their return value. `MembarAnalysis::update` clears incoming dependencies for the atomic's leading ordering barrier, then returns before recording the broadcast's outgoing scratch reads. The following scan can overwrite the result before all warps have read it, corrupting stream-compaction output and causing intermittent illegal GPU memory accesses in TBE backward.

Continue processing the operation after accounting for its leading barrier. This retains its outgoing scratch reads and allows the existing hazard analysis to insert a barrier before overlapping scratch is reused. The leading barrier's state reset remains intact, avoiding a duplicate barrier before the atomic.

Add release and acquire-release atomic-to-scan regression cases to `test-membar.mlir`. Both require synchronization before the scan and prohibit a redundant barrier before the atomic; the file runs generic and AMD membar analysis.

This fixes the compiler dependency tracking underlying TestX 562950342570955 (`test_gpu_tritonbench_triton_table_batched_embedding`, Triton beta, B200/CUDA 12.8). D119561803 is the separate kernel workaround; this diff changes no kernel code and does not depend on it.

Differential Revision: D119670476


