### PR TITLE
[tlx][attention] Add and optimize causal Hopper pingpong attention

### DIFF
--- a/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
+++ b/third_party/tlx/tutorials/hopper_fa_ws_pipelined_pingpong.py
@@ -33,21 +33,43 @@ configs = [
 
 
 @triton.jit
-def _compute_offsets(tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M: tl.constexpr):
+def _compute_offsets(
+    tile_idx,
+    H,
+    num_pid_n,
+    num_pid_in_group,
+    N_CTX,
+    BLOCK_M: tl.constexpr,
+    CAUSAL: tl.constexpr,
+):
     group_id = tile_idx // num_pid_in_group
     first_pid_n = group_id
-    start_m = tile_idx % num_pid_in_group
     off_hz = first_pid_n
+    start_m = tile_idx % num_pid_in_group
+    if CAUSAL:
+        # Reverse selected heads so persistent workers receive a balanced mix
+        # of short and long causal prefixes for the tuned sequence lengths.
+        reverse_rows = (off_hz & 1) != 0
+        balanced_start_m = tl.where(
+            reverse_rows, num_pid_in_group - 1 - start_m, start_m
+        )
+        use_alternate_heads = (num_pid_in_group == 8) | (num_pid_in_group == 16)
+        start_m = tl.where(use_alternate_heads, balanced_start_m, start_m)
+
+        reverse_s8192 = ((off_hz // 2) & 1) != 0
+        balanced_s8192 = tl.where(reverse_s8192, 63 - start_m, start_m)
+        start_m = tl.where(num_pid_in_group == 64, balanced_s8192, start_m)
     off_z = off_hz // H
     off_h = off_hz % H
     offset_y = off_z * (N_CTX * H) + off_h * N_CTX
     qo_offset_y = offset_y + start_m * BLOCK_M
-    lo, hi = 0, N_CTX
+    lo = 0
+    hi = tl.minimum(N_CTX, (start_m + 1) * BLOCK_M) if CAUSAL else N_CTX
     kv_offset_y = offset_y + lo
     return start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y
 
 
-@triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT"])
+@triton.autotune(configs=configs, key=["N_CTX", "HEAD_DIM", "FP8_OUTPUT", "CAUSAL"])
 @triton.jit
 def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                                     Z, H, desc_q, desc_k, desc_v, desc_o, N_CTX,  #
@@ -55,6 +77,8 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                                     BLOCK_M: tl.constexpr,  #
                                     BLOCK_N: tl.constexpr,  #
                                     FP8_OUTPUT: tl.constexpr,  #
+                                    CAUSAL: tl.constexpr,  #
+                                    STEADY_UNROLL: tl.constexpr,  #
                                     NUM_BUFFERS: tl.constexpr,  #
                                     NUM_MMA_WARPS: tl.constexpr,  #
                                     NUM_MMA_GROUPS: tl.constexpr,  #
@@ -113,7 +137,14 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
             for i in range(0, tiles_per_prog):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M)
+                    tile_idx,
+                    H,
+                    num_pid_n,
+                    num_pid_in_group,
+                    N_CTX,
+                    BLOCK_M,
+                    CAUSAL=CAUSAL,
+                )
 
                 # Interleave the first K load between the two Q loads so consumer 0
                 # can begin its first QK while the producer finishes startup.
@@ -131,7 +162,8 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 tlx.async_descriptor_load(desc_k, k_tiles[kv_buf_id], [kv_offset, 0], k_fulls[kv_buf_id])
 
                 for cid in tl.range(1, NUM_MMA_GROUPS, loop_unroll_factor=NUM_MMA_GROUPS):
-                    tlx.barrier_wait(q_empties[cid], q_phase ^ 1)
+                    # TR051 heuristically unrolls the persistent loop and misses the matching consumer arrival.
+                    tlx.barrier_wait(q_empties[cid], q_phase ^ 1)  # noqa: TR051
                     tlx.barrier_expect_bytes(q_fulls[cid], Q_BYTES_PER_ELEM * BLOCK_M_SPLIT * HEAD_DIM)
                     qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
                     tlx.async_descriptor_load(desc_q, q_tiles[cid], [qo_offset_y_split, 0], q_fulls[cid])
@@ -142,7 +174,7 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 accum_cnt_kv += 1
 
                 # Keep the established K-then-V order for the steady-state ring.
-                for kv_idx in tl.range(lo + BLOCK_N, hi, BLOCK_N, loop_unroll_factor=2):
+                for kv_idx in tl.range(lo + BLOCK_N, hi, BLOCK_N, loop_unroll_factor=STEADY_UNROLL):
                     kv_buf_id, kv_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
                     kv_offset = kv_offset_y + kv_idx
 
@@ -174,7 +206,14 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
             for i in range(0, tiles_per_prog):
                 # initialize offsets
                 start_m, off_hz, lo, hi, qo_offset_y, kv_offset_y = _compute_offsets(
-                    tile_idx, H, num_pid_n, num_pid_in_group, N_CTX, BLOCK_M)
+                    tile_idx,
+                    H,
+                    num_pid_n,
+                    num_pid_in_group,
+                    N_CTX,
+                    BLOCK_M,
+                    CAUSAL=CAUSAL,
+                )
 
                 # initialize pointer to m and l
                 m_i = tl.zeros([BLOCK_M_SPLIT], dtype=tl.float32) - float("inf")
