### PR TITLE
[TLX][AMD] Account for async wait tokens across region branches

### DIFF
--- a/python/test/unit/language/test_tlx_amd_gfx1250.py
+++ b/python/test/unit/language/test_tlx_amd_gfx1250.py
@@ -134,6 +134,36 @@ def test_async_amd_desc_load_correctness_gfx1250(device, M, N):
     torch.testing.assert_close(x, output)
 
 
+@triton.jit
+def _async_amd_desc_warp_token_wait_kernel(src, dst, n):
+    desc = tl.make_tensor_descriptor(src, [64, 32], [32, 1], [32, 32])
+    buffers = tlx.local_alloc((32, 32), tl.float16, 2)
+    for i in tl.range(0, n, num_stages=1):
+        with tlx.warp_pipeline_stage("load", priority=1):
+            token0 = tlx.async_amd_descriptor_load(desc, tlx.local_view(buffers, 0), [0, 0])
+            token1 = tlx.async_amd_descriptor_load(desc, tlx.local_view(buffers, 1), [32, 0])
+        tlx.async_amd_descriptor_wait(tokens=[token0])
+        with tlx.warp_pipeline_stage("store", priority=0):
+            value = tlx.local_load(tlx.local_view(buffers, 0))
+            offsets = tl.arange(0, 32)[:, None] * 32 + tl.arange(0, 32)[None, :]
+            tl.store(dst + i * 1024 + offsets, value)
+        tlx.async_amd_descriptor_wait(tokens=[token1])
+
+
+@pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250 hardware")
+@pytest.mark.parametrize("iterations", [1, 3])
+def test_async_amd_desc_token_wait_warp_pipeline_gfx1250(device, iterations):
+    import re
+
+    src = torch.randn((64, 32), dtype=torch.float16, device=device)
+    dst = torch.empty((iterations, 32, 32), dtype=torch.float16, device=device)
+    compiled = _async_amd_desc_warp_token_wait_kernel[(1, )](src, dst, iterations, num_stages=1)
+    # Wait for the first load while allowing the second load to remain in flight.
+    assert re.search(r"s_wait_tensorcnt\s+(?:0x)?1\b", compiled.asm["amdgcn"])
+    assert re.search(r"s_wait_tensorcnt\s+(?:0x)?0\b", compiled.asm["amdgcn"])
+    torch.testing.assert_close(dst, src[:32].expand(iterations, -1, -1))
+
+
 @pytest.mark.skipif(not is_hip_gfx1250(), reason="Requires gfx1250 hardware")
 def test_async_amd_desc_load_fused_correctness_gfx1250(device):
     rows, cols = 16, 32

--- a/test/TritonGPU/amd/amd-update-async-wait-count.mlir
+++ b/test/TritonGPU/amd/amd-update-async-wait-count.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file --tritonamdgpu-update-async-wait-count=gfx-arch=gfx1250 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --tritonamdgpu-warp-pipeline --tritonamdgpu-update-async-wait-count=gfx-arch=gfx1250 | FileCheck %s
 
 // Simple case without any branching
 
