### PR TITLE
[TLX][AMD] Fix barrier phase waits on gfx1250

### DIFF
--- a/python/test/unit/language/test_tlx_amd_gfx1250.py
+++ b/python/test/unit/language/test_tlx_amd_gfx1250.py
@@ -231,5 +231,7 @@ def test_wait_arrive_non_ws_gfx1250(BLOCK_SIZE, device):
     kernel = run_tlx_square(tlx_square_non_ws, BLOCK_SIZE, device, expected_arrival_count=4)
 
     ttgir = kernel.asm["ttgir"]
-    assert ((ttgir.count("amdgpu.init_barrier") == 1) and (ttgir.count("amdgpu.read_barrier_phase") == 3)
-            and (ttgir.count("amdgpu.arrive_barrier") == 3)), f"TTGIR {ttgir}"
+    assert ((ttgir.count("amdg.init_barrier") == 1) and (ttgir.count("amdg.read_barrier_phase") == 3)
+            and (ttgir.count("amdg.arrive_barrier") == 3)), f"TTGIR {ttgir}"
+    assert "s_wait_dscnt" in kernel.asm["amdgcn"]
+    assert "s_waitcnt" not in kernel.asm["amdgcn"]

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -7,6 +7,18 @@
 // COMMON-DAG: [[$GLOBAL_MMRA_TAG:#[A-Za-z0-9_]+]] = #llvm.mmra_tag<"amdgpu-synchronize-as":"global">
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // COMMON-LABEL: read_barrier_phase
+  tt.func @read_barrier_phase(%alloc: !ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>) -> i32 {
+    // COMMON: %[[PHASE:.*]] = llvm.load {{.*}} : !llvm.ptr<3> -> i32
+    // CHECK-NEXT: rocdl.s.waitcnt 49279
+    // GFX950-NEXT: rocdl.s.waitcnt 49279
+    // GFX906-NEXT: rocdl.s.waitcnt 49279
+    // GFX1250-NEXT: rocdl.s.wait.dscnt 0
+    // COMMON-NEXT: llvm.return %[[PHASE]] : i32
+    %phase = "amdg.read_barrier_phase"(%alloc) : (!ttg.memdesc<1xi64, #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>, #ttg.shared_memory, mutable>) -> i32
+    tt.return %phase : i32
+  }
+
   // COMMON-LABEL: lower_barrier
   tt.func @lower_barrier() {
     // COMMON: llvm.fence syncscope("workgroup") release {llvm.mmra = [[$LOCAL_MMRA_TAG]]}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BarrierOpConversion.cpp
@@ -119,12 +119,10 @@ struct ReadBarrierPhaseOpConversion
 
     auto res = b.load(i32_ty, phaseBaseAddr);
 
-    GCNBuilder phaseReadBuilder;
-    MLIRContext *ctx = rewriter.getContext();
-    auto &wait_cnt = *phaseReadBuilder.create("s_waitcnt lgkmcnt(0)");
-    wait_cnt();
-    phaseReadBuilder.launch(rewriter, loc, void_ty(ctx),
-                            true /*hasSideEffects*/);
+    // gfx12 uses a separate LDS counter; let the target-specific lowering
+    // select s_wait_dscnt instead of the legacy s_waitcnt instruction.
+    triton::amdgpu::MemoryCounterWaitOp::create(rewriter, loc, nullptr, nullptr,
+                                                rewriter.getI32IntegerAttr(0));
     rewriter.replaceOp(op, res);
     return success();
   }


### PR DESCRIPTION
TLX barrier phase reads emit `s_waitcnt lgkmcnt(0)`, which gfx1250 does not support, causing kernels that use barrier waits to fail compilation.

Lower the wait through `MemoryCounterWaitOp` so gfx1250 uses `s_wait_dscnt 0` while older targets retain `s_waitcnt`. Add a lit regression for gfx906, gfx942, gfx950, and gfx1250, and update the existing TLX barrier runtime test to check the current amdg operation names and emitted wait instruction.