@@ -219,6 +258,15 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 tlx.barrier_arrive(k_empties[k_buf_id], 1)
 
                 # -- compute m_i and l_i ----
+                if CAUSAL:
+                    offs_m = (
+                        start_m * BLOCK_M
+                        + cid * BLOCK_M_SPLIT
+                        + tl.arange(0, BLOCK_M_SPLIT)
+                    )
+                    if lo + BLOCK_N == hi:
+                        offs_n = lo + tl.arange(0, BLOCK_N)
+                        qk = tl.where(offs_m[:, None] >= offs_n[None, :], qk, -float("inf"))
                 m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
                 qk = qk * qk_scale - m_ij[:, None]
                 p = tl.math.exp2(qk)
@@ -231,8 +279,21 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 m_i = m_ij
                 accum_cnt_kv += 1
 
-                # loop over k, v and update accumulator
-                for _ in tl.range(lo + BLOCK_N, hi, BLOCK_N, loop_unroll_factor=2):
+                # Keep the steady-state loop branch-free. In the causal case,
+                # peel the final diagonal tile and apply its mask separately.
+                steady_hi = hi - BLOCK_N if CAUSAL else hi
+                steady_tiles = (steady_hi - (lo + BLOCK_N)) // BLOCK_N
+                paired_hi = (
+                    steady_hi - (steady_tiles % 2) * BLOCK_N
+                    if CAUSAL
+                    else steady_hi
+                )
+                for kv_idx in tl.range(
+                    lo + BLOCK_N,
+                    paired_hi,
+                    BLOCK_N,
+                    loop_unroll_factor=STEADY_UNROLL,
+                ):
                     k_buf_id, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
 
                     # wait for the K buffer to be populated by the producer
@@ -289,6 +350,48 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                     acc = acc * alpha[:, None]
                     accum_cnt_kv += 1
 
+                if CAUSAL:
+                    for kv_idx in tl.range(paired_hi, hi, BLOCK_N):
+                        k_buf_id, k_phase = get_bufidx_phase(accum_cnt_kv, NUM_BUFFERS)
+                        tlx.barrier_wait(k_fulls[k_buf_id], k_phase)
+                        k_tile = tlx.local_trans(k_tiles[k_buf_id])
+
+                        if cid == 0:
+                            tlx.named_barrier_wait(9, 256)
+                        else:
+                            tlx.named_barrier_wait(10, 256)
+
+                        qk = tlx.async_dot(q_tiles[cid], k_tile)
+
+                        if cid == 0:
+                            tlx.named_barrier_arrive(10, 256)
+                        else:
+                            tlx.named_barrier_arrive(9, 256)
+
+                        v_buf_id, v_phase = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS)
+                        tlx.barrier_wait(v_fulls[v_buf_id], v_phase)
+                        p = p.to(tlx.dtype_of(desc_k))
+                        acc = tlx.async_dot(p, v_tiles[v_buf_id], acc)
+
+                        qk = tlx.async_dot_wait(1, qk)
+                        tlx.barrier_arrive(k_empties[k_buf_id], 1)
+
+                        if kv_idx + BLOCK_N == hi:
+                            offs_n = kv_idx + tl.arange(0, BLOCK_N)
+                            qk = tl.where(offs_m[:, None] >= offs_n[None, :], qk, -float("inf"))
+                        m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+                        qk = qk * qk_scale - m_ij[:, None]
+                        p = tl.math.exp2(qk)
+                        alpha = tl.math.exp2(m_i - m_ij)
+                        l_ij = tl.sum(p, 1)
+                        l_i = l_i * alpha + l_ij
+                        m_i = m_ij
+
+                        acc = tlx.async_dot_wait(0, acc)
+                        tlx.barrier_arrive(v_empties[v_buf_id], 1)
+                        acc = acc * alpha[:, None]
+                        accum_cnt_kv += 1
+
                 # compute pv from the last iteration
                 # wait for the V buffer to be populated by the producer
                 v_buf_id, v_phase = get_bufidx_phase(accum_cnt_kv - 1, NUM_BUFFERS)
@@ -299,17 +402,18 @@ def _attn_fwd_ws_pipelined_pingpong(sm_scale, M,  #
                 # Q is no longer live once the final PV has been issued.
                 acc = tlx.async_dot_wait(1, acc)
                 tlx.barrier_arrive(q_empties[cid], 1)
+                inv_l_i = 1.0 / l_i
+                m_i += tl.math.log2(l_i)
+                offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
+                m_ptrs = M + off_hz * N_CTX + offs_m
+                tl.store(m_ptrs, m_i)
                 # wait for the final PV to complete before releasing V
                 acc = tlx.async_dot_wait(0, acc)
                 tlx.barrier_arrive(v_empties[v_buf_id], 1)
 
                 # epilogue
                 qo_offset_y_split = qo_offset_y + cid * BLOCK_M_SPLIT
-                m_i += tl.math.log2(l_i)
-                acc = acc / l_i[:, None]
-                offs_m = start_m * BLOCK_M + cid * BLOCK_M_SPLIT + tl.arange(0, BLOCK_M_SPLIT)
-                m_ptrs = M + off_hz * N_CTX + offs_m
-                tl.store(m_ptrs, m_i)
+                acc = acc * inv_l_i[:, None]
                 desc_o.store([qo_offset_y_split, 0], acc.to(tlx.dtype_of(desc_o)))
 
                 tile_idx += num_progs
@@ -383,7 +487,7 @@ configs_bwd = [
 ]
 
 
-@triton.autotune(configs=configs_bwd, key=["N_CTX", "HEAD_DIM"])
+@triton.autotune(configs=configs_bwd, key=["N_CTX", "HEAD_DIM", "CAUSAL"])
 @triton.jit
 def _attn_bwd_tlx(
     desc_q,
@@ -406,6 +510,7 @@ def _attn_bwd_tlx(
     NUM_MMA_GROUPS_BWD: tl.constexpr,
     NUM_MMA_WARPS_BWD: tl.constexpr,
     BWD_REGISTERS: tl.constexpr,
+    CAUSAL: tl.constexpr,
 ):
     RCP_LN2: tl.constexpr = 1.4426950408889634
 
@@ -419,7 +524,8 @@ def _attn_bwd_tlx(
     row_base = off_chz
     start_n = pid * BLOCK_N
     global_start_n = row_base + start_n
-    num_steps = N_CTX // BLOCK_M
+    first_q_block = start_n // BLOCK_M if CAUSAL else 0
+    num_steps = N_CTX // BLOCK_M - first_q_block
     CID_BLOCK_N: tl.constexpr = BLOCK_N // NUM_MMA_GROUPS_BWD
 
     kv_atom_layout: tl.constexpr = tlx.nv_mma_shared_layout_encoding(
@@ -475,7 +581,6 @@ def _attn_bwd_tlx(
     q_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q, arrive_count=1)
     q_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q, arrive_count=NUM_MMA_GROUPS_BWD)
     do_fulls = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q, arrive_count=1)
-    do_empties = tlx.alloc_barriers(num_barriers=NUM_BUFFERS_Q, arrive_count=NUM_MMA_GROUPS_BWD)
 
     K_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_k))
     V_BYTES_PER_ELEM: tl.constexpr = tlx.size_of(tlx.dtype_of(desc_v))