@@ -753,6 +754,284 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     // Nothing in between => count = 0
     // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 0
     %w2 = amdg.async_tdm_wait %2 {num = 0 : i32}
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#tdm_shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // Forming warp stages must not hide the second outstanding copy when the
+  // first copy's commit token becomes a stage result. Both RUN lines agree.
+  // CHECK-LABEL: @warp_pipeline_token_wait
+  tt.func @warp_pipeline_token_wait(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf0: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %buf1: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %out: !tt.ptr<f32>, %n: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %n step %c1 {
+      %copy0 = ttg.async_copy_global_to_local %src, %buf0 : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group0 = ttg.async_commit_group tokens %copy0
+      %copy1 = ttg.async_copy_global_to_local %src, %buf1 : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group1 = ttg.async_commit_group tokens %copy1
+      rocdl.sched.barrier none {triton.warp_pipeline.border = "load"}
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+      %wait0 = ttg.async_wait %group0 {num = 1 : i32}
+      %value = tt.load %out : !tt.ptr<f32>
+      tt.store %out, %value : !tt.ptr<f32>
+      rocdl.sched.barrier none {triton.warp_pipeline.border = "compute"}
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 0 : i32
+      %wait1 = ttg.async_wait %group1 {num = 0 : i32}
+    }
+    tt.return
+  }
+
+  // Follow nested, nonzero result indices to their corresponding yields.
+  // Copies after the producer inside both regions must be counted once.
+  // CHECK-LABEL: @execute_region_nested_results
+  tt.func @execute_region_nested_results(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>) {
+    %outer:2 = scf.execute_region -> (!ttg.async.token, !ttg.async.token) {
+      %inner:2 = scf.execute_region -> (!ttg.async.token, !ttg.async.token) {
+        %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        %group0 = ttg.async_commit_group tokens %copy0
+        %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        %group1 = ttg.async_commit_group tokens %copy1
+        scf.yield %group1, %group0 : !ttg.async.token, !ttg.async.token
+      }
+      scf.execute_region {
+        %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        scf.yield
+      }
+      scf.yield %inner#0, %inner#1 : !ttg.async.token, !ttg.async.token
+    }
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2 : i32
+    %wait0 = ttg.async_wait %outer#1 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait1 = ttg.async_wait %outer#0 {num = 0 : i32}
+    // Multiple tokens use the minimum count.
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait2 = ttg.async_wait %outer#1, %outer#0 {num = 0 : i32}
+    tt.return
+  }
+
+  // Count intervening regions, retaining the minimum over conditional paths.
+  // Forwarding an external token through a yield must not double-count the
+  // region. Also exercise a wait nested in a separate execute_region.
+  // CHECK-LABEL: @execute_region_forwarded_token
+  tt.func @execute_region_forwarded_token(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %forwarded = scf.execute_region -> !ttg.async.token {
+      scf.if %cond {
+        %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      } else {
+        %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        %copy3 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      }
+      scf.execute_region {
+        %copy4 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        scf.yield
+      }
+      scf.yield %group0 : !ttg.async.token
+    }
+    scf.execute_region {
+      %copy5 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 3 : i32
+      %wait0 = ttg.async_wait %group0 {num = 0 : i32}
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 3 : i32
+      %wait1 = ttg.async_wait %forwarded {num = 0 : i32}
+      scf.yield
+    }
+    tt.return
+  }
+
+  // Follow stage results on both the initial and loop-backedge token paths.
+  // CHECK-LABEL: @execute_region_loop_carried_token
+  tt.func @execute_region_loop_carried_token(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %n: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %initial = scf.execute_region -> !ttg.async.token {
+      %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group0 = ttg.async_commit_group tokens %copy0
+      %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      scf.yield %group0 : !ttg.async.token
+    }
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%token = %initial) -> !ttg.async.token {
+      scf.execute_region {
+        %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        scf.yield
+      }
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 2 : i32
+      %wait = ttg.async_wait %token {num = 0 : i32}
+      %next = scf.execute_region -> !ttg.async.token {
+        %copy3 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        %group1 = ttg.async_commit_group tokens %copy3
+        %copy4 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        scf.yield %group1 : !ttg.async.token
+      }
+      scf.yield %next : !ttg.async.token
+    }
+    tt.return
+  }
+
+  // A stage may pass a token back unchanged. Traversing the resulting def-use
+  // cycle must terminate even when the loop contains no new async operations.
+  // CHECK-LABEL: @execute_region_loop_forwarding_cycle
+  tt.func @execute_region_loop_forwarding_cycle(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %n: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %result = scf.for %i = %c0 to %n step %c1 iter_args(%token = %group0) -> !ttg.async.token {
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 0 : i32
+      %wait = ttg.async_wait %token {num = 0 : i32}
+      %next = scf.execute_region -> !ttg.async.token {
+        scf.yield %token : !ttg.async.token
+      }
+      scf.yield %next : !ttg.async.token
+    }
+    tt.return
+  }
+
+  // Multi-block execute regions remain unsupported: do not assume that every
+  // block executes or that the first block has a yield for each result.
+  // CHECK-LABEL: @execute_region_multiblock_conservative
+  tt.func @execute_region_multiblock_conservative(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %token = scf.execute_region -> !ttg.async.token {
+      cf.cond_br %cond, ^bb1, ^bb2
+    ^bb1:
+      %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group1 = ttg.async_commit_group tokens %copy1
+      scf.yield %group1 : !ttg.async.token
+    ^bb2:
+      scf.yield %group0 : !ttg.async.token
+    }
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0 : i32
+    %wait0 = ttg.async_wait %token {num = 0 : i32}
+    %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    // Only the unconditional copy after the region can be counted.
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait1 = ttg.async_wait %group0 {num = 0 : i32}
+    tt.return
+  }
+
+  // TDM token waits share the same traversal, but count only TDM instructions.
+  // CHECK-LABEL: @execute_region_tdm_tokens
+  tt.func @execute_region_tdm_tokens(%desc: !tt.tensordesc<128x16xf16>, %tdm_buf: !ttg.memdesc<128x16xf16, #tdm_shared, #smem, mutable>, %src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>) {
+    %tokens:2 = scf.execute_region -> (!ttg.async.token, !ttg.async.token) {
+      %tdm0 = amdg.async_tdm_copy_global_to_local %desc into %tdm_buf : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #tdm_shared, #smem, mutable>
+      %tdm1 = amdg.async_tdm_copy_global_to_local %desc into %tdm_buf : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #tdm_shared, #smem, mutable>
+      scf.yield %tdm0, %tdm1 : !ttg.async.token, !ttg.async.token
+    }
+    scf.execute_region {
+      %copy = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %tdm2 = amdg.async_tdm_copy_global_to_local %desc into %tdm_buf : !tt.tensordesc<128x16xf16> -> !ttg.memdesc<128x16xf16, #tdm_shared, #smem, mutable>
+      scf.yield
+    }
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 2 : i32
+    %wait0 = amdg.async_tdm_wait %tokens#0 {num = 0 : i32}
+    // CHECK: amdg.async_tdm_intrinsic_wait {{.*}} {count = 1 : i32
+    %wait1 = amdg.async_tdm_wait %tokens#1 {num = 0 : i32}
+    tt.return
+  }
+
+  // Each result maps to a different incoming token on each branch. Count the
+  // suffix after that token, then take the minimum across the two branches.
+  // CHECK-LABEL: @if_result_tokens
+  tt.func @if_result_tokens(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %tokens:2 = scf.if %cond -> (!ttg.async.token, !ttg.async.token) {
+      %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group0 = ttg.async_commit_group tokens %copy0
+      %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group1 = ttg.async_commit_group tokens %copy1
+      scf.yield %group1, %group0 : !ttg.async.token, !ttg.async.token
+    } else {
+      %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group2 = ttg.async_commit_group tokens %copy2
+      %copy3 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %copy4 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group4 = ttg.async_commit_group tokens %copy4
+      scf.yield %group4, %group2 : !ttg.async.token, !ttg.async.token
+    }
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait0 = ttg.async_wait %tokens#1 {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 0 : i32
+    %wait1 = ttg.async_wait %tokens#0 {num = 0 : i32}
+    tt.return
+  }
+
+  // Forwarded external tokens count the selected branch once, including copies
+  // in nested regions, and retain the common suffix after the conditional.
+  // CHECK-LABEL: @if_forwarded_token
+  tt.func @if_forwarded_token(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %token = scf.if %cond -> !ttg.async.token {
+      scf.execute_region {
+        %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+        scf.yield
+      }
+      scf.yield %group0 : !ttg.async.token
+    } else {
+      %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %copy3 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      scf.yield %group0 : !ttg.async.token
+    }
+    %copy4 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2 : i32
+    %wait0 = ttg.async_wait %token {num = 0 : i32}
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 2 : i32
+    %wait1 = ttg.async_wait %group0 {num = 0 : i32}
+    tt.return
+  }
+
+  // scf.condition's predicate is not a forwarded operand. The before and after
+  // regions have different argument lists, so their raw argument indices cannot
+  // be used as yield/condition operand indices.
+  // CHECK-LABEL: @while_region_token_mapping
+  tt.func @while_region_token_mapping(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %false = arith.constant false
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %result = scf.while (%pred = %cond, %token = %group0) : (i1, !ttg.async.token) -> !ttg.async.token {
+      // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+      %wait0 = ttg.async_wait %token {num = 0 : i32}
+      scf.condition(%pred) %token : !ttg.async.token
+    } do {
+    ^bb0(%token: !ttg.async.token):
+      %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      %group2 = ttg.async_commit_group tokens %copy2
+      %copy3 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      scf.yield %false, %group2 : i1, !ttg.async.token
+    }
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait1 = ttg.async_wait %result {num = 0 : i32}
+    tt.return
+  }
+
+  // Intervening cyclic region graphs fall back to zero, while known copies
+  // outside them are still counted. Static scf.for counts are tested above.
+  // CHECK-LABEL: @while_intervening_count_conservative
+  tt.func @while_intervening_count_conservative(%src: tensor<128x!tt.ptr<f32>, #blocked>, %buf: !ttg.memdesc<128xf32, #shared, #smem, mutable>, %cond: i1) {
+    %false = arith.constant false
+    %copy0 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    %group0 = ttg.async_commit_group tokens %copy0
+    %result = scf.while (%pred = %cond) : (i1) -> i1 {
+      %copy1 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+      scf.condition(%pred) %pred : i1
+    } do {
+    ^bb0(%pred: i1):
+      scf.yield %false : i1
+    }
+    %copy2 = ttg.async_copy_global_to_local %src, %buf : tensor<128x!tt.ptr<f32>, #blocked> -> <128xf32, #shared, #smem, mutable>
+    // CHECK: amdg.async_wait {{.*}} {num_inst = 1 : i32
+    %wait = ttg.async_wait %group0 {num = 0 : i32}
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -2,11 +2,16 @@
 
 #include "amd/lib/TritonAMDGPUTransforms/Utility.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "third_party/amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/DescriptorMemoryLayouts.h"
 #include "triton/Tools/LayoutUtils.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 #include <limits>
 
@@ -19,6 +24,51 @@ namespace {
 int deduceMinCountInBlock(Block &block,
                           const std::function<int(Operation *)> &countFunc);
 
+// Count the minimum over entry-to-exit paths through single-block regions.
+// Region successors may skip a region or select mutually exclusive regions.
+// Cycles and unstructured control flow contribute zero conservatively.
+int deduceMinCountInRegions(RegionBranchOpInterface branch,
+                            const std::function<int(Operation *)> &countFunc) {
+  llvm::SmallPtrSet<Region *, 4> activeRegions;
+  llvm::DenseMap<Region *, int> regionCounts;
+  auto visit = [&](auto &&visit,
+                   RegionBranchPoint point) -> std::optional<int> {
+    SmallVector<RegionSuccessor> successors;
+    branch.getSuccessorRegions(point, successors);
+    if (successors.empty())
+      return std::nullopt;
+
+    int minCount = std::numeric_limits<int>::max();
+    for (RegionSuccessor successor : successors) {
+      if (successor.isOperation()) {
+        minCount = 0;
+        continue;
+      }
+      Region *region = successor.getSuccessor();
+      if (auto it = regionCounts.find(region); it != regionCounts.end()) {
+        minCount = std::min(minCount, it->second);
+        continue;
+      }
+      if (!region->hasOneBlock() || !activeRegions.insert(region).second)
+        return std::nullopt;
+      llvm::scope_exit guard([&] { activeRegions.erase(region); });
+      auto terminator = dyn_cast<RegionBranchTerminatorOpInterface>(
+          region->front().getTerminator());
+      if (!terminator)
+        return std::nullopt;
+      auto suffixCount = visit(visit, RegionBranchPoint(terminator));
+      if (!suffixCount)
+        return std::nullopt;
+      int count =
+          deduceMinCountInBlock(region->front(), countFunc) + *suffixCount;
+      regionCounts[region] = count;
+      minCount = std::min(minCount, count);
+    }
+    return minCount;
+  };
+  return visit(visit, RegionBranchPoint::parent()).value_or(0);
+}
+
 // Returns the minimum found when accumulating countFunc(op) between begin and
 // end (inclusive)
 int deduceMinCountBetweeOps(Operation *beginOp, Operation *endOp,
@@ -27,17 +77,7 @@ int deduceMinCountBetweeOps(Operation *beginOp, Operation *endOp,
   assert(beginOp == endOp || beginOp->isBeforeInBlock(endOp));
   int count = 0;
   for (auto op = beginOp; op != endOp; op = op->getNextNode()) {
-    if (auto ifOp = llvm::dyn_cast<scf::IfOp>(op)) {
-      if (ifOp.getElseRegion().empty())
-        continue;
-
-      assert(!ifOp.getThenRegion().empty() && !ifOp.getElseRegion().empty());
-      auto minThen =
-          deduceMinCountInBlock(ifOp.getThenRegion().front(), countFunc);
-      auto minElse =
-          deduceMinCountInBlock(ifOp.getElseRegion().front(), countFunc);
-      count += std::min(minThen, minElse);
-    } else if (auto forOp = llvm::dyn_cast<scf::ForOp>(op)) {
+    if (auto forOp = llvm::dyn_cast<scf::ForOp>(op)) {
       if (std::optional<APInt> tripCount = forOp.getStaticTripCount()) {
         uint64_t tcVal = 0;
         if (forOp.getUnsignedCmp() && tripCount->ugt(0))
@@ -47,6 +87,8 @@ int deduceMinCountBetweeOps(Operation *beginOp, Operation *endOp,
         if (tcVal > 0)
           count += tcVal * deduceMinCountInBlock(*forOp.getBody(), countFunc);
       }
+    } else if (auto branch = dyn_cast<RegionBranchOpInterface>(op)) {
+      count += deduceMinCountInRegions(branch, countFunc);
     } else {
       count += countFunc(op);
     }
@@ -65,6 +107,7 @@ int deduceMinCountInBlock(Block &block,
 
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
                              const std::function<int(Operation *)> &countFunc,
+                             llvm::SmallDenseSet<Value> &activeTokens,
                              int pathSum, int foundMin) {
   // If the value is not defined in the same region as the consumer we need to
   // peel the parent region of consumer until we arrive at value's region
@@ -74,54 +117,70 @@ int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
     consumerOp = consumerOp->getParentOp();
   }
 
-  // Break recursion if we arrive at the producer updating the path based on the
-  // ops between producer and consumer
-  if (Operation *defOp = defValue.getDefiningOp()) {
+  auto result = dyn_cast<OpResult>(defValue);
+  Operation *owner =
+      result ? result.getOwner() : defValue.getParentRegion()->getParentOp();
+  auto branch = dyn_cast<RegionBranchOpInterface>(owner);
+  if (result) {
     pathSum +=
-        deduceMinCountBetweeOps(defOp->getNextNode(), consumerOp, countFunc);
-    foundMin = std::min(foundMin, pathSum);
-    return foundMin;
-  }
-  // If value is a loop carried argument (BlockArgument) we need to look at
-  // initial arguments of the loop and the previous iteration
-  if (auto arg = mlir::dyn_cast<BlockArgument>(defValue)) {
-    Block *block = arg.getOwner();
-    auto forOp = dyn_cast<scf::ForOp>(block->getParentOp());
-
-    // Failed to track, return 0 conservatively.
-    if (!forOp || forOp.getBody()->empty()) {
+        deduceMinCountBetweeOps(owner->getNextNode(), consumerOp, countFunc);
+    if (!branch)
+      return std::min(foundMin, pathSum);
+  } else {
+    if (!branch || !defValue.getParentRegion()->hasOneBlock())
       return 0;
-    }
-
-    Operation *firstOpInLoop = &*forOp.getBody()->begin();
-    pathSum += deduceMinCountBetweeOps(firstOpInLoop, consumerOp, countFunc);
-
-    // Break recursion early if we exceed previous min
-    if (pathSum >= foundMin)
-      return foundMin;
-
-    Value incomingVal = forOp.getInitArgs()[arg.getArgNumber() - 1];
-    int countLoopInit = deduceMinCountOnDefChain(incomingVal, forOp, countFunc,
-                                                 pathSum, foundMin);
-
-    Operation *yieldOp = block->getTerminator();
-    Value prevVal = yieldOp->getOperand(arg.getArgNumber() - 1);
-    int countPreviousIter = deduceMinCountOnDefChain(
-        prevVal, yieldOp, countFunc, pathSum, foundMin);
-
-    return std::min(std::min(countLoopInit, countPreviousIter), foundMin);
+    pathSum += deduceMinCountBetweeOps(
+        &defValue.getParentRegion()->front().front(), consumerOp, countFunc);
   }
 
-  // Unsupported value, return 0 conservatively.
-  return 0;
+  // Region results and entry arguments are successor inputs. Trace each
+  // incoming operand from its predecessor, counting only that path's copies.
+  // A result/argument index need not be its index among successor inputs.
+  if (llvm::any_of(owner->getRegions(), [](Region &region) {
+        return !region.empty() && !region.hasOneBlock();
+      }))
+    return 0;
+  if (!activeTokens.insert(defValue).second)
+    return 0;
+  llvm::scope_exit guard([&] { activeTokens.erase(defValue); });
+  if (pathSum >= foundMin)
+    return foundMin;
+
+  RegionSuccessor successor = result
+                                  ? RegionSuccessor(owner)
+                                  : RegionSuccessor(defValue.getParentRegion());
+  ValueRange inputs = branch.getSuccessorInputs(successor);
+  auto input = llvm::find(inputs, defValue);
+  if (input == inputs.end())
+    return 0;
+  unsigned index = std::distance(inputs.begin(), input);
+  SmallVector<RegionBranchPoint> predecessors;
+  branch.getPredecessors(successor, predecessors);
+  if (predecessors.empty())
+    return 0;
+  for (RegionBranchPoint predecessor : predecessors) {
+    auto terminator = predecessor.getTerminatorPredecessorOrNull();
+    OperandRange operands = predecessor.isParent()
+                                ? branch.getEntrySuccessorOperands(successor)
+                                : terminator.getSuccessorOperands(successor);
+    if (index >= operands.size())
+      return 0;
+    Operation *endpoint =
+        predecessor.isParent() ? owner : terminator.getOperation();
+    foundMin = std::min(
+        foundMin, deduceMinCountOnDefChain(operands[index], endpoint, countFunc,
+                                           activeTokens, pathSum, foundMin));
+  }
+  return foundMin;
 }
 
 } // namespace
 
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
                              llvm::function_ref<int(Operation *)> countFunc) {
-  return deduceMinCountOnDefChain(defValue, consumerOp, countFunc, 0,
-                                  std::numeric_limits<int>::max());
+  llvm::SmallDenseSet<Value> activeTokens;
+  return deduceMinCountOnDefChain(defValue, consumerOp, countFunc, activeTokens,
+                                  0, std::numeric_limits<int>::max());
 }
 
 // On GFX9, lanes in a warp have to write contiguously to shared memory which


### PR DESCRIPTION
Warp-pipeline stages and conditionals forward async tokens through their results. Treating the enclosing operation as the token producer skips copies issued between the actual producer and the region exit. For example, after two copies in a load stage, waiting on the first copy's token emits a full wait instead of allowing the second copy to overlap compute. Copies nested in intervening stage regions are also missed.

Unhardcode `scf.if` op and switch to `RegionBranchOpInterface` to allow handle region ops uniformly, including `scf.execute_region` used by warp pipelining.

Use `RegionBranchOpInterface` and `RegionBranchTerminatorOpInterface` to map results and region arguments to their incoming operands. Trace from each predecessor's entry or terminator and retain the minimum count across paths. Use successor-input positions rather than raw result, argument, or terminator operand indices; these differ for loop induction variables and scf.condition predicates. This handles nested stages, conditional results, forwarded external tokens, and loop-carried tokens through regions with different argument lists.

Count intervening single-block regions by walking their acyclic successor graph and taking the minimum over entry-to-exit paths. Keep static `scf.for` trip-count handling specialized. Cyclic or multi-block region graphs contribute zero conservatively, and guard token-forwarding cycles so tracing terminates. The shared analysis handles ordinary async-copy and TDM token waits with their respective hardware-counter filters.