### PR TITLE
[TLX][agent] Add AMD GEMM support to kernel optimization agent (#3553)

### DIFF
--- a/third_party/tlx/tools/agents/kernel_optimization/README.md
+++ b/third_party/tlx/tools/agents/kernel_optimization/README.md
@@ -71,7 +71,11 @@ python -m third_party.tlx.tools.agents.kernel_optimization.cli \
   --commit-message "Optimize my kernel with TLX agent"
 ```
 
-`--arch` selects `harnesses/<arch>/targets/<kernel>`; `harness`/`cases`/`target` can also be passed explicitly.
+`--arch` and `--target-name` select
+`harnesses/<arch>/targets/<target-name>`. `--target-name` defaults to the kernel
+filename stem; use it when an implementation-specific filename such as
+`amd_gemm_warp_pipeline.py` should use the generic `gemm` target contract.
+`harness`/`cases`/`target` can also be passed explicitly.
 
 `--prior-run` accepts a completed output directory or its `experiments.json`. It
 imports recomputed source hashes for exact cross-run deduplication and bounded,
@@ -181,6 +185,41 @@ Target-specific `harness.py`/`cases.json`/`target.json` live colocated under `ha
 device you are tuning for. Architecture-wide notes, known optimization tricks, and shared
 target metadata can live directly under `harnesses/<arch>/`. Pass an existing TLX tutorial such as
 `third_party/tlx/tutorials/blackwell_gemm_ws.py` as `--kernel`.
+
+AMD gfx950 GEMM is available under `harnesses/gfx950/targets/gemm/`. The target uses
+the ROCm PyTorch convention `device="cuda:0"` with `backend="hip"` and accepts any
+complete candidate source that exports `matmul(a, b)`.
+
+AMD timing uses `rocprofv3 --kernel-trace` device timestamps after a 20-second
+steady-state burn, rather than short `do_bench` wall-clock measurements that can catch
+the transient MI350 boost clock. A conservative 3x-IQR filter removes only extreme
+system-noise samples before variance checks; raw trace samples remain in the profile
+artifacts. Summary and deep profile requests also collect
+supported PMC groups, including `MfmaUtil`, `VALUBusy`, `MemUnitStalled`, HBM fetch
+size, and LDS conflicts. Raw commands, logs, traces, and counter CSVs remain under the
+experiment artifacts directory. Set `TLX_AMD_STEADY_STATE_SECONDS` to override the
+burn duration for debugging, and `TLX_ROCPROFV3` when `rocprofv3` is not on `PATH`.
+
+Deep profiles additionally run `fb_att` by default for one selected dispatch of the
+dominant kernel. Its local `_ui` directory contains the per-wave instruction timeline
+and source mapping. Set `TLX_FB_ATT` when the wrapper is not on `PATH`. Candidate
+summary profiles use rocprofv3 only; ATT is reserved for baseline/final or other deep
+profiles because it is diagnostic instrumentation, not a promotion timing source.
+Unsupported PMC groups and ATT failures are retained as diagnostics without discarding
+correctness results.
+
+For an initial AMD smoke run, disable automatic commits and use a small search budget.
+The tutorial below is only a convenient seed, not a reference implementation or claim
+of optimality:
+
+```bash
+python -m third_party.tlx.tools.agents.kernel_optimization.cli \
+  --kernel third_party/tlx/tutorials/amd_gemm_warp_pipeline.py \
+  --arch gfx950 --target-name gemm \
+  --output-dir /tmp/tlx-agent-gfx950 \
+  --max-rounds 1 --candidates-per-round 1 \
+  --min-speedup 1.05 --no-commit-winner
+```
 
 `harnesses/host/targets/vector_add/harness.py` is a minimal CPU-friendly harness for smoke tests
 without a real GPU. Candidate must export `vector_add(a, b)`; on CPU the benchmark uses

--- a/third_party/tlx/tools/agents/kernel_optimization/__init__.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/__init__.py
@@ -1,3 +1,4 @@
+from .amd_att import collect_fb_att, find_fb_att
 from .harness import (
     BuildError,
     HarnessExecutionError,
@@ -15,11 +16,11 @@ from .models import (
     KernelOptimizationResult,
     KernelTarget,
     OptimizationBudget,
+    per_case_speedups,
     PerformanceSummary,
     TimingSamples,
     VALID_STRATEGIES,
     VerificationResult,
-    per_case_speedups,
     weighted_geometric_speedup,
 )
 from .optimizer import KernelOptimizer
@@ -32,6 +33,7 @@ from .providers import (
     MockLLMProvider,
     TLX_PROMPT_PREAMBLE,
 )
+from .rocm_profiler import collect_rocprofv3, find_rocprofv3
 
 __all__ = [
     "BuildError",
@@ -41,7 +43,11 @@ __all__ = [
     "CandidateProvider",
     "CaseEvaluation",
     "CodexCandidateProvider",
+    "collect_fb_att",
+    "collect_rocprofv3",
     "ExperimentSummary",
+    "find_fb_att",
+    "find_rocprofv3",
     "FixedCandidateProvider",
     "HarnessExecutionError",
     "HarnessTimeoutError",

--- a/third_party/tlx/tools/agents/kernel_optimization/amd_att.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/amd_att.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ATT_COUNTERS: tuple[str, ...] = ()
+
+
+def find_fb_att(environment: Mapping[str, str] | None = None) -> Path | None:
+    env = os.environ if environment is None else environment
+    configured = env.get("TLX_FB_ATT")
+    if configured:
+        path = Path(configured).resolve()
+        return path if path.is_file() and os.access(path, os.X_OK) else None
+
+    discovered = shutil.which("fb_att", path=env.get("PATH"))
+    if discovered:
+        return Path(discovered).resolve()
+    default = Path("/usr/local/bin/fb_att")
+    return (
+        default.resolve() if default.is_file() and os.access(default, os.X_OK) else None
+    )
+
+
+def collect_fb_att(
+    workload: Sequence[str],
+    artifacts_dir: Path,
+    *,
+    kernel_filter: str,
+    iteration: int = 4,
+    counters: Sequence[str] = DEFAULT_ATT_COUNTERS,
+    perfcounter_control: int = 3,
+    buffer_size: str | None = None,
+    timeout_seconds: float = 900.0,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    if not workload:
+        raise ValueError("fb_att workload must not be empty")
+    if not kernel_filter.strip():
+        raise ValueError("fb_att kernel_filter must not be empty")
+    if iteration <= 0:
+        raise ValueError("fb_att iteration must be positive")
+
+    executable = find_fb_att(environment)
+    if executable is None:
+        return {"error": "fb_att was not found; set TLX_FB_ATT or PATH"}
+
+    artifacts_dir = artifacts_dir.resolve()
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = Path(tempfile.mkdtemp(prefix="fb-att-", dir=artifacts_dir))
+    capture_dir = run_dir / "capture"
+    iteration_range = f"[{iteration}-{iteration}]"
+    command: list[str] = [
+        str(executable),
+        "--fb-specify-kernel",
+        kernel_filter,
+        "--kernel-iteration-range",
+        iteration_range,
+        "--fb-output-directory",
+        str(capture_dir),
+    ]
+    if counters:
+        command.extend(
+            (
+                "--att-perfcounter-ctrl",
+                str(perfcounter_control),
+                "--att-perfcounters",
+                " ".join(counters),
+            )
+        )
+    if buffer_size:
+        command.extend(("--att-buffer-size", buffer_size))
+    # fb_att inserts rocprofv3's `--` separator itself.
+    command.extend(str(argument) for argument in workload)
+
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=dict(os.environ if environment is None else environment),
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        completed = subprocess.CompletedProcess(command, 1, "", str(error))
+
+    _write_process_artifacts(run_dir, command, completed)
+    ui_directories = (
+        sorted(path for path in capture_dir.rglob("*_ui") if path.is_dir())
+        if capture_dir.exists()
+        else []
+    )
+    wstates = sorted(capture_dir.rglob("wstates*.json")) if capture_dir.exists() else []
+    result: dict[str, Any] = {
+        "tool": "fb_att",
+        "tool_path": str(executable),
+        "schema_version": 1,
+        "valid": completed.returncode == 0 and bool(wstates),
+        "kernel_filter": kernel_filter,
+        "iteration_range": iteration_range,
+        "counters": list(counters),
+        "perfcounter_control": perfcounter_control,
+        "artifacts": {
+            "directory": str(run_dir),
+            "capture_directory": str(capture_dir),
+            "ui_directories": [str(path) for path in ui_directories],
+            "wstates": [str(path) for path in wstates],
+            "command": str(run_dir / "command.json"),
+            "stdout": str(run_dir / "stdout.txt"),
+            "stderr": str(run_dir / "stderr.txt"),
+        },
+    }
+    if completed.returncode != 0:
+        result["error"] = f"fb_att failed with code {completed.returncode}"
+    elif not wstates:
+        result["error"] = "fb_att produced no wstates JSON"
+    return result
+
+
+def _write_process_artifacts(
+    run_dir: Path,
+    command: Sequence[str],
+    completed: subprocess.CompletedProcess[str],
+) -> None:
+    (run_dir / "command.json").write_text(
+        json.dumps(
+            {
+                "argv": list(command),
+                "returncode": completed.returncode,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    (run_dir / "stdout.txt").write_text(completed.stdout or "")
+    (run_dir / "stderr.txt").write_text(completed.stderr or "")

--- a/third_party/tlx/tools/agents/kernel_optimization/cli.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -43,10 +44,23 @@ def _parse_args(arguments: list[str] | None = None) -> argparse.Namespace:
         description="Optimize a Triton or TLX kernel with a deterministic harness."
     )
     parser.add_argument("--kernel", type=Path, required=True)
-    parser.add_argument("--reference-kernel", type=Path, default=None, help="Optional reference kernel source used as correctness oracle (harness verify can compare candidate vs reference).")
+    parser.add_argument(
+        "--reference-kernel",
+        type=Path,
+        default=None,
+        help="Optional reference kernel source used as correctness oracle (harness verify can compare candidate vs reference).",
+    )
     parser.add_argument("--harness", type=Path, default=None)
     parser.add_argument("--cases", type=Path, default=None)
     parser.add_argument("--target", type=Path, default=None)
+    parser.add_argument(
+        "--target-name",
+        default=None,
+        help=(
+            "Target contract under harnesses/<arch>/targets/<target-name>; "
+            "defaults to the kernel filename stem."
+        ),
+    )
     parser.add_argument(
         "--arch",
         default=None,
@@ -157,13 +171,20 @@ def _budget_from_args(args: argparse.Namespace) -> OptimizationBudget:
     )
 
 
-def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | None, target: Path | None, arch: str | None) -> tuple[Path, Path, Path]:
+def _resolve_harness_paths(
+    kernel: Path,
+    harness: Path | None,
+    cases: Path | None,
+    target: Path | None,
+    arch: str | None,
+    target_name: str | None = None,
+) -> tuple[Path, Path, Path]:
     # Kernel-only invocation: infer harness/cases/target from
     # harnesses/<arch>/targets/<stem>/
     # e.g. --kernel gemm.py -> harnesses/blackwell/targets/gemm/{harness.py,cases.json,target.json}
     # Harness must be colocated with cases (target-specific), so both are resolved together.
     base = Path(__file__).resolve().parent / "harnesses"
-    stem = kernel.stem  # gemm, vector_add, etc.
+    stem = target_name or kernel.stem  # gemm, vector_add, etc.
     if base.exists() and (harness is None or cases is None or target is None):
         archs = sorted(
             p.name
@@ -182,8 +203,14 @@ def _resolve_harness_paths(kernel: Path, harness: Path | None, cases: Path | Non
             if target is None and (tdir / "target.json").exists():
                 target = tdir / "target.json"
     if harness is None or cases is None or target is None:
-        missing = [n for n, v in [("harness", harness), ("cases", cases), ("target", target)] if v is None]
-        raise SystemExit(f"missing required {'/'.join(missing)}; pass them explicitly or use a kernel with harnesses/<arch>/targets/<name>/")
+        missing = [
+            n
+            for n, v in [("harness", harness), ("cases", cases), ("target", target)]
+            if v is None
+        ]
+        raise SystemExit(
+            f"missing required {'/'.join(missing)}; pass them explicitly or use a kernel with harnesses/<arch>/targets/<name>/"
+        )
     return harness, cases, target
 
 
@@ -214,35 +241,72 @@ def _probe_cuda_compute_capability(device: str | None) -> tuple[int, int]:
     return torch.cuda.get_device_capability(device_index)
 
 
+def _probe_rocm_architecture(device: str | None) -> str:
+    try:
+        import torch
+    except ImportError as error:
+        raise SystemExit(
+            "HIP target validation requires torch to be importable"
+        ) from error
+    if not torch.cuda.is_available() or not getattr(torch.version, "hip", None):
+        raise SystemExit("HIP target selected, but no ROCm device is available")
+    torch_device = torch.device(device or "cuda")
+    if torch_device.type != "cuda":
+        raise SystemExit(f"HIP target selected, but target device is {device!r}")
+    device_index = torch_device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device_index)
+    architecture = str(getattr(properties, "gcnArchName", ""))
+    return architecture or str(torch.cuda.get_device_name(device_index))
+
+
 def _validate_host_matches_target(
     target: KernelTarget,
     arch: str | None,
-    capability_probe: Callable[[str | None], tuple[int, int]] = _probe_cuda_compute_capability,
+    capability_probe: Callable[
+        [str | None], tuple[int, int]
+    ] = _probe_cuda_compute_capability,
+    rocm_arch_probe: Callable[[str | None], str] = _probe_rocm_architecture,
 ) -> None:
-    if target.backend != "cuda":
-        return
-    expected_major = _expected_cuda_major(arch or target.architecture)
-    if expected_major is None:
-        return
     previous_environment: dict[str, str | None] = {}
     try:
         for key, value in target.environment.items():
             previous_environment[key] = os.environ.get(key)
             os.environ[key] = value
-        actual_major, actual_minor = capability_probe(target.device)
+        backend = target.backend.lower()
+        if backend == "cuda":
+            expected_major = _expected_cuda_major(arch or target.architecture)
+            if expected_major is None:
+                return
+            actual_major, actual_minor = capability_probe(target.device)
+            if actual_major != expected_major:
+                expected = f"sm_{expected_major}x"
+                actual = f"sm_{actual_major}{actual_minor}"
+                raise SystemExit(
+                    f"--arch {arch or target.architecture} expects {expected}, "
+                    f"but {target.device or 'cuda'} is {actual}"
+                )
+        elif backend in {"amd", "hip", "rocm"}:
+            expected_match = re.search(
+                r"gfx[0-9a-f]+", (arch or target.architecture).lower()
+            )
+            if expected_match is None:
+                return
+            expected = expected_match.group(0)
+            actual = rocm_arch_probe(target.device)
+            actual_match = re.search(r"gfx[0-9a-f]+", actual.lower())
+            if actual_match is None or expected != actual_match.group(0):
+                raise SystemExit(
+                    f"--arch {arch or target.architecture} expects {expected}, "
+                    f"but {target.device or 'cuda'} is {actual}"
+                )
     finally:
         for key, value in previous_environment.items():
             if value is None:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
-    if actual_major != expected_major:
-        expected = f"sm_{expected_major}x"
-        actual = f"sm_{actual_major}{actual_minor}"
-        raise SystemExit(
-            f"--arch {arch or target.architecture} expects {expected}, "
-            f"but {target.device or 'cuda'} is {actual}"
-        )
 
 
 def _performance_commit_body(
@@ -421,7 +485,14 @@ def _report_commit(commit_result: object) -> None:
 
 def main() -> int:
     args = _parse_args()
-    harness_path, cases_path, target_path = _resolve_harness_paths(args.kernel, args.harness, args.cases, args.target, args.arch)
+    harness_path, cases_path, target_path = _resolve_harness_paths(
+        args.kernel,
+        args.harness,
+        args.cases,
+        args.target,
+        args.arch,
+        args.target_name,
+    )
     case_payloads = _load_json(cases_path)
     target_payload = _load_json(target_path)
     cases = tuple(

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/cases.json
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/cases.json
@@ -1,0 +1,28 @@
+[
+  {
+    "case_id": "square_4096",
+    "parameters": {
+      "m": 4096,
+      "n": 4096,
+      "k": 4096,
+      "dtype": "float16",
+      "seed": 0,
+      "profile": true
+    },
+    "weight": 2.0,
+    "protected": true
+  },
+  {
+    "case_id": "rectangular_8192x4096x2048",
+    "parameters": {
+      "m": 8192,
+      "n": 4096,
+      "k": 2048,
+      "dtype": "float16",
+      "seed": 1,
+      "profile": false
+    },
+    "weight": 1.0,
+    "protected": true
+  }
+]

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/harness.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/harness.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import torch
+
+_AGENT_DIR = Path(__file__).resolve().parents[4]
+if str(_AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(_AGENT_DIR))
+
+from amd_att import collect_fb_att  # noqa: E402
+from rocm_profiler import (  # noqa: E402
+    collect_rocprofv3,
+    filter_extreme_timing_outliers,
+)
+
+_ATT_ITERATION = 4
+_ATT_LAUNCHES = 3
+_ATT_WARMUP = 2
+_COUNTER_BURN_SECONDS = 0.0
+_PROFILE_LAUNCHES = 50
+_STEADY_STATE_SECONDS = 20.0
+
+
+def build(kernel_source: str, target: dict[str, Any]) -> dict[str, Any]:
+    if str(target.get("backend", "")).lower() not in {"amd", "hip", "rocm"}:
+        return {"success": False, "diagnostics": "gfx950 harness requires HIP"}
+    if not getattr(torch.version, "hip", None):
+        return {
+            "success": False,
+            "diagnostics": "gfx950 harness requires a ROCm-enabled PyTorch build",
+        }
+    directory = tempfile.TemporaryDirectory(prefix="tlx-agent-gfx950-gemm-")
+    source_path = Path(directory.name) / "candidate.py"
+    source_path.write_text(kernel_source)
+    try:
+        module = _load_module(source_path, "tlx_agent_gfx950_candidate")
+    except Exception as error:  # noqa: BLE001
+        directory.cleanup()
+        return {
+            "success": False,
+            "diagnostics": f"candidate import failed: {type(error).__name__}: {error}",
+        }
+    if not callable(getattr(module, "matmul", None)):
+        directory.cleanup()
+        return {"success": False, "diagnostics": "candidate must define matmul(a, b)"}
+    return {
+        "success": True,
+        "artifact": (
+            directory,
+            module,
+            source_path,
+            str(target.get("device") or "cuda"),
+        ),
+    }
+
+
+def verify(
+    artifact: tuple[Any, ModuleType, Path, str], case: dict[str, Any]
+) -> dict[str, Any]:
+    _, module, _, device = artifact
+    a, b = _inputs(case, device)
+    try:
+        actual = module.matmul(a, b)
+        expected = torch.matmul(a, b)
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+    except Exception as error:  # noqa: BLE001
+        return {"passed": False, "diagnostics": f"{type(error).__name__}: {error}"}
+    return {"passed": True}
+
+
+def benchmark(
+    artifact: tuple[Any, ModuleType, Path, str],
+    case: dict[str, Any],
+    repetitions: int,
+) -> dict[str, Any]:
+    _, _, source_path, device = artifact
+    launches = max(repetitions, _PROFILE_LAUNCHES)
+    burn_seconds = _steady_state_seconds()
+    with tempfile.TemporaryDirectory(prefix="tlx-agent-gfx950-timing-") as directory:
+        case_path = Path(directory) / "case.json"
+        case_path.write_text(json.dumps(case, indent=2, sort_keys=True) + "\n")
+        profile_result = collect_rocprofv3(
+            _profile_workload_command(
+                source_path,
+                case_path,
+                device,
+                burn_seconds=burn_seconds,
+                launches=launches,
+            ),
+            Path(directory),
+            level="timing",
+            sample_count=launches,
+            timeout_seconds=max(120.0, burn_seconds + 60.0),
+        )
+    if error := profile_result.get("error"):
+        raise RuntimeError(str(error))
+    kernels = profile_result.get("kernels", [])
+    raw_samples = kernels[0].get("samples_us", []) if kernels else []
+    if not raw_samples:
+        raise RuntimeError(
+            f"rocprofv3 produced no kernel timing samples: {profile_result}"
+        )
+    samples = filter_extreme_timing_outliers(raw_samples)
+    return {
+        "samples_us": samples,
+        "warmup_count": 0,
+        "cache_policy": f"steady_state_{burn_seconds:g}s_rocprofv3_iqr3",
+    }
+
+
+def profile(
+    artifact: tuple[Any, ModuleType, Path, str],
+    case: dict[str, Any],
+    request: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    _, _, source_path, device = artifact
+    request = request or {}
+    tools = [str(tool) for tool in request.get("tools", ())]
+    result: dict[str, Any] = {
+        "level": str(request.get("level", "summary")),
+        "tools": tools,
+        "scope": "dominant_kernel",
+    }
+    if not bool(case.get("parameters", {}).get("profile", True)):
+        result["diagnostics"] = ["rocprofv3 skipped for this case"]
+        return result
+    if not {"rocprofv3", "fb_att"}.intersection(tools):
+        result["diagnostics"] = ["no supported AMD profiler was requested"]
+        return result
+    artifacts_dir_raw = request.get("artifacts_dir")
+    if not artifacts_dir_raw:
+        result["rocprofv3"] = {"error": "profile request has no artifacts_dir"}
+        return result
+
+    artifacts_dir = Path(str(artifacts_dir_raw))
+    case_path = artifacts_dir / "case.json"
+    case_path.write_text(json.dumps(case, indent=2, sort_keys=True) + "\n")
+    burn_seconds = _steady_state_seconds()
+    if "rocprofv3" in tools:
+        result["rocprofv3"] = collect_rocprofv3(
+            _profile_workload_command(
+                source_path,
+                case_path,
+                device,
+                burn_seconds=burn_seconds,
+                launches=_PROFILE_LAUNCHES,
+            ),
+            artifacts_dir,
+            level=str(result["level"]),
+            sample_count=_PROFILE_LAUNCHES,
+            timeout_seconds=max(120.0, burn_seconds + 60.0),
+            counter_workload=_profile_workload_command(
+                source_path,
+                case_path,
+                device,
+                burn_seconds=_COUNTER_BURN_SECONDS,
+                launches=10,
+            ),
+        )
+    if "fb_att" in tools:
+        rocprof = result.get("rocprofv3", {})
+        summary = rocprof.get("summary", {}) if isinstance(rocprof, Mapping) else {}
+        kernel_filter = str(
+            case.get("parameters", {}).get("profile_kernel", "")
+            or summary.get("dominant_kernel", "")
+        ).removesuffix(".kd")
+        if kernel_filter:
+            result["fb_att"] = collect_fb_att(
+                _profile_workload_command(
+                    source_path,
+                    case_path,
+                    device,
+                    burn_seconds=0.0,
+                    warmup=_ATT_WARMUP,
+                    launches=_ATT_LAUNCHES,
+                ),
+                artifacts_dir,
+                kernel_filter=kernel_filter,
+                iteration=_ATT_ITERATION,
+                timeout_seconds=180.0,
+            )
+        else:
+            result["fb_att"] = {
+                "error": "fb_att requires a dominant kernel from rocprofv3"
+            }
+    return result
+
+
+def _profile_workload_command(
+    source_path: Path,
+    case_path: Path,
+    device: str,
+    *,
+    burn_seconds: float,
+    launches: int,
+    warmup: int = 0,
+) -> list[str]:
+    return [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--profile-workload",
+        "--candidate",
+        str(source_path),
+        "--case-json",
+        str(case_path),
+        "--device",
+        device,
+        "--burn-seconds",
+        str(burn_seconds),
+        "--warmup",
+        str(warmup),
+        "--launches",
+        str(launches),
+    ]
+
+
+def _steady_state_seconds() -> float:
+    value = float(os.environ.get("TLX_AMD_STEADY_STATE_SECONDS", _STEADY_STATE_SECONDS))
+    if value < 0:
+        raise ValueError("TLX_AMD_STEADY_STATE_SECONDS must be non-negative")
+    return value
+
+
+def _load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load candidate from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _inputs(case: Mapping[str, Any], device: str) -> tuple[torch.Tensor, torch.Tensor]:
+    parameters = case["parameters"]
+    m = int(parameters["m"])
+    n = int(parameters["n"])
+    k = int(parameters["k"])
+    dtype = getattr(torch, str(parameters.get("dtype", "float16")))
+    generator = torch.Generator(device=device)
+    generator.manual_seed(int(parameters.get("seed", 0)))
+    a = torch.randn((m, k), device=device, dtype=dtype, generator=generator)
+    b = torch.randn((k, n), device=device, dtype=dtype, generator=generator)
+    return a, b
+
+
+def _profile_workload(args: argparse.Namespace) -> None:
+    case = json.loads(args.case_json.read_text())
+    module = _load_module(args.candidate, "tlx_agent_gfx950_profile_candidate")
+    a, b = _inputs(case, args.device)
+    # Compile before warmup so ATT iteration 4 means the first measured launch
+    # after this launch plus two explicit warmups.
+    module.matmul(a, b)
+    torch.cuda.synchronize()
+    for _ in range(args.warmup):
+        module.matmul(a, b)
+    torch.cuda.synchronize()
+    deadline = time.monotonic() + args.burn_seconds
+    while time.monotonic() < deadline:
+        module.matmul(a, b)
+    torch.cuda.synchronize()
+    for _ in range(args.launches):
+        module.matmul(a, b)
+    torch.cuda.synchronize()
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile-workload", action="store_true")
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--case-json", type=Path, required=True)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--burn-seconds", type=float, default=0.0)
+    parser.add_argument("--warmup", type=int, default=0)
+    parser.add_argument("--launches", type=int, default=_PROFILE_LAUNCHES)
+    args = parser.parse_args()
+    if not args.profile_workload:
+        parser.error("this entry point is only for rocprofv3 workload execution")
+    _profile_workload(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/target.json
+++ b/third_party/tlx/tools/agents/kernel_optimization/harnesses/gfx950/targets/gemm/target.json
@@ -1,0 +1,7 @@
+{
+  "backend": "hip",
+  "architecture": "gfx950",
+  "device": "cuda:0",
+  "environment": {},
+  "optimization_guidance": "Target AMD CDNA4/gfx950. Preserve wavefront, LDS, waitcnt, and warp-pipeline synchronization invariants. Prefer existing gfx9 TLX GEMM patterns and measured changes to MFMA shape, occupancy, LDS layout, prefetch depth, and wave pipelining. Do not introduce NVIDIA-only TMA, TMEM, mbarrier, or warp-specialization APIs."
+}

--- a/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/optimizer.py
@@ -12,21 +12,22 @@ from .artifacts import ArtifactStore, CandidateArtifactPaths
 from .harness import HarnessExecutionError, SubprocessHarness
 from .models import (
     AutoCommitResult,
+    CaseEvaluation,
     ExperimentSummary,
     InputCase,
+    is_promotable,
     KernelOptimizationRequest,
     KernelOptimizationResult,
-    PerformanceSummary,
-    is_promotable,
     passes_protected_cases,
     per_case_speedups,
+    PerformanceSummary,
     weighted_geometric_speedup,
 )
 from .profiling import (
-    ProfileRequest,
     compact_profile_summary,
-    extract_ncu_duration_us,
-    ncu_regression_diagnostic,
+    extract_native_profiler_duration_us,
+    native_profiler_regression_diagnostic,
+    ProfileRequest,
 )
 from .providers import CandidateContext, CandidateProvider, CodexCandidateProvider
 from .source import source_digest
@@ -60,7 +61,10 @@ def _profile_request(
         level=level,
         tools=_PROFILE_TOOLS,
         experiment_id=experiment_id,
-        artifacts_dir=artifacts_dir / "experiments" / experiment_id / "profile_artifacts",
+        artifacts_dir=artifacts_dir
+        / "experiments"
+        / experiment_id
+        / "profile_artifacts",
         reason=reason,
     )
 
@@ -86,15 +90,16 @@ def _diagnostic_profile_request(
 
 
 def _profiles_by_case(performance: PerformanceSummary) -> dict[str, dict[str, Any]]:
-    return {evaluation.case_id: dict(evaluation.profile) for evaluation in performance.cases}
+    return {
+        evaluation.case_id: dict(evaluation.profile) for evaluation in performance.cases
+    }
 
 
 def _diagnostic_error_profiles(
     cases: tuple[InputCase, ...], error: Exception
 ) -> dict[str, dict[str, Any]]:
     return {
-        case.case_id: {"error": f"{type(error).__name__}: {error}"}
-        for case in cases
+        case.case_id: {"error": f"{type(error).__name__}: {error}"} for case in cases
     }
 
 
@@ -150,9 +155,10 @@ def _report_candidate_summary(experiment_id: str, proposal: object) -> None:
         ("expected", getattr(proposal, "expected_effect", "")),
         ("risk", getattr(proposal, "risk", "")),
     )
-    details = " ".join(
-        f"{name}={value!r}" for name, value in fields if value
-    ) or "change='candidate source edited'"
+    details = (
+        " ".join(f"{name}={value!r}" for name, value in fields if value)
+        or "change='candidate source edited'"
+    )
     print(f"[tlx-agent] {experiment_id} {details}", file=sys.stderr, flush=True)
 
 
@@ -199,7 +205,7 @@ def _report_performance(
 
 def _profile_log_parts(profile: Mapping[str, Any]) -> list[str]:
     if not profile:
-        return ["ncu=unavailable"]
+        return ["native_profiler=unavailable"]
     compact = compact_profile_summary(profile)
     parts: list[str] = []
     proton_totals = _find_mapping_with_keys(
@@ -218,13 +224,25 @@ def _profile_log_parts(profile: Mapping[str, Any]) -> list[str]:
             value = _coerce_float(proton_totals.get(key))
             if value is not None:
                 parts.append(f"{label}={value:.3f}")
-    ncu_duration = extract_ncu_duration_us(compact)
-    if ncu_duration is None:
-        ncu_duration = extract_ncu_duration_us(profile)
-    if ncu_duration is not None:
-        parts.append(f"ncu.duration_us={ncu_duration:.3f}")
+    profiler_name, profiler_duration = extract_native_profiler_duration_us(compact)
+    if profiler_duration is None:
+        profiler_name, profiler_duration = extract_native_profiler_duration_us(profile)
+    if profiler_name is not None and profiler_duration is not None:
+        parts.append(f"{profiler_name.lower()}.duration_us={profiler_duration:.3f}")
     else:
-        parts.append("ncu=unavailable")
+        parts.append("native_profiler=unavailable")
+    att = compact.get("fb_att")
+    if isinstance(att, Mapping):
+        valid = att.get("valid")
+        if isinstance(valid, bool):
+            parts.append(f"fb_att.valid={str(valid).lower()}")
+        att_artifacts = att.get("artifacts")
+        if isinstance(att_artifacts, Mapping):
+            ui_directories = att_artifacts.get("ui_directories")
+            if isinstance(ui_directories, list) and ui_directories:
+                parts.append(f"fb_att.ui={ui_directories[0]}")
+        if att.get("error"):
+            parts.append(f"fb_att.error={att['error']}")
     diagnostic = compact.get(_DIAGNOSTIC_PROFILE_KEY)
     if not isinstance(diagnostic, Mapping):
         diagnostic = profile.get(_DIAGNOSTIC_PROFILE_KEY)
@@ -360,10 +378,14 @@ def _is_correct_and_stable(
 
 
 def _is_near_threshold(speedup: float, threshold: float) -> bool:
-    return threshold - _NEAR_THRESHOLD_WINDOW <= speedup <= threshold + _NEAR_THRESHOLD_WINDOW
+    return (
+        threshold - _NEAR_THRESHOLD_WINDOW
+        <= speedup
+        <= threshold + _NEAR_THRESHOLD_WINDOW
+    )
 
 
-def _ncu_regression_diagnostics(
+def _native_profiler_regression_diagnostics(
     baseline: PerformanceSummary,
     candidate: PerformanceSummary,
 ) -> str:
@@ -373,7 +395,11 @@ def _ncu_regression_diagnostics(
         baseline_evaluation = baseline_by_case.get(evaluation.case_id)
         if baseline_evaluation is None:
             continue
-        diagnostic = ncu_regression_diagnostic(
+        if _benchmark_uses_native_profiler(
+            baseline_evaluation
+        ) and _benchmark_uses_native_profiler(evaluation):
+            continue
+        diagnostic = native_profiler_regression_diagnostic(
             baseline_evaluation.profile,
             evaluation.profile,
         )
@@ -415,6 +441,16 @@ def _report_candidate_artifacts(
     )
 
 
+def _benchmark_uses_native_profiler(evaluation: CaseEvaluation) -> bool:
+    tool, duration = extract_native_profiler_duration_us(evaluation.profile)
+    return (
+        tool is not None
+        and duration is not None
+        and evaluation.timing is not None
+        and tool.lower() in evaluation.timing.cache_policy.lower()
+    )
+
+
 class KernelOptimizer:
     def __init__(self, provider: CandidateProvider | None = None) -> None:
         self._provider = provider or CodexCandidateProvider()
@@ -434,6 +470,7 @@ class KernelOptimizer:
             ref_path.write_text(request.reference_kernel_source)
             # Expose to harness workers via env var
             import os
+
             os.environ["TLX_REFERENCE_KERNEL_PATH"] = str(ref_path)
         harness = SubprocessHarness(
             request.harness_path, request.budget.max_candidate_seconds
@@ -597,10 +634,12 @@ class KernelOptimizer:
                     # Persist per-case profiles for this candidate regardless of promotion.
                     perf_profiles = _profiles_by_case(performance)
                     profile_path = store.write_profile(experiment_id, perf_profiles)
-                    ncu_diagnostics = _ncu_regression_diagnostics(baseline, performance)
+                    profiler_diagnostics = _native_profiler_regression_diagnostics(
+                        baseline, performance
+                    )
                     status = (
                         "promoted"
-                        if not ncu_diagnostics
+                        if not profiler_diagnostics
                         and is_promotable(performance, request.budget, request.cases)
                         and speedup > best_performance.aggregate_speedup
                         else "rejected"
@@ -632,7 +671,7 @@ class KernelOptimizer:
                     decision = (
                         "correct and exceeded speedup threshold"
                         if status == "promoted"
-                        else ncu_diagnostics
+                        else profiler_diagnostics
                         or rejection_diagnostics
                         or f"speedup below {request.budget.min_speedup:.4f}x threshold"
                     )
@@ -715,9 +754,7 @@ class KernelOptimizer:
                         diagnostics=message,
                     )
                 experiments.append(experiment)
-                store.write_json(
-                    f"experiments/{experiment_id}/result.json", experiment
-                )
+                store.write_json(f"experiments/{experiment_id}/result.json", experiment)
             if exhausted:
                 break
             if not promoted_this_round:
@@ -741,13 +778,15 @@ class KernelOptimizer:
                 baseline, final_profile, request.cases
             ),
         )
-        final_ncu_diagnostics = _ncu_regression_diagnostics(baseline, final_profile)
+        final_profiler_diagnostics = _native_profiler_regression_diagnostics(
+            baseline, final_profile
+        )
         if best_experiment_id != "baseline" and (
-            final_ncu_diagnostics
+            final_profiler_diagnostics
             or not is_promotable(final_profile, request.budget, request.cases)
         ):
-            if final_ncu_diagnostics:
-                diagnostics.append(f"final: rejected: {final_ncu_diagnostics}")
+            if final_profiler_diagnostics:
+                diagnostics.append(f"final: rejected: {final_profiler_diagnostics}")
             best_source = request.kernel_source
             final_profile = baseline
             final_profiles = baseline_profiles
@@ -788,7 +827,7 @@ class KernelOptimizer:
             final_profile,
             baseline=baseline,
             cases=request.cases,
-            diagnostics=final_ncu_diagnostics,
+            diagnostics=final_profiler_diagnostics,
         )
         store.write_aggregated_profile("best_profile", best_profiles)
         # Doc-compatible alias: experiments.json mirrors the experiments list.

--- a/third_party/tlx/tools/agents/kernel_optimization/profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/profiling.py
@@ -197,12 +197,16 @@ class ProfileRequest:
             reason=str(payload.get("reason", "")),
             diagnostic_only=bool(payload.get("diagnostic_only", False)),
             granularity=(
-                str(payload["granularity"]) if payload.get("granularity") is not None else None
+                str(payload["granularity"])
+                if payload.get("granularity") is not None
+                else None
             ),
         )
 
 
-def normalize_profile_request(profile: bool | ProfileRequest | Mapping[str, Any]) -> ProfileRequest | None:
+def normalize_profile_request(
+    profile: bool | ProfileRequest | Mapping[str, Any],
+) -> ProfileRequest | None:
     if profile is False or profile is None:
         return None
     if profile is True:
@@ -214,7 +218,9 @@ def normalize_profile_request(profile: bool | ProfileRequest | Mapping[str, Any]
     raise TypeError("profile must be bool, ProfileRequest, or mapping")
 
 
-def profile_request_to_json(profile: bool | ProfileRequest | Mapping[str, Any]) -> dict[str, Any] | bool:
+def profile_request_to_json(
+    profile: bool | ProfileRequest | Mapping[str, Any],
+) -> dict[str, Any] | bool:
     request = normalize_profile_request(profile)
     return request.to_json() if request is not None else False
 
@@ -250,7 +256,9 @@ def resolve_profile_tools(
     default: Iterable[object] = (),
 ) -> tuple[str, ...]:
     """Resolve target-neutral profiler names while preserving request order."""
-    requested = tuple(str(tool) for tool in tools) or tuple(str(tool) for tool in default)
+    requested = tuple(str(tool) for tool in tools) or tuple(
+        str(tool) for tool in default
+    )
     resolved: list[str] = []
     for tool in requested:
         if tool == "native_profiler" and native_profiler is not None:
@@ -268,14 +276,27 @@ def resolve_profile_request_for_target(
     if request is None:
         return None
     backend = str(target.get("backend", "")).strip().lower()
-    native_profiler = "ncu" if backend in {"cuda", "nvidia"} else None
-    return replace(
-        request,
-        tools=resolve_profile_tools(
-            request.tools,
-            native_profiler=native_profiler,
-        ),
-    ).to_json()
+    if backend in {"cuda", "nvidia"}:
+        native_profiler = "ncu"
+    elif backend in {"amd", "hip", "rocm"}:
+        native_profiler = "rocprofv3"
+    else:
+        native_profiler = None
+    tools = resolve_profile_tools(
+        request.tools,
+        native_profiler=native_profiler,
+    )
+    if backend in {"amd", "hip", "rocm"}:
+        resolved: list[str] = []
+        for tool in tools:
+            if tool == "proton_launch":
+                if request.level == "deep" and "fb_att" not in resolved:
+                    resolved.append("fb_att")
+                continue
+            if tool not in resolved:
+                resolved.append(tool)
+        tools = tuple(resolved)
+    return replace(request, tools=tools).to_json()
 
 
 def profile_accepts_request(profile_fn: Callable[..., Any]) -> bool:
@@ -311,7 +332,9 @@ def compact_profile_output(
     serialized = json.dumps(dict(raw_profile))
     if len(serialized.encode("utf-8")) <= _INLINE_PROFILE_LIMIT_BYTES:
         return dict(raw_profile)
-    artifacts_dir_raw = request_payload.get("artifacts_dir") if request_payload else None
+    artifacts_dir_raw = (
+        request_payload.get("artifacts_dir") if request_payload else None
+    )
     if artifacts_dir_raw:
         artifacts_dir = Path(str(artifacts_dir_raw))
         if artifacts_dir.is_absolute():
@@ -553,7 +576,9 @@ def select_ncu_metric_names(
     return {"metrics": selected, "diagnostics": diagnostics}
 
 
-def normalize_ncu_metrics(raw_metrics: Mapping[str, Any], level: str = "summary") -> dict[str, Any]:
+def normalize_ncu_metrics(
+    raw_metrics: Mapping[str, Any], level: str = "summary"
+) -> dict[str, Any]:
     selected = select_ncu_metric_names(raw_metrics.keys(), level)
     result: dict[str, Any] = {
         "level": level,
@@ -602,14 +627,35 @@ def extract_ncu_duration_us(profile: Mapping[str, Any]) -> float | None:
     for key in SUMMARY_NCU_METRIC_ALIASES["duration_us"]:
         if key in ncu:
             value = ncu[key]
-            return _duration_to_us(_metric_record_value(value), _metric_record_unit(value))
+            return _duration_to_us(
+                _metric_record_value(value), _metric_record_unit(value)
+            )
     raw_metrics = ncu.get("raw_metrics")
     if isinstance(raw_metrics, Mapping):
         for key in SUMMARY_NCU_METRIC_ALIASES["duration_us"]:
             if key in raw_metrics:
                 value = raw_metrics[key]
-                return _duration_to_us(_metric_record_value(value), _metric_record_unit(value))
+                return _duration_to_us(
+                    _metric_record_value(value), _metric_record_unit(value)
+                )
     return None
+
+
+def extract_native_profiler_duration_us(
+    profile: Mapping[str, Any],
+) -> tuple[str | None, float | None]:
+    if isinstance(profile.get("ncu"), Mapping):
+        duration = extract_ncu_duration_us(profile)
+        if duration is not None:
+            return "NCU", duration
+    rocprof = profile.get("rocprofv3")
+    if isinstance(rocprof, Mapping):
+        summary = rocprof.get("summary")
+        if isinstance(summary, Mapping):
+            duration = _coerce_float(summary.get("duration_us"))
+            if duration is not None:
+                return "rocprofv3", duration
+    return None, None
 
 
 def ncu_regression_diagnostic(
@@ -627,6 +673,28 @@ def ncu_regression_diagnostic(
     return ""
 
 
+def native_profiler_regression_diagnostic(
+    baseline_profile: Mapping[str, Any], candidate_profile: Mapping[str, Any]
+) -> str:
+    baseline_tool, baseline_us = extract_native_profiler_duration_us(baseline_profile)
+    candidate_tool, candidate_us = extract_native_profiler_duration_us(
+        candidate_profile
+    )
+    if (
+        baseline_tool is None
+        or baseline_tool != candidate_tool
+        or baseline_us is None
+        or candidate_us is None
+    ):
+        return ""
+    if candidate_us > baseline_us * 1.01:
+        return (
+            f"{baseline_tool} duration regressed: "
+            f"candidate {candidate_us:.3f}us > baseline {baseline_us:.3f}us by >1%"
+        )
+    return ""
+
+
 def compact_profile_summary(profile: Mapping[str, Any]) -> dict[str, Any]:
     preferred = (
         "level",
@@ -635,6 +703,8 @@ def compact_profile_summary(profile: Mapping[str, Any]) -> dict[str, Any]:
         "summary",
         "proton",
         "ncu",
+        "rocprofv3",
+        "fb_att",
         "native_profiler",
         "diagnostics",
         "diagnostic_proton_intra_kernel",
@@ -833,7 +903,9 @@ def _normalize_header(header: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", header.strip().lower()).strip("_")
 
 
-def _first_header(headers: Mapping[str, str], candidates: tuple[str, ...]) -> str | None:
+def _first_header(
+    headers: Mapping[str, str], candidates: tuple[str, ...]
+) -> str | None:
     for candidate in candidates:
         if candidate in headers:
             return headers[candidate]

--- a/third_party/tlx/tools/agents/kernel_optimization/rocm_profiler.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/rocm_profiler.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SUMMARY_COUNTER_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("MfmaUtil", "VALUBusy", "MemUnitStalled"),
+)
+
+DEEP_COUNTER_GROUPS: tuple[tuple[str, ...], ...] = (
+    *SUMMARY_COUNTER_GROUPS,
+    ("FETCH_SIZE",),
+    ("SQ_LDS_BANK_CONFLICT", "SQ_LDS_ADDR_CONFLICT"),
+)
+
+_PROFILER_ENV_TO_CLEAR = (
+    "ROCP_TOOL_LIBRARIES",
+    "HSA_TOOLS_LIB",
+    "ROCPROFILER_LIBRARY_CTOR",
+)
+
+_PROFILER_PRELOAD_MARKERS = (
+    "fbrocrof",
+    "rocprof",
+    "roctracer",
+)
+
+
+def find_rocprofv3(environment: Mapping[str, str] | None = None) -> Path | None:
+    env = os.environ if environment is None else environment
+    configured = env.get("TLX_ROCPROFV3") or env.get("ROCPROFV3")
+    if configured:
+        path = Path(configured).resolve()
+        return path if path.is_file() and os.access(path, os.X_OK) else None
+
+    discovered = shutil.which("rocprofv3", path=env.get("PATH"))
+    if discovered:
+        return Path(discovered).resolve()
+
+    candidates = [Path("/opt/rocm/bin/rocprofv3"), Path("/usr/bin/rocprofv3")]
+    internal_root = Path("/usr/local/fbcode/platform010/lib")
+    if internal_root.is_dir():
+        candidates.extend(
+            sorted(
+                internal_root.glob("rocm-*/bin/rocprofv3"),
+                key=_rocm_version_key,
+                reverse=True,
+            )
+        )
+    return next(
+        (
+            path.resolve()
+            for path in candidates
+            if path.is_file() and os.access(path, os.X_OK)
+        ),
+        None,
+    )
+
+
+def parse_rocprof_kernel_trace(
+    csv_text: str, *, sample_count: int = 3
+) -> dict[str, Any]:
+    if sample_count <= 0:
+        raise ValueError("sample_count must be positive")
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if reader.fieldnames is None:
+        return {"summary": {}, "kernels": [], "diagnostics": ["empty kernel trace"]}
+    headers = {_normalize_header(name): name for name in reader.fieldnames}
+    name_key = _header(headers, "kernel_name", "name")
+    start_key = _header(headers, "start_timestamp", "start_timestamp_ns")
+    end_key = _header(headers, "end_timestamp", "end_timestamp_ns")
+    if name_key is None or start_key is None or end_key is None:
+        return {
+            "summary": {},
+            "kernels": [],
+            "diagnostics": ["kernel trace is missing name/start/end columns"],
+        }
+
+    timings: dict[str, list[float]] = {}
+    resources: dict[str, dict[str, float]] = {}
+    for row in reader:
+        name = str(row.get(name_key, "")).strip()
+        start = _float(row.get(start_key))
+        end = _float(row.get(end_key))
+        if not name or start is None or end is None or end <= start:
+            continue
+        timings.setdefault(name, []).append((end - start) / 1000.0)
+        resources.setdefault(name, _resource_values(row, headers))
+
+    if not timings:
+        return {
+            "summary": {},
+            "kernels": [],
+            "diagnostics": ["kernel trace contains no valid dispatches"],
+        }
+
+    eligible = {
+        name: values for name, values in timings.items() if len(values) >= sample_count
+    } or timings
+    kernels = [
+        _kernel_summary(name, values, resources.get(name, {}), sample_count)
+        for name, values in eligible.items()
+    ]
+    kernels.sort(key=lambda item: float(item["total_sampled_us"]), reverse=True)
+    dominant = kernels[0]
+    return {
+        "summary": {
+            "duration_us": dominant["median_us"],
+            "dominant_kernel": dominant["name"],
+            "scope": "dominant_kernel",
+            "kernel_count": len(kernels),
+        },
+        "kernels": kernels,
+        "diagnostics": [],
+    }
+
+
+def parse_rocprof_counter_collection(
+    csv_text: str,
+) -> dict[str, dict[str, float]]:
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if reader.fieldnames is None:
+        return {}
+    headers = {_normalize_header(name): name for name in reader.fieldnames}
+    kernel_key = _header(headers, "kernel_name", "name")
+    counter_key = _header(headers, "counter_name", "metric_name")
+    value_key = _header(headers, "counter_value", "metric_value", "value")
+    if kernel_key is None or counter_key is None or value_key is None:
+        return {}
+
+    values: dict[str, dict[str, list[float]]] = {}
+    for row in reader:
+        kernel = str(row.get(kernel_key, "")).strip()
+        counter = str(row.get(counter_key, "")).strip()
+        value = _float(row.get(value_key))
+        if not kernel or not counter or value is None:
+            continue
+        values.setdefault(kernel, {}).setdefault(counter, []).append(value)
+    return {
+        kernel: {
+            counter: statistics.median(samples) for counter, samples in counters.items()
+        }
+        for kernel, counters in values.items()
+    }
+
+
+def filter_extreme_timing_outliers(samples: Sequence[float]) -> list[float]:
+    values = list(samples)
+    if len(values) < 4:
+        return values
+    lower_quartile, _, upper_quartile = statistics.quantiles(
+        values, n=4, method="inclusive"
+    )
+    interquartile_range = upper_quartile - lower_quartile
+    if interquartile_range <= 0:
+        return values
+    lower_bound = lower_quartile - 3 * interquartile_range
+    upper_bound = upper_quartile + 3 * interquartile_range
+    filtered = [value for value in values if lower_bound <= value <= upper_bound]
+    return filtered if len(filtered) >= 3 else values
+
+
+def collect_rocprofv3(
+    workload: Sequence[str],
+    artifacts_dir: Path,
+    *,
+    level: str = "summary",
+    sample_count: int = 3,
+    timeout_seconds: float = 900.0,
+    environment: Mapping[str, str] | None = None,
+    counter_workload: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    if not workload:
+        raise ValueError("rocprofv3 workload must not be empty")
+    if level not in {"timing", "summary", "deep"}:
+        raise ValueError("rocprofv3 level must be 'timing', 'summary', or 'deep'")
+    artifacts_dir = artifacts_dir.resolve()
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    profiler = find_rocprofv3(environment)
+    if profiler is None:
+        return {"error": "rocprofv3 was not found; set TLX_ROCPROFV3 or PATH"}
+
+    run_dir = Path(tempfile.mkdtemp(prefix="rocprofv3-", dir=artifacts_dir))
+    env = _profiler_environment(profiler, environment)
+    diagnostics: list[str] = []
+    trace_dir = run_dir / "trace"
+    completed = _run_pass(
+        profiler,
+        workload,
+        trace_dir,
+        "trace",
+        (),
+        env,
+        timeout_seconds,
+    )
+    if completed.returncode != 0:
+        return {
+            "error": f"rocprofv3 kernel trace failed with code {completed.returncode}",
+            "artifacts": _pass_artifacts(run_dir, trace_dir),
+        }
+
+    trace_files = sorted(trace_dir.rglob("*kernel_trace.csv"))
+    if not trace_files:
+        return {
+            "error": "rocprofv3 produced no kernel trace CSV",
+            "artifacts": _pass_artifacts(run_dir, trace_dir),
+        }
+    try:
+        profile = parse_rocprof_kernel_trace(
+            trace_files[0].read_text(), sample_count=sample_count
+        )
+    except (OSError, UnicodeDecodeError, csv.Error) as error:
+        return {
+            "error": (
+                "failed to read rocprofv3 kernel trace: "
+                f"{type(error).__name__}: {error}"
+            ),
+            "artifacts": _pass_artifacts(run_dir, trace_dir),
+        }
+
+    counter_groups = (
+        ()
+        if level == "timing"
+        else SUMMARY_COUNTER_GROUPS
+        if level == "summary"
+        else DEEP_COUNTER_GROUPS
+    )
+    counter_workload = counter_workload or workload
+    counter_values: dict[str, dict[str, float]] = {}
+    counter_files: list[Path] = []
+    for index, counters in enumerate(counter_groups):
+        pass_dir = run_dir / f"counters-{index}"
+        completed = _run_pass(
+            profiler,
+            counter_workload,
+            pass_dir,
+            f"counters-{index}",
+            counters,
+            env,
+            timeout_seconds,
+        )
+        if completed.returncode != 0:
+            diagnostics.append(
+                f"counter group {index} failed with code {completed.returncode}"
+            )
+            continue
+        files = sorted(pass_dir.rglob("*counter_collection*.csv"))
+        if not files:
+            diagnostics.append(f"counter group {index} produced no CSV")
+            continue
+        counter_files.extend(files)
+        for path in files:
+            _merge_counters(
+                counter_values,
+                parse_rocprof_counter_collection(path.read_text()),
+            )
+
+    dominant = profile.get("summary", {}).get("dominant_kernel")
+    profile.update(
+        {
+            "tool": "rocprofv3",
+            "tool_path": str(profiler),
+            "schema_version": 1,
+            "level": level,
+            "counters": counter_values.get(str(dominant), {}),
+            "diagnostics": [*profile.get("diagnostics", []), *diagnostics],
+            "artifacts": {
+                "directory": str(run_dir),
+                "kernel_trace_csv": str(trace_files[0]),
+                "counter_collection_csv": [str(path) for path in counter_files],
+            },
+        }
+    )
+    return profile
+
+
+def _run_pass(
+    profiler: Path,
+    workload: Sequence[str],
+    output_dir: Path,
+    output_file: str,
+    counters: Sequence[str],
+    environment: Mapping[str, str],
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        str(profiler),
+        "--mangled-kernels",
+        "true",
+        "--output-format",
+        "csv",
+        "--output-directory",
+        str(output_dir),
+        "--output-file",
+        output_file,
+    ]
+    rocm_root = profiler.parent.parent
+    if (rocm_root / "share" / "rocprofiler-sdk").is_dir():
+        command.extend(("--rocm-root", str(rocm_root)))
+    if counters:
+        command.extend(("--pmc", ",".join(counters)))
+    else:
+        command.extend(("--kernel-trace", "true"))
+    command.extend(("--", *[str(argument) for argument in workload]))
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=dict(environment),
+            cwd=output_dir,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        completed = subprocess.CompletedProcess(command, 1, "", str(error))
+    (output_dir / "command.json").write_text(
+        json.dumps(
+            {
+                "argv": command,
+                "returncode": completed.returncode,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    (output_dir / "stdout.txt").write_text(completed.stdout or "")
+    (output_dir / "stderr.txt").write_text(completed.stderr or "")
+    return completed
+
+
+def _profiler_environment(
+    profiler: Path, environment: Mapping[str, str] | None
+) -> dict[str, str]:
+    env = dict(os.environ if environment is None else environment)
+    for key in _PROFILER_ENV_TO_CLEAR:
+        env.pop(key, None)
+    preload = _sanitize_ld_preload(env.get("LD_PRELOAD", ""))
+    if preload:
+        env["LD_PRELOAD"] = preload
+    else:
+        env.pop("LD_PRELOAD", None)
+    rocm_root = profiler.parent.parent
+    metrics = rocm_root / "share" / "rocprofiler-sdk"
+    if metrics.is_dir():
+        env.setdefault("ROCPROFILER_METRICS_PATH", str(metrics))
+    return env
+
+
+def _sanitize_ld_preload(value: str) -> str:
+    libraries = (entry for entry in re.split(r"[:\s]+", value) if entry)
+    return ":".join(
+        library
+        for library in libraries
+        if not any(marker in library.lower() for marker in _PROFILER_PRELOAD_MARKERS)
+    )
+
+
+def _rocm_version_key(profiler: Path) -> tuple[int, ...]:
+    match = re.fullmatch(r"rocm-(\d+(?:\.\d+)*)", profiler.parent.parent.name)
+    return (
+        tuple(int(component) for component in match.group(1).split("."))
+        if match
+        else ()
+    )
+
+
+def _pass_artifacts(run_dir: Path, pass_dir: Path) -> dict[str, Any]:
+    return {
+        "directory": str(run_dir),
+        "command": str(pass_dir / "command.json"),
+        "stdout": str(pass_dir / "stdout.txt"),
+        "stderr": str(pass_dir / "stderr.txt"),
+    }
+
+
+def _merge_counters(
+    destination: dict[str, dict[str, float]],
+    source: Mapping[str, Mapping[str, float]],
+) -> None:
+    for kernel, counters in source.items():
+        destination.setdefault(kernel, {}).update(counters)
+
+
+def _kernel_summary(
+    name: str,
+    durations: Sequence[float],
+    resources: Mapping[str, float],
+    sample_count: int,
+) -> dict[str, Any]:
+    sampled = list(durations[-sample_count:])
+    return {
+        "name": name,
+        "dispatches": len(durations),
+        "sampled_dispatches": len(sampled),
+        "median_us": statistics.median(sampled),
+        "total_sampled_us": sum(sampled),
+        "samples_us": sampled,
+        "resources": dict(resources),
+    }
+
+
+def _resource_values(
+    row: Mapping[str, Any], headers: Mapping[str, str]
+) -> dict[str, float]:
+    aliases = {
+        "workgroup_size": "workgroup_size",
+        "lds_bytes": "lds_block_size",
+        "vgpr_count": "vgpr_count",
+        "accum_vgpr_count": "accum_vgpr_count",
+        "sgpr_count": "sgpr_count",
+    }
+    result: dict[str, float] = {}
+    for output_name, header_name in aliases.items():
+        key = headers.get(header_name)
+        value = _float(row.get(key)) if key else None
+        if value is not None:
+            result[output_name] = value
+    return result
+
+
+def _normalize_header(header: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", header.strip().lower()).strip("_")
+
+
+def _header(headers: Mapping[str, str], *names: str) -> str | None:
+    return next((headers[name] for name in names if name in headers), None)
+
+
+def _float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(str(value).strip().replace(",", ""))
+    except ValueError:
+        return None

--- a/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_kernel_agent.py
@@ -6,6 +6,7 @@ import json
 import tempfile
 import unittest
 from contextlib import redirect_stderr
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -22,27 +23,27 @@ from .models import (
     AutoCommitResult,
     CaseEvaluation,
     InputCase,
+    is_promotable,
     KernelOptimizationRequest,
     KernelTarget,
     OptimizationBudget,
+    per_case_speedups,
     PerformanceSummary,
     PriorExperimentEvidence,
     PriorRunEvidence,
     TimingSamples,
     VerificationResult,
-    is_promotable,
-    per_case_speedups,
     weighted_geometric_speedup,
 )
-from .optimizer import KernelOptimizer, _profile_log_parts
+from .optimizer import _profile_log_parts, KernelOptimizer
 from .profiling import ProfileRequest
 from .providers import (
+    _build_prompt,
+    _read_candidate_metadata,
     CandidateContext,
     CandidateProposal,
     FixedCandidateProvider,
     MockLLMProvider,
-    _build_prompt,
-    _read_candidate_metadata,
 )
 from .source import (
     apply_candidate_diff,
@@ -497,7 +498,9 @@ class ScoringTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "empty"):
             validate_kernel_source("   \n")
 
-    def test_kernel_optimization_request_disables_diagnostic_proton_by_default(self) -> None:
+    def test_kernel_optimization_request_disables_diagnostic_proton_by_default(
+        self,
+    ) -> None:
         request = KernelOptimizationRequest(
             kernel_source="VALUE = 1\n",
             harness_path=Path(__file__),
@@ -680,6 +683,32 @@ class HarnessTest(unittest.TestCase):
 
         _validate_host_matches_target(target, "host", capability_probe=fail_probe)
 
+    def test_rocm_arch_validation_rejects_mismatched_host(self) -> None:
+        target = KernelTarget("hip", "gfx950", device="cuda:0")
+        with self.assertRaisesRegex(SystemExit, "expects gfx950.*is gfx942"):
+            _validate_host_matches_target(
+                target,
+                "gfx950",
+                rocm_arch_probe=lambda device: "gfx942",
+            )
+
+    def test_rocm_arch_validation_accepts_matching_host(self) -> None:
+        target = KernelTarget("hip", "gfx950", device="cuda:0")
+        _validate_host_matches_target(
+            target,
+            "gfx950",
+            rocm_arch_probe=lambda device: "gfx950:sramecc+:xnack-",
+        )
+
+    def test_rocm_arch_validation_rejects_prefix_match(self) -> None:
+        target = KernelTarget("hip", "gfx90", device="cuda:0")
+        with self.assertRaisesRegex(SystemExit, "expects gfx90.*is gfx900"):
+            _validate_host_matches_target(
+                target,
+                "gfx90",
+                rocm_arch_probe=lambda device: "gfx900:sramecc+:xnack-",
+            )
+
     def test_resolves_arch_first_harness_layout(self) -> None:
         kernel = Path("gemm.py")
         harness, cases, target = _resolve_harness_paths(
@@ -696,11 +725,23 @@ class HarnessTest(unittest.TestCase):
         self.assertEqual(cases.name, "cases.json")
         self.assertEqual(target.name, "target.json")
 
+    def test_resolves_gfx950_gemm_harness(self) -> None:
+        harness, cases, target = _resolve_harness_paths(
+            Path("amd_gemm_warp_pipeline.py"),
+            None,
+            None,
+            None,
+            "gfx950",
+            "gemm",
+        )
+        expected = Path(__file__).with_name("harnesses") / "gfx950" / "targets" / "gemm"
+        self.assertEqual(harness, expected / "harness.py")
+        self.assertEqual(cases, expected / "cases.json")
+        self.assertEqual(target, expected / "target.json")
+
     def test_default_arch_only_uses_arches_with_matching_target(self) -> None:
         kernel = Path("vector_add.py")
-        harness, cases, target = _resolve_harness_paths(
-            kernel, None, None, None, None
-        )
+        harness, cases, target = _resolve_harness_paths(kernel, None, None, None, None)
         self.assertEqual(
             harness,
             Path(__file__).with_name("harnesses")
@@ -743,7 +784,9 @@ class HarnessTest(unittest.TestCase):
         )
         self.assertEqual(performance.cases[0].profile.get("bottleneck"), "synthetic")
 
-    def test_profile_request_passed_after_benchmark_with_case_artifact_dir(self) -> None:
+    def test_profile_request_passed_after_benchmark_with_case_artifact_dir(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             harness_path = Path(tmp) / "three_arg_harness.py"
             harness_path.write_text(
@@ -803,7 +846,9 @@ class HarnessTest(unittest.TestCase):
                 "    return {'case_id': case['case_id'], 'request': request, 'exists': Path(request['artifacts_dir']).exists()}\n"
             )
             artifacts_dir = Path(tmp) / "profiles"
-            performance = SubprocessHarness(harness_path, timeout_seconds=30.0).evaluate(
+            performance = SubprocessHarness(
+                harness_path, timeout_seconds=30.0
+            ).evaluate(
                 "source",
                 (InputCase("case a", {}),),
                 KernelTarget("cuda", "blackwell"),
@@ -823,7 +868,9 @@ class HarnessTest(unittest.TestCase):
             self.assertEqual(request["tools"], ["proton_launch", "ncu"])
             self.assertEqual(Path(str(request["artifacts_dir"])).parent, artifacts_dir)
 
-    def test_large_profile_spills_to_raw_profile_when_artifacts_dir_available(self) -> None:
+    def test_large_profile_spills_to_raw_profile_when_artifacts_dir_available(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             harness_path = Path(tmp) / "big_profile_harness.py"
             harness_path.write_text(
@@ -1121,7 +1168,7 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertIn("[tlx-agent] r001-c001 status=promoted", output)
             self.assertIn("speedup=1.2500x", output)
             self.assertIn("decision=correct and exceeded speedup threshold", output)
-            self.assertIn("ncu=unavailable", output)
+            self.assertIn("native_profiler=unavailable", output)
             self.assertIn("[tlx-agent] final status=revalidated", output)
             self.assertEqual(result.winner_experiment_id, "r001-c001")
             self.assertEqual(result.winner_commit_title, "Use faster latency path")
@@ -1214,7 +1261,7 @@ class KernelOptimizerTest(unittest.TestCase):
         self.assertIn("median=120.000us", feedback)
         self.assertIn("cv=0.0000", feedback)
         self.assertIn("speedup=0.8333x", feedback)
-        self.assertIn("ncu=unavailable", feedback)
+        self.assertIn("native_profiler=unavailable", feedback)
 
     def test_continues_after_round_without_promotion(self) -> None:
         provider = FixedCandidateProvider(
@@ -1354,13 +1401,19 @@ class KernelOptimizerTest(unittest.TestCase):
             self.assertEqual(result.stopping_reason, "finalist_revalidation_failed")
             self.assertEqual(result.best_kernel, baseline_source)
             self.assertEqual(result.final.cases[0].profile["marker"], "baseline")
-            self.assertEqual((output_dir / "best_kernel.py").read_text(), baseline_source)
+            self.assertEqual(
+                (output_dir / "best_kernel.py").read_text(), baseline_source
+            )
             self.assertEqual(best_profile, baseline_profile)
             self.assertEqual(final_profile, baseline_profile)
 
     def test_optimizer_uses_profile_policy_and_records_profile_paths(self) -> None:
         provider = FixedCandidateProvider(
-            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster")]
+            [
+                CandidateProposal(
+                    "LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster"
+                )
+            ]
         )
         with tempfile.TemporaryDirectory() as tmp:
             harness_path = _write_policy_harness(Path(tmp))
@@ -1382,7 +1435,9 @@ class KernelOptimizerTest(unittest.TestCase):
             )
 
         baseline_request = result.baseline.cases[0].profile["request"]
-        candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
+        candidate_request = (
+            result.experiments[1].performance.cases[0].profile["request"]
+        )  # type: ignore[union-attr]
         final_request = result.final.cases[0].profile["request"]
         self.assertEqual(baseline_request["level"], "deep")
         expected_tools = ["proton_launch", "native_profiler"]
@@ -1436,7 +1491,9 @@ class KernelOptimizerTest(unittest.TestCase):
                     output_dir=Path(tmp) / "out",
                 )
             )
-        candidate_request = result.experiments[1].performance.cases[0].profile["request"]  # type: ignore[union-attr]
+        candidate_request = (
+            result.experiments[1].performance.cases[0].profile["request"]
+        )  # type: ignore[union-attr]
         self.assertEqual(candidate_request["level"], "deep")
         self.assertEqual(
             candidate_request["tools"],
@@ -1447,7 +1504,11 @@ class KernelOptimizerTest(unittest.TestCase):
 
     def test_ncu_regression_diagnostic_vetoes_candidate(self) -> None:
         provider = FixedCandidateProvider(
-            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 102\n", "fast-wrapper")]
+            [
+                CandidateProposal(
+                    "LATENCY_US = 80\nCORRECT = True\nNCU_US = 102\n", "fast-wrapper"
+                )
+            ]
         )
         with tempfile.TemporaryDirectory() as tmp:
             stderr = io.StringIO()
@@ -1470,6 +1531,125 @@ class KernelOptimizerTest(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertEqual(result.experiments[1].status, "rejected")
         self.assertIn("NCU duration regressed", stderr.getvalue())
+
+    def test_rocprof_regression_diagnostic_vetoes_candidate(self) -> None:
+        baseline = _performance(("a", 100.0))
+        baseline = PerformanceSummary(
+            cases=(
+                replace(
+                    baseline.cases[0],
+                    profile={"rocprofv3": {"summary": {"duration_us": 100.0}}},
+                ),
+            )
+        )
+        candidate = _performance(("a", 80.0))
+        candidate = PerformanceSummary(
+            cases=(
+                replace(
+                    candidate.cases[0],
+                    profile={"rocprofv3": {"summary": {"duration_us": 102.0}}},
+                ),
+            )
+        )
+        harness = Mock()
+        harness.evaluate.side_effect = [baseline, candidate, baseline]
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "fast-wrapper")]
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            stderr = io.StringIO()
+            with (
+                patch.object(
+                    optimizer_module,
+                    "SubprocessHarness",
+                    return_value=harness,
+                ),
+                redirect_stderr(stderr),
+            ):
+                result = KernelOptimizer(provider).optimize(
+                    KernelOptimizationRequest(
+                        kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                        harness_path=Path(directory) / "unused_harness.py",
+                        cases=(InputCase("a", {}),),
+                        target=KernelTarget("hip", "gfx950"),
+                        budget=OptimizationBudget(
+                            max_rounds=1,
+                            candidates_per_round=1,
+                            min_speedup=1.01,
+                            benchmark_repetitions=2,
+                        ),
+                        output_dir=Path(directory) / "out",
+                    )
+                )
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.experiments[1].status, "rejected")
+        self.assertIn("rocprofv3 duration regressed", stderr.getvalue())
+
+    def test_rocprof_profile_does_not_veto_rocprof_benchmark(self) -> None:
+        baseline = _performance(("a", 100.0))
+        baseline_timing = baseline.cases[0].timing
+        assert baseline_timing is not None
+        baseline = PerformanceSummary(
+            cases=(
+                replace(
+                    baseline.cases[0],
+                    timing=replace(
+                        baseline_timing,
+                        cache_policy="steady_state_20s_rocprofv3_iqr3",
+                    ),
+                    profile={"rocprofv3": {"summary": {"duration_us": 100.0}}},
+                ),
+            )
+        )
+        candidate = _performance(("a", 80.0))
+        candidate_timing = candidate.cases[0].timing
+        assert candidate_timing is not None
+        candidate = PerformanceSummary(
+            cases=(
+                replace(
+                    candidate.cases[0],
+                    timing=replace(
+                        candidate_timing,
+                        cache_policy="steady_state_20s_rocprofv3_iqr3",
+                    ),
+                    profile={"rocprofv3": {"summary": {"duration_us": 102.0}}},
+                ),
+            )
+        )
+        harness = Mock()
+        harness.evaluate.side_effect = [baseline, candidate, candidate]
+        provider = FixedCandidateProvider(
+            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\n", "faster")]
+        )
+
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.object(
+                optimizer_module,
+                "SubprocessHarness",
+                return_value=harness,
+            ),
+        ):
+            result = KernelOptimizer(provider).optimize(
+                KernelOptimizationRequest(
+                    kernel_source="LATENCY_US = 100\nCORRECT = True\n",
+                    harness_path=Path(directory) / "unused_harness.py",
+                    cases=(InputCase("a", {}),),
+                    target=KernelTarget("hip", "gfx950"),
+                    budget=OptimizationBudget(
+                        max_rounds=1,
+                        candidates_per_round=1,
+                        min_speedup=1.01,
+                        benchmark_repetitions=2,
+                    ),
+                    output_dir=Path(directory) / "out",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.experiments[1].status, "promoted")
 
     def test_missing_ncu_does_not_veto_candidate(self) -> None:
         provider = FixedCandidateProvider(
@@ -1523,16 +1703,33 @@ class KernelOptimizerTest(unittest.TestCase):
             "proton.intra.tile=start_n:3840/logical_block:31/curr_m:3968/mma_producer_j:32/load_input_j:31",
             parts,
         )
-        self.assertIn(
-            "proton.intra.dominant_wait=reduction_wait_dq:2.852us", parts
-        )
+        self.assertIn("proton.intra.dominant_wait=reduction_wait_dq:2.852us", parts)
         self.assertIn(f"proton.intra.trace={trace_path}", parts)
 
-    def test_diagnostic_proton_profiles_baseline_and_successful_final_only(self) -> None:
+    def test_profile_log_includes_fb_att_artifact(self) -> None:
+        parts = _profile_log_parts(
+            {
+                "fb_att": {
+                    "valid": True,
+                    "artifacts": {"ui_directories": ["/tmp/gemm_0_ui"]},
+                }
+            }
+        )
+
+        self.assertIn("fb_att.valid=true", parts)
+        self.assertIn("fb_att.ui=/tmp/gemm_0_ui", parts)
+
+    def test_diagnostic_proton_profiles_baseline_and_successful_final_only(
+        self,
+    ) -> None:
         provider = FixedCandidateProvider(
             [
-                CandidateProposal("LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower"),
-                CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster"),
+                CandidateProposal(
+                    "LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower"
+                ),
+                CandidateProposal(
+                    "LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster"
+                ),
             ]
         )
         with tempfile.TemporaryDirectory() as tmp:
@@ -1564,7 +1761,10 @@ class KernelOptimizerTest(unittest.TestCase):
             if request["tools"] == ["proton_intra_kernel"]
         ]
         self.assertEqual(
-            [(request["experiment_id"], request["reason"]) for request in diagnostic_requests],
+            [
+                (request["experiment_id"], request["reason"])
+                for request in diagnostic_requests
+            ],
             [("baseline", "baseline_diagnostic"), ("final", "final_winner_diagnostic")],
         )
         candidate_diagnostics = [
@@ -1577,7 +1777,9 @@ class KernelOptimizerTest(unittest.TestCase):
         self.assertEqual(result.experiments[1].status, "rejected")
         self.assertEqual(result.experiments[2].status, "promoted")
         self.assertEqual(result.final.aggregate_speedup, 1.25)
-        self.assertIn("diagnostic_proton_intra_kernel", result.baseline.cases[0].profile)
+        self.assertIn(
+            "diagnostic_proton_intra_kernel", result.baseline.cases[0].profile
+        )
         self.assertIn("diagnostic_proton_intra_kernel", result.final.cases[0].profile)
         self.assertNotIn(
             "diagnostic_proton_intra_kernel",
@@ -1587,11 +1789,22 @@ class KernelOptimizerTest(unittest.TestCase):
         self.assertEqual(baseline_diag["tools"], ["proton_intra_kernel"])
         self.assertEqual(baseline_diag["artifacts"]["trace"], "/tmp/proton.trace")
         self.assertNotIn("trace_events", baseline_diag)
-        self.assertEqual(best_profile["a"]["diagnostic_proton_intra_kernel"]["summary"]["granularity"], "warp")
+        self.assertEqual(
+            best_profile["a"]["diagnostic_proton_intra_kernel"]["summary"][
+                "granularity"
+            ],
+            "warp",
+        )
 
-    def test_diagnostic_proton_does_not_duplicate_final_when_baseline_wins(self) -> None:
+    def test_diagnostic_proton_does_not_duplicate_final_when_baseline_wins(
+        self,
+    ) -> None:
         provider = FixedCandidateProvider(
-            [CandidateProposal("LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower")]
+            [
+                CandidateProposal(
+                    "LATENCY_US = 120\nCORRECT = True\nNCU_US = 100\n", "slower"
+                )
+            ]
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1620,14 +1833,21 @@ class KernelOptimizerTest(unittest.TestCase):
         ]
         self.assertFalse(result.success)
         self.assertEqual(
-            [(request["experiment_id"], request["reason"]) for request in diagnostic_requests],
+            [
+                (request["experiment_id"], request["reason"])
+                for request in diagnostic_requests
+            ],
             [("baseline", "baseline_diagnostic")],
         )
         self.assertIn("diagnostic_proton_intra_kernel", result.final.cases[0].profile)
 
     def test_diagnostic_proton_is_promotion_neutral(self) -> None:
         provider = FixedCandidateProvider(
-            [CandidateProposal("LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster")]
+            [
+                CandidateProposal(
+                    "LATENCY_US = 80\nCORRECT = True\nNCU_US = 90\n", "faster"
+                )
+            ]
         )
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1652,7 +1872,9 @@ class KernelOptimizerTest(unittest.TestCase):
         self.assertEqual(result.experiments[1].status, "promoted")
         self.assertEqual(result.final.aggregate_speedup, 1.25)
         self.assertEqual(
-            result.final.cases[0].profile["diagnostic_proton_intra_kernel"]["ncu"]["summary"]["duration_us"],
+            result.final.cases[0].profile["diagnostic_proton_intra_kernel"]["ncu"][
+                "summary"
+            ]["duration_us"],
             999999.0,
         )
 

--- a/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
+++ b/third_party/tlx/tools/agents/kernel_optimization/test_profiling.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+import importlib.util
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import ModuleType
 from unittest import mock
+from unittest.mock import patch
 
+from . import rocm_profiler as rocm_profiler_module
+from .amd_att import collect_fb_att
 from .profiling import (
-    ProfileRequest,
     compact_profile_summary,
     export_ncu_report_details,
+    extract_native_profiler_duration_us,
     extract_ncu_duration_us,
+    native_profiler_regression_diagnostic,
     ncu_regression_diagnostic,
     normalize_ncu_metrics,
     normalize_profile_request,
@@ -18,9 +25,17 @@ from .profiling import (
     parse_ncu_query_metrics,
     parse_proton_launch_attribution,
     per_case_profile_request,
+    ProfileRequest,
     resolve_profile_request_for_target,
     resolve_profile_tools,
     select_ncu_metric_names,
+)
+from .rocm_profiler import (
+    collect_rocprofv3,
+    filter_extreme_timing_outliers,
+    find_rocprofv3,
+    parse_rocprof_counter_collection,
+    parse_rocprof_kernel_trace,
 )
 
 
@@ -96,8 +111,22 @@ class ProfileRequestTest(unittest.TestCase):
         assert amd is not None
         self.assertEqual(
             amd["tools"],
-            ["proton_launch", "native_profiler", "ncu"],
+            ["rocprofv3", "ncu"],
         )
+
+        hip = resolve_profile_request_for_target(payload, {"backend": "hip"})
+        assert hip is not None
+        self.assertEqual(hip["tools"], ["rocprofv3", "ncu"])
+
+        deep = resolve_profile_request_for_target(
+            ProfileRequest(
+                level="deep",
+                tools=("proton_launch", "native_profiler"),
+            ).to_json(),
+            {"backend": "hip"},
+        )
+        assert deep is not None
+        self.assertEqual(deep["tools"], ["fb_att", "rocprofv3"])
 
     def test_per_case_profile_request_expands_absolute_dir(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -194,12 +223,14 @@ class ProfileParsingTest(unittest.TestCase):
 
     def test_parse_ncu_csv_and_metric_selection(self) -> None:
         csv_text = (
-            'ID,Metric Name,Metric Unit,Metric Value\n'
+            "ID,Metric Name,Metric Unit,Metric Value\n"
             '0,gpu__time_duration.sum,ns,"2,000"\n'
-            '1,sm__throughput.avg.pct_of_peak_sustained_elapsed,%,75.5\n'
+            "1,sm__throughput.avg.pct_of_peak_sustained_elapsed,%,75.5\n"
         )
         metrics = parse_ncu_csv(csv_text)
-        self.assertEqual(metrics["gpu__time_duration.sum"], {"value": 2000.0, "unit": "ns"})
+        self.assertEqual(
+            metrics["gpu__time_duration.sum"], {"value": 2000.0, "unit": "ns"}
+        )
         selected = select_ncu_metric_names(metrics.keys(), "summary")
         self.assertEqual(selected["metrics"]["duration_us"], "gpu__time_duration.sum")
         self.assertIsNone(selected["metrics"]["dram_throughput_pct"])
@@ -472,13 +503,266 @@ class ProfileParsingTest(unittest.TestCase):
         self.assertIn("regressed", ncu_regression_diagnostic(old_flat, normalized))
         self.assertEqual(ncu_regression_diagnostic(normalized, old_flat), "")
 
+        rocprof_baseline = {"rocprofv3": {"summary": {"duration_us": 10.0}}}
+        rocprof_candidate = {"rocprofv3": {"summary": {"duration_us": 10.2}}}
+        self.assertEqual(
+            extract_native_profiler_duration_us(rocprof_baseline),
+            ("rocprofv3", 10.0),
+        )
+        self.assertIn(
+            "rocprofv3 duration regressed",
+            native_profiler_regression_diagnostic(rocprof_baseline, rocprof_candidate),
+        )
+        self.assertEqual(
+            native_profiler_regression_diagnostic(old_flat, rocprof_candidate),
+            "",
+        )
+        self.assertEqual(
+            extract_native_profiler_duration_us(
+                {"rocprofv3": {"summary": {"duration_us": "invalid"}}}
+            ),
+            (None, None),
+        )
+
+    def test_parses_rocprof_kernel_trace_and_resources(self) -> None:
+        trace = (
+            "Kernel_Name,Start_Timestamp,End_Timestamp,Workgroup_Size,"
+            "LDS_Block_Size,VGPR_Count,Accum_VGPR_Count,SGPR_Count\n"
+            "helper,0,1000,64,0,8,0,16\n"
+            "gemm,1000,5000,256,32768,64,16,32\n"
+            "gemm,5000,9200,256,32768,64,16,32\n"
+            "gemm,9200,13000,256,32768,64,16,32\n"
+        )
+        profile = parse_rocprof_kernel_trace(trace, sample_count=2)
+        self.assertEqual(profile["summary"]["dominant_kernel"], "gemm")
+        self.assertEqual(profile["summary"]["duration_us"], 4.0)
+        self.assertEqual(profile["summary"]["scope"], "dominant_kernel")
+        self.assertEqual(profile["kernels"][0]["dispatches"], 3)
+        self.assertEqual(profile["kernels"][0]["resources"]["lds_bytes"], 32768.0)
+
+    def test_parses_rocprof_counter_collection(self) -> None:
+        counters = (
+            "Kernel_Name,Counter_Name,Counter_Value\n"
+            "gemm,SQ_WAVES,100\n"
+            "gemm,SQ_WAVES,120\n"
+            "gemm,SQ_INSTS_MFMA,40\n"
+            "helper,SQ_WAVES,2\n"
+        )
+        parsed = parse_rocprof_counter_collection(counters)
+        self.assertEqual(parsed["gemm"]["SQ_WAVES"], 110.0)
+        self.assertEqual(parsed["gemm"]["SQ_INSTS_MFMA"], 40.0)
+        self.assertEqual(parsed["helper"]["SQ_WAVES"], 2.0)
+
+    def test_filters_only_extreme_rocprof_timing_outliers(self) -> None:
+        samples = [100.0, 101.0, 99.0, 102.0, 98.0, 1000.0]
+
+        self.assertEqual(
+            filter_extreme_timing_outliers(samples),
+            [100.0, 101.0, 99.0, 102.0, 98.0],
+        )
+        self.assertEqual(
+            filter_extreme_timing_outliers([100.0, 100.0, 100.0, 100.0]),
+            [100.0, 100.0, 100.0, 100.0],
+        )
+
+    def test_finds_newest_internal_rocprof_by_numeric_version(self) -> None:
+        candidates = (
+            Path("/usr/local/fbcode/platform010/lib/rocm-6.9/bin/rocprofv3"),
+            Path("/usr/local/fbcode/platform010/lib/rocm-6.10/bin/rocprofv3"),
+        )
+
+        with (
+            patch.object(
+                rocm_profiler_module.shutil,
+                "which",
+                return_value=None,
+            ),
+            patch.object(Path, "is_dir", autospec=True, return_value=True),
+            patch.object(Path, "glob", autospec=True, return_value=iter(candidates)),
+            patch.object(
+                Path,
+                "is_file",
+                autospec=True,
+                side_effect=lambda path: path in candidates,
+            ),
+            patch.object(
+                rocm_profiler_module.os,
+                "access",
+                return_value=True,
+            ),
+        ):
+            profiler = find_rocprofv3({"PATH": ""})
+
+        self.assertEqual(profiler, candidates[1])
+
+    def test_collects_rocprof_trace_and_counters_from_external_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            profiler = root / "rocprofv3"
+            profiler.write_text(
+                "#!/usr/bin/python3\n"
+                "import os\n"
+                "import sys\n"
+                "from pathlib import Path\n"
+                "args = sys.argv[1:]\n"
+                "assert os.environ['LD_PRELOAD'] == '/usr/lib64/libzstd.so.1'\n"
+                "assert args[args.index('--mangled-kernels') + 1] == 'true'\n"
+                "output_dir = Path(args[args.index('--output-directory') + 1])\n"
+                "output_file = args[args.index('--output-file') + 1]\n"
+                "output_dir.mkdir(parents=True, exist_ok=True)\n"
+                "(Path.cwd() / '.rocprofv3').mkdir()\n"
+                "if '--kernel-trace' in args:\n"
+                "    (output_dir / f'{output_file}_kernel_trace.csv').write_text(\n"
+                "        'Kernel_Name,Start_Timestamp,End_Timestamp,VGPR_Count\\n'\n"
+                "        'gemm,0,4000,64\\n'\n"
+                "        'gemm,4000,8200,64\\n'\n"
+                "        'gemm,8200,12000,64\\n'\n"
+                "    )\n"
+                "else:\n"
+                "    counters = args[args.index('--pmc') + 1].split(',')\n"
+                "    rows = ''.join(f'gemm,{counter},100\\n' for counter in counters)\n"
+                "    (output_dir / f'{output_file}_counter_collection.csv').write_text(\n"
+                "        'Kernel_Name,Counter_Name,Counter_Value\\n' + rows\n"
+                "    )\n"
+                "print('fake rocprofv3')\n"
+            )
+            profiler.chmod(0o755)
+
+            profile = collect_rocprofv3(
+                ("/usr/bin/python3", "-c", "pass"),
+                root / "artifacts",
+                environment={
+                    "TLX_ROCPROFV3": str(profiler),
+                    "LD_PRELOAD": (
+                        "/tmp/librocprofiler-sdk-tool.so:/usr/lib64/libzstd.so.1"
+                    ),
+                },
+            )
+
+            self.assertEqual(profile["tool"], "rocprofv3")
+            self.assertEqual(profile["summary"]["dominant_kernel"], "gemm")
+            self.assertEqual(profile["summary"]["duration_us"], 4.0)
+            self.assertEqual(profile["counters"]["MfmaUtil"], 100.0)
+            self.assertEqual(profile["kernels"][0]["samples_us"], [4.0, 4.2, 3.8])
+            self.assertTrue(Path(profile["artifacts"]["kernel_trace_csv"]).exists())
+            self.assertTrue(
+                (
+                    Path(profile["artifacts"]["kernel_trace_csv"]).parent / ".rocprofv3"
+                ).is_dir()
+            )
+
+    def test_collect_rocprof_returns_error_for_unreadable_trace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            profiler = root / "rocprofv3"
+            profiler.write_text(
+                "#!/usr/bin/python3\n"
+                "import sys\n"
+                "from pathlib import Path\n"
+                "args = sys.argv[1:]\n"
+                "output_dir = Path(args[args.index('--output-directory') + 1])\n"
+                "output_file = args[args.index('--output-file') + 1]\n"
+                "output_dir.mkdir(parents=True, exist_ok=True)\n"
+                "(output_dir / f'{output_file}_kernel_trace.csv').write_bytes(b'\\xff')\n"
+            )
+            profiler.chmod(0o755)
+
+            profile = collect_rocprofv3(
+                ("/usr/bin/python3", "-c", "pass"),
+                root / "artifacts",
+                level="timing",
+                environment={"TLX_ROCPROFV3": str(profiler)},
+            )
+
+            self.assertIn("failed to read rocprofv3 kernel trace", profile["error"])
+            self.assertTrue(Path(profile["artifacts"]["command"]).exists())
+
+    def test_gfx950_benchmark_surfaces_rocprof_error(self) -> None:
+        harness_path = (
+            Path(__file__).with_name("harnesses")
+            / "gfx950"
+            / "targets"
+            / "gemm"
+            / "harness.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "test_gfx950_harness", harness_path
+        )
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertIsNotNone(spec.loader)
+        assert spec.loader is not None
+        harness = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, {"torch": ModuleType("torch")}):
+            spec.loader.exec_module(harness)
+
+        with (
+            patch.object(
+                harness,
+                "collect_rocprofv3",
+                return_value={
+                    "error": "rocprofv3 was not found; set TLX_ROCPROFV3 or PATH"
+                },
+            ),
+            self.assertRaisesRegex(RuntimeError, "set TLX_ROCPROFV3 or PATH"),
+        ):
+            harness.benchmark(
+                (None, None, Path("/tmp/candidate.py"), "cuda"),
+                {"case_id": "square"},
+                repetitions=3,
+            )
+
+    def test_collects_fb_att_without_rocprof_separator(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            profiler = root / "fb_att"
+            profiler.write_text(
+                "#!/usr/bin/python3\n"
+                "import sys\n"
+                "from pathlib import Path\n"
+                "args = sys.argv[1:]\n"
+                "assert '--' not in args\n"
+                "assert args[args.index('--att-perfcounter-ctrl') + 1] == '3'\n"
+                "output_dir = Path(args[args.index('--fb-output-directory') + 1])\n"
+                "ui_dir = output_dir / 'fbrocrof_1' / 'gemm_0_ui'\n"
+                "ui_dir.mkdir(parents=True)\n"
+                "(ui_dir / 'wstates0.json').write_text('{}')\n"
+            )
+            profiler.chmod(0o755)
+
+            profile = collect_fb_att(
+                ("/usr/bin/python3", "-c", "pass"),
+                root / "artifacts",
+                kernel_filter="gemm",
+                counters=("SQ_LDS_BANK_CONFLICT",),
+                environment={"TLX_FB_ATT": str(profiler)},
+            )
+
+            self.assertTrue(profile["valid"])
+            self.assertEqual(profile["kernel_filter"], "gemm")
+            self.assertEqual(profile["iteration_range"], "[4-4]")
+            self.assertEqual(profile["perfcounter_control"], 3)
+            self.assertEqual(len(profile["artifacts"]["ui_directories"]), 1)
+            self.assertTrue(Path(profile["artifacts"]["wstates"][0]).exists())
+
     def test_compact_profile_summary_omits_raw_blobs(self) -> None:
         compact = compact_profile_summary(
             {
                 "level": "summary",
                 "summary": {"duration_us": 1.0},
                 "raw": "x" * 5000,
-                "ncu": {"raw_metrics": {"huge": "blob"}, "summary": {"duration_us": 1.0}},
+                "ncu": {
+                    "raw_metrics": {"huge": "blob"},
+                    "summary": {"duration_us": 1.0},
+                },
+                "rocprofv3": {
+                    "summary": {"duration_us": 2.0},
+                    "raw_metrics": {"huge": "blob"},
+                },
+                "fb_att": {
+                    "valid": True,
+                    "artifacts": {"ui_directories": ["/tmp/gemm_0_ui"]},
+                },
                 "native_profiler": {
                     "raw": "x" * 5000,
                     "summary": {"duration_us": 1.0},
@@ -494,6 +778,9 @@ class ProfileParsingTest(unittest.TestCase):
         self.assertEqual(compact["level"], "summary")
         self.assertNotIn("raw", compact)
         self.assertNotIn("raw_metrics", compact["ncu"])
+        self.assertEqual(compact["rocprofv3"]["summary"]["duration_us"], 2.0)
+        self.assertNotIn("raw_metrics", compact["rocprofv3"])
+        self.assertTrue(compact["fb_att"]["valid"])
         self.assertIn("native_profiler", compact)
         self.assertNotIn("raw", compact["native_profiler"])
         diagnostic = compact["diagnostic_proton_intra_kernel"]


### PR DESCRIPTION
Summary:

The kernel optimization agent previously had no reliable first-class AMD execution and profiling path: native profiling resolved only to NCU, host validation understood only CUDA architectures, and there was no ready-to-run gfx950 GEMM target.

This change adds a generic gfx950 GEMM target contract for any complete candidate source that exports `matmul(a, b)`. `amd_gemm_warp_pipeline.py` is only a convenient smoke-test seed, not the target implementation or a claim of optimality. The new `--target-name` option lets implementation-specific filenames select the generic `gemm` contract.

Promotion timing now uses raw `rocprofv3 --kernel-trace` device timestamps after a configurable 20-second steady-state burn. It keeps the final 50 dispatches, applies a conservative 3x-IQR filter only to extreme timing outliers, and preserves raw traces and samples. Summary/deep profiling collects gfx950-validated `MfmaUtil`, `VALUBusy`, `MemUnitStalled`, `FETCH_SIZE`, and LDS conflict counters in separate passes. Profiler environment sanitization preserves required libraries such as zstd while removing inherited profiler instrumentation, and internal `.rocprofv3` data stays inside experiment artifacts.

Deep baseline/final profiles additionally use `fb_att` by default, following the validated gfx950 workflow: no extra `--` separator, a selected dispatch, local output, and a kernel substring normalized from the rocprof name. ATT validity requires generated `wstates` data, not merely exit code 0. Raw rocprofv3 PMC remains the default counter source because enabling ATT counters on this host can exit successfully without producing a trace; the collector still supports explicit ATT counters.

Because AMD promotion timing is already produced by rocprofv3, a second independent rocprof profile replay no longer acts as a duplicate 1% veto. NCU regression protection remains unchanged when benchmark timing comes from a different source. Correctness, variance, and aggregate speedup continue to control promotion.

This diff is intentionally limited to AMD bring-up and profiler reliability. It does not add paired measurement, experiment ledgers, retrieval, or broader CLI orchestration.

Reviewed By: htyu

Differential Revision: D118570120


