### PR TITLE
[autoWS] Support rank-3 descriptors in 2CTA B loads

### DIFF
--- a/test/Hopper/TwoCTA/transform_2cta_loads.mlir
+++ b/test/Hopper/TwoCTA/transform_2cta_loads.mlir
@@ -96,6 +96,76 @@ module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32,
 
 // -----
 
+// Rank-3 BMM descriptors use a leading unit block dimension so a globally
+// persistent worker can change batches without reconstructing descriptors.
+// The descriptor load still produces the rank-2 tile consumed by dot.  The B
+// transform must split the descriptor's last dimension, not the result's
+// dimension number, and preserve the leading batch index.
+// CHECK-LABEL: @matmul_2cta_rank3_descriptors
+// CHECK: tt.make_tensor_descriptor %{{.*}} : !tt.ptr<f16>, !tt.tensordesc<1x128x64xf16>
+// CHECK: tt.make_tensor_descriptor %{{.*}} : !tt.ptr<f16>, !tt.tensordesc<1x64x64xf16>
+// CHECK: tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}, %{{.*}}] {{.*}}two_cta_load{{.*}} : !tt.tensordesc<1x128x64xf16>
+// CHECK: %[[CTA_ID_3D:.*]] = nvg.cluster_id
+// CHECK: %[[MOD_3D:.*]] = arith.remsi %[[CTA_ID_3D]], %{{.*}}
+// CHECK: %[[OFF_3D:.*]] = arith.muli %[[MOD_3D]], %{{.*}}
+// CHECK: %[[N_3D:.*]] = arith.addi %{{.*}}, %[[OFF_3D]]
+// CHECK: tt.descriptor_load %{{.*}}[%{{.*}}, %{{.*}}, %[[N_3D]]] {{.*}}two_cta_load{{.*}} : !tt.tensordesc<1x64x64xf16> -> tensor<64x64xf16
+// CHECK: ttng.tc_gen5_mma {{.*}} {two_ctas}
+
+#blocked_r3 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1_r3 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_r3 = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#shared_r3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem_r3 = #ttg.shared_memory
+#tmem_r3 = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+
+module attributes {"ttg.cluster-dim-x" = 2 : i32, "ttg.cluster-dim-y" = 1 : i32, "ttg.cluster-dim-z" = 1 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @matmul_2cta_rank3_descriptors(
+      %a_ptr: !tt.ptr<f16>,
+      %b_ptr: !tt.ptr<f16>,
+      %B: i32 {tt.divisibility = 16 : i32},
+      %M: i32 {tt.divisibility = 16 : i32},
+      %N: i32 {tt.divisibility = 16 : i32},
+      %K: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %true = arith.constant true
+    %c128_i32 = arith.constant 128 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %stride_b = arith.extsi %K : i32 to i64
+    %n_i64 = arith.extsi %N : i32 to i64
+    %stride_a_batch = arith.muli %stride_b, %c128_i64 : i64
+    %stride_b_batch = arith.muli %stride_b, %n_i64 : i64
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked_r3>
+    %batch = tt.get_program_id y : i32
+    %pid = tt.get_program_id x : i32
+    %offs_am = arith.muli %pid, %c128_i32 : i32
+    %offs_bn = arith.muli %pid, %c128_i32 : i32
+
+    %a_desc = tt.make_tensor_descriptor %a_ptr, [%B, %M, %K], [%stride_a_batch, %stride_b, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<1x128x64xf16>
+    %b_desc = tt.make_tensor_descriptor %b_ptr, [%B, %K, %N], [%stride_b_batch, %n_i64, %c1_i64] : !tt.ptr<f16>, !tt.tensordesc<1x64x128xf16>
+
+    %accumulator = scf.for %k = %c0_i32 to %c1_i32 step %c1_i32 iter_args(%acc = %cst) -> (tensor<128x128xf32, #blocked_r3>) : i32 {
+      %offs_k = arith.muli %k, %c64_i32 : i32
+      %a = tt.descriptor_load %a_desc[%batch, %offs_am, %offs_k] : !tt.tensordesc<1x128x64xf16> -> tensor<128x64xf16, #blocked1_r3>
+      %a_smem = ttg.local_alloc %a : (tensor<128x64xf16, #blocked1_r3>) -> !ttg.memdesc<128x64xf16, #shared_r3, #smem_r3>
+      %b = tt.descriptor_load %b_desc[%batch, %offs_k, %offs_bn] : !tt.tensordesc<1x64x128xf16> -> tensor<64x128xf16, #blocked1_r3>
+      %b_smem = ttg.local_alloc %b : (tensor<64x128xf16, #blocked1_r3>) -> !ttg.memdesc<64x128xf16, #shared_r3, #smem_r3>
+      %acc_layout = ttg.convert_layout %acc : tensor<128x128xf32, #blocked_r3> -> tensor<128x128xf32, #blocked3_r3>
+      %acc_tmem, %token = ttng.tmem_alloc %acc_layout : (tensor<128x128xf32, #blocked3_r3>) -> (!ttg.memdesc<128x128xf32, #tmem_r3, #ttng.tensor_memory, mutable>, !ttg.async.token)
+      %mma_token = ttng.tc_gen5_mma %a_smem, %b_smem, %acc_tmem[%token], %true, %true {two_ctas} : !ttg.memdesc<128x64xf16, #shared_r3, #smem_r3>, !ttg.memdesc<64x128xf16, #shared_r3, #smem_r3>, !ttg.memdesc<128x128xf32, #tmem_r3, #ttng.tensor_memory, mutable>
+      %result, %load_token = ttng.tmem_load %acc_tmem[%mma_token] : !ttg.memdesc<128x128xf32, #tmem_r3, #ttng.tensor_memory, mutable> -> tensor<128x128xf32, #blocked3_r3>
+      %result_layout = ttg.convert_layout %result : tensor<128x128xf32, #blocked3_r3> -> tensor<128x128xf32, #blocked_r3>
+      scf.yield %result_layout : tensor<128x128xf32, #blocked_r3>
+    }
+    tt.return
+  }
+}
+
+// -----
+
 // Test: A single full V descriptor load split between two 2-CTA PV MMAs must
 // become one cooperative half-width load and two zero-copy shared-memory
 // views. This avoids two TMA loads without staging V through registers.

--- a/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/Transform2CTALoads.cpp
@@ -129,6 +129,28 @@ struct BLoadTrace {
   unsigned splitDim = 1;
 };
 
+// Descriptor loads may drop leading unit block dimensions from their tensor
+// result.  BMM uses this to keep one rank-3 [B, K, N] descriptor while feeding
+// the rank-2 [K, N] tile expected by dot.  Map the MMA/result dimension back
+// to the descriptor dimension, accepting only this unambiguous prefix-unit
+// form.
+static FailureOr<unsigned> mapResultDimToDescriptor(tt::TensorDescType descType,
+                                                    RankedTensorType resultType,
+                                                    unsigned resultDim) {
+  auto blockShape = descType.getBlockType().getShape();
+  auto resultShape = resultType.getShape();
+  if (resultDim >= resultShape.size() || blockShape.size() < resultShape.size())
+    return failure();
+
+  unsigned rankDelta = blockShape.size() - resultShape.size();
+  if (!llvm::all_of(blockShape.take_front(rankDelta),
+                    [](int64_t dim) { return dim == 1; }))
+    return failure();
+  if (!llvm::equal(blockShape.drop_front(rankDelta), resultShape))
+    return failure();
+  return rankDelta + resultDim;
+}
+
 // Trace B operand from MMA back through LocalAllocOp and cheap layout/view ops
 // to find the DescriptorLoadOp. When B is transposed, either before allocation
 // with tt.trans or after allocation with ttg.memdesc_trans, split the
@@ -219,10 +241,11 @@ struct Transform2CTALoads
     }
 
     // A 2-CTA TMA load is issued by both CTAs as one hardware CTA-group
-    // transaction. Mark every rank-2 descriptor load in the cooperative
-    // kernel, including A operands (K/V) that are not visited by B splitting.
-    // Rank-1 metadata loads remain ordinary per-CTA loads, matching TLX's raw
-    // M/D bulk-copy path.
+    // transaction. Mark every descriptor load producing a rank-2 MMA tile in
+    // the cooperative kernel, including rank-3 descriptors with a leading
+    // unit block dimension and A operands (K/V) that are not visited by B
+    // splitting. Rank-1 metadata loads remain ordinary per-CTA loads, matching
+    // TLX's raw M/D bulk-copy path.
     //
     // Cooperative marking is a performance choice, not a correctness
     // requirement: leaving a load unmarked keeps the pre-existing per-CTA
@@ -428,12 +451,20 @@ struct Transform2CTALoads
     assert(descType && "expected descriptor load type to be captured before "
                        "2-CTA load transformation");
     auto blockShape = descType.getBlockType().getShape();
-    assert(blockShape.size() == 2 && "Expected 2D block shape");
+    auto origResultType =
+        cast<RankedTensorType>(descLoad.getResult().getType());
+    auto descriptorSplitDim =
+        mapResultDimToDescriptor(descType, origResultType, splitDim);
+    if (failed(descriptorSplitDim)) {
+      LDBG("descriptor/result ranks do not have a supported unit-prefix "
+           "relationship");
+      return failure();
+    }
     SmallVector<int64_t> newBlockShape(blockShape.begin(), blockShape.end());
-    int64_t blockN = blockShape[splitDim];
+    int64_t blockN = blockShape[*descriptorSplitDim];
     assert(blockN % 2 == 0 && "BLOCK_N must be even for 2-CTA B splitting");
     int64_t halfN = blockN / 2;
-    newBlockShape[splitDim] = halfN;
+    newBlockShape[*descriptorSplitDim] = halfN;
 
     if (halfN < 16) {
       LDBG("halfN=" << halfN << " too small, skipping");
@@ -491,18 +522,19 @@ struct Transform2CTALoads
 
     // New N-dimension index = original + CTA offset.
     SmallVector<Value> newIndices(descLoad.getIndices());
-    newIndices[splitDim] =
-        arith::AddIOp::create(builder, loc, newIndices[splitDim], offset);
+    newIndices[*descriptorSplitDim] = arith::AddIOp::create(
+        builder, loc, newIndices[*descriptorSplitDim], offset);
 
     // --- Step 3: Create new DescriptorLoadOp with half-width result ---
-    auto origResultType =
-        cast<RankedTensorType>(descLoad.getResult().getType());
     auto origEncoding =
         cast<ttg::BlockedEncodingAttr>(origResultType.getEncoding());
+    SmallVector<int64_t> newResultShape(origResultType.getShape().begin(),
+                                        origResultType.getShape().end());
+    newResultShape[splitDim] = halfN;
     auto newEncoding =
-        getCompatibleEncoding(origEncoding, newBlockShape, splitDim, ctx);
+        getCompatibleEncoding(origEncoding, newResultShape, splitDim, ctx);
     auto halfResultType =
-        RankedTensorType::get(newBlockShape, elemType, newEncoding);
+        RankedTensorType::get(newResultShape, elemType, newEncoding);
 
     auto newDescLoad = tt::DescriptorLoadOp::create(
         builder, loc, halfResultType, newDesc, newIndices);


### PR DESCRIPTION
Extends `Transform2CTALoads` to handle a rank-3 descriptor with a leading unit block dimension that produces a rank-2 MMA tile. This enables globally persistent batched matmul to change batches without rebuilding descriptors.

Unsupported rank relationships continue to fail closed. The focused transform test passes, and a B200 runtime probe covers ordinary/transposed B, broadcast fallbacks, aligned K/N tails, and 50 repeated launches. On `(B,M,N,K)=(65,256,136,4104)`, full persistence is 63.7 us versus 66.5 us for the mixed schedule.