### PR TITLE
[Triton] Fix cycle detection in CallGraph walk

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -434,9 +434,11 @@ private:
   void doWalk(FunctionOpInterface funcOp,
               DenseSet<FunctionOpInterface> &visited, UpdateEdgeFn updateEdgeFn,
               UpdateNodeFn updateNodeFn) {
-    if (visited.count(funcOp)) {
+    auto [_, inserted] = visited.insert(funcOp);
+    if (!inserted) {
       llvm::report_fatal_error("Cycle detected in call graph");
     }
+
     if constexpr (UpdateNodeOrder == WalkOrder::PreOrder) {
       updateNodeFn(funcOp);
     }

--- a/unittest/Analysis/CMakeLists.txt
+++ b/unittest/Analysis/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_triton_ut(
   NAME TestTritonAnalysis
-  SRCS UtilityTest.cpp TMAMulticastTest.cpp
+  SRCS UtilityTest.cpp TMAMulticastTest.cpp CallGraphTest.cpp
   LIBS
     TritonAnalysis
     TritonIR

--- a/unittest/Analysis/CallGraphTest.cpp
+++ b/unittest/Analysis/CallGraphTest.cpp
@@ -1,0 +1,106 @@
+#include "triton/Analysis/Utility.h"
+
+#include "mlir/Parser/Parser.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace mlir {
+namespace {
+
+// root -> {left, right} -> leaf. An acyclic graph whose leaf is reachable
+// through two distinct paths.
+constexpr StringLiteral kDiamondCallGraph = R"MLIR(
+  tt.func private @leaf() {
+    tt.return
+  }
+  tt.func private @left() {
+    tt.call @leaf() : () -> ()
+    tt.return
+  }
+  tt.func private @right() {
+    tt.call @leaf() : () -> ()
+    tt.return
+  }
+  tt.func public @root() {
+    tt.call @left() : () -> ()
+    tt.call @right() : () -> ()
+    tt.return
+  }
+)MLIR";
+
+constexpr StringLiteral kSelfRecursiveCallGraph = R"MLIR(
+  tt.func private @recurse() {
+    tt.call @recurse() : () -> ()
+    tt.return
+  }
+  tt.func public @root() {
+    tt.call @recurse() : () -> ()
+    tt.return
+  }
+)MLIR";
+
+constexpr StringLiteral kMutuallyRecursiveCallGraph = R"MLIR(
+  tt.func private @ping() {
+    tt.call @pong() : () -> ()
+    tt.return
+  }
+  tt.func private @pong() {
+    tt.call @ping() : () -> ()
+    tt.return
+  }
+  tt.func public @root() {
+    tt.call @ping() : () -> ()
+    tt.return
+  }
+)MLIR";
+
+OwningOpRef<ModuleOp> parseModule(MLIRContext &context, StringRef source) {
+  context.loadDialect<triton::TritonDialect>();
+  return parseSourceString<ModuleOp>(source, &context);
+}
+
+// Records the order in which the walk visits nodes.
+SmallVector<std::string> walkNodeOrder(ModuleOp moduleOp) {
+  triton::CallGraph<int> callGraph(moduleOp);
+  SmallVector<std::string> visited;
+  callGraph.walk([](CallOpInterface, FunctionOpInterface) {},
+                 [&](FunctionOpInterface funcOp) {
+                   visited.push_back(funcOp.getName().str());
+                 });
+  return visited;
+}
+
+} // namespace
+
+// A node reachable through several paths is not a cycle: the walk visits it
+// once per path and must not report a cycle.
+TEST(Analysis, CallGraphWalksDiamondWithoutReportingACycle) {
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module = parseModule(context, kDiamondCallGraph);
+  ASSERT_TRUE(module);
+
+  EXPECT_EQ(
+      walkNodeOrder(*module),
+      SmallVector<std::string>({"root", "left", "leaf", "right", "leaf"}));
+}
+
+TEST(AnalysisDeathTest, CallGraphWalkRejectsSelfRecursion) {
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module = parseModule(context, kSelfRecursiveCallGraph);
+  ASSERT_TRUE(module);
+
+  EXPECT_DEATH(walkNodeOrder(*module), "Cycle detected in call graph");
+}
+
+TEST(AnalysisDeathTest, CallGraphWalkRejectsMutualRecursion) {
+  MLIRContext context;
+  OwningOpRef<ModuleOp> module =
+      parseModule(context, kMutuallyRecursiveCallGraph);
+  ASSERT_TRUE(module);
+
+  EXPECT_DEATH(walkNodeOrder(*module), "Cycle detected in call graph");
+}
+
+} // namespace mlir


### PR DESCRIPTION
When doing the DFS walk on the call graph, the set recording visited nodes was totally unused, so cycle detection was not working.

Test plan: added tests that would fail without fix