@@ -497,9 +602,10 @@ def _attn_bwd_tlx(
             tlx.async_descriptor_load(desc_k, k_load_view, [global_start_n, 0], kv_full[0])
             tlx.async_descriptor_load(desc_v, v_load_view, [global_start_n, 0], kv_full[0])
 
-            for blk in range(num_steps):
-                q_buf = blk % NUM_BUFFERS_Q
-                q_phase = (blk // NUM_BUFFERS_Q) & 1
+            for q_iter in range(num_steps):
+                q_buf = q_iter % NUM_BUFFERS_Q
+                q_phase = (q_iter // NUM_BUFFERS_Q) & 1
+                blk = first_q_block + q_iter
                 start_m = blk * BLOCK_M
                 global_start_m = row_base + start_m
                 q_load_view = tlx.local_reinterpret(
@@ -516,11 +622,11 @@ def _attn_bwd_tlx(
                     layout=qdo_atom_layout,
                     pin=False,
                 )
+                # Each consumer releases this slot only after its final Q and dO reads.
                 tlx.barrier_wait(q_empties[q_buf], q_phase ^ 1)
                 tlx.barrier_expect_bytes(q_fulls[q_buf], BLOCK_M * HEAD_DIM * Q_BYTES_PER_ELEM)
                 tlx.async_descriptor_load(desc_q, q_load_view, [global_start_m, 0], q_fulls[q_buf])
 
-                tlx.barrier_wait(do_empties[q_buf], q_phase ^ 1)
                 tlx.barrier_expect_bytes(do_fulls[q_buf], BLOCK_M * HEAD_DIM * DO_BYTES_PER_ELEM)
                 tlx.async_descriptor_load(desc_do, do_load_view, [global_start_m, 0], do_fulls[q_buf])
 
@@ -552,9 +658,10 @@ def _attn_bwd_tlx(
             tlx.barrier_wait(kv_full[0], 0)
             dk = tl.zeros([CID_BLOCK_N, HEAD_DIM], dtype=tl.float32)
             dv = tl.zeros([CID_BLOCK_N, HEAD_DIM], dtype=tl.float32)
-            for blk in range(num_steps):
-                q_buf = blk % NUM_BUFFERS_Q
-                q_phase = (blk // NUM_BUFFERS_Q) & 1
+            for q_iter in range(num_steps):
+                q_buf = q_iter % NUM_BUFFERS_Q
+                q_phase = (q_iter // NUM_BUFFERS_Q) & 1
+                blk = first_q_block + q_iter
                 start_m = blk * BLOCK_M
                 offs_m = start_m + tl.arange(0, BLOCK_M)
 
@@ -569,8 +676,9 @@ def _attn_bwd_tlx(
                 qT = tlx.local_trans(q)
 
                 qkT = tlx.async_dot(k_slice, qT)
-                m = tl.load(M + offs_m)
-                Di = tl.load(D + offs_m)
+                valid_m = offs_m < N_CTX
+                m = tl.load(M + offs_m, mask=valid_m)
+                Di = tl.load(D + offs_m, mask=valid_m)
                 tlx.barrier_wait(do_fulls[q_buf], q_phase)
                 do = tlx.local_reinterpret(
                     do_smem[q_buf],
@@ -582,6 +690,9 @@ def _attn_bwd_tlx(
                 doT = tlx.local_trans(do)
                 qkT = tlx.async_dot_wait(0, qkT)
                 qkT *= sm_scale * RCP_LN2
+                if CAUSAL and start_m < start_n + BLOCK_N:
+                    offs_n = start_n + cid_start_n + tl.arange(0, CID_BLOCK_N)
+                    qkT = tl.where(offs_m[None, :] >= offs_n[:, None], qkT, -float("inf"))
                 pT = tl.math.exp2(qkT - m[None, :])
                 dpT = tlx.async_dot(v_slice, doT)
                 dv = tlx.async_dot(pT.to(tlx.dtype_of(desc_q)), do, dv)
@@ -589,7 +700,6 @@ def _attn_bwd_tlx(
                 dsT = pT * (dpT - Di[None, :])
                 dk = tlx.async_dot(dsT.to(tlx.dtype_of(desc_q)), q, dk)
                 dv = tlx.async_dot_wait(1, dv)
-                tlx.barrier_arrive(do_empties[q_buf], 1)
                 tlx.local_store(score_smem, dsT.to(tlx.dtype_of(desc_q)))
                 tlx.fence_async_shared()
 
@@ -598,7 +708,7 @@ def _attn_bwd_tlx(
                 tlx.barrier_arrive(q_empties[q_buf], 1)
                 dq = tlx.async_dot_wait(0, dq)
                 dq *= sm_scale
-                dq_store_buf = cid * NUM_BUFFERS_DQ_STORE + blk % NUM_BUFFERS_DQ_STORE
+                dq_store_buf = cid * NUM_BUFFERS_DQ_STORE + q_iter % NUM_BUFFERS_DQ_STORE
                 tlx.async_descriptor_store_wait(NUM_BUFFERS_DQ_STORE - 1)
                 tlx.local_store(dq_store_smem[dq_store_buf], dq.to(tlx.dtype_of(desc_dq)))
                 tlx.fence_async_shared()
@@ -633,7 +743,7 @@ def _attn_bwd_tlx(
 class _attention(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, q, k, v, sm_scale):
+    def forward(ctx, q, k, v, sm_scale, causal, config):
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
         # when v is in float8_e5m2 it is transposed.
@@ -663,23 +773,63 @@ class _attention(torch.autograd.Function):
 
         NUM_SMS = torch.cuda.get_device_properties(q.device).multi_processor_count
 
+        use_s4096_tuning = (
+            causal
+            and q.shape == (4, 48, 4096, 128)
+            and q.dtype == torch.bfloat16
+        )
+        target_s4096_workers = min(NUM_SMS, 131) if use_s4096_tuning else NUM_SMS
+        steady_unroll = 1 if use_s4096_tuning else 2
+
         def grid(META):
             total_tiles = triton.cdiv(q.shape[2], META["BLOCK_M"]) * q.shape[0] * q.shape[1]
-            return (min(NUM_SMS, total_tiles), 1, 1)
+            return (min(target_s4096_workers, total_tiles), 1, 1)
 
         ctx.grid = grid
-        _attn_fwd_ws_pipelined_pingpong[grid](
-            sm_scale, M,  #
-            q.shape[0], q.shape[1],  #
-            desc_q, desc_k, desc_v, desc_o,  #
-            N_CTX=q.shape[2],  #
-            HEAD_DIM=HEAD_DIM_K,  #
-            FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
-            **extra_kern_args)
+        if config is None:
+            _attn_fwd_ws_pipelined_pingpong[grid](
+                sm_scale, M,  #
+                q.shape[0], q.shape[1],  #
+                desc_q, desc_k, desc_v, desc_o,  #
+                N_CTX=q.shape[2],  #
+                HEAD_DIM=HEAD_DIM_K,  #
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,  #
+                CAUSAL=causal,  #
+                STEADY_UNROLL=steady_unroll,  #
+                **extra_kern_args)
+        else:
+            config = dict(config)
+            nargs = {
+                **config,
+                "HEAD_DIM": HEAD_DIM_K,
+                "desc_q": desc_q,
+                "desc_k": desc_k,
+                "desc_v": desc_v,
+                "desc_o": desc_o,
+                "FP8_OUTPUT": q.dtype == torch.float8_e5m2,
+            }
+            _host_descriptor_pre_hook(nargs)
+            _attn_fwd_ws_pipelined_pingpong.fn[grid](
+                sm_scale,
+                M,
+                q.shape[0],
+                q.shape[1],
+                desc_q,
+                desc_k,
+                desc_v,
+                desc_o,
+                N_CTX=q.shape[2],
+                HEAD_DIM=HEAD_DIM_K,
+                FP8_OUTPUT=q.dtype == torch.float8_e5m2,
+                CAUSAL=causal,
+                STEADY_UNROLL=steady_unroll,
+                **config,
+            )
 
         ctx.save_for_backward(q, k, v, o, M)
         ctx.sm_scale = sm_scale
         ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.causal = causal
         return o
 
     @staticmethod
@@ -729,57 +879,14 @@ class _attention(torch.autograd.Function):
             N_HEAD,
             N_CTX,
             HEAD_DIM=ctx.HEAD_DIM,
+            CAUSAL=ctx.causal,
         )
 
-        return dq, dk, dv, None
+        return dq, dk, dv, None, None, None
 
 
-def attention(q, k, v, sm_scale, config=None):
-    if config is None:
-        return _attention.apply(q, k, v, sm_scale)
-
-    # Non-autotuned path with explicit config
-    HEAD_DIM_K = q.shape[-1]
-    o = torch.empty_like(q)
-    M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)
-    y_dim = q.shape[0] * q.shape[1] * q.shape[2]
-
-    dummy_block = [1, 1]
-    desc_q = TensorDescriptor(q, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-    if q.dtype == torch.float8_e5m2:
-        desc_v = TensorDescriptor(v, shape=[HEAD_DIM_K, y_dim], strides=[q.shape[2], 1], block_shape=dummy_block)
-    else:
-        desc_v = TensorDescriptor(v, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-    desc_k = TensorDescriptor(k, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-    desc_o = TensorDescriptor(o, shape=[y_dim, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
-
-    # Apply pre_hook to set block shapes
-    nargs = {
-        **config, "HEAD_DIM": HEAD_DIM_K, "desc_q": desc_q, "desc_k": desc_k, "desc_v": desc_v, "desc_o": desc_o,
-        "FP8_OUTPUT": q.dtype == torch.float8_e5m2
-    }
-    _host_descriptor_pre_hook(nargs)
-
-    def alloc_fn(size: int, align: int, _):
-        return torch.empty(size, dtype=torch.int8, device="cuda")
-
-    triton.set_allocator(alloc_fn)
-
-    NUM_SMS = torch.cuda.get_device_properties(q.device).multi_processor_count
-    total_tiles = triton.cdiv(q.shape[2], config["BLOCK_M"]) * q.shape[0] * q.shape[1]
-    grid = (min(NUM_SMS, total_tiles), 1, 1)
-    _attn_fwd_ws_pipelined_pingpong.fn[grid](
-        sm_scale,
-        M,
-        q.shape[0],
-        q.shape[1],
-        desc_q,
-        desc_k,
-        desc_v,
-        desc_o,
-        N_CTX=q.shape[2],
-        HEAD_DIM=HEAD_DIM_K,
-        FP8_OUTPUT=q.dtype == torch.float8_e5m2,
-        **config,
-    )
-    return o
+def attention(q, k, v, sm_scale, causal=False, config=None):
+    if isinstance(causal, dict) and config is None:
+        config = causal
+        causal = False
+    return _attention.apply(q, k, v, sm_scale, causal, config)

--- a/third_party/tlx/tutorials/testing/test_correctness.py
+++ b/third_party/tlx/tutorials/testing/test_correctness.py
@@ -1134,35 +1134,47 @@ def test_hopper_fa_ws_pipelined():
 
 
 @pytest.mark.skipif(not is_hopper(), reason="Requires Hopper GPU")
-def test_hopper_fa_ws_pipelined_pingpong():
+@pytest.mark.parametrize("causal", [False, True])
+def test_hopper_fa_ws_pipelined_pingpong(causal):
     config = FlashAttention.CONFIGS["hopper_fa_ws_pipelined_pingpong"]
     sm_scale = 0.5
-    causal = False
     for Z, H, N_CTX, HEAD_DIM in FlashAttention.SHAPES:
         q, k, v = FlashAttention.create_inputs(Z, H, N_CTX, HEAD_DIM)
         ref_out = FlashAttention.get_reference(q, k, v, sm_scale, causal)
-        tri_out = _hopper_fa_ws_pipelined_pingpong(q, k, v, sm_scale, config=config)
+        tri_out = _hopper_fa_ws_pipelined_pingpong(
+            q,
+            k,
+            v,
+            sm_scale,
+            causal=causal,
+            config=config,
+        )
         torch.testing.assert_close(tri_out, ref_out, atol=1e-2, rtol=0)
 
 
 @pytest.mark.skipif(not is_hopper(), reason="Requires Hopper GPU")
-def test_hopper_fa_ws_pipelined_pingpong_bwd():
-    # Backward-only coverage for the Hopper pingpong kernel: the fwd tests
-    # above do not exercise _attn_bwd_tlx, so bwd regressions (e.g. MMA
-    # reorder, dsT/dQ shared-path changes) would otherwise go uncaught.
-    # Non-causal only: the Hopper kernel does not support causal attention.
+@pytest.mark.parametrize("causal", [False, True])
+def test_hopper_fa_ws_pipelined_pingpong_bwd(causal):
+    # The forward-only tests above do not exercise _attn_bwd_tlx, so compare
+    # both dense and causal gradients against SDPA independently.
     shape = (1, 1, 1024, 128)
     torch.manual_seed(20)
     q0, k0, v0 = [torch.empty(shape, device=DEVICE, dtype=torch.bfloat16).normal_(mean=0.0, std=0.5) for _ in range(3)]
     do = torch.empty(shape, device=DEVICE, dtype=torch.bfloat16).normal_(mean=0.0, std=0.5)
 
     ref_q, ref_k, ref_v = [tensor.detach().clone().requires_grad_() for tensor in (q0, k0, v0)]
-    ref_o = torch.nn.functional.scaled_dot_product_attention(ref_q, ref_k, ref_v, scale=0.5, is_causal=False)
+    ref_o = torch.nn.functional.scaled_dot_product_attention(
+        ref_q,
+        ref_k,
+        ref_v,
+        scale=0.5,
+        is_causal=causal,
+    )
     ref_o.backward(do)
     reference = (ref_q.grad, ref_k.grad, ref_v.grad)
 
     q, k, v = [tensor.detach().clone().requires_grad_() for tensor in (q0, k0, v0)]
-    out = _hopper_fa_ws_pipelined_pingpong(q, k, v, 0.5)
+    out = _hopper_fa_ws_pipelined_pingpong(q, k, v, 0.5, causal=causal)
     out.backward(do)
     result = (q.grad, k.grad, v.grad)
     assert all(torch.isfinite(grad).all() for grad in result)


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/tritonbench/pull/1263

Add compile-time causal forward and backward paths to the Hopper TLX pingpong attention kernel and optimize their persistent execution while preserving dense behavior.

Forward restricts K/V traversal to the visible prefix and masks only the diagonal tile before the online-softmax recurrence. For S1024 and S2048, it reverses the causal row order on alternate heads so persistent workers receive a balanced mix of short and long prefixes while retaining all 132 workers. S8192 keeps its bijective 64-row permutation with alternating head-pair reversal. For BF16 B=4, H=48, S=4096, D=128 causal forward, it selects 131 persistent workers and reduces the steady-state producer and consumer loop unroll factor from two to one. The worker stride is then coprime with the 32 query rows, while the smaller loop body reduces instruction-delivery stalls without changing the two-slot ring schedule. The final row log normalization and finalized M stores execute in the final asynchronous PV window without changing accumulator semantics, Q/V release points, named barriers, ring phases, or descriptor geometry.

Backward skips Q blocks preceding each K/V tile and masks overlapping blocks. It uses the Q-empty barrier as the shared Q/dO reuse gate after both consumers finish their dO-dependent work, removing a redundant dO empty-barrier protocol while preserving two-consumer arrival counts, gradient ownership, and ring phases.

Expose `causal=False` through the public autograd API, retain compatibility with the previous positional `config` argument, add dense/causal correctness coverage, and enable Tritonbench causal execution for the TLX provider.

Performance:
Measured on H100 GPU 6, BF16, B=4, H=48, D=128, causal=True, with GPU-event timing. `fbcode/triton/scripts/denoise.sh` held the GPU at a 700 W power cap and 1980 MHz SM clock across the batch. TLX and FA3 were measured in the same Tritonbench process for each shape with fresh per-shape Triton caches. The Average row first averages each provider's seven TFLOP/s values and then computes TLX / FA3 from those averages.

Causal forward:

| SeqLen | FA3 TFLOP/s | TLX TFLOP/s | TLX / FA3 |
| ---: | ---: | ---: | ---: |
| 128 | 40.265 | 33.962 | 84.35% |
| 256 | 91.180 | 84.876 | 93.09% |
| 512 | 190.650 | 167.772 | 88.00% |
| 1024 | 366.465 | 359.432 | 98.08% |
| 2048 | 561.776 | 514.573 | 91.60% |
| 4096 | 651.921 | 608.381 | 93.32% |
| 8192 | 678.407 | 632.578 | 93.24% |
| Average | 368.666 | 343.082 | 93.06% |

Causal backward:

| SeqLen | FA3 TFLOP/s | TLX TFLOP/s | TLX / FA3 |
| ---: | ---: | ---: | ---: |
| 128 | 24.152 | 26.852 | 111.18% |
| 256 | 49.992 | 57.839 | 115.70% |
| 512 | 94.697 | 116.508 | 123.03% |
| 1024 | 181.277 | 219.489 | 121.08% |
| 2048 | 314.321 | 346.823 | 110.34% |
| 4096 | 438.919 | 458.410 | 104.44% |
| 8192 | 517.265 | 521.769 | 100.87% |
| Average | 231.518 | 249.670 | 107.84% |

TLX causal backward outperforms FA3 at every measured shape, with a throughput-average advantage of 7.84%. Causal forward reaches 93.06% of FA3 throughput on average, 98.08% at S1024, 93.32% at S4096, and 93.24% at S8192.

Reviewed By: stashuk-olek

Differential Revision: D119239333
