### PR TITLE
[TLX] Use target warp size in post-AST fixup instead of hardcode

### DIFF
--- a/python/test/unit/language/test_tlx_codegen.py
+++ b/python/test/unit/language/test_tlx_codegen.py
@@ -7,6 +7,7 @@ parametrized across targets and dtypes.
 import pytest
 import triton
 import triton.language as tl
+from triton._C.libtriton import ir
 from triton.backends.compiler import GPUTarget
 import triton.language.extra.tlx as tlx
 from triton._filecheck import run_parser
@@ -663,6 +664,12 @@ class TestReuseGroup:
             )
 
 
+SM80 = GPUTarget("cuda", 80, 32)
+
+SM90 = GPUTarget("cuda", 90, 32)
+
+SM100 = GPUTarget("cuda", 100, 32)
+
 GFX950 = GPUTarget("hip", "gfx950", 64)
 
 GFX942 = GPUTarget("hip", "gfx942", 64)
@@ -705,6 +712,46 @@ def _warp_predicate_kernel(x_ptr, lhs_ptr, rhs_ptr, side_ptr, size: tl.constexpr
     )
     tl.store(lhs_ptr + offsets, lhs)
     tl.store(rhs_ptr + offsets, rhs)
+
+
+@pytest.mark.parametrize(
+    "target,expected_warp_size",
+    [
+        (SM80, 32),
+        (SM90, 32),
+        (SM100, 32),
+        (GFX942, 64),
+        (GFX950, 64),
+        (GFX1250, 32),
+    ],
+    ids=["sm80", "sm90", "sm100", "gfx942", "gfx950", "gfx1250"],
+)
+def test_raw_ttir_uses_target_warp_size(target, expected_warp_size):
+    backend = triton.compiler.compiler.make_backend(target)
+    options = backend.parse_options({})
+    assert options.warp_size == expected_warp_size
+    context = ir.context()
+    ir.load_dialects(context)
+    backend.load_dialects(context)
+    source = ASTSource(
+        fn=_async_local_slice_dot_kernel,
+        signature={
+            "q_ptr": "*fp16",
+            "k_ptr": "*fp16",
+            "output_ptr": "*fp32",
+        },
+        constexprs={},
+    )
+
+    module = source.make_ir(
+        target,
+        options,
+        backend.get_codegen_implementation(options),
+        backend.get_module_map(),
+        context,
+    )
+
+    assert module.get_int_attr("ttg.threads-per-warp") == expected_warp_size
 
 
 @triton.jit

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -238,7 +238,7 @@ class HIPBackend(BaseBackend):
                 pm,
                 f"hip:{options.arch}",
                 options.num_warps,
-                64,
+                options.warp_size,
                 options.num_ctas,
                 [1, 1, 1],
             )

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -761,7 +761,7 @@ class CUDABackend(BaseBackend):
                 pm,
                 f"cuda:{capability}",
                 options.num_warps,
-                32,
+                options.warp_size,
                 options.num_ctas,
                 list(options.cluster_dims),
             )


### PR DESCRIPTION
Summary:
**TL;DR: GFX1250+ changes warp size from 64 to 32. Instead of hardcoding warp size for AMD/Nvidia, use `options.warp_size` to match target hardware.**

D119281673 moved TritonTLXFixup into the post-AST-lowering callback, but the new backend hooks passed hard-coded thread counts: 64 for AMD and 32 for NVIDIA. GFX1250 uses wave32, so its raw TLX TTIR incorrectly received ttg.threads-per-warp = 64.

Pass `options.warp_size` to the fixup in both backends so the metadata follows the parsed target configuration. Add device-independent raw-TTIR coverage for SM80, SM90, SM100, GFX942, GFX950, and GFX1250, verifying both the backend option and emitted module attribute.

Differential Revision: D119753